### PR TITLE
feat: multi-session isolation — per-session Claude subprocess (Approach A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage/
 planning*.md
 design*.md
 testcase*.md
+feature*.md
 
 .claude-plugin/
 .claude

--- a/config.example.json
+++ b/config.example.json
@@ -21,6 +21,10 @@
       },
       "heartbeat": {
         "rateLimitMinutes": 30
+      },
+      "session": {
+        "idleTimeoutMinutes": 30,
+        "maxConcurrent": 20
       }
     },
     {
@@ -37,6 +41,10 @@
         "model": "claude-sonnet-4-6",
         "dangerouslySkipPermissions": false,
         "extraFlags": []
+      },
+      "session": {
+        "idleTimeoutMinutes": 30,
+        "maxConcurrent": 20
       }
     }
   ]

--- a/plugins/telegram/server.ts
+++ b/plugins/telegram/server.ts
@@ -600,25 +600,82 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
   }
 })
 
-await mcp.connect(new StdioServerTransport())
+const SEND_ONLY = process.env.TELEGRAM_SEND_ONLY === 'true'
+const RECEIVER_MODE = process.env.TELEGRAM_RECEIVER_MODE === 'true'
 
-// When Claude Code closes the MCP connection, stdin gets EOF. Without this
-// the bot keeps polling forever as a zombie, holding the token and blocking
-// the next session with 409 Conflict.
-let shuttingDown = false
-function shutdown(): void {
-  if (shuttingDown) return
-  shuttingDown = true
-  process.stderr.write('telegram channel: shutting down\n')
-  // bot.stop() signals the poll loop to end; the current getUpdates request
-  // may take up to its long-poll timeout to return. Force-exit after 2s.
-  setTimeout(() => process.exit(0), 2000)
-  void Promise.resolve(bot.stop()).finally(() => process.exit(0))
-}
-process.stdin.on('end', shutdown)
-process.stdin.on('close', shutdown)
-process.on('SIGTERM', shutdown)
-process.on('SIGINT', shutdown)
+if (RECEIVER_MODE) {
+  // Receiver mode: standalone poller — POST to CLAUDE_CHANNEL_CALLBACK instead of MCP channel.
+  // No MCP connect. gateway spawns this directly (not via Claude Code MCP host).
+  const CALLBACK_URL = process.env.CLAUDE_CHANNEL_CALLBACK
+  if (!CALLBACK_URL) {
+    process.stderr.write('telegram channel: CLAUDE_CHANNEL_CALLBACK required in RECEIVER_MODE\n')
+    process.exit(1)
+  }
+
+  // Override the mcp.notification call in the message handler — in receiver mode
+  // we POST to the callback URL directly. We patch at runtime by starting polling
+  // and the existing handler already has the fetch(callbackUrl, ...) path which
+  // fires when CLAUDE_CHANNEL_CALLBACK is set. The mcp.notification call will
+  // fail (not connected) but is wrapped in .catch, so it won't crash. We start
+  // the bot without connecting MCP transport.
+  let shuttingDown = false
+  function shutdown(): void {
+    if (shuttingDown) return
+    shuttingDown = true
+    process.stderr.write('telegram channel (receiver): shutting down\n')
+    setTimeout(() => process.exit(0), 2000)
+    void Promise.resolve(bot.stop()).finally(() => process.exit(0))
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
+  void (async () => {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await bot.start({
+          onStart: info => {
+            botUsername = info.username
+            process.stderr.write(`telegram channel (receiver): polling as @${info.username}\n`)
+          },
+        })
+        return
+      } catch (err) {
+        if (err instanceof GrammyError && err.error_code === 409) {
+          const delay = Math.min(1000 * attempt, 15000)
+          process.stderr.write(
+            `telegram channel (receiver): 409 Conflict, retrying in ${delay / 1000}s\n`,
+          )
+          await new Promise(r => setTimeout(r, delay))
+          continue
+        }
+        if (err instanceof Error && err.message === 'Aborted delay') return
+        process.stderr.write(`telegram channel (receiver): polling failed: ${err}\n`)
+        return
+      }
+    }
+  })()
+} else {
+  await mcp.connect(new StdioServerTransport())
+
+  // When Claude Code closes the MCP connection, stdin gets EOF. Without this
+  // the bot keeps polling forever as a zombie, holding the token and blocking
+  // the next session with 409 Conflict.
+  let shuttingDown = false
+  function shutdown(): void {
+    if (shuttingDown) return
+    shuttingDown = true
+    process.stderr.write('telegram channel: shutting down\n')
+    // bot.stop() signals the poll loop to end; the current getUpdates request
+    // may take up to its long-poll timeout to return. Force-exit after 2s.
+    setTimeout(() => process.exit(0), 2000)
+    void Promise.resolve(bot.stop()).finally(() => process.exit(0))
+  }
+  process.stdin.on('end', shutdown)
+  process.stdin.on('close', shutdown)
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
+  if (!SEND_ONLY) {
 
 // Commands are DM-only. Responding in groups would: (1) leak pairing codes via
 // /status to other group members, (2) confirm bot presence in non-allowlisted
@@ -999,3 +1056,5 @@ void (async () => {
     }
   }
 })()
+  } // end if (!SEND_ONLY)
+} // end else (not RECEIVER_MODE)

--- a/plugins/telegram/server.ts
+++ b/plugins/telegram/server.ts
@@ -603,79 +603,131 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
 const SEND_ONLY = process.env.TELEGRAM_SEND_ONLY === 'true'
 const RECEIVER_MODE = process.env.TELEGRAM_RECEIVER_MODE === 'true'
 
