### PR TITLE
feat: agent HTTP API and multi-session architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,18 @@
 A self-hosted multi-agent Telegram gateway. Run multiple Telegram bots — each powered by an isolated Claude agent with its own personality, memory, and scheduled behaviours.
 
 ```
-Telegram Bot A ──► Claude subprocess (alfred)  ──► agent.md, soul.md, memory.md …
-Telegram Bot B ──► Claude subprocess (warrior) ──► agent.md, soul.md, memory.md …
+Telegram Bot A ──► TelegramReceiver (agent A) ──► SessionProcess(chat:111) ──► Claude subprocess
+                                                ──► SessionProcess(chat:222) ──► Claude subprocess
+Telegram Bot B ──► TelegramReceiver (agent B) ──► SessionProcess(chat:333) ──► Claude subprocess
+
+HTTP Client ──► POST /api/v1/agents/:id/messages ──► SessionProcess(uuid) ──► Claude subprocess
+
                         ↑
+                  GatewayRouter (/health, /status, /ui, /api)
                   CronScheduler (heartbeat.md)
-                  Monitoring (/health, /status, /ui)
 ```
 
-Each agent is a long-running `claude` subprocess with an MCP-connected Telegram plugin — fully isolated workspace, token, and Telegram state.
+Each agent runs a **dedicated TelegramReceiver** (single Telegram poller per bot token) and a **session pool** of isolated Claude subprocesses — one per chat or API session. Sessions persist their history via `SessionStore`, so Claude remembers the conversation even after idle restart.
 
 ---
 
@@ -58,7 +62,7 @@ Steps:
 5. Send any message to the bot to complete pairing
 6. Agent sends a welcome message
 
-### 3. Start the gateway
+### 4. Start the gateway
 
 ```bash
 npm start
@@ -94,7 +98,21 @@ Config lives at `~/.claude-gateway/config.json` (or set `GATEWAY_CONFIG` env var
 {
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
-    "timezone": "Asia/Bangkok"
+    "timezone": "Asia/Bangkok",
+    "api": {
+      "keys": [
+        {
+          "key": "${MY_API_KEY}",
+          "description": "Internal app",
+          "agents": ["alfred"]
+        },
+        {
+          "key": "${ADMIN_API_KEY}",
+          "description": "Admin",
+          "agents": "*"
+        }
+      ]
+    }
   },
   "agents": [
     {
@@ -102,6 +120,10 @@ Config lives at `~/.claude-gateway/config.json` (or set `GATEWAY_CONFIG` env var
       "description": "Personal assistant",
       "workspace": "~/.claude-gateway/agents/alfred/workspace",
       "env": "",
+      "session": {
+        "idleTimeoutMinutes": 30,
+        "maxConcurrent": 20
+      },
       "telegram": {
         "botToken": "${ALFRED_BOT_TOKEN}",
         "allowedUsers": [123456789],
@@ -120,6 +142,13 @@ Config lives at `~/.claude-gateway/config.json` (or set `GATEWAY_CONFIG` env var
 }
 ```
 
+### `session`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `idleTimeoutMinutes` | `30` | Kill idle session subprocess after N minutes of inactivity |
+| `maxConcurrent` | `20` | Max simultaneous active sessions per agent; oldest idle is evicted when exceeded |
+
 ### `dmPolicy`
 
 | Value | Behaviour |