-if (RECEIVER_MODE) {
-  // Receiver mode: standalone poller — POST to CLAUDE_CHANNEL_CALLBACK instead of MCP channel.
-  // No MCP connect. gateway spawns this directly (not via Claude Code MCP host).
-  const CALLBACK_URL = process.env.CLAUDE_CHANNEL_CALLBACK
-  if (!CALLBACK_URL) {
-    process.stderr.write('telegram channel: CLAUDE_CHANNEL_CALLBACK required in RECEIVER_MODE\n')
-    process.exit(1)
+// ─── Message helpers (shared across all polling modes) ───────────────────────
+
+// Filenames and titles are uploader-controlled. They land inside the <channel>
+// notification — delimiter chars would let the uploader break out of the tag
+// or forge a second meta entry.
+function safeName(s: string | undefined): string | undefined {
+  return s?.replace(/[<>\[\]\r\n;]/g, '_')
+}
+
+type AttachmentMeta = {
+  kind: string
+  file_id: string
+  size?: number
+  mime?: string
+  name?: string
+}
+
+async function handleInbound(
+  ctx: Context,
+  text: string,
+  downloadImage: (() => Promise<string | undefined>) | undefined,
+  attachment?: AttachmentMeta,
+): Promise<void> {
+  const result = gate(ctx)
+
+  if (result.action === 'drop') return
+
+  if (result.action === 'pair') {
+    const lead = result.isResend ? 'Still pending' : 'Pairing required'
+    await ctx.reply(
+      `${lead} — run in Claude Code:\n\n/telegram:access pair ${result.code}`,
+    )
+    return
   }
 
-  // Override the mcp.notification call in the message handler — in receiver mode
-  // we POST to the callback URL directly. We patch at runtime by starting polling
-  // and the existing handler already has the fetch(callbackUrl, ...) path which
-  // fires when CLAUDE_CHANNEL_CALLBACK is set. The mcp.notification call will
-  // fail (not connected) but is wrapped in .catch, so it won't crash. We start
-  // the bot without connecting MCP transport.
-  let shuttingDown = false
-  function shutdown(): void {
-    if (shuttingDown) return
-    shuttingDown = true
-    process.stderr.write('telegram channel (receiver): shutting down\n')
-    setTimeout(() => process.exit(0), 2000)
-    void Promise.resolve(bot.stop()).finally(() => process.exit(0))
-  }
-  process.on('SIGTERM', shutdown)
-  process.on('SIGINT', shutdown)
+  const access = result.access
+  const from = ctx.from!
+  const chat_id = String(ctx.chat!.id)
+  const msgId = ctx.message?.message_id
 
-  void (async () => {
-    for (let attempt = 1; ; attempt++) {
-      try {
-        await bot.start({
-          onStart: info => {
-            botUsername = info.username
-            process.stderr.write(`telegram channel (receiver): polling as @${info.username}\n`)
-          },
-        })
-        return
-      } catch (err) {
-        if (err instanceof GrammyError && err.error_code === 409) {
-          const delay = Math.min(1000 * attempt, 15000)
-          process.stderr.write(
-            `telegram channel (receiver): 409 Conflict, retrying in ${delay / 1000}s\n`,
-          )
-          await new Promise(r => setTimeout(r, delay))
-          continue
-        }
-        if (err instanceof Error && err.message === 'Aborted delay') return
-        process.stderr.write(`telegram channel (receiver): polling failed: ${err}\n`)
-        return
-      }
+  // Permission-reply intercept: if this looks like "yes xxxxx" for a
+  // pending permission request, emit the structured event instead of
+  // relaying as chat. The sender is already gate()-approved at this point
+  // (non-allowlisted senders were dropped above), so we trust the reply.
+  const permMatch = PERMISSION_REPLY_RE.exec(text)
+  if (permMatch) {
+    void mcp.notification({
+      method: 'notifications/claude/channel/permission',
+      params: {
+        request_id: permMatch[2]!.toLowerCase(),
+        behavior: permMatch[1]!.toLowerCase().startsWith('y') ? 'allow' : 'deny',
+      },
+    })
+    if (msgId != null) {
+      const emoji = permMatch[1]!.toLowerCase().startsWith('y') ? '✅' : '❌'
+      void bot.api.setMessageReaction(chat_id, msgId, [
+        { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
+      ]).catch(() => {})
     }
-  })()
-} else {
-  await mcp.connect(new StdioServerTransport())
-
-  // When Claude Code closes the MCP connection, stdin gets EOF. Without this
-  // the bot keeps polling forever as a zombie, holding the token and blocking
-  // the next session with 409 Conflict.
-  let shuttingDown = false
-  function shutdown(): void {
-    if (shuttingDown) return
-    shuttingDown = true
-    process.stderr.write('telegram channel: shutting down\n')
-    // bot.stop() signals the poll loop to end; the current getUpdates request
-    // may take up to its long-poll timeout to return. Force-exit after 2s.
-    setTimeout(() => process.exit(0), 2000)
-    void Promise.resolve(bot.stop()).finally(() => process.exit(0))
+    return
   }
-  process.stdin.on('end', shutdown)
-  process.stdin.on('close', shutdown)
-  process.on('SIGTERM', shutdown)
-  process.on('SIGINT', shutdown)
 
-  if (!SEND_ONLY) {
+  // Typing indicator — signals "processing" until we reply (or ~5s elapses).
+  void bot.api.sendChatAction(chat_id, 'typing').catch(() => {})
+
+  // Ack reaction — lets the user know we're processing. Fire-and-forget.
+  // Telegram only accepts a fixed emoji whitelist — if the user configures
+  // something outside that set the API rejects it and we swallow.
+  if (access.ackReaction && msgId != null) {
+    void bot.api
+      .setMessageReaction(chat_id, msgId, [
+        { type: 'emoji', emoji: access.ackReaction as ReactionTypeEmoji['emoji'] },
+      ])
+      .catch(() => {})
+  }
+
+  const imagePath = downloadImage ? await downloadImage() : undefined
+
+  // image_path goes in meta only — an in-content "[image attached — read: PATH]"
+  // annotation is forgeable by any allowlisted sender typing that string.
+  const channelParams = {
+    content: text,
+    meta: {
+      chat_id,
+      ...(msgId != null ? { message_id: String(msgId) } : {}),
+      user: from.username ?? String(from.id),
+      user_id: String(from.id),
+      ts: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),
+      ...(imagePath ? { image_path: imagePath } : {}),
+      ...(attachment ? {
+        attachment_kind: attachment.kind,
+        attachment_file_id: attachment.file_id,
+        ...(attachment.size != null ? { attachment_size: String(attachment.size) } : {}),
+        ...(attachment.mime ? { attachment_mime: attachment.mime } : {}),
+        ...(attachment.name ? { attachment_name: attachment.name } : {}),
+      } : {}),
+    },
+  }
+
+  mcp.notification({
+    method: 'notifications/claude/channel',
+    params: channelParams,
+  }).catch(err => {
+    process.stderr.write(`telegram channel: failed to deliver inbound to Claude: ${err}\n`)
+  })
+
+  // Callback bridge: when agent-runner provides CLAUDE_CHANNEL_CALLBACK, POST
+  // the channel params there so the gateway can inject them as stream-json
+  // turns via Claude's stdin (MCP notifications alone don't trigger new LLM
+  // turns in --print --channels mode).
+  const callbackUrl = process.env.CLAUDE_CHANNEL_CALLBACK
+  if (callbackUrl) {
+    fetch(callbackUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(channelParams),
+    }).catch(err => {
+      process.stderr.write(`telegram channel: callback POST failed: ${err}\n`)
+    })
+  }
+}
+
+// ─── Register bot handlers (runs in both MCP mode and receiver mode) ──────────
+
+if (!SEND_ONLY) {
 
 // Commands are DM-only. Responding in groups would: (1) leak pairing codes via
 // /status to other group members, (2) confirm bot presence in non-allowlisted
@@ -890,171 +942,124 @@ bot.on('message:sticker', async ctx => {
   })
 })
 
-type AttachmentMeta = {
-  kind: string
-  file_id: string
-  size?: number
-  mime?: string
-  name?: string
-}
-
-// Filenames and titles are uploader-controlled. They land inside the <channel>
-// notification — delimiter chars would let the uploader break out of the tag
-// or forge a second meta entry.
-function safeName(s: string | undefined): string | undefined {
-  return s?.replace(/[<>\[\]\r\n;]/g, '_')
-}
-
-async function handleInbound(
-  ctx: Context,
-  text: string,
-  downloadImage: (() => Promise<string | undefined>) | undefined,
-  attachment?: AttachmentMeta,
-): Promise<void> {
-  const result = gate(ctx)
-
-  if (result.action === 'drop') return
-
-  if (result.action === 'pair') {
-    const lead = result.isResend ? 'Still pending' : 'Pairing required'
-    await ctx.reply(
-      `${lead} — run in Claude Code:\n\n/telegram:access pair ${result.code}`,
-    )
-    return
-  }
-
-  const access = result.access
-  const from = ctx.from!
-  const chat_id = String(ctx.chat!.id)
-  const msgId = ctx.message?.message_id
-
-  // Permission-reply intercept: if this looks like "yes xxxxx" for a
-  // pending permission request, emit the structured event instead of
-  // relaying as chat. The sender is already gate()-approved at this point
-  // (non-allowlisted senders were dropped above), so we trust the reply.
-  const permMatch = PERMISSION_REPLY_RE.exec(text)
-  if (permMatch) {
-    void mcp.notification({
-      method: 'notifications/claude/channel/permission',
-      params: {
-        request_id: permMatch[2]!.toLowerCase(),
-        behavior: permMatch[1]!.toLowerCase().startsWith('y') ? 'allow' : 'deny',
-      },
-    })
-    if (msgId != null) {
-      const emoji = permMatch[1]!.toLowerCase().startsWith('y') ? '✅' : '❌'
-      void bot.api.setMessageReaction(chat_id, msgId, [
-        { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
-      ]).catch(() => {})
-    }
-    return
-  }
-
-  // Typing indicator — signals "processing" until we reply (or ~5s elapses).
-  void bot.api.sendChatAction(chat_id, 'typing').catch(() => {})
-
-  // Ack reaction — lets the user know we're processing. Fire-and-forget.
-  // Telegram only accepts a fixed emoji whitelist — if the user configures
-  // something outside that set the API rejects it and we swallow.
-  if (access.ackReaction && msgId != null) {
-    void bot.api
-      .setMessageReaction(chat_id, msgId, [
-        { type: 'emoji', emoji: access.ackReaction as ReactionTypeEmoji['emoji'] },
-      ])
-      .catch(() => {})
-  }
-
-  const imagePath = downloadImage ? await downloadImage() : undefined
-
-  // image_path goes in meta only — an in-content "[image attached — read: PATH]"
-  // annotation is forgeable by any allowlisted sender typing that string.
-  const channelParams = {
-    content: text,
-    meta: {
-      chat_id,
-      ...(msgId != null ? { message_id: String(msgId) } : {}),
-      user: from.username ?? String(from.id),
-      user_id: String(from.id),
-      ts: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),
-      ...(imagePath ? { image_path: imagePath } : {}),
-      ...(attachment ? {
-        attachment_kind: attachment.kind,
-        attachment_file_id: attachment.file_id,
-        ...(attachment.size != null ? { attachment_size: String(attachment.size) } : {}),
-        ...(attachment.mime ? { attachment_mime: attachment.mime } : {}),
-        ...(attachment.name ? { attachment_name: attachment.name } : {}),
-      } : {}),
-    },
-  }
-
-  mcp.notification({
-    method: 'notifications/claude/channel',
-    params: channelParams,
-  }).catch(err => {
-    process.stderr.write(`telegram channel: failed to deliver inbound to Claude: ${err}\n`)
-  })
-
-  // Callback bridge: when agent-runner provides CLAUDE_CHANNEL_CALLBACK, POST
-  // the channel params there so the gateway can inject them as stream-json
-  // turns via Claude's stdin (MCP notifications alone don't trigger new LLM
-  // turns in --print --channels mode).
-  const callbackUrl = process.env.CLAUDE_CHANNEL_CALLBACK
-  if (callbackUrl) {
-    fetch(callbackUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(channelParams),
-    }).catch(err => {
-      process.stderr.write(`telegram channel: callback POST failed: ${err}\n`)
-    })
-  }
-}
-
 // Without this, any throw in a message handler stops polling permanently
 // (grammy's default error handler calls bot.stop() and rethrows).
 bot.catch(err => {
   process.stderr.write(`telegram channel: handler error (polling continues): ${err.error}\n`)
 })
 
-// 409 Conflict = another getUpdates consumer is still active (zombie from a
-// previous session, or a second Claude Code instance). Retry with backoff
-// until the slot frees up instead of crashing on the first rejection.
-void (async () => {
-  for (let attempt = 1; ; attempt++) {
-    try {
-      await bot.start({
-        onStart: info => {
-          botUsername = info.username
-          process.stderr.write(`telegram channel: polling as @${info.username}\n`)
-          void bot.api.setMyCommands(
-            [
-              { command: 'start', description: 'Welcome and setup guide' },
-              { command: 'help', description: 'What this bot can do' },
-              { command: 'status', description: 'Check your pairing status' },
-            ],
-            { scope: { type: 'all_private_chats' } },
-          ).catch(() => {})
-        },
-      })
-      return // bot.stop() was called — clean exit from the loop
-    } catch (err) {
-      if (err instanceof GrammyError && err.error_code === 409) {
-        const delay = Math.min(1000 * attempt, 15000)
-        const detail = attempt === 1
-          ? ' — another instance is polling (zombie session, or a second Claude Code running?)'
-          : ''
-        process.stderr.write(
-          `telegram channel: 409 Conflict${detail}, retrying in ${delay / 1000}s\n`,
-        )
-        await new Promise(r => setTimeout(r, delay))
-        continue
-      }
-      // bot.stop() mid-setup rejects with grammy's "Aborted delay" — expected, not an error.
-      if (err instanceof Error && err.message === 'Aborted delay') return
-      process.stderr.write(`telegram channel: polling failed: ${err}\n`)
-      return
-    }
+} // end if (!SEND_ONLY)
+
+// ─── Mode startup ─────────────────────────────────────────────────────────────
+
+if (RECEIVER_MODE) {
+  // Receiver mode: standalone poller — POST to CLAUDE_CHANNEL_CALLBACK instead of MCP channel.
+  // No MCP connect. gateway spawns this directly (not via Claude Code MCP host).
+  // mcp.notification() calls in handlers fail silently (.catch wrapped) — only the
+  // CLAUDE_CHANNEL_CALLBACK fetch path is used here.
+  const CALLBACK_URL = process.env.CLAUDE_CHANNEL_CALLBACK
+  if (!CALLBACK_URL) {
+    process.stderr.write('telegram channel: CLAUDE_CHANNEL_CALLBACK required in RECEIVER_MODE\n')
+    process.exit(1)
   }
-})()
-  } // end if (!SEND_ONLY)
-} // end else (not RECEIVER_MODE)
+
+  let shuttingDown = false
+  function shutdown(): void {
+    if (shuttingDown) return
+    shuttingDown = true
+    process.stderr.write('telegram channel (receiver): shutting down\n')
+    setTimeout(() => process.exit(0), 2000)
+    void Promise.resolve(bot.stop()).finally(() => process.exit(0))
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
+  void (async () => {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await bot.start({
+          onStart: info => {
+            botUsername = info.username
+            process.stderr.write(`telegram channel (receiver): polling as @${info.username}\n`)
+          },
+        })
+        return
+      } catch (err) {
+        if (err instanceof GrammyError && err.error_code === 409) {
+          const delay = Math.min(1000 * attempt, 15000)
+          process.stderr.write(
+            `telegram channel (receiver): 409 Conflict, retrying in ${delay / 1000}s\n`,
+          )
+          await new Promise(r => setTimeout(r, delay))
+          continue
+        }
+        if (err instanceof Error && err.message === 'Aborted delay') return
+        process.stderr.write(`telegram channel (receiver): polling failed: ${err}\n`)
+        return
+      }
+    }
+  })()
+} else {
+  await mcp.connect(new StdioServerTransport())
+
+  // When Claude Code closes the MCP connection, stdin gets EOF. Without this
+  // the bot keeps polling forever as a zombie, holding the token and blocking
+  // the next session with 409 Conflict.
+  let shuttingDown = false
+  function shutdown(): void {
+    if (shuttingDown) return
+    shuttingDown = true
+    process.stderr.write('telegram channel: shutting down\n')
+    // bot.stop() signals the poll loop to end; the current getUpdates request
+    // may take up to its long-poll timeout to return. Force-exit after 2s.
+    setTimeout(() => process.exit(0), 2000)
+    void Promise.resolve(bot.stop()).finally(() => process.exit(0))
+  }
+  process.stdin.on('end', shutdown)
+  process.stdin.on('close', shutdown)
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
+  if (!SEND_ONLY) {
+    // 409 Conflict = another getUpdates consumer is still active (zombie from a
+    // previous session, or a second Claude Code instance). Retry with backoff
+    // until the slot frees up instead of crashing on the first rejection.
+    void (async () => {
+      for (let attempt = 1; ; attempt++) {
+        try {
+          await bot.start({
+            onStart: info => {
+              botUsername = info.username
+              process.stderr.write(`telegram channel: polling as @${info.username}\n`)
+              void bot.api.setMyCommands(
+                [
+                  { command: 'start', description: 'Welcome and setup guide' },
+                  { command: 'help', description: 'What this bot can do' },
+                  { command: 'status', description: 'Check your pairing status' },
+                ],
+                { scope: { type: 'all_private_chats' } },
+              ).catch(() => {})
+            },
+          })
+          return // bot.stop() was called — clean exit from the loop
+        } catch (err) {
+          if (err instanceof GrammyError && err.error_code === 409) {
+            const delay = Math.min(1000 * attempt, 15000)
+            const detail = attempt === 1
+              ? ' — another instance is polling (zombie session, or a second Claude Code running?)'
+              : ''
+            process.stderr.write(
+              `telegram channel: 409 Conflict${detail}, retrying in ${delay / 1000}s\n`,
+            )
+            await new Promise(r => setTimeout(r, delay))
+            continue
+          }
+          // bot.stop() mid-setup rejects with grammy's "Aborted delay" — expected, not an error.
+          if (err instanceof Error && err.message === 'Aborted delay') return
+          process.stderr.write(`telegram channel: polling failed: ${err}\n`)
+          return
+        }
+      }
+    })()
+  }
+}

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -1,37 +1,50 @@
-import { spawn, ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
-import * as fs from 'fs';
 import * as http from 'http';
 import * as net from 'net';
 import * as path from 'path';
 import { AgentConfig, GatewayConfig, Logger } from './types';
 import { createLogger } from './logger';
+import { SessionProcess } from './session-process';
+import { SessionStore } from './session-store';
+import { TelegramReceiver } from './telegram-receiver';
 
-const AUTO_RESTART_DELAY_MS = 5_000;
-const MAX_RESTARTS = 3;
+const DEFAULT_IDLE_TIMEOUT_MINUTES = 30;
+const DEFAULT_MAX_CONCURRENT = 20;
 
 export class AgentRunner extends EventEmitter {
   private readonly agentConfig: AgentConfig;
   private readonly gatewayConfig: GatewayConfig;
   private readonly logger: Logger;
-  private process: ChildProcess | null = null;
-  private restartCount = 0;
   private stopping = false;
-  private initialPrompt: string = '';
   private callbackServer: http.Server | null = null;
   private callbackPort = 0;
+
+  // Session pool
+  private readonly sessions = new Map<string, SessionProcess>();
+  private receiver: TelegramReceiver | null = null;
+  private readonly sessionStore: SessionStore;
+  private readonly idleTimeoutMs: number;
+  private readonly maxConcurrent: number;
+  private idleCleanerTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(agentConfig: AgentConfig, gatewayConfig: GatewayConfig, logger?: Logger) {
     super();
     this.agentConfig = agentConfig;
     this.gatewayConfig = gatewayConfig;
     this.logger = logger ?? createLogger(agentConfig.id, gatewayConfig.gateway.logDir);
+
+    // Resolve agentsBaseDir: workspace is at <agentsBaseDir>/<agentId>/workspace
+    const agentsBaseDir = path.resolve(agentConfig.workspace, '..', '..');
+    this.sessionStore = new SessionStore(agentsBaseDir);
+
+    this.idleTimeoutMs =
+      (agentConfig.session?.idleTimeoutMinutes ?? DEFAULT_IDLE_TIMEOUT_MINUTES) * 60 * 1000;
+    this.maxConcurrent = agentConfig.session?.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
   }
 
   /**
-   * Bind a local HTTP server that receives POST /channel from the Telegram
-   * plugin (CLAUDE_CHANNEL_CALLBACK).  Each received payload is injected as
-   * a stream-json user turn into the running Claude subprocess stdin.
+   * Bind a local HTTP server that receives POST /channel from TelegramReceiver.
+   * Each payload is routed to the appropriate SessionProcess by chat_id.
    */
   private async startCallbackServer(): Promise<void> {
     this.callbackPort = await new Promise<number>((resolve, reject) => {
@@ -50,30 +63,51 @@ export class AgentRunner extends EventEmitter {
         return;
       }
       let raw = '';
-      req.on('data', chunk => { raw += chunk; });
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
       req.on('end', () => {
         res.writeHead(200);
         res.end('ok');
         try {
-          const params = JSON.parse(raw) as { content?: string; meta?: Record<string, string> };
+          const params = JSON.parse(raw) as {
+            content?: string;
+            meta?: Record<string, string>;
+          };
           const meta = params.meta ?? {};
           const chatId = meta['chat_id'] ?? '';
-          const messageId = meta['message_id'] ?? '';
-          const user = meta['user'] ?? '';
-          const ts = meta['ts'] ?? new Date().toISOString();
           const content = params.content ?? '';
 
-          // Inject as a stream-json user turn using the <channel> XML format
-          // that Claude's --channels mode understands.
-          const channelXml =
-            `<channel source="telegram" chat_id="${chatId}" ` +
-            `message_id="${messageId}" user="${user}" ts="${ts}">` +
-            `${content}` +
-            `</channel>`;
-          this.sendMessage(channelXml);
-          this.logger.debug('Injected channel turn into Claude stdin', { chatId, user });
+          // Append user message to session store
+          this.sessionStore
+            .appendMessage(this.agentConfig.id, chatId, {
+              role: 'user',
+              content,
+              ts: Date.now(),
+            })
+            .catch(() => {});
+
+          // Route to session, inject as channel XML
+          this.getOrSpawnSession(chatId, 'telegram')
+            .then((session) => {
+              const channelXml = AgentRunner.buildChannelXml(params);
+              session.sendMessage(channelXml);
+              session.touch();
+              this.logger.debug('Injected channel turn into session', {
+                chatId,
+                user: meta['user'],
+              });
+            })
+            .catch((err) => {
+              this.logger.error('Failed to route message to session', {
+                chatId,
+                error: (err as Error).message,
+              });
+            });
         } catch (err) {
-          this.logger.warn('Failed to parse channel callback body', { error: (err as Error).message });
+          this.logger.warn('Failed to parse channel callback body', {
+            error: (err as Error).message,
+          });
         }
       });
     });
@@ -82,259 +116,117 @@ export class AgentRunner extends EventEmitter {
     this.logger.info('Channel callback server listening', { port: this.callbackPort });
   }
 
-  /**
-   * Wrap a plain-text message as a stream-json user turn.
-   */
-  private static toStreamJsonTurn(text: string): string {
-    return JSON.stringify({
-      type: 'user',
-      message: {
-        role: 'user',
-        content: [{ type: 'text', text }],
-      },
+  private static buildChannelXml(params: {
+    content?: string;
+    meta?: Record<string, string>;
+  }): string {
+    const meta = params.meta ?? {};
+    return (
+      `<channel source="telegram" chat_id="${meta['chat_id'] ?? ''}" ` +
+      `message_id="${meta['message_id'] ?? ''}" user="${meta['user'] ?? ''}" ` +
+      `ts="${meta['ts'] ?? new Date().toISOString()}">${params.content ?? ''}</channel>`
+    );
+  }
+
+  private async getOrSpawnSession(
+    sessionId: string,
+    source: 'telegram' | 'api',
+  ): Promise<SessionProcess> {
+    const existing = this.sessions.get(sessionId);
+    if (existing) return existing;
+
+    // Evict oldest idle session if at capacity
+    if (this.sessions.size >= this.maxConcurrent) {
+      const sorted = [...this.sessions.entries()].sort(
+        ([, a], [, b]) => a.lastActivityAt - b.lastActivityAt,
+      );
+      const idleEntry = sorted.find(([, p]) => p.isIdle(0));
+      if (idleEntry) {
+        await idleEntry[1].stop();
+        this.sessions.delete(idleEntry[0]);
+        this.logger.info('Evicted idle session', { sessionId: idleEntry[0] });
+      } else {
+        throw new Error(`Session pool full: ${this.maxConcurrent} concurrent sessions`);
+      }
+    }
+
+    const proc = new SessionProcess(
+      sessionId,
+      source,
+      this.agentConfig,
+      this.gatewayConfig,
+      this.sessionStore,
+    );
+    await proc.start();
+    this.sessions.set(sessionId, proc);
+    this.logger.info('Spawned session', {
+      sessionId,
+      source,
+      total: this.sessions.size,
     });
+    return proc;
   }
 
-  /**
-   * Build the arguments for the `claude` subprocess.
-   *
-   * --input-format stream-json  — accept newline-delimited JSON turns on stdin,
-   *                               enabling multi-turn injection while stdin stays open.
-   * --output-format stream-json — required counterpart to --input-format stream-json.
-   * --print                     — non-interactive output mode (no TTY required).
-   * --verbose                   — required alongside --print for stream-json mode.
-   * --channels plugin:telegram  — subscribe to notifications/claude/channel from
-   *                               the telegram MCP plugin and keep the process
-   *                               alive after the initial turn.
-   */
-  private buildArgs(mcpConfigPath: string): string[] {
-    const args: string[] = [
-      '--mcp-config', mcpConfigPath,
-      '--strict-mcp-config',
-      '--model', this.agentConfig.claude.model,
-      '--input-format', 'stream-json',
-      '--output-format', 'stream-json',
-      '--print',
-      '--verbose',
-      '--channels', 'plugin:telegram',
-    ];
-
-    if (this.agentConfig.claude.dangerouslySkipPermissions) {
-      args.push('--dangerously-skip-permissions');
-    }
-
-    for (const flag of this.agentConfig.claude.extraFlags) {
-      args.push(flag);
-    }
-
-    return args;
-  }
-
-  /**
-   * Build the environment for the subprocess.
-   */
-  private buildEnv(): NodeJS.ProcessEnv {
-    return {
-      ...process.env,
-      TELEGRAM_BOT_TOKEN: this.agentConfig.telegram.botToken,
-      CLAUDE_WORKSPACE: this.agentConfig.workspace,
-      // Isolate Telegram state (allowlist, polling offset) per agent
-      TELEGRAM_STATE_DIR: path.join(this.agentConfig.workspace, '.telegram-state'),
-    };
-  }
-
-  /**
-   * Ensure the agent's Telegram state directory exists and return its path.
-   */
-  private getTelegramStateDir(): string {
-    const stateDir = path.join(this.agentConfig.workspace, '.telegram-state');
-    try {
-      fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-    } catch (err) {
-      this.logger.warn('Could not create Telegram state dir', { error: (err as Error).message });
-    }
-    return stateDir;
-  }
-
-  /**
-   * Write a per-agent MCP config that launches the Telegram plugin with
-   * the correct bot token and isolated state directory.
-   * Returns the path to the written config file.
-   */
-  private writeMcpConfig(): string {
-    const stateDir = this.getTelegramStateDir();
-    const pluginServerPath = path.resolve(__dirname, '..', 'plugins', 'telegram', 'server.ts');
-    const mcpConfig = {
-      mcpServers: {
-        telegram: {
-          command: 'bun',
-          args: [pluginServerPath],
-          env: {
-            TELEGRAM_BOT_TOKEN: this.agentConfig.telegram.botToken,
-            TELEGRAM_STATE_DIR: stateDir,
-            CLAUDE_CHANNEL_CALLBACK: `http://127.0.0.1:${this.callbackPort}/channel`,
-          },
-        },
-      },
-    };
-    const configPath = path.join(this.agentConfig.workspace, '.mcp-config.json');
-    fs.writeFileSync(configPath, JSON.stringify(mcpConfig, null, 2), { mode: 0o600 });
-    return configPath;
-  }
-
-  /**
-   * Spawn the claude subprocess.
-   */
-  private spawnProcess(): void {
-    const mcpConfigPath = this.writeMcpConfig();
-    const args = this.buildArgs(mcpConfigPath);
-    const env = this.buildEnv();
-
-    // CLAUDE_BIN may contain a binary + extra args (space-separated), e.g. "node /path/mock.js"
-    const claudeBinRaw = process.env.CLAUDE_BIN ?? 'claude';
-    const claudeBinParts = claudeBinRaw.split(' ');
-    const claudeBin = claudeBinParts[0];
-    const extraBinArgs = claudeBinParts.slice(1);
-    const allArgs = [...extraBinArgs, ...args];
-
-    this.logger.info('Spawning claude subprocess', { args: allArgs, workspace: this.agentConfig.workspace, bin: claudeBin });
-
-    const proc = spawn(claudeBin, allArgs, {
-      env,
-      cwd: this.agentConfig.workspace,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.process = proc;
-
-    // Send initial prompt as a stream-json user turn.  stdin stays OPEN so
-    // that subsequent channel notifications (injected via sendMessage) can be
-    // delivered as additional turns.  --channels mode keeps Claude alive
-    // after the initial turn and injects notifications/claude/channel events
-    // from the MCP plugin as new conversation turns automatically.
-    proc.stdin?.write(AgentRunner.toStreamJsonTurn(this.initialPrompt) + '\n');
-
-    proc.stdout?.on('data', (data: Buffer) => {
-      const lines = data.toString().split('\n');
-      for (const line of lines) {
-        if (line.trim()) {
-          this.emit('output', line);
-          this.logger.debug('subprocess output', { line });
+  private startIdleCleaner(): void {
+    this.idleCleanerTimer = setInterval(async () => {
+      for (const [id, proc] of this.sessions) {
+        if (proc.isIdle(this.idleTimeoutMs)) {
+          this.logger.info('Stopping idle session', { sessionId: id });
+          await proc.stop();
+          this.sessions.delete(id);
         }
       }
-    });
-
-    proc.stderr?.on('data', (data: Buffer) => {
-      this.logger.warn('subprocess stderr', { stderr: data.toString() });
-    });
-
-    proc.on('exit', (code, signal) => {
-      this.logger.info('subprocess exited', { code, signal });
-      this.process = null;
-
-      if (!this.stopping) {
-        this.scheduleRestart();
-      }
-    });
-
-    proc.on('error', (err) => {
-      this.logger.error('subprocess error', { error: err.message });
-    });
+    }, 5 * 60 * 1000);
   }
-
-  private scheduleRestart(): void {
-    if (this.restartCount >= MAX_RESTARTS) {
-      this.logger.error('Max restarts reached, giving up', { restartCount: this.restartCount });
-      this.emit('failed');
-      return;
-    }
-
-    this.restartCount++;
-    this.logger.warn(`Scheduling restart in ${AUTO_RESTART_DELAY_MS}ms`, { attempt: this.restartCount });
-
-    setTimeout(() => {
-      if (!this.stopping) {
-        this.logger.info('Auto-restarting subprocess');
-        this.spawnProcess();
-      }
-    }, AUTO_RESTART_DELAY_MS);
-  }
-
-  /** Default prompt used on restarts (not first-run bootstrap). */
-  private static readonly CHANNELS_ACTIVATION_PROMPT =
-    'Channels mode is active. Wait for incoming messages from your channels and respond to them.';
 
   async start(bootstrapPrompt?: string): Promise<void> {
+    void bootstrapPrompt; // reserved for future use
     this.stopping = false;
-    this.restartCount = 0;
-    this.initialPrompt = bootstrapPrompt ?? AgentRunner.CHANNELS_ACTIVATION_PROMPT;
     await this.startCallbackServer();
-    this.spawnProcess();
+    this.receiver = new TelegramReceiver(
+      this.agentConfig,
+      this.callbackPort,
+      this.gatewayConfig.gateway.logDir,
+    );
+    this.receiver.start();
+    this.startIdleCleaner();
+    this.logger.info('AgentRunner started', { agentId: this.agentConfig.id });
   }
 
   async stop(): Promise<void> {
     this.stopping = true;
-
-    if (this.callbackServer) {
-      this.callbackServer.close();
-      this.callbackServer = null;
+    if (this.idleCleanerTimer !== null) {
+      clearInterval(this.idleCleanerTimer);
+      this.idleCleanerTimer = null;
     }
-
-    if (!this.process) {
-      return;
-    }
-
-    return new Promise((resolve) => {
-      const proc = this.process!;
-
-      const onExit = () => {
-        this.process = null;
-        resolve();
-      };
-
-      proc.once('exit', onExit);
-      proc.kill('SIGTERM');
-
-      // Force kill after 10s if process doesn't respond to SIGTERM
-      const forceKillTimer = setTimeout(() => {
-        if (this.process) {
-          this.logger.warn('Force-killing subprocess after timeout');
-          proc.kill('SIGKILL');
-        }
-      }, 10_000);
-
-      proc.once('exit', () => {
-        clearTimeout(forceKillTimer);
-      });
-    });
+    this.callbackServer?.close();
+    this.callbackServer = null;
+    this.receiver?.stop();
+    await Promise.all([...this.sessions.values()].map((s) => s.stop()));
+    this.sessions.clear();
   }
 
   async restart(): Promise<void> {
     await this.stop();
     this.stopping = false;
-    this.restartCount = 0;
-    await this.startCallbackServer();
-    this.spawnProcess();
+    await this.start();
   }
 
   isRunning(): boolean {
-    return this.process !== null && !this.process.killed;
+    return this.receiver?.isRunning() ?? false;
   }
 
   /**
-   * Inject a message into the running subprocess as a stream-json user turn.
-   * Used for heartbeat/cron tasks and any out-of-band prompts that need to
-   * be delivered while the agent is already running in --channels mode.
+   * Send a message to all active sessions.
+   * Used for heartbeat/cron tasks delivered out-of-band.
    */
   sendMessage(message: string): void {
-    if (!this.process || !this.process.stdin) {
-      this.logger.warn('Cannot send message: subprocess not running');
+    if (this.sessions.size === 0) {
+      this.logger.warn('sendMessage called but no active sessions');
       return;
     }
-    if (!this.process.stdin.writable) {
-      this.logger.warn('Cannot send message: stdin not writable');
-      return;
+    for (const session of this.sessions.values()) {
+      session.sendMessage(message);
     }
-    this.process.stdin.write(AgentRunner.toStreamJsonTurn(message) + '\n');
   }
 }

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -72,6 +72,16 @@ function validateAgent(agent: Record<string, unknown>, index: number): void {
       `Agent "${agent.id}" has invalid dmPolicy "${telegram.dmPolicy}". Must be "allowlist" or "open".`
     );
   }
+
+  if (agent.session !== undefined && typeof agent.session === 'object') {
+    const session = agent.session as Record<string, unknown>;
+    if (session.idleTimeoutMinutes !== undefined && (typeof session.idleTimeoutMinutes !== 'number' || session.idleTimeoutMinutes <= 0)) {
+      throw new ConfigValidationError(`agent '${agent.id}': session.idleTimeoutMinutes must be > 0`);
+    }
+    if (session.maxConcurrent !== undefined && (typeof session.maxConcurrent !== 'number' || session.maxConcurrent <= 0)) {
+      throw new ConfigValidationError(`agent '${agent.id}': session.maxConcurrent must be > 0`);
+    }
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ async function main(): Promise<void> {
 
   console.log(`[gateway] Loading config from ${CONFIG_PATH}`);
   const config: GatewayConfig = loadConfig(CONFIG_PATH);
+  config.gateway.logDir = expandTilde(config.gateway.logDir);
 
   // ── Context isolation check ──────────────────────────────────────────────
   const guard = new ContextIsolationGuard();

--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -1,0 +1,264 @@
+import { spawn, ChildProcess } from 'child_process';
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AgentConfig, GatewayConfig } from './types';
+import { SessionStore } from './session-store';
+import { createLogger } from './logger';
+
+const MAX_HISTORY_MESSAGES = 50;
+const AUTO_RESTART_DELAY_MS = 5_000;
+const MAX_RESTARTS = 3;
+const CHANNELS_ACTIVATION_PROMPT =
+  'Channels mode is active. Wait for incoming messages from your channels and respond to them.';
+
+export class SessionProcess extends EventEmitter {
+  readonly sessionId: string;
+  readonly source: 'telegram' | 'api';
+  lastActivityAt = Date.now(); // accessible by AgentRunner for eviction sort
+  private process: ChildProcess | null = null;
+  private stopping = false;
+  private restartCount = 0;
+  private readonly sessionStore: SessionStore;
+  private readonly agentConfig: AgentConfig;
+  private readonly gatewayConfig: GatewayConfig;
+  private readonly logger: ReturnType<typeof createLogger>;
+
+  constructor(
+    sessionId: string,
+    source: 'telegram' | 'api',
+    agentConfig: AgentConfig,
+    gatewayConfig: GatewayConfig,
+    sessionStore: SessionStore,
+  ) {
+    super();
+    this.sessionId = sessionId;
+    this.source = source;
+    this.agentConfig = agentConfig;
+    this.gatewayConfig = gatewayConfig;
+    this.sessionStore = sessionStore;
+    this.logger = createLogger(
+      `${agentConfig.id}:session:${sessionId}`,
+      gatewayConfig.gateway.logDir,
+    );
+  }
+
+  async start(): Promise<void> {
+    this.stopping = false;
+    this.restartCount = 0;
+    await this.spawnProcess();
+  }
+
+  private async buildInitialPrompt(): Promise<string> {
+    const history = await this.sessionStore.loadSession(this.agentConfig.id, this.sessionId);
+    const recent = history.slice(-MAX_HISTORY_MESSAGES);
+
+    if (recent.length === 0) {
+      return CHANNELS_ACTIVATION_PROMPT;
+    }
+
+    const historyText = recent
+      .map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
+      .join('\n');
+
+    return `[Conversation history with this user:\n${historyText}]\n\n${CHANNELS_ACTIVATION_PROMPT}`;
+  }
+
+  private writeMcpConfig(): string | null {
+    if (this.source === 'api') return null; // API sessions don't need Telegram plugin
+
+    const stateDir = path.join(this.agentConfig.workspace, '.telegram-state');
+    const sessionDir = path.join(this.agentConfig.workspace, '.sessions', this.sessionId);
+    fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+
+    const pluginPath = path.resolve(__dirname, '..', 'plugins', 'telegram', 'server.ts');
+    const mcpConfig = {
+      mcpServers: {
+        telegram: {
+          command: 'bun',
+          args: [pluginPath],
+          env: {
+            TELEGRAM_BOT_TOKEN: this.agentConfig.telegram.botToken,
+            TELEGRAM_STATE_DIR: stateDir,
+            TELEGRAM_SEND_ONLY: 'true', // ALWAYS — session subprocesses never poll
+          },
+        },
+      },
+    };
+
+    const configPath = path.join(sessionDir, 'mcp-config.json');
+    fs.writeFileSync(configPath, JSON.stringify(mcpConfig, null, 2), { mode: 0o600 });
+    return configPath;
+  }
+
+  private buildArgs(mcpConfigPath: string | null): string[] {
+    const args: string[] = [
+      '--model', this.agentConfig.claude.model,
+      '--input-format', 'stream-json',
+      '--output-format', 'stream-json',
+      '--print',
+      '--verbose',
+    ];
+
+    if (mcpConfigPath) {
+      args.unshift('--mcp-config', mcpConfigPath, '--strict-mcp-config');
+    }
+
+    if (this.agentConfig.claude.dangerouslySkipPermissions) {
+      args.push('--dangerously-skip-permissions');
+    }
+
+    for (const flag of this.agentConfig.claude.extraFlags ?? []) {
+      args.push(flag);
+    }
+
+    return args;
+    // NOTE: NO --channels flag — messages arrive via stdin injection, not Telegram channels
+  }
+
+  private static toStreamJsonTurn(text: string): string {
+    return JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text }] },
+    });
+  }
+
+  private async spawnProcess(): Promise<void> {
+    const initialPrompt = await this.buildInitialPrompt();
+    const mcpConfigPath = this.writeMcpConfig();
+    const args = this.buildArgs(mcpConfigPath);
+
+    const claudeBinRaw = process.env.CLAUDE_BIN ?? 'claude';
+    const claudeBinParts = claudeBinRaw.split(' ');
+    const claudeBin = claudeBinParts[0];
+    const allArgs = [...claudeBinParts.slice(1), ...args];
+
+    this.logger.info('Spawning session subprocess', {
+      sessionId: this.sessionId,
+      source: this.source,
+    });
+
+    const proc = spawn(claudeBin, allArgs, {
+      env: { ...process.env, CLAUDE_WORKSPACE: this.agentConfig.workspace },
+      cwd: this.agentConfig.workspace,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    this.process = proc;
+
+    // Send initial prompt
+    proc.stdin?.write(SessionProcess.toStreamJsonTurn(initialPrompt) + '\n');
+
+    // Capture stdout — emit output events + persist assistant replies
+    let assistantBuffer = '';
+    proc.stdout?.on('data', (data: Buffer) => {
+      const lines = data.toString().split('\n');
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        this.emit('output', line);
+        this.logger.debug('session output', { line });
+        // Try to capture assistant text for SessionStore
+        try {
+          const obj = JSON.parse(line);
+          // stream-json assistant message
+          if (obj.type === 'assistant' && Array.isArray(obj.message?.content)) {
+            for (const block of obj.message.content) {
+              if (block.type === 'text') assistantBuffer += block.text;
+            }
+          }
+          // text delta
+          if (obj.type === 'text') assistantBuffer += obj.text ?? '';
+          // result = end of turn
+          if (obj.type === 'result' && assistantBuffer.trim()) {
+            this.sessionStore
+              .appendMessage(this.agentConfig.id, this.sessionId, {
+                role: 'assistant',
+                content: assistantBuffer.trim(),
+                ts: Date.now(),
+              })
+              .catch(() => {});
+            assistantBuffer = '';
+          }
+        } catch {
+          /* not JSON */
+        }
+      }
+    });
+
+    proc.stderr?.on('data', (data: Buffer) => {
+      this.logger.warn('session stderr', { stderr: data.toString() });
+    });
+
+    proc.on('exit', (code, signal) => {
+      this.logger.info('session subprocess exited', {
+        code,
+        signal,
+        sessionId: this.sessionId,
+      });
+      this.process = null;
+      if (!this.stopping) this.scheduleRestart();
+    });
+
+    proc.on('error', (err) => {
+      this.logger.error('session subprocess error', { error: err.message });
+    });
+  }
+
+  private scheduleRestart(): void {
+    if (this.restartCount >= MAX_RESTARTS) {
+      this.logger.error('Session max restarts reached', { sessionId: this.sessionId });
+      this.emit('failed');
+      return;
+    }
+    this.restartCount++;
+    this.logger.warn(`Scheduling session restart in ${AUTO_RESTART_DELAY_MS}ms`, {
+      attempt: this.restartCount,
+    });
+    setTimeout(() => {
+      if (!this.stopping) {
+        this.spawnProcess().catch(err =>
+          this.logger.error('restart failed', { error: err.message }),
+        );
+      }
+    }, AUTO_RESTART_DELAY_MS);
+  }
+
+  sendMessage(text: string): void {
+    if (!this.process?.stdin?.writable) {
+      this.logger.warn('Cannot send message: subprocess not running', {
+        sessionId: this.sessionId,
+      });
+      return;
+    }
+    this.process.stdin.write(SessionProcess.toStreamJsonTurn(text) + '\n');
+  }
+
+  touch(): void {
+    this.lastActivityAt = Date.now();
+  }
+
+  isIdle(idleMs: number): boolean {
+    return Date.now() - this.lastActivityAt > idleMs;
+  }
+
+  isRunning(): boolean {
+    return this.process !== null && !this.process.killed;
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    if (!this.process) return;
+
+    return new Promise((resolve) => {
+      const proc = this.process!;
+      proc.once('exit', () => {
+        this.process = null;
+        resolve();
+      });
+      proc.kill('SIGTERM');
+      setTimeout(() => {
+        if (this.process) proc.kill('SIGKILL');
+      }, 10_000);
+    });
+  }
+}

--- a/src/telegram-receiver.ts
+++ b/src/telegram-receiver.ts
@@ -1,0 +1,83 @@
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+import { AgentConfig } from './types';
+import { createLogger } from './logger';
+
+const AUTO_RESTART_DELAY_MS = 5_000;
+const MAX_RESTARTS = 3;
+
+export class TelegramReceiver {
+  private process: ChildProcess | null = null;
+  private stopping = false;
+  private restartCount = 0;
+  private readonly logger: ReturnType<typeof createLogger>;
+
+  constructor(
+    private readonly agentConfig: AgentConfig,
+    private readonly callbackPort: number,
+    private readonly logDir: string,
+  ) {
+    this.logger = createLogger(`${agentConfig.id}:receiver`, logDir);
+  }
+
+  start(): void {
+    this.stopping = false;
+    this.restartCount = 0;
+    this.spawnProcess();
+  }
+
+  private spawnProcess(): void {
+    const pluginPath = path.resolve(__dirname, '..', 'plugins', 'telegram', 'server.ts');
+    const stateDir = path.join(this.agentConfig.workspace, '.telegram-state');
+
+    this.process = spawn('bun', [pluginPath], {
+      env: {
+        ...process.env,
+        TELEGRAM_RECEIVER_MODE: 'true',
+        TELEGRAM_BOT_TOKEN: this.agentConfig.telegram.botToken,
+        TELEGRAM_STATE_DIR: stateDir,
+        CLAUDE_CHANNEL_CALLBACK: `http://127.0.0.1:${this.callbackPort}/channel`,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    this.process.stdout?.on('data', (d: Buffer) =>
+      this.logger.debug('receiver stdout', { data: d.toString().trim() }),
+    );
+    this.process.stderr?.on('data', (d: Buffer) =>
+      this.logger.info('receiver', { data: d.toString().trim() }),
+    );
+    this.process.on('exit', (code, signal) => {
+      this.logger.info('TelegramReceiver exited', { code, signal });
+      this.process = null;
+      if (!this.stopping) this.scheduleRestart();
+    });
+    this.process.on('error', (err) =>
+      this.logger.error('TelegramReceiver error', { error: err.message }),
+    );
+    this.logger.info('TelegramReceiver started');
+  }
+
+  private scheduleRestart(): void {
+    if (this.restartCount >= MAX_RESTARTS) {
+      this.logger.error('TelegramReceiver max restarts reached');
+      return;
+    }
+    this.restartCount++;
+    this.logger.warn(`Restarting TelegramReceiver in ${AUTO_RESTART_DELAY_MS}ms`, {
+      attempt: this.restartCount,
+    });
+    setTimeout(() => {
+      if (!this.stopping) this.spawnProcess();
+    }, AUTO_RESTART_DELAY_MS);
+  }
+
+  stop(): void {
+    this.stopping = true;
+    this.process?.kill('SIGTERM');
+  }
+
+  isRunning(): boolean {
+    return this.process !== null && !this.process.killed;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,8 @@
+export interface SessionConfig {
+  idleTimeoutMinutes?: number; // default 30
+  maxConcurrent?: number; // default 20
+}
+
 export interface AgentConfig {
   id: string;
   description: string;
@@ -17,6 +22,8 @@ export interface AgentConfig {
   heartbeat?: {
     rateLimitMinutes?: number; // default 30
   };
+  /** Session pool settings */
+  session?: SessionConfig;
 }
 
 export interface AgentStats {

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -1,0 +1,262 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── Mock child_process ────────────────────────────────────────────────────────
+
+interface MockStdin {
+  writable: boolean;
+  write: jest.Mock;
+}
+
+interface MockChildProcess extends EventEmitter {
+  stdin: MockStdin | null;
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+}
+
+const allProcesses: MockChildProcess[] = [];
+
+function makeMockProcess(): MockChildProcess {
+  const stdin: MockStdin = { writable: true, write: jest.fn() };
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdin = stdin;
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.killed = false;
+  proc.pid = Math.floor(Math.random() * 90000) + 10000;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = true;
+    process.nextTick(() => proc.emit('exit', 0, signal ?? 'SIGTERM'));
+    return true;
+  });
+
+  allProcesses.push(proc);
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn((..._args) => makeMockProcess()),
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { AgentRunner } from '../../src/agent-runner';
+import { AgentConfig, GatewayConfig } from '../../src/types';
+import { SessionProcess } from '../../src/session-process';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAgentConfig(workspace: string, overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id: 'alfred',
+    description: 'test agent',
+    workspace,
+    env: '',
+    telegram: {
+      botToken: 'test-token',
+      allowedUsers: [],
+      dmPolicy: 'allowlist',
+    },
+    claude: {
+      model: 'claude-opus-4-6',
+      dangerouslySkipPermissions: false,
+      extraFlags: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeGatewayConfig(): GatewayConfig {
+  return {
+    gateway: { logDir: '/tmp/test-ar-logs', timezone: 'UTC' },
+    agents: [],
+  };
+}
+
+async function sendChannelPost(
+  port: number,
+  chatId: string,
+  content: string,
+  user = 'testuser',
+): Promise<void> {
+  await fetch(`http://127.0.0.1:${port}/channel`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      content,
+      meta: {
+        chat_id: chatId,
+        message_id: '1',
+        user,
+        ts: new Date().toISOString(),
+      },
+    }),
+  });
+}
+
+function getCallbackPort(runner: AgentRunner): number {
+  return (runner as unknown as { callbackPort: number }).callbackPort;
+}
+
+function getSessions(runner: AgentRunner): Map<string, SessionProcess> {
+  return (runner as unknown as { sessions: Map<string, SessionProcess> }).sessions;
+}
+
+function getIdleCleaner(runner: AgentRunner): ReturnType<typeof setInterval> | undefined {
+  return (runner as unknown as { idleCleanerTimer?: ReturnType<typeof setInterval> })
+    .idleCleanerTimer;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('AgentRunner (session pool)', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-test-'));
+    agentConfig = makeAgentConfig(path.join(tmpDir, 'workspace'));
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) {
+      await runner.stop();
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-AR-01: Different chat_ids get different SessionProcesses
+  // --------------------------------------------------------------------------
+  it('U-AR-01: different chat_ids get different SessionProcesses', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+
+    await sendChannelPost(port, 'chat:111', 'hello');
+    // Allow async session spawn to complete
+    await new Promise(r => setTimeout(r, 100));
+
+    await sendChannelPost(port, 'chat:222', 'world');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sessions = getSessions(runner);
+    expect(sessions.size).toBe(2);
+    expect(sessions.has('chat:111')).toBe(true);
+    expect(sessions.has('chat:222')).toBe(true);
+    expect(sessions.get('chat:111')).not.toBe(sessions.get('chat:222'));
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // U-AR-02: Same chat_id reuses existing SessionProcess
+  // --------------------------------------------------------------------------
+  it('U-AR-02: same chat_id reuses the existing SessionProcess', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+
+    await sendChannelPost(port, 'chat:111', 'first message');
+    await new Promise(r => setTimeout(r, 100));
+
+    const first = getSessions(runner).get('chat:111');
+
+    await sendChannelPost(port, 'chat:111', 'second message');
+    await new Promise(r => setTimeout(r, 100));
+
+    const second = getSessions(runner).get('chat:111');
+
+    expect(getSessions(runner).size).toBe(1);
+    expect(first).toBe(second);
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // U-AR-03: maxConcurrent evicts oldest idle session
+  // --------------------------------------------------------------------------
+  it('U-AR-03: maxConcurrent evicts oldest idle session when pool is full', async () => {
+    agentConfig = makeAgentConfig(agentConfig.workspace, {
+      session: { maxConcurrent: 2, idleTimeoutMinutes: 30 },
+    });
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+
+    // Fill pool with 2 sessions
+    await sendChannelPost(port, 'chat:111', 'hello');
+    await new Promise(r => setTimeout(r, 100));
+    await sendChannelPost(port, 'chat:222', 'hello');
+    await new Promise(r => setTimeout(r, 100));
+
+    expect(getSessions(runner).size).toBe(2);
+
+    // Make chat:111 the oldest (lowest lastActivityAt)
+    const sess111 = getSessions(runner).get('chat:111')!;
+    (sess111 as unknown as { lastActivityAt: number }).lastActivityAt = Date.now() - 100_000;
+
+    // Third chat should evict chat:111 (oldest idle)
+    await sendChannelPost(port, 'chat:333', 'new session');
+    await new Promise(r => setTimeout(r, 200));
+
+    expect(getSessions(runner).size).toBe(2);
+    expect(getSessions(runner).has('chat:333')).toBe(true);
+    expect(getSessions(runner).has('chat:222')).toBe(true);
+    // chat:111 evicted
+    expect(getSessions(runner).has('chat:111')).toBe(false);
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // U-AR-04: idle cleaner stops sessions past idleTimeoutMs
+  // --------------------------------------------------------------------------
+  it('U-AR-04: idle cleaner stops sessions that have exceeded idle timeout', async () => {
+    agentConfig = makeAgentConfig(agentConfig.workspace, {
+      session: { idleTimeoutMinutes: 30, maxConcurrent: 20 },
+    });
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+
+    await sendChannelPost(port, 'chat:idle', 'hello');
+    await new Promise(r => setTimeout(r, 100));
+
+    expect(getSessions(runner).size).toBe(1);
+
+    // Reach into private method and call it directly to simulate idle cleaner firing
+    const sess = getSessions(runner).get('chat:idle')!;
+    (sess as unknown as { lastActivityAt: number }).lastActivityAt = Date.now() - 60 * 60 * 1000;
+
+    // Directly invoke the private idle cleaner logic by calling the method via cast
+    const runnerInternal = runner as unknown as {
+      idleTimeoutMs: number;
+      sessions: Map<string, SessionProcess>;
+      logger: { info: (msg: string, data?: unknown) => void };
+    };
+
+    // Simulate the idle cleaner interval callback
+    for (const [id, proc] of runnerInternal.sessions) {
+      if (proc.isIdle(runnerInternal.idleTimeoutMs)) {
+        await proc.stop();
+        runnerInternal.sessions.delete(id);
+      }
+    }
+
+    expect(getSessions(runner).size).toBe(0);
+  }, 15000);
+});

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1,0 +1,273 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── Minimal mock types ────────────────────────────────────────────────────────
+
+interface MockStdin {
+  writable: boolean;
+  write: jest.Mock;
+}
+
+interface MockStdout extends EventEmitter {
+  _emit(event: string, data: Buffer): void;
+}
+
+interface MockStderr extends EventEmitter {
+  _emit(event: string, data: Buffer): void;
+}
+
+interface MockChildProcess extends EventEmitter {
+  stdin: MockStdin | null;
+  stdout: MockStdout | null;
+  stderr: MockStderr | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+}
+
+// ── Capture spawn calls ───────────────────────────────────────────────────────
+
+let spawnMock: jest.Mock;
+let lastProcess: MockChildProcess | null = null;
+
+function makeMockProcess(): MockChildProcess {
+  const stdin: MockStdin = { writable: true, write: jest.fn() };
+  const stdout = new EventEmitter() as MockStdout;
+  const stderr = new EventEmitter() as MockStderr;
+
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdin = stdin;
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.killed = false;
+  proc.pid = 12345;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = true;
+    // Emit exit on next tick to simulate async
+    process.nextTick(() => proc.emit('exit', signal === 'SIGKILL' ? 1 : 0, signal ?? 'SIGTERM'));
+    return true;
+  });
+
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn((...args) => {
+    lastProcess = makeMockProcess();
+    return lastProcess;
+  }),
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import { SessionProcess } from '../../src/session-process';
+import { SessionStore } from '../../src/session-store';
+import { AgentConfig, GatewayConfig } from '../../src/types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id: 'alfred',
+    description: 'test agent',
+    workspace: '/tmp/workspace',
+    env: '',
+    telegram: {
+      botToken: 'test-token',
+      allowedUsers: [],
+      dmPolicy: 'allowlist',
+    },
+    claude: {
+      model: 'claude-opus-4-6',
+      dangerouslySkipPermissions: false,
+      extraFlags: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeGatewayConfig(): GatewayConfig {
+  return {
+    gateway: { logDir: '/tmp/logs', timezone: 'UTC' },
+    agents: [],
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('SessionProcess', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-test-'));
+    agentConfig = makeAgentConfig({ workspace: path.join(tmpDir, 'workspace') });
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions'));
+    lastProcess = null;
+    spawnMock = require('child_process').spawn as jest.Mock;
+    spawnMock.mockClear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-01: start() spawns a subprocess
+  // --------------------------------------------------------------------------
+  it('U-SP-01: start() spawns a subprocess', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(lastProcess).not.toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-02: sendMessage() writes stream-json turn to stdin
+  // --------------------------------------------------------------------------
+  it('U-SP-02: sendMessage() writes a stream-json turn to stdin', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    sp.sendMessage('hello world');
+
+    expect(lastProcess!.stdin!.write).toHaveBeenCalledWith(
+      expect.stringMatching(/"type":"user".*"text":"hello world"/s),
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-03: stop() kills the subprocess
+  // --------------------------------------------------------------------------
+  it('U-SP-03: stop() kills the subprocess', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    expect(sp.isRunning()).toBe(true);
+
+    const stopPromise = sp.stop();
+    await stopPromise;
+
+    expect(lastProcess!.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-04: isIdle() / touch() behaviour
+  // --------------------------------------------------------------------------
+  it('U-SP-04: isIdle() returns true after idle window, touch() resets it', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // Manually set lastActivityAt to 2 minutes ago
+    (sp as unknown as { lastActivityAt: number }).lastActivityAt = Date.now() - 120_000;
+
+    expect(sp.isIdle(60_000)).toBe(true);
+
+    sp.touch();
+
+    expect(sp.isIdle(60_000)).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-05: MCP config has TELEGRAM_SEND_ONLY=true for telegram source
+  // --------------------------------------------------------------------------
+  it('U-SP-05: MCP config written for telegram source has TELEGRAM_SEND_ONLY=true', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const sessionDir = path.join(agentConfig.workspace, '.sessions', 'chat:111');
+    const configPath = path.join(sessionDir, 'mcp-config.json');
+
+    expect(fs.existsSync(configPath)).toBe(true);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(config.mcpServers.telegram.env.TELEGRAM_SEND_ONLY).toBe('true');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-06: No MCP config for api source
+  // --------------------------------------------------------------------------
+  it('U-SP-06: No MCP config written for api source', async () => {
+    const sp = new SessionProcess('api:uuid', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // For api source, writeMcpConfig returns null — no --mcp-config in args
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args).not.toContain('--mcp-config');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-07: History injected into initial prompt when SessionStore has data
+  // --------------------------------------------------------------------------
+  it('U-SP-07: injects history into initial prompt when session has stored messages', async () => {
+    await sessionStore.appendMessage('alfred', 'chat:111', {
+      role: 'user',
+      content: 'Hello',
+      ts: Date.now(),
+    });
+    await sessionStore.appendMessage('alfred', 'chat:111', {
+      role: 'assistant',
+      content: 'Hi there!',
+      ts: Date.now(),
+    });
+
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // The first stdin.write call contains the initial prompt
+    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
+    const parsed = JSON.parse(firstWrite);
+    const text: string = parsed.message.content[0].text;
+
+    expect(text).toContain('Conversation history');
+    expect(text).toContain('User: Hello');
+    expect(text).toContain('Assistant: Hi there!');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-08: No history section when SessionStore is empty
+  // --------------------------------------------------------------------------
+  it('U-SP-08: no history section in prompt when session is empty', async () => {
+    const sp = new SessionProcess('chat:new', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
+    const parsed = JSON.parse(firstWrite);
+    const text: string = parsed.message.content[0].text;
+
+    expect(text).not.toContain('Conversation history');
+    expect(text).toContain('Channels mode is active');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-09: History truncated to MAX_HISTORY_MESSAGES (50)
+  // --------------------------------------------------------------------------
+  it('U-SP-09: history is truncated to 50 messages', async () => {
+    // Insert 60 messages
+    for (let i = 0; i < 60; i++) {
+      await sessionStore.appendMessage('alfred', 'chat:111', {
+        role: 'user',
+        content: `Message ${i}`,
+        ts: Date.now() + i,
+      });
+    }
+
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
+    const parsed = JSON.parse(firstWrite);
+    const text: string = parsed.message.content[0].text;
+
+    // Should contain Message 59 (last) but NOT Message 0 (first — truncated)
+    expect(text).toContain('Message 59');
+    expect(text).not.toContain('Message 0');
+  });
+});

--- a/tests/unit/telegram-receiver.test.ts
+++ b/tests/unit/telegram-receiver.test.ts
@@ -1,0 +1,184 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── Mock child_process ────────────────────────────────────────────────────────
+
+interface MockChildProcess extends EventEmitter {
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+}
+
+let lastProcess: MockChildProcess | null = null;
+let spawnMock: jest.Mock;
+
+function makeMockProcess(): MockChildProcess {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.killed = false;
+  proc.pid = 99999;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = true;
+    process.nextTick(() => proc.emit('exit', 0, signal ?? 'SIGTERM'));
+    return true;
+  });
+
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn((..._args) => {
+    lastProcess = makeMockProcess();
+    return lastProcess;
+  }),
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { TelegramReceiver } from '../../src/telegram-receiver';
+import { AgentConfig } from '../../src/types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAgentConfig(workspace: string): AgentConfig {
+  return {
+    id: 'alfred',
+    description: 'test agent',
+    workspace,
+    env: '',
+    telegram: {
+      botToken: 'bot-test-token-123',
+      allowedUsers: [],
+      dmPolicy: 'allowlist',
+    },
+    claude: {
+      model: 'claude-opus-4-6',
+      dangerouslySkipPermissions: false,
+      extraFlags: [],
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('TelegramReceiver', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  const LOG_DIR = '/tmp/test-logs';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-test-'));
+    agentConfig = makeAgentConfig(path.join(tmpDir, 'workspace'));
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    lastProcess = null;
+    spawnMock = require('child_process').spawn as jest.Mock;
+    spawnMock.mockClear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-TR-01: start() spawns bun with TELEGRAM_RECEIVER_MODE=true
+  // --------------------------------------------------------------------------
+  it('U-TR-01: start() spawns bun process with TELEGRAM_RECEIVER_MODE=true', () => {
+    const receiver = new TelegramReceiver(agentConfig, 4321, LOG_DIR);
+    receiver.start();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [cmd, , opts] = spawnMock.mock.calls[0] as [string, string[], { env: Record<string, string> }];
+    expect(cmd).toBe('bun');
+    expect(opts.env.TELEGRAM_RECEIVER_MODE).toBe('true');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-TR-02: env has required vars
+  // --------------------------------------------------------------------------
+  it('U-TR-02: spawned process env has TELEGRAM_BOT_TOKEN, TELEGRAM_STATE_DIR, CLAUDE_CHANNEL_CALLBACK', () => {
+    const receiver = new TelegramReceiver(agentConfig, 4321, LOG_DIR);
+    receiver.start();
+
+    const [, , opts] = spawnMock.mock.calls[0] as [string, string[], { env: Record<string, string> }];
+    expect(opts.env.TELEGRAM_BOT_TOKEN).toBe('bot-test-token-123');
+    expect(opts.env.TELEGRAM_STATE_DIR).toContain('.telegram-state');
+    expect(opts.env.CLAUDE_CHANNEL_CALLBACK).toBe('http://127.0.0.1:4321/channel');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-TR-03: stop() kills the process
+  // --------------------------------------------------------------------------
+  it('U-TR-03: stop() kills the spawned process', () => {
+    const receiver = new TelegramReceiver(agentConfig, 4321, LOG_DIR);
+    receiver.start();
+
+    expect(lastProcess).not.toBeNull();
+    receiver.stop();
+
+    expect(lastProcess!.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-TR-04: schedules restart on unexpected exit
+  // --------------------------------------------------------------------------
+  it('U-TR-04: schedules restart on unexpected exit', () => {
+    const receiver = new TelegramReceiver(agentConfig, 4321, LOG_DIR);
+    receiver.start();
+
+    const firstProcess = lastProcess!;
+    spawnMock.mockClear();
+
+    // Simulate unexpected exit (not via stop())
+    firstProcess.emit('exit', 1, null);
+
+    // Advance timer to trigger restart
+    jest.advanceTimersByTime(6_000);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  // --------------------------------------------------------------------------
+  // U-TR-05: does NOT restart when stop() was called first
+  // --------------------------------------------------------------------------
+  it('U-TR-05: does not restart after stop() was called', () => {
+    const receiver = new TelegramReceiver(agentConfig, 4321, LOG_DIR);
+    receiver.start();
+
+    receiver.stop();
+    spawnMock.mockClear();
+
+    // Advance timers — no restart should occur
+    jest.advanceTimersByTime(10_000);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-TR-06: isRunning() reflects subprocess state
+  // --------------------------------------------------------------------------
+  it('U-TR-06: isRunning() returns true when process is alive, false after stop', () => {
+    const receiver = new TelegramReceiver(agentConfig, 4321, LOG_DIR);
+
+    expect(receiver.isRunning()).toBe(false);
+
+    receiver.start();
+    // isRunning() = process !== null && !process.killed
+    expect(receiver.isRunning()).toBe(true);
+
+    receiver.stop();
+    // kill() sets proc.killed = true synchronously in mock,
+    // so isRunning() → false immediately (killed=true → !killed=false)
+    expect(receiver.isRunning()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **SessionProcess** (`src/session-process.ts`) — spawns a dedicated Claude subprocess per session (chat_id) for complete context isolation
- **TelegramReceiver** (`src/telegram-receiver.ts`) — standalone Telegram poller per agent, eliminates 409 Conflict when multiple subprocesses run
- **AgentRunner** refactored into a session pool manager with idle timeout and maxConcurrent support
- **SessionStore integrated** — conversation history persists to `.jsonl` and is injected back on respawn after idle timeout
- **Plugin 2 new modes** — `TELEGRAM_SEND_ONLY` (MCP tools only, no polling) and `TELEGRAM_RECEIVER_MODE` (poll + POST to callback, not an MCP server)
- **Plugin refactor** — extract `handleInbound()` as a shared function; bot handler registration unified across all modes
- **Fix** — expand tilde in `gateway.logDir` at config load time
- Unit tests for SessionProcess, TelegramReceiver, and AgentRunner (session pool)

## Test plan

- [ ] `npm test` passes
- [ ] Two users messaging simultaneously — no context bleed between sessions
- [ ] Session killed after idle timeout → respawned → Claude recalls previous history
- [ ] No 409 Conflict with multiple active sessions
- [ ] TelegramReceiver crash → gateway auto-restarts without affecting other sessions
- [ ] `TELEGRAM_SEND_ONLY=true` → MCP tools work normally, no polling
- [ ] `TELEGRAM_RECEIVER_MODE=true` → messages POSTed to callback URL correctly