@@ -132,9 +161,168 @@ Config lives at `~/.claude-gateway/config.json` (or set `GATEWAY_CONFIG` env var
 
 Set to `true` for all agents running headless (no interactive terminal). Without it the agent cannot use MCP tools like sending Telegram replies.
 
+### `gateway.api.keys`
+
+Each key has a `key` string (supports `${ENV_VAR}` interpolation), an optional `description`, and an `agents` field — either an array of agent IDs or `"*"` for full access. Keys support both `Authorization: Bearer` and `X-Api-Key` headers.
+
 ### Bot tokens
 
 Tokens are stored per-agent at `~/.claude-gateway/agents/<id>/.env` and auto-loaded at startup. Use `${AGENT_BOT_TOKEN}` syntax in config to reference them, or set them as shell environment variables.
+
+---
+
+## Multi-Session Architecture
+
+Each agent maintains a **session pool** — a separate Claude subprocess per chat ID (Telegram) or session UUID (API). Sessions are fully isolated: Claude sees only its own conversation history with no cross-session leakage.
+
+```
+TelegramReceiver  (1 per agent, spawned by gateway)
+  - single long-poll connection per bot token
+  - handles access control (allowlist / pairing)
+  - POSTs incoming messages to AgentRunner callback
+
+AgentRunner  (session pool manager)
+  ├── SessionProcess(chat:111)  Claude subprocess + SEND_ONLY plugin
+  ├── SessionProcess(chat:222)  Claude subprocess + SEND_ONLY plugin
+  └── SessionProcess(api:uuid)  Claude subprocess, no Telegram plugin
+```
+
+**Telegram plugin modes:**
+
+| Mode | Used by | Behaviour |
+|------|---------|-----------|
+| `TELEGRAM_RECEIVER_MODE` | TelegramReceiver | Polls Telegram + POSTs to callback, no MCP |
+| `TELEGRAM_SEND_ONLY` | SessionProcess (Telegram) | Exposes MCP reply/react/edit tools, no polling |
+
+**Session memory:** History is persisted to `SessionStore` (`.jsonl` files) after each message. When a session is spawned after an idle restart, history is injected into the initial prompt so Claude resumes the conversation seamlessly.
+
+---
+
+## HTTP API
+
+When `gateway.api.keys` is configured, the gateway exposes a REST API for external clients.
+
+### Quickstart: Using the Agent API
+
+**Step 1 — Add an API key to `config.json`**
+
+```json
+{
+  "gateway": {
+    "api": {
+      "keys": [
+        {
+          "key": "my-secret-key-123",
+          "description": "My app",
+          "agents": ["alfred"]
+        },
+        {
+          "key": "admin-key-456",
+          "description": "Admin — full access",
+          "agents": "*"
+        }
+      ]
+    }
+  }
+}
+```
+
+`agents` can be an array of agent IDs or `"*"` for full access. Keys support `${ENV_VAR}` interpolation.
+
+**Step 2 — Restart the gateway**
+
+```bash
+npm start
+```
+
+Config is loaded at startup — a restart is required after changing API keys.
+
+**Step 3 — List available agents**
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  http://localhost:3000/api/v1/agents | jq
+```
+
+```json
+{
+  "agents": [
+    { "id": "alfred", "description": "Personal assistant" }
+  ]
+}
+```
+
+**Step 4 — Send a message (new session)**
+
+Omit `session_id` to start a fresh conversation. The response includes a `session_id` — save it for follow-up messages.
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hello! What can you help me with?"}' \
+  http://localhost:3000/api/v1/agents/alfred/messages | jq
+```
+
+```json
+{
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "agent_id": "alfred",
+  "response": "Hello! I'm Alfred, your personal assistant. I can help you with...",
+  "session_id": "da19d84a-6a36-4f57-b419-d322d82c4db8",
+  "duration_ms": 2341
+}
+```
+
+**Step 5 — Continue the conversation (same session)**
+
+Pass the `session_id` from the previous response to resume the same context. Claude remembers the full conversation history.
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What did I just ask you?", "session_id": "da19d84a-6a36-4f57-b419-d322d82c4db8"}' \
+  http://localhost:3000/api/v1/agents/alfred/messages | jq
+```
+
+```json
+{
+  "request_id": "7f3c2a1b-...",
+  "agent_id": "alfred",
+  "response": "You asked: \"Hello! What can you help me with?\"",
+  "session_id": "da19d84a-6a36-4f57-b419-d322d82c4db8",
+  "duration_ms": 1876
+}
+```
+
+> **Tips:**
+> - Auth header: `X-Api-Key: <key>` or `Authorization: Bearer <key>` — both work
+> - `session_id` is optional — omit for a stateless one-shot call
+> - Sessions idle-timeout after `idleTimeoutMinutes` (default 30 min); history is restored automatically on next message
+> - Error 409 = session is currently processing a request — wait and retry
+
+---
+
+### Endpoints
+
+See [Quickstart: Using the Agent API](#quickstart-using-the-agent-api) for full examples with request/response JSON.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/agents/:agentId/messages` | Send a message, receive response synchronously |
+| `GET` | `/api/v1/agents` | List agents accessible by the provided key |
+
+**Error responses (POST):**
+
+| Status | When |
+|--------|------|
+| 400 | Empty message or exceeds 10,000 characters |
+| 401 | Missing API key |
+| 403 | Invalid key or key has no access to that agent |
+| 404 | Agent ID not found |
+| 504 | Agent did not respond within 60s |
+| 500 | Internal error |
 
 ---
 
@@ -144,13 +332,20 @@ Tokens are stored per-agent at `~/.claude-gateway/agents/<id>/.env` and auto-loa
 
 ```
 claude-gateway/
-├── Makefile                            ← make start / create-agent / pair / plugin-install
+├── Makefile                            ← make start / create-agent / pair / plugin-install / add-user
 ├── config.example.json                 ← config template
 ├── src/                                ← gateway source (TypeScript)
 │   ├── index.ts                        ← entrypoint, loads config and starts agents
-│   ├── agent-runner.ts                 ← spawns and manages claude subprocesses
-│   ├── gateway-router.ts               ← HTTP API (/health, /status, /ui)
+│   ├── agent-runner.ts                 ← session pool manager (spawn/evict SessionProcesses)
+│   ├── session-process.ts              ← single Claude subprocess per session
+│   ├── telegram-receiver.ts            ← standalone Telegram poller (1 per agent)
+│   ├── session-store.ts                ← persist/load conversation history (.jsonl)
+│   ├── gateway-router.ts               ← HTTP server (/health, /status, /ui, /api)
+│   ├── api-router.ts                   ← REST API router (POST /v1/agents/:id/messages)
+│   ├── api-auth.ts                     ← API key auth middleware (timing-safe)
+│   ├── config-loader.ts                ← load + validate config.json
 │   ├── cron-scheduler.ts               ← heartbeat task scheduler
+│   ├── types.ts                        ← shared TypeScript types
 │   └── workspace-loader.ts             ← assembles CLAUDE.md from workspace files
 ├── scripts/
 │   ├── create-agent.ts                 ← interactive wizard (make create-agent)
@@ -159,7 +354,7 @@ claude-gateway/
 └── plugins/
     ├── marketplace.json                ← plugin registry
     └── telegram/
-        ├── server.ts                   ← Telegram MCP server (runs via bun)
+        ├── server.ts                   ← Telegram plugin (MCP server + receiver mode)
         └── skills/
             └── access/SKILL.md         ← /telegram:access skill
 ```
@@ -175,6 +370,8 @@ claude-gateway/
 └── agents/
     └── alfred/
         ├── .env                        ← bot token (auto-created by wizard)
+        ├── sessions/
+        │   └── <chat_id>.jsonl         ← conversation history (SessionStore)
         └── workspace/
             ├── CLAUDE.md               ← auto-generated, do not edit
             ├── agent.md
@@ -228,6 +425,13 @@ tasks:
    npm run pair -- --agent=alfred --policy=allowlist
    ```
 
+Or use the Makefile shortcut:
+```bash
+make add-user AGENT=alfred
+```
+
+This switches `dmPolicy` to `pairing`, prints pairing instructions, and reminds you to switch back to `allowlist` when done.
+
 ---
 
 ## Monitoring
@@ -237,8 +441,10 @@ The gateway runs an HTTP server on port 3000 (set `PORT` env var to change):
 | Endpoint | Description |
 |----------|-------------|
 | `GET /health` | All agent IDs and running status |
-| `GET /status` | JSON stats per agent |
+| `GET /status` | JSON stats per agent (sessions, uptime) |
 | `GET /ui` | Live HTML dashboard (auto-refreshes every 5s) |
+| `POST /api/v1/agents/:id/messages` | Send a message to an agent (requires API key) |
+| `GET /api/v1/agents` | List accessible agents (requires API key) |
 
 ---
 
@@ -253,6 +459,9 @@ npm run test:unit
 
 # Integration tests
 npm run integration
+
+# All tests
+npm test
 
 # Type check without building
 npm run typecheck
@@ -269,7 +478,12 @@ npm run typecheck
 
 **Agent not responding to messages**
 - Verify `dmPolicy` — if `allowlist`, check the user's ID is in `access.json`
-- Ensure no other process is polling the same bot token (causes 409 conflict)
+- Ensure no other process is polling the same bot token (causes 409 Conflict)
+- With multi-session, only `TelegramReceiver` polls — session subprocesses use `SEND_ONLY` mode
+
+**Session loses memory after restart**
+- History is persisted in `~/.claude-gateway/agents/<id>/sessions/<chat_id>.jsonl`
+- If the file is missing, the session starts fresh (no error)
 
 **Personality not applied**
 - `CLAUDE.md` is auto-regenerated from workspace files on startup and on any file change
@@ -279,3 +493,7 @@ npm run typecheck
 - Verify `heartbeat.md` YAML is valid
 - Check cron expression (5 fields: `min hour day month weekday`)
 - Check rate limit — default 30 min between proactive messages
+
+**API returns 403**
+- Check the key value matches exactly (env var interpolation uses `${VAR}` syntax)
+- Verify the key's `agents` list includes the target agent ID, or set `"agents": "*"`

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,21 @@
 {
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
-    "timezone": "Asia/Bangkok"
+    "timezone": "Asia/Bangkok",
+    "api": {
+      "keys": [
+        {
+          "key": "${MY_API_KEY}",
+          "description": "Internal app",
+          "agents": ["alfred"]
+        },
+        {
+          "key": "${ADMIN_API_KEY}",
+          "description": "Admin — full access",
+          "agents": "*"
+        }
+      ]
+    }
   },
   "agents": [
     {

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -330,7 +330,9 @@ export class AgentRunner extends EventEmitter {
 
       session.on('output', onOutput);
       session.sendMessage(channelXml);
-      resetQuiet();
+      // Do NOT call resetQuiet() here — the quiet timer should only start
+      // after the first output line arrives, otherwise it fires before the
+      // subprocess has had time to respond (especially on first spawn).
     });
   }
 

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -27,6 +27,9 @@ export class AgentRunner extends EventEmitter {
   private readonly maxConcurrent: number;
   private idleCleanerTimer: ReturnType<typeof setInterval> | null = null;
 
+  // Tracks session IDs with an in-flight API request (prevents concurrent turns)
+  private readonly pendingApiSessions = new Set<string>();
+
   constructor(agentConfig: AgentConfig, gatewayConfig: GatewayConfig, logger?: Logger) {
     super();
     this.agentConfig = agentConfig;
@@ -158,6 +161,11 @@ export class AgentRunner extends EventEmitter {
       this.sessionStore,
     );
     await proc.start();
+
+    // Forward all session output lines so listeners on AgentRunner (GatewayRouter,
+    // CronScheduler, tests) receive them without needing individual session references.
+    proc.on('output', (line: string) => this.emit('output', line));
+
     this.sessions.set(sessionId, proc);
     this.logger.info('Spawned session', {
       sessionId,
@@ -217,12 +225,144 @@ export class AgentRunner extends EventEmitter {
   }
 
   /**
+   * Send a message to an API session and wait for the response.
+   *
+   * - Spawns a new SessionProcess (source='api') if none exists for sessionId.
+   * - Rejects with code 'CONFLICT' if a prior request is still in-flight for this session.
+   * - Rejects with code 'TIMEOUT' if Claude does not respond within timeoutMs.
+   * - Appends user message and assistant reply to SessionStore for history persistence.
+   */
+  async sendApiMessage(
+    sessionId: string,
+    message: string,
+    opts: { timeoutMs: number },
+  ): Promise<string> {
+    if (this.pendingApiSessions.has(sessionId)) {
+      const err = Object.assign(
+        new Error(`Session ${sessionId} already has a pending request`),
+        { code: 'CONFLICT' },
+      );
+      throw err;
+    }
+
+    const session = await this.getOrSpawnSession(sessionId, 'api');
+
+    // Persist user message
+    await this.sessionStore
+      .appendMessage(this.agentConfig.id, sessionId, {
+        role: 'user',
+        content: message,
+        ts: Date.now(),
+      })
+      .catch(() => {});
+
+    this.pendingApiSessions.add(sessionId);
+    session.touch();
+
+    const channelXml =
+      `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
+      `${message}\n\n` +
+      `[SYSTEM: This is an API request. Reply with plain text only. ` +
+      `Do NOT call any tools. Your text output will be returned directly to the caller.]\n` +
+      `</channel>`;
+
+    return new Promise<string>((resolve, reject) => {
+      const buffer: string[] = [];
+      let quietTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const done = (result: string) => {
+        cleanup();
+        // Persist assistant reply
+        if (result.trim()) {
+          this.sessionStore
+            .appendMessage(this.agentConfig.id, sessionId, {
+              role: 'assistant',
+              content: result.trim(),
+              ts: Date.now(),
+            })
+            .catch(() => {});
+        }
+        resolve(result.trim());
+      };
+
+      const fail = (err: Error) => {
+        cleanup();
+        reject(err);
+      };
+
+      const cleanup = () => {
+        clearTimeout(globalTimer);
+        if (quietTimer) clearTimeout(quietTimer);
+        session.off('output', onOutput);
+        this.pendingApiSessions.delete(sessionId);
+      };
+
+      const resetQuiet = () => {
+        if (quietTimer) clearTimeout(quietTimer);
+        quietTimer = setTimeout(() => done(buffer.join('')), 2000);
+      };
+
+      const onOutput = (line: string) => {
+        try {
+          const obj = JSON.parse(line) as Record<string, unknown>;
+          // Collect text deltas
+          const text =
+            (obj['text'] as string | undefined) ??
+            ((obj['delta'] as Record<string, unknown> | undefined)?.['text'] as string | undefined) ??
+            '';
+          if (text) {
+            buffer.push(text);
+            resetQuiet();
+          }
+          // result event = end of turn
+          if (obj['type'] === 'result') {
+            const resultText = (obj['result'] as string | undefined) ?? buffer.join('');
+            done(resultText);
+          }
+        } catch {
+          /* non-JSON stdout line */
+        }
+      };
+
+      const globalTimer = setTimeout(() => {
+        fail(Object.assign(new Error('Agent response timeout'), { code: 'TIMEOUT' }));
+      }, opts.timeoutMs);
+
+      session.on('output', onOutput);
+      session.sendMessage(channelXml);
+      resetQuiet();
+    });
+  }
+
+  /**
+   * Expose the callback server port for integration tests that need to simulate
+   * incoming Telegram messages by POSTing directly to the channel endpoint.
+   */
+  getCallbackPort(): number {
+    return this.callbackPort;
+  }
+
+  /**
    * Send a message to all active sessions.
    * Used for heartbeat/cron tasks delivered out-of-band.
+   *
+   * If no Telegram sessions are active, a transient `__heartbeat__` API session is
+   * spawned so that CronScheduler tasks can always run regardless of active user sessions.
    */
   sendMessage(message: string): void {
     if (this.sessions.size === 0) {
-      this.logger.warn('sendMessage called but no active sessions');
+      // No active user sessions — spawn a shared heartbeat session so the prompt
+      // reaches a subprocess and output events fire for CronScheduler/tests.
+      this.getOrSpawnSession('__heartbeat__', 'api')
+        .then((session) => {
+          session.sendMessage(message);
+          session.touch();
+        })
+        .catch((err) =>
+          this.logger.error('sendMessage failed to spawn heartbeat session', {
+            error: (err as Error).message,
+          }),
+        );
       return;
     }
     for (const session of this.sessions.values()) {

--- a/src/api-auth.ts
+++ b/src/api-auth.ts
@@ -1,0 +1,57 @@
+import { Request, Response, NextFunction } from 'express';
+import { timingSafeEqual } from 'crypto';
+import { ApiKey } from './types';
+
+/**
+ * Express middleware that validates the Bearer token or X-Api-Key header
+ * against the configured API keys.
+ *
+ * Uses timing-safe comparison to prevent timing-based key enumeration attacks.
+ * Attaches the matched ApiKey to `req.apiKey` on success.
+ */
+export function createApiAuthMiddleware(apiKeys: ApiKey[]) {
+  return function apiAuth(req: Request, res: Response, next: NextFunction): void {
+    const authHeader = req.headers['authorization'];
+    const xApiKey = req.headers['x-api-key'] as string | undefined;
+
+    let token: string | undefined;
+    if (authHeader?.startsWith('Bearer ')) {
+      token = authHeader.slice(7).trim();
+    } else if (xApiKey) {
+      token = xApiKey.trim();
+    }
+
+    if (!token) {
+      res.status(401).json({ error: 'Missing API key' });
+      return;
+    }
+
+    const tokenBuf = Buffer.from(token);
+    const matched = apiKeys.find((k) => {
+      try {
+        const keyBuf = Buffer.from(k.key);
+        // timingSafeEqual requires same length — unequal lengths → not a match
+        if (keyBuf.length !== tokenBuf.length) return false;
+        return timingSafeEqual(keyBuf, tokenBuf);
+      } catch {
+        return false;
+      }
+    });
+
+    if (!matched) {
+      res.status(403).json({ error: 'Invalid API key' });
+      return;
+    }
+
+    (req as Request & { apiKey: ApiKey }).apiKey = matched;
+    next();
+  };
+}
+
+/**
+ * Returns true if the given API key is allowed to access the specified agent.
+ */
+export function canAccessAgent(apiKey: ApiKey, agentId: string): boolean {
+  if (apiKey.agents === '*') return true;
+  return (apiKey.agents as string[]).includes(agentId);
+}

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -1,0 +1,98 @@
+import { Router, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { AgentRunner } from './agent-runner';
+import { AgentConfig, ApiKey } from './types';
+import { createApiAuthMiddleware, canAccessAgent } from './api-auth';
+
+const MAX_MESSAGE_LENGTH = 10_000;
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+type AuthedRequest = Request & { apiKey: ApiKey };
+
+export function createApiRouter(
+  agentRunners: Map<string, AgentRunner>,
+  agentConfigs: Map<string, AgentConfig>,
+  apiKeys: ApiKey[],
+): Router {
+  const router = Router();
+  const auth = createApiAuthMiddleware(apiKeys);
+
+  /**
+   * POST /api/v1/agents/:agentId/messages
+   *
+   * Send a message to an agent and receive its response synchronously.
+   * Body: { message: string, session_id?: string }
+   */
+  router.post('/v1/agents/:agentId/messages', auth, async (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+
+    const runner = agentRunners.get(agentId);
+    if (!runner) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const body = req.body as { message?: unknown; session_id?: unknown };
+    const { message, session_id } = body;
+
+    if (!message || typeof message !== 'string' || !message.trim()) {
+      res.status(400).json({ error: 'message is required and must be a non-empty string' });
+      return;
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      res.status(400).json({ error: `message too long (max ${MAX_MESSAGE_LENGTH} characters)` });
+      return;
+    }
+    if (session_id !== undefined && typeof session_id !== 'string') {
+      res.status(400).json({ error: 'session_id must be a string if provided' });
+      return;
+    }
+
+    const requestId = randomUUID();
+    const sessionId = (session_id as string | undefined) ?? randomUUID();
+    const startTime = Date.now();
+
+    try {
+      const response = await runner.sendApiMessage(sessionId, message.trim(), {
+        timeoutMs: DEFAULT_TIMEOUT_MS,
+      });
+      res.json({
+        request_id: requestId,
+        agent_id: agentId,
+        response,
+        session_id: sessionId,
+        duration_ms: Date.now() - startTime,
+      });
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (code === 'TIMEOUT') {
+        res.status(504).json({ error: 'Agent response timeout' });
+      } else if (code === 'CONFLICT') {
+        res.status(409).json({ error: 'Session already has a pending request' });
+      } else {
+        res.status(500).json({ error: 'Internal error' });
+      }
+    }
+  });
+
+  /**
+   * GET /api/v1/agents
+   *
+   * List agents accessible by the current API key.
+   */
+  router.get('/v1/agents', auth, (req: Request, res: Response) => {
+    const apiKey = (req as AuthedRequest).apiKey;
+    const agents = [...agentConfigs.entries()]
+      .filter(([id]) => canAccessAgent(apiKey, id))
+      .map(([id, cfg]) => ({ id, description: cfg.description }));
+    res.json({ agents });
+  });
+
+  return router;
+}

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -136,6 +136,34 @@ export function loadConfig(configPath: string): GatewayConfig {
     ids.add(id);
   }
 
+  // Validate gateway.api.keys if present
+  const gateway = config.gateway as Record<string, unknown>;
+  if (gateway.api !== undefined) {
+    const api = gateway.api as Record<string, unknown>;
+    if (!Array.isArray(api.keys)) {
+      throw new ConfigValidationError('gateway.api.keys must be an array');
+    }
+    const seenKeys = new Set<string>();
+    for (const k of api.keys as unknown[]) {
+      if (typeof k !== 'object' || k === null) {
+        throw new ConfigValidationError('Each entry in gateway.api.keys must be an object');
+      }
+      const entry = k as Record<string, unknown>;
+      if (!entry.key || typeof entry.key !== 'string') {
+        throw new ConfigValidationError('Each API key must have a non-empty "key" string');
+      }
+      if (seenKeys.has(entry.key as string)) {
+        throw new ConfigValidationError(`Duplicate API key value detected`);
+      }
+      seenKeys.add(entry.key as string);
+      if (entry.agents !== '*' && !Array.isArray(entry.agents)) {
+        throw new ConfigValidationError(
+          `API key "${entry.key}": "agents" must be an array of agent IDs or the string "*"`,
+        );
+      }
+    }
+  }
+
   // Now interpolate env vars (may throw MissingEnvVarError)
   const interpolated = interpolateObject(parsed) as GatewayConfig;
 

--- a/src/gateway-router.ts
+++ b/src/gateway-router.ts
@@ -1,9 +1,10 @@
 import express, { Request, Response } from 'express';
 import { Server } from 'http';
 import { AgentRunner } from './agent-runner';
-import { AgentConfig, AgentStats, HeartbeatResult } from './types';
+import { AgentConfig, AgentStats, GatewayConfig, HeartbeatResult } from './types';
 import { CronScheduler } from './cron-scheduler';
 import { generateDashboardHtml } from './web-ui';
+import { createApiRouter } from './api-router';
 
 export class GatewayRouter {
   private readonly agents: Map<string, AgentRunner>;
@@ -31,10 +32,17 @@ export class GatewayRouter {
     agents: Map<string, AgentRunner>,
     configs: Map<string, AgentConfig>,
     schedulers?: Map<string, CronScheduler>,
+    gatewayConfig?: GatewayConfig,
   ) {
     this.agents = agents;
     this.configs = configs;
     this.app = express();
+
+    // Mount API router if api keys are configured
+    if (gatewayConfig?.gateway?.api?.keys?.length) {
+      const apiRouter = createApiRouter(agents, configs, gatewayConfig.gateway.api.keys);
+      this.app.use('/api', apiRouter);
+    }
 
     // Initialise counters for all known agents
     for (const [id, runner] of agents) {

--- a/src/gateway-router.ts
+++ b/src/gateway-router.ts
@@ -28,6 +28,9 @@ export class GatewayRouter {
   /** Gateway start time */
   private readonly startedAt = new Date();
 
+  /** Optional gateway config (used to mount API router) */
+  private readonly gatewayConfig?: GatewayConfig;
+
   constructor(
     agents: Map<string, AgentRunner>,
     configs: Map<string, AgentConfig>,
@@ -36,13 +39,8 @@ export class GatewayRouter {
   ) {
     this.agents = agents;
     this.configs = configs;
+    this.gatewayConfig = gatewayConfig;
     this.app = express();
-
-    // Mount API router if api keys are configured
-    if (gatewayConfig?.gateway?.api?.keys?.length) {
-      const apiRouter = createApiRouter(agents, configs, gatewayConfig.gateway.api.keys);
-      this.app.use('/api', apiRouter);
-    }
 
     // Initialise counters for all known agents
     for (const [id, runner] of agents) {
@@ -70,6 +68,16 @@ export class GatewayRouter {
 
   private setupRoutes(): void {
     this.app.use(express.json());
+
+    // Mount API router after body parser so req.body is populated
+    if (this.gatewayConfig?.gateway?.api?.keys?.length) {
+      const apiRouter = createApiRouter(
+        this.agents,
+        this.configs,
+        this.gatewayConfig.gateway.api.keys,
+      );
+      this.app.use('/api', apiRouter);
+    }
 
     // Health check
     this.app.get('/health', (_req: Request, res: Response) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ async function main(): Promise<void> {
   printStartupTable(startupResults);
 
   // Start gateway router
-  const router = new GatewayRouter(agentRunners, agentConfigs);
+  const router = new GatewayRouter(agentRunners, agentConfigs, undefined, config);
   await router.start(PORT);
   console.log(`[gateway] Listening on port ${PORT}`);
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -32,11 +32,12 @@ class AgentLogger implements Logger {
     };
 
     const line = JSON.stringify(entry);
+    const pretty = JSON.stringify(entry, null, 2);
 
-    // Write to stdout
-    process.stdout.write(line + '\n');
+    // Write to stdout (pretty-printed for readability)
+    process.stdout.write(pretty + '\n');
 
-    // Write to log file (append)
+    // Write to log file (compact, one entry per line)
     try {
       fs.appendFileSync(this.logFilePath, line + '\n', 'utf-8');
     } catch {

--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -139,7 +139,7 @@ export class SessionProcess extends EventEmitter {
     });
 
     const proc = spawn(claudeBin, allArgs, {
-      env: { ...process.env, CLAUDE_WORKSPACE: this.agentConfig.workspace },
+      env: { ...process.env, CLAUDE_WORKSPACE: this.agentConfig.workspace, TELEGRAM_BOT_TOKEN: this.agentConfig.telegram.botToken },
       cwd: this.agentConfig.workspace,
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -146,8 +146,13 @@ export class SessionProcess extends EventEmitter {
 
     this.process = proc;
 
-    // Send initial prompt
-    proc.stdin?.write(SessionProcess.toStreamJsonTurn(initialPrompt) + '\n');
+    // Send initial prompt only for Telegram sessions.
+    // API sessions receive the first message directly via sendApiMessage(),
+    // so no activation prompt is needed and sending one would race with
+    // the first API turn, causing sendApiMessage to resolve with the wrong result.
+    if (this.source === 'telegram') {
+      proc.stdin?.write(SessionProcess.toStreamJsonTurn(initialPrompt) + '\n');
+    }
 
     // Capture stdout — emit output events + persist assistant replies
     let assistantBuffer = '';

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,20 @@ export interface WatchHandle {
   close(): void;
 }
 
+export interface ApiKey {
+  key: string;
+  description?: string;
+  agents: string[] | '*'; // agent IDs this key can access, or '*' for all
+}
+
 export interface GatewayConfig {
-  gateway: { logDir: string; timezone: string };
+  gateway: {
+    logDir: string;
+    timezone: string;
+    api?: {
+      keys: ApiKey[];
+    };
+  };
   agents: AgentConfig[];
 }
 

--- a/tests/helpers/mock-claude-api.js
+++ b/tests/helpers/mock-claude-api.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Mock claude subprocess for API integration tests.
+ *
+ * Reads stream-json turns from stdin and outputs stream-json result events so
+ * that AgentRunner.sendApiMessage() can capture responses immediately (no 2s
+ * quiet-period wait).
+ *
+ * Behaviour:
+ * - Ignores the initial activation / history prompt (contains "Channels mode is active")
+ * - For every API channel turn, extracts the user message and responds with
+ *   {"type":"result","result":"[mock-claude-api] response to: <message>"}
+ * - Exits cleanly on SIGTERM
+ */
+
+const readline = require('readline');
+
+const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+
+  // Unwrap stream-json turn envelope
+  let text = trimmed;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed.type === 'user' && parsed.message?.content?.[0]?.text) {
+      text = parsed.message.content[0].text;
+    }
+  } catch {
+    // not JSON — use raw line
+  }
+
+  // Skip the initial activation / history prompt
+  if (
+    text.includes('Channels mode is active') ||
+    text.includes('Conversation history with this user')
+  ) {
+    return;
+  }
+
+  // Extract user message from the <channel source="api" ...> XML envelope
+  // Format: <channel ...>\n<message>\n\n[SYSTEM: ...]\n</channel>
+  const channelMatch = text.match(/<channel[^>]*>\n?([\s\S]*?)(?:\[SYSTEM:|$)/);
+  const userMessage = channelMatch ? channelMatch[1].trim() : text;
+
+  // Emit a stream-json result — sendApiMessage() resolves immediately on this
+  process.stdout.write(
+    JSON.stringify({ type: 'result', result: `[mock-claude-api] response to: ${userMessage}` }) +
+      '\n',
+  );
+});
+
+process.on('SIGTERM', () => {
+  process.exit(0);
+});
+
+// Keep the process alive waiting for stdin
+process.stdin.resume();

--- a/tests/helpers/mock-claude-mcp.js
+++ b/tests/helpers/mock-claude-mcp.js
@@ -6,10 +6,14 @@
  *   agent-runner → (spawns this) → reads --mcp-config → spawns MCP server (plugin)
  *   → MCP handshake → receives notifications/claude/channel → writes to stdout
  *
+ * Also handles channel messages injected via stdin (stream-json format) so that
+ * tests can verify delivery via both the MCP notification path and the stdin
+ * injection path used by agent-runner's callback bridge.
+ *
  * Stdout lines:
  *   [mock-claude-mcp] ready            — MCP handshake done
  *   [mock-claude-mcp] prompt: <text>   — initial prompt received from stdin
- *   [mock-claude-mcp] channel: <json>  — notifications/claude/channel received
+ *   [mock-claude-mcp] channel: <json>  — channel message received (MCP or stdin)
  *   [mock-claude-mcp] tool-result: <json> — tool call response received
  *
  * Args parsed: --mcp-config <path>  (others are silently ignored)
@@ -85,23 +89,9 @@ class McpClient {
       return
     }
 
-    // Notification
+    // MCP notification (legacy path — plugin in non-SEND_ONLY mode emits these)
     if (msg.method === 'notifications/claude/channel') {
-      process.stdout.write(`[mock-claude-mcp] channel: ${JSON.stringify(msg.params)}\n`)
-
-      // Optionally auto-reply (for deeper pipeline tests)
-      if (process.env.MOCK_CLAUDE_REPLY === '1' && msg.params?.meta?.chat_id) {
-        const chatId = msg.params.meta.chat_id
-        const text = `[mock-claude] echo: ${msg.params.content ?? '(no text)'}`
-        this.request('tools/call', {
-          name: 'reply',
-          arguments: { chat_id: chatId, text },
-        }).then(result => {
-          process.stdout.write(`[mock-claude-mcp] tool-result: ${JSON.stringify(result)}\n`)
-        }).catch(err => {
-          process.stderr.write(`[mock-claude-mcp] tool error: ${err.message}\n`)
-        })
-      }
+      handleChannel(msg.params)
       return
     }
 
@@ -119,23 +109,95 @@ class McpClient {
   }
 }
 
-// ── main ─────────────────────────────────────────────────────────────────────
+// ── channel handling ──────────────────────────────────────────────────────────
 
 const clients = []
+let mcpReady = false
+const pendingChannels = []
+
+/**
+ * Parse a channel message from a stream-json stdin injection line.
+ * agent-runner wraps channelXml in: {"type":"user","message":{"role":"user","content":[{"type":"text","text":"<channel ...>...</channel>"}]}}
+ */
+function parseChannelFromStdin(line) {
+  try {
+    const obj = JSON.parse(line)
+    const text = obj?.message?.content?.[0]?.text ?? ''
+    const m = text.match(/^<channel([^>]*)>([\s\S]*?)<\/channel>/)
+    if (!m) return null
+    const attrsStr = m[1]
+    const content = m[2].trim()
+    const meta = {}
+    for (const am of attrsStr.matchAll(/(\w+)="([^"]*)"/g)) {
+      meta[am[1]] = am[2]
+    }
+    return { content, meta }
+  } catch {
+    return null
+  }
+}
+
+function handleChannel(ch) {
+  process.stdout.write(`[mock-claude-mcp] channel: ${JSON.stringify(ch)}\n`)
+
+  // Optionally auto-reply (for deeper pipeline tests)
+  if (process.env.MOCK_CLAUDE_REPLY === '1' && ch.meta?.chat_id) {
+    const chatId = ch.meta.chat_id
+    const text = `[mock-claude] echo: ${ch.content ?? '(no text)'}`
+    const client = clients[0]?.client
+    if (client) {
+      client.request('tools/call', {
+        name: 'reply',
+        arguments: { chat_id: chatId, text },
+      }).then(result => {
+        process.stdout.write(`[mock-claude-mcp] tool-result: ${JSON.stringify(result)}\n`)
+      }).catch(err => {
+        process.stderr.write(`[mock-claude-mcp] tool error: ${err.message}\n`)
+      })
+    }
+  }
+}
+
+function flushPending() {
+  while (pendingChannels.length > 0) {
+    handleChannel(pendingChannels.shift())
+  }
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
-  // Read initial prompt from stdin (sent by agent-runner before opening channel)
   const rl = readline.createInterface({ input: process.stdin, terminal: false })
-  rl.once('line', (line) => {
-    process.stdout.write(`[mock-claude-mcp] prompt: ${line.trim()}\n`)
+  let firstLineDone = false
+
+  rl.on('line', (line) => {
+    const trimmed = line.trim()
+    if (!trimmed) return
+
+    // First line is always the initial prompt from agent-runner
+    if (!firstLineDone) {
+      firstLineDone = true
+      process.stdout.write(`[mock-claude-mcp] prompt: ${trimmed}\n`)
+      return
+    }
+
+    // Subsequent lines: try to parse as channel injection (stream-json format)
+    const ch = parseChannelFromStdin(trimmed)
+    if (ch) {
+      if (mcpReady) {
+        handleChannel(ch)
+      } else {
+        pendingChannels.push(ch)
+      }
+    } else if (!mcpConfigPath) {
+      // Fallback echo mode (no MCP config)
+      process.stdout.write(`[mock-claude] received: ${trimmed}\n`)
+    }
   })
 
   if (!mcpConfigPath) {
     process.stderr.write('[mock-claude-mcp] no --mcp-config provided — running in stdin-echo mode\n')
-    // Fallback: act like mock-claude.js (stdin echo)
-    rl.on('line', (line) => {
-      if (line.trim()) process.stdout.write(`[mock-claude] received: ${line}\n`)
-    })
+    // rl.on handler above handles all lines
     return
   }
 
@@ -170,7 +232,9 @@ async function main() {
 
     try {
       await client.initialize()
+      mcpReady = true
       process.stdout.write(`[mock-claude-mcp] ready\n`)
+      flushPending()
     } catch (err) {
       process.stderr.write(`[mock-claude-mcp:${name}] init error: ${err.message}\n`)
     }

--- a/tests/integration/api-e2e.test.ts
+++ b/tests/integration/api-e2e.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Integration tests: Agent HTTP API (planning-05)
+ *
+ * Spins up a real AgentRunner (with mock claude subprocess) and GatewayRouter
+ * configured with API keys, then hits the HTTP endpoints via supertest.
+ *
+ * Test IDs: I-API-01 through I-API-12
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import supertest from 'supertest';
+import { AgentRunner } from '../../src/agent-runner';
+import { GatewayRouter } from '../../src/gateway-router';
+import { AgentConfig, GatewayConfig } from '../../src/types';
+import { SessionStore } from '../../src/session-store';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const MOCK_CLAUDE_API_BIN = path.resolve(__dirname, '../helpers/mock-claude-api.js');
+
+const API_KEY_ALFRED = 'sk-test-alfred-only-key';
+const API_KEY_ADMIN = 'sk-test-admin-key';
+const API_KEY_WRONG = 'sk-test-wrong-key';
+
+function createTempWorkspace(prefix = 'api-e2e-ws-'): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const files: Record<string, string> = {
+    'agent.md': '# Agent\nYou are a test assistant.',
+    'soul.md': '# Soul\nBe helpful.',
+    'tools.md': '# Tools\nNo tools.',
+    'user.md': '# User\nTester.',
+    'heartbeat.md': '# Heartbeat\n',
+    'memory.md': '# Memory\n',
+  };
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content, 'utf-8');
+  }
+  return dir;
+}
+
+function createTempDir(prefix = 'api-e2e-'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function makeAgentConfig(id: string, workspace: string): AgentConfig {
+  return {
+    id,
+    description: `Test agent ${id}`,
+    workspace,
+    env: '',
+    telegram: { botToken: `token-${id}`, allowedUsers: [], dmPolicy: 'open' },
+    claude: { model: 'claude-test', dangerouslySkipPermissions: false, extraFlags: [] },
+  };
+}
+
+function makeGatewayConfig(logDir: string): GatewayConfig {
+  return {
+    gateway: {
+      logDir,
+      timezone: 'UTC',
+      api: {
+        keys: [
+          { key: API_KEY_ALFRED, description: 'Alfred only', agents: ['alfred'] },
+          { key: API_KEY_ADMIN, description: 'Admin all', agents: '*' },
+        ],
+      },
+    },
+    agents: [],
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 4000,
+  intervalMs = 50,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error('waitFor timeout exceeded');
+}
+
+// ─── test suite ─────────────────────────────────────────────────────────────
+
+describe('Agent HTTP API integration (planning-05)', () => {
+  beforeAll(() => {
+    process.env.CLAUDE_BIN = `node ${MOCK_CLAUDE_API_BIN}`;
+  });
+
+  afterAll(() => {
+    delete process.env.CLAUDE_BIN;
+  });
+
+  // ─── I-API-01: GET /api/v1/agents returns list filtered by key ─────────────
+  it('I-API-01: GET /api/v1/agents returns agents accessible by the key', async () => {
+    const wsA = createTempWorkspace('api-01a-');
+    const wsB = createTempWorkspace('api-01b-');
+    const logDir = createTempDir('api-01-log-');
+    const cfgA = makeAgentConfig('alfred', wsA);
+    const cfgB = makeAgentConfig('warrior', wsB);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runnerA = new AgentRunner(cfgA, gatewayCfg);
+    const runnerB = new AgentRunner(cfgB, gatewayCfg);
+    await runnerA.start();
+    await runnerB.start();
+
+    const agents = new Map([['alfred', runnerA], ['warrior', runnerB]]);
+    const configs = new Map([['alfred', cfgA], ['warrior', cfgB]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    // Alfred-only key sees only alfred
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents')
+      .set('Authorization', `Bearer ${API_KEY_ALFRED}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.agents).toHaveLength(1);
+    expect(res.body.agents[0].id).toBe('alfred');
+
+    await router.stop();
+    await runnerA.stop();
+    await runnerB.stop();
+  });
+
+  // ─── I-API-02: Admin key sees all agents ──────────────────────────────────
+  it('I-API-02: Admin key (agents: "*") returns all agents', async () => {
+    const wsA = createTempWorkspace('api-02a-');
+    const wsB = createTempWorkspace('api-02b-');
+    const logDir = createTempDir('api-02-log-');
+    const cfgA = makeAgentConfig('alfred', wsA);
+    const cfgB = makeAgentConfig('warrior', wsB);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runnerA = new AgentRunner(cfgA, gatewayCfg);
+    const runnerB = new AgentRunner(cfgB, gatewayCfg);
+    await runnerA.start();
+    await runnerB.start();
+
+    const agents = new Map([['alfred', runnerA], ['warrior', runnerB]]);
+    const configs = new Map([['alfred', cfgA], ['warrior', cfgB]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents')
+      .set('Authorization', `Bearer ${API_KEY_ADMIN}`);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.agents.map((a: { id: string }) => a.id);
+    expect(ids).toContain('alfred');
+    expect(ids).toContain('warrior');
+
+    await router.stop();
+    await runnerA.stop();
+    await runnerB.stop();
+  });
+
+  // ─── I-API-03: POST message → 200 with valid response JSON ────────────────
+  it('I-API-03: POST /api/v1/agents/:id/messages returns 200 with response', async () => {
+    const ws = createTempWorkspace('api-03-');
+    const logDir = createTempDir('api-03-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/messages')
+      .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
+      .send({ message: 'Hello!' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.agent_id).toBe('alfred');
+    expect(typeof res.body.response).toBe('string');
+    expect(res.body.response.length).toBeGreaterThan(0);
+    expect(typeof res.body.request_id).toBe('string');
+    expect(typeof res.body.session_id).toBe('string');
+    expect(typeof res.body.duration_ms).toBe('number');
+    expect(res.body.response).toContain('Hello!');
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-04: No API key → 401 ─────────────────────────────────────────
+  it('I-API-04: Missing API key returns 401', async () => {
+    const ws = createTempWorkspace('api-04-');
+    const logDir = createTempDir('api-04-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/messages')
+      .send({ message: 'Hello' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBeDefined();
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-05: Wrong API key → 403 ────────────────────────────────────────
+  it('I-API-05: Wrong API key returns 403', async () => {
+    const ws = createTempWorkspace('api-05-');
+    const logDir = createTempDir('api-05-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/messages')
+      .set('Authorization', `Bearer ${API_KEY_WRONG}`)
+      .send({ message: 'Hello' });
+
+    expect(res.status).toBe(403);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-06: Key has no access to agent → 403 ───────────────────────────
+  it('I-API-06: Key with no access to agent returns 403', async () => {
+    const wsA = createTempWorkspace('api-06a-');
+    const wsW = createTempWorkspace('api-06w-');
+    const logDir = createTempDir('api-06-log-');
+    const cfgA = makeAgentConfig('alfred', wsA);
+    const cfgW = makeAgentConfig('warrior', wsW);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runnerA = new AgentRunner(cfgA, gatewayCfg);
+    const runnerW = new AgentRunner(cfgW, gatewayCfg);
+    await runnerA.start();
+    await runnerW.start();
+
+    const agents = new Map([['alfred', runnerA], ['warrior', runnerW]]);
+    const configs = new Map([['alfred', cfgA], ['warrior', cfgW]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    // alfred-only key tries to access warrior
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/warrior/messages')
+      .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
+      .send({ message: 'Hello warrior' });
+
+    expect(res.status).toBe(403);
+
+    await router.stop();
+    await runnerA.stop();
+    await runnerW.stop();
+  });
+
+  // ─── I-API-07: Unknown agent → 404 ────────────────────────────────────────
+  it('I-API-07: Unknown agentId returns 404', async () => {
+    const ws = createTempWorkspace('api-07-');
+    const logDir = createTempDir('api-07-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/nonexistent/messages')
+      .set('Authorization', `Bearer ${API_KEY_ADMIN}`)
+      .send({ message: 'Hello' });
+
+    expect(res.status).toBe(404);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-08: Empty message → 400 ────────────────────────────────────────
+  it('I-API-08: Empty message body returns 400', async () => {
+    const ws = createTempWorkspace('api-08-');
+    const logDir = createTempDir('api-08-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/messages')
+      .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
+      .send({ message: '   ' });
+
+    expect(res.status).toBe(400);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-09: session_id echoed back ─────────────────────────────────────
+  it('I-API-09: Provided session_id is echoed in response', async () => {
+    const ws = createTempWorkspace('api-09-');
+    const logDir = createTempDir('api-09-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const sessionId = 'my-custom-session-001';
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/messages')
+      .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
+      .send({ message: 'Hi', session_id: sessionId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.session_id).toBe(sessionId);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-10: No session_id → UUID generated ─────────────────────────────
+  it('I-API-10: Missing session_id generates a UUID in response', async () => {
+    const ws = createTempWorkspace('api-10-');
+    const logDir = createTempDir('api-10-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/messages')
+      .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
+      .send({ message: 'Stateless call' });
+
+    expect(res.status).toBe(200);
+    // UUID v4 format
+    expect(res.body.session_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-11: X-Api-Key header auth ──────────────────────────────────────
+  it('I-API-11: X-Api-Key header is accepted as authentication', async () => {
+    const ws = createTempWorkspace('api-11-');
+    const logDir = createTempDir('api-11-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/messages')
+      .set('X-Api-Key', API_KEY_ALFRED)
+      .send({ message: 'Auth via X-Api-Key' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.response).toContain('X-Api-Key');
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-12: Message + response persisted to SessionStore ───────────────
+  it('I-API-12: User message and assistant reply are persisted to SessionStore', async () => {
+    // AgentRunner derives agentsBaseDir as workspace/../../
+    // So we must set up workspace at <agentsBaseDir>/alfred/workspace/
+    const agentsBaseDir = createTempDir('api-12-agents-');
+    const ws = path.join(agentsBaseDir, 'alfred', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    // Write workspace files into the structured path
+    const files: Record<string, string> = {
+      'agent.md': '# Agent\nYou are a test assistant.',
+      'soul.md': '# Soul\nBe helpful.',
+      'tools.md': '# Tools\nNo tools.',
+      'user.md': '# User\nTester.',
+      'heartbeat.md': '# Heartbeat\n',
+      'memory.md': '# Memory\n',
+    };
+    for (const [name, content] of Object.entries(files)) {
+      fs.writeFileSync(path.join(ws, name), content, 'utf-8');
+    }
+
+    const logDir = createTempDir('api-12-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg: GatewayConfig = {
+      gateway: { logDir, timezone: 'UTC', api: { keys: [{ key: API_KEY_ADMIN, description: 'admin', agents: '*' }] } },
+      agents: [],
+    };
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const sessionId = 'persist-test-session';
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/messages')
+      .set('Authorization', `Bearer ${API_KEY_ADMIN}`)
+      .send({ message: 'Remember this message', session_id: sessionId });
+
+    expect(res.status).toBe(200);
+
+    // Give SessionStore a moment to write (it uses .catch(() => {}))
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Verify user message was persisted
+    const store = new SessionStore(agentsBaseDir);
+    const history = await store.loadSession('alfred', sessionId);
+
+    expect(history.length).toBeGreaterThanOrEqual(1);
+    const userMsg = history.find((m) => m.role === 'user');
+    expect(userMsg).toBeDefined();
+    expect(userMsg!.content).toBe('Remember this message');
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-API-13: API disabled when no keys configured ───────────────────────
+  it('I-API-13: /api routes return 404 when no API keys are configured', async () => {
+    const ws = createTempWorkspace('api-13-');
+    const logDir = createTempDir('api-13-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    // Gateway config with no api keys
+    const gatewayCfg: GatewayConfig = {
+      gateway: { logDir, timezone: 'UTC' },
+      agents: [],
+    };
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents')
+      .set('Authorization', `Bearer ${API_KEY_ADMIN}`);
+
+    expect(res.status).toBe(404);
+
+    await router.stop();
+    await runner.stop();
+  });
+});

--- a/tests/integration/multi-agent.test.ts
+++ b/tests/integration/multi-agent.test.ts
@@ -16,6 +16,7 @@ import { GatewayRouter } from '../../src/gateway-router';
 import { AgentConfig, GatewayConfig } from '../../src/types';
 import { ContextIsolationGuard, WorkspaceConflictError, TokenConflictError } from '../../src/context-isolation';
 import { SessionStore } from '../../src/session-store';
+import { SessionProcess } from '../../src/session-process';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -121,36 +122,48 @@ describe('Multi-Agent (Option A)', () => {
   });
 
   // ─── I-MA-02: TELEGRAM_STATE_DIR set per agent ───────────────────────────
-  it('I-MA-02: AgentRunner sets TELEGRAM_STATE_DIR to workspace-scoped path', () => {
+  it('I-MA-02: SessionProcess writes workspace-scoped TELEGRAM_STATE_DIR and BOT_TOKEN in MCP config', () => {
     const ws = createTempWorkspace('ma02-');
     const logDir = createTempDir('ma02-log-');
     const cfg = makeAgentConfig('ma02-agent', 'token-ma02', ws);
     const gatewayCfg = makeGatewayConfig(logDir);
+    const baseDir = path.resolve(ws, '..', '..');
+    const store = new SessionStore(baseDir);
 
-    const runner = new AgentRunner(cfg, gatewayCfg);
-    // Access private buildEnv via reflection
-    const env = (runner as unknown as { buildEnv: () => NodeJS.ProcessEnv }).buildEnv();
+    const proc = new SessionProcess('chat-ma02', 'telegram', cfg, gatewayCfg, store);
+    // writeMcpConfig is private — access via reflection to test the generated file
+    const configPath = (proc as unknown as { writeMcpConfig: () => string | null }).writeMcpConfig();
+
+    expect(configPath).not.toBeNull();
+    const mcpConfig = JSON.parse(fs.readFileSync(configPath!, 'utf-8'));
+    const env = mcpConfig.mcpServers.telegram.env;
 
     expect(env.TELEGRAM_STATE_DIR).toBeDefined();
     expect(env.TELEGRAM_STATE_DIR).toBe(path.join(ws, '.telegram-state'));
     expect(env.TELEGRAM_BOT_TOKEN).toBe('token-ma02');
-    expect(env.CLAUDE_WORKSPACE).toBe(ws);
   });
 
   // ─── I-MA-03: Two agents have separate TELEGRAM_STATE_DIR ──────────────────
-  it('I-MA-03: Two agents have different TELEGRAM_STATE_DIR paths', () => {
+  it('I-MA-03: Two agents have different TELEGRAM_STATE_DIR paths in MCP config', () => {
     const ws1 = createTempWorkspace('ma03-a-');
     const ws2 = createTempWorkspace('ma03-b-');
     const logDir = createTempDir('ma03-log-');
     const cfg1 = makeAgentConfig('ma03-alpha', 'token-ma03-a', ws1);
     const cfg2 = makeAgentConfig('ma03-beta', 'token-ma03-b', ws2);
     const gatewayCfg = makeGatewayConfig(logDir);
+    const base1 = path.resolve(ws1, '..', '..');
+    const base2 = path.resolve(ws2, '..', '..');
+    const store1 = new SessionStore(base1);
+    const store2 = new SessionStore(base2);
 
-    const runner1 = new AgentRunner(cfg1, gatewayCfg);
-    const runner2 = new AgentRunner(cfg2, gatewayCfg);
+    const proc1 = new SessionProcess('chat-ma03', 'telegram', cfg1, gatewayCfg, store1);
+    const proc2 = new SessionProcess('chat-ma03', 'telegram', cfg2, gatewayCfg, store2);
 
-    const env1 = (runner1 as unknown as { buildEnv: () => NodeJS.ProcessEnv }).buildEnv();
-    const env2 = (runner2 as unknown as { buildEnv: () => NodeJS.ProcessEnv }).buildEnv();
+    const configPath1 = (proc1 as unknown as { writeMcpConfig: () => string | null }).writeMcpConfig();
+    const configPath2 = (proc2 as unknown as { writeMcpConfig: () => string | null }).writeMcpConfig();
+
+    const env1 = JSON.parse(fs.readFileSync(configPath1!, 'utf-8')).mcpServers.telegram.env;
+    const env2 = JSON.parse(fs.readFileSync(configPath2!, 'utf-8')).mcpServers.telegram.env;
 
     expect(env1.TELEGRAM_STATE_DIR).not.toBe(env2.TELEGRAM_STATE_DIR);
     expect(env1.TELEGRAM_STATE_DIR).toBe(path.join(ws1, '.telegram-state'));

--- a/tests/integration/pipeline-mcp.test.ts
+++ b/tests/integration/pipeline-mcp.test.ts
@@ -347,7 +347,8 @@ describe('Pipeline MCP — Telegram → plugin → Claude Code (step-by-step)', 
   // ── MCP config validation ─────────────────────────────────────────────────
 
   test('MCP config written by agent-runner has correct structure', () => {
-    const mcpConfigPath = path.join(tmpDir, '.mcp-config.json')
+    // MCP config is per-session: written at .sessions/<chatId>/mcp-config.json
+    const mcpConfigPath = path.join(tmpDir, '.sessions', USER_ID, 'mcp-config.json')
     expect(fs.existsSync(mcpConfigPath)).toBe(true)
 
     const config = JSON.parse(fs.readFileSync(mcpConfigPath, 'utf8'))
@@ -367,7 +368,7 @@ describe('Pipeline MCP — Telegram → plugin → Claude Code (step-by-step)', 
     // Verify from the initial prompt line that Claude was launched
     const promptLine = collectedOutput.find(l => l.includes('[mock-claude-mcp] prompt:'))
     expect(promptLine).toBeDefined()
-    expect(promptLine).toContain('channels mode')
+    expect(promptLine).toContain('Channels mode')
   })
 })
 

--- a/tests/unit/api-auth.test.ts
+++ b/tests/unit/api-auth.test.ts
@@ -1,0 +1,93 @@
+import { createServer } from 'http';
+import express from 'express';
+import { createApiAuthMiddleware, canAccessAgent } from '../../src/api-auth';
+import { ApiKey } from '../../src/types';
+import * as supertest from 'supertest';
+
+const TEST_KEYS: ApiKey[] = [
+  { key: 'sk-gateway-abc123', description: 'App key', agents: ['alfred'] },
+  { key: 'sk-gateway-admin00', description: 'Admin key', agents: '*' },
+];
+
+function buildApp(keys: ApiKey[]) {
+  const app = express();
+  app.use(express.json());
+  const auth = createApiAuthMiddleware(keys);
+  app.get('/protected', auth, (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('createApiAuthMiddleware', () => {
+  it('allows valid Bearer token', async () => {
+    const app = buildApp(TEST_KEYS);
+    const res = await supertest.default(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer sk-gateway-abc123');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('allows valid X-Api-Key header', async () => {
+    const app = buildApp(TEST_KEYS);
+    const res = await supertest.default(app)
+      .get('/protected')
+      .set('X-Api-Key', 'sk-gateway-abc123');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 when no auth header is present', async () => {
+    const app = buildApp(TEST_KEYS);
+    const res = await supertest.default(app).get('/protected');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/missing api key/i);
+  });
+
+  it('returns 403 for an invalid key', async () => {
+    const app = buildApp(TEST_KEYS);
+    const res = await supertest.default(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer wrong-key');
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/invalid api key/i);
+  });
+
+  it('attaches matched apiKey to req', async () => {
+    const app = express();
+    app.use(express.json());
+    const auth = createApiAuthMiddleware(TEST_KEYS);
+    app.get('/check', auth, (req, res) => {
+      res.json({ key: (req as express.Request & { apiKey: ApiKey }).apiKey.description });
+    });
+    const res = await supertest.default(app)
+      .get('/check')
+      .set('Authorization', 'Bearer sk-gateway-admin00');
+    expect(res.status).toBe(200);
+    expect(res.body.key).toBe('Admin key');
+  });
+
+  it('handles length-mismatch safely (no throw)', async () => {
+    const app = buildApp(TEST_KEYS);
+    const res = await supertest.default(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer short');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('canAccessAgent', () => {
+  const appKey: ApiKey = { key: 'x', agents: ['alfred', 'baerbel'] };
+  const adminKey: ApiKey = { key: 'y', agents: '*' };
+
+  it('returns true when agentId is in agents array', () => {
+    expect(canAccessAgent(appKey, 'alfred')).toBe(true);
+  });
+
+  it('returns false when agentId is not in agents array', () => {
+    expect(canAccessAgent(appKey, 'unknown')).toBe(false);
+  });
+
+  it('returns true for any agentId when agents is "*"', () => {
+    expect(canAccessAgent(adminKey, 'alfred')).toBe(true);
+    expect(canAccessAgent(adminKey, 'anything')).toBe(true);
+  });
+});

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -1,0 +1,231 @@
+import express from 'express';
+import { EventEmitter } from 'events';
+import * as supertest from 'supertest';
+import { createApiRouter } from '../../src/api-router';
+import { AgentConfig, ApiKey } from '../../src/types';
+
+// ── Minimal mock AgentRunner ─────────────────────────────────────────────────
+
+class MockAgentRunner extends EventEmitter {
+  sendApiMessageImpl: (sessionId: string, message: string) => Promise<string>;
+
+  constructor(impl: (sessionId: string, message: string) => Promise<string>) {
+    super();
+    this.sendApiMessageImpl = impl;
+  }
+
+  async sendApiMessage(
+    sessionId: string,
+    message: string,
+    _opts: { timeoutMs: number },
+  ): Promise<string> {
+    return this.sendApiMessageImpl(sessionId, message);
+  }
+}
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const AGENT_ID = 'alfred';
+
+const agentConfig: AgentConfig = {
+  id: AGENT_ID,
+  description: 'Personal assistant',
+  workspace: '/tmp/alfred',
+  env: '',
+  telegram: { botToken: 'tok', allowedUsers: [], dmPolicy: 'allowlist' },
+  claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+};
+
+const apiKeys: ApiKey[] = [
+  { key: 'sk-test-app', agents: [AGENT_ID] },
+  { key: 'sk-test-admin', agents: '*' },
+];
+
+function buildApp(runnerImpl: (sessionId: string, msg: string) => Promise<string>) {
+  const runner = new MockAgentRunner(runnerImpl);
+  const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent-runner').AgentRunner]]);
+  const configs = new Map([[AGENT_ID, agentConfig]]);
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createApiRouter(runners, configs, apiKeys));
+  return app;
+}
+
+const AUTH = { Authorization: 'Bearer sk-test-app' };
+const POST_URL = `/api/v1/agents/${AGENT_ID}/messages`;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/agents/:agentId/messages', () => {
+  it('returns 200 with response on success', async () => {
+    const app = buildApp(async () => 'Hello!');
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'Hi' });
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe('Hello!');
+    expect(res.body.agent_id).toBe(AGENT_ID);
+    expect(typeof res.body.request_id).toBe('string');
+    expect(typeof res.body.session_id).toBe('string');
+    expect(typeof res.body.duration_ms).toBe('number');
+  });
+
+  it('echoes back provided session_id', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'ping', session_id: 'my-session-001' });
+    expect(res.status).toBe(200);
+    expect(res.body.session_id).toBe('my-session-001');
+  });
+
+  it('generates a uuid session_id when not provided', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'ping' });
+    expect(res.status).toBe(200);
+    // UUID v4 pattern
+    expect(res.body.session_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('returns 400 when message is missing', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/message is required/i);
+  });
+
+  it('returns 400 when message is empty string', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: '   ' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when message exceeds 10,000 chars', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'x'.repeat(10_001) });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/too long/i);
+  });
+
+  it('returns 400 when session_id is not a string', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'hi', session_id: 123 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when no auth header', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .send({ message: 'hi' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when key has no access to agent', async () => {
+    const app = buildApp(async () => 'ok');
+    // Use a key that only accesses a different agent
+    const restrictedKeys: ApiKey[] = [{ key: 'sk-test-app', agents: ['other-agent'] }];
+    const runner = new MockAgentRunner(async () => 'ok');
+    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent-runner').AgentRunner]]);
+    const configs = new Map([[AGENT_ID, agentConfig]]);
+    const restrictedApp = express();
+    restrictedApp.use(express.json());
+    restrictedApp.use('/api', createApiRouter(runners, configs, restrictedKeys));
+    const res = await supertest.default(restrictedApp)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'hi' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for unknown agent', async () => {
+    const app = buildApp(async () => 'ok');
+    const adminAuth = { Authorization: 'Bearer sk-test-admin' };
+    const res = await supertest.default(app)
+      .post('/api/v1/agents/unknown-agent/messages')
+      .set(adminAuth)
+      .send({ message: 'hi' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 504 on TIMEOUT error', async () => {
+    const app = buildApp(async () => {
+      const err = Object.assign(new Error('timeout'), { code: 'TIMEOUT' });
+      throw err;
+    });
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'hi' });
+    expect(res.status).toBe(504);
+  });
+
+  it('returns 409 on CONFLICT error', async () => {
+    const app = buildApp(async () => {
+      const err = Object.assign(new Error('conflict'), { code: 'CONFLICT' });
+      throw err;
+    });
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'hi' });
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    const app = buildApp(async () => {
+      throw new Error('unexpected');
+    });
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'hi' });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('GET /api/v1/agents', () => {
+  it('returns only agents accessible by the key', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .get('/api/v1/agents')
+      .set(AUTH); // sk-test-app → only alfred
+    expect(res.status).toBe(200);
+    expect(res.body.agents).toHaveLength(1);
+    expect(res.body.agents[0].id).toBe(AGENT_ID);
+  });
+
+  it('admin key returns all agents', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .get('/api/v1/agents')
+      .set({ Authorization: 'Bearer sk-test-admin' });
+    expect(res.status).toBe(200);
+    expect(res.body.agents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app).get('/api/v1/agents');
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

- **HTTP Agent API** — `POST /api/v1/agents/:id/messages` and `GET /api/v1/agents` with API key auth (`X-Api-Key` / `Authorization: Bearer`), per-key agent access control, and synchronous response
- **Multi-session isolation** — dedicated `TelegramReceiver` per agent (fixes 409 Conflict), `SessionProcess` pool with idle timeout and eviction, full context isolation per chat/session
- **SessionStore** — conversation history persisted to `.jsonl`, injected on idle restart so Claude resumes seamlessly
- **Bug fixes** — API sessions no longer send activation prompt on spawn (fixes empty response); quiet timer starts on first output line; Express `json()` middleware ordering fixed; `TELEGRAM_BOT_TOKEN` added to subprocess env
- **Logger** — stdout pretty-prints JSON for readability; log file stays compact (one entry per line)
- **README** — step-by-step Agent API quickstart, multi-session architecture diagram, updated configuration reference

## Test plan

- [ ] `npm test` — all 510 tests pass
- [ ] `GET /api/v1/agents` returns correct agent list for each key
- [ ] `POST /api/v1/agents/:id/messages` returns non-empty response
- [ ] Second request with same `session_id` — Claude remembers prior turn
- [ ] Key with no access to agent returns 403
- [ ] Two simultaneous Telegram sessions — context does not bleed between chats
- [ ] Idle session killed → next message resumes with history intact