### PR TITLE
feat: support Claude Code plugins and stdio MCP servers in gateway sessions

### DIFF
--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -1,6 +1,7 @@
 import { spawn, ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { AgentConfig, GatewayConfig } from './types';
 import { SessionStore } from './session-store';
@@ -64,6 +65,36 @@ export class SessionProcess extends EventEmitter {
     return `[Conversation history with this user:\n${historyText}]\n\n${CHANNELS_ACTIVATION_PROMPT}`;
   }
 
+  /**
+   * Read stdio MCP servers from Claude Code's user-scoped config (~/.claude/settings.json).
+   * Returns empty object if file doesn't exist, can't be parsed, or has no mcpServers.
+   */
+  private readUserScopedMcp(): Record<string, unknown> {
+    try {
+      const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+      const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      return (parsed?.mcpServers as Record<string, unknown>) ?? {};
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Read stdio MCP servers from Claude Code's project-scoped config (~/.claude.json).
+   * Looks up projects[workspace].mcpServers for the agent's workspace path.
+   * Returns empty object if not found or on any error.
+   */
+  private readProjectScopedMcp(): Record<string, unknown> {
+    try {
+      const claudeJsonPath = path.join(os.homedir(), '.claude.json');
+      const parsed = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf-8'));
+      const projectServers = parsed?.projects?.[this.agentConfig.workspace]?.mcpServers;
+      return (projectServers as Record<string, unknown>) ?? {};
+    } catch {
+      return {};
+    }
+  }
+
   private writeMcpConfig(): string | null {
     if (this.source === 'api') return null; // API sessions don't need Telegram plugin
 
@@ -72,8 +103,20 @@ export class SessionProcess extends EventEmitter {
     fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
 
     const pluginPath = path.resolve(__dirname, '..', 'plugins', 'telegram', 'server.ts');
+
+    // Merge stdio servers from Claude Code user + project configs (project overrides user).
+    // Skip "telegram" from both — gateway always generates its own telegram config below.
+    const userServers = this.readUserScopedMcp();
+    const projectServers = this.readProjectScopedMcp();
+    const extraServers: Record<string, unknown> = {};
+    for (const [name, server] of Object.entries({ ...userServers, ...projectServers })) {
+      if (name !== 'telegram') extraServers[name] = server;
+    }
+
     const mcpConfig = {
       mcpServers: {
+        ...extraServers,
+        // Telegram always wins — must stay last to override any accidental collision
         telegram: {
           command: 'bun',
           args: [pluginPath],
@@ -88,6 +131,10 @@ export class SessionProcess extends EventEmitter {
 
     const configPath = path.join(sessionDir, 'mcp-config.json');
     fs.writeFileSync(configPath, JSON.stringify(mcpConfig, null, 2), { mode: 0o600 });
+
+    const serverNames = Object.keys(mcpConfig.mcpServers);
+    this.logger.debug('MCP config written', { sessionId: this.sessionId, servers: serverNames });
+
     return configPath;
   }
 
@@ -101,7 +148,10 @@ export class SessionProcess extends EventEmitter {
     ];
 
     if (mcpConfigPath) {
-      args.unshift('--mcp-config', mcpConfigPath, '--strict-mcp-config');
+      // NOTE: --strict-mcp-config is intentionally omitted.
+      // With --strict-mcp-config, Claude Code blocks all plugin MCP servers (e.g. figma).
+      // Without it, enabled plugins (figma, etc.) load automatically alongside --mcp-config.
+      args.unshift('--mcp-config', mcpConfigPath);
     }
 
     if (this.agentConfig.claude.dangerouslySkipPermissions) {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -3,6 +3,16 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+// ── os.homedir mock (set per-test) ────────────────────────────────────────────
+let mockHomeDir: string | null = null;
+jest.mock('os', () => {
+  const real = jest.requireActual<typeof os>('os');
+  return {
+    ...real,
+    homedir: () => mockHomeDir ?? real.homedir(),
+  };
+});
+
 // ── Minimal mock types ────────────────────────────────────────────────────────
 
 interface MockStdin {
@@ -110,12 +120,14 @@ describe('SessionProcess', () => {
     gatewayConfig = makeGatewayConfig();
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions'));
     lastProcess = null;
+    mockHomeDir = null;
     spawnMock = require('child_process').spawn as jest.Mock;
     spawnMock.mockClear();
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    mockHomeDir = null;
     jest.clearAllMocks();
   });
 
@@ -269,5 +281,179 @@ describe('SessionProcess', () => {
     // Should contain Message 59 (last) but NOT Message 0 (first — truncated)
     expect(text).toContain('Message 59');
     expect(text).not.toContain('Message 0');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-10: --strict-mcp-config must NOT be in subprocess args
+  // --------------------------------------------------------------------------
+  it('U-SP-10: subprocess is spawned without --strict-mcp-config', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args).not.toContain('--strict-mcp-config');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-11: --mcp-config is still present for telegram sessions
+  // --------------------------------------------------------------------------
+  it('U-SP-11: --mcp-config arg is present for telegram sessions', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args).toContain('--mcp-config');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-12: User-scoped stdio MCP servers merged into mcp-config.json
+  // --------------------------------------------------------------------------
+  it('U-SP-12: user-scoped stdio mcpServers are merged into mcp-config.json', async () => {
+    // Setup fake home with settings.json containing a custom MCP server
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-home-'));
+    try {
+      fs.mkdirSync(path.join(fakeHome, '.claude'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fakeHome, '.claude', 'settings.json'),
+        JSON.stringify({
+          mcpServers: {
+            github: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'] },
+          },
+        }),
+      );
+      mockHomeDir = fakeHome;
+
+      const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+
+      const configPath = path.join(agentConfig.workspace, '.sessions', 'chat:111', 'mcp-config.json');
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+      expect(config.mcpServers.github).toBeDefined();
+      expect(config.mcpServers.github.command).toBe('npx');
+      expect(config.mcpServers.telegram).toBeDefined(); // gateway telegram still present
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-13: Project-scoped MCP servers override user-scoped on name collision
+  // --------------------------------------------------------------------------
+  it('U-SP-13: project-scoped servers override user-scoped on name collision', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-home-'));
+    try {
+      fs.mkdirSync(path.join(fakeHome, '.claude'), { recursive: true });
+
+      // User-scoped: github with command "old"
+      fs.writeFileSync(
+        path.join(fakeHome, '.claude', 'settings.json'),
+        JSON.stringify({
+          mcpServers: {
+            github: { command: 'old', args: [] },
+          },
+        }),
+      );
+
+      // Project-scoped: github with command "new" (should win)
+      fs.writeFileSync(
+        path.join(fakeHome, '.claude.json'),
+        JSON.stringify({
+          projects: {
+            [agentConfig.workspace]: {
+              mcpServers: {
+                github: { command: 'new', args: [] },
+              },
+            },
+          },
+        }),
+      );
+      mockHomeDir = fakeHome;
+
+      const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+
+      const configPath = path.join(agentConfig.workspace, '.sessions', 'chat:111', 'mcp-config.json');
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+      expect(config.mcpServers.github.command).toBe('new');
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-14: "telegram" in user/project config is skipped — gateway telegram wins
+  // --------------------------------------------------------------------------
+  it('U-SP-14: telegram server in user config is skipped, gateway telegram always wins', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-home-'));
+    try {
+      fs.mkdirSync(path.join(fakeHome, '.claude'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fakeHome, '.claude', 'settings.json'),
+        JSON.stringify({
+          mcpServers: {
+            telegram: { command: 'bad-command', args: [] }, // should be ignored
+          },
+        }),
+      );
+      mockHomeDir = fakeHome;
+
+      const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+
+      const configPath = path.join(agentConfig.workspace, '.sessions', 'chat:111', 'mcp-config.json');
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+      expect(config.mcpServers.telegram.command).toBe('bun'); // gateway version
+      expect(config.mcpServers.telegram.command).not.toBe('bad-command');
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-15: Missing or corrupt Claude config files → no error, only telegram
+  // --------------------------------------------------------------------------
+  it('U-SP-15: missing or corrupt Claude config files produce no error, only telegram in config', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-home-'));
+    try {
+      // No settings.json, no .claude.json
+      mockHomeDir = fakeHome;
+
+      const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await expect(sp.start()).resolves.not.toThrow();
+
+      const configPath = path.join(agentConfig.workspace, '.sessions', 'chat:111', 'mcp-config.json');
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+      expect(Object.keys(config.mcpServers)).toEqual(['telegram']);
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-16: API session — no MCP config, no --mcp-config arg (unchanged)
+  // --------------------------------------------------------------------------
+  it('U-SP-16: api session still has no --mcp-config even with user-scoped servers', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-home-'));
+    try {
+      fs.mkdirSync(path.join(fakeHome, '.claude'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fakeHome, '.claude', 'settings.json'),
+        JSON.stringify({ mcpServers: { github: { command: 'npx', args: [] } } }),
+      );
+      mockHomeDir = fakeHome;
+
+      const sp = new SessionProcess('api:uuid', 'api', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+
+      const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+      expect(args).not.toContain('--mcp-config');
+      expect(args).not.toContain('--strict-mcp-config');
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Remove `--strict-mcp-config` from session subprocess args so Claude Code plugins (e.g. `figma@claude-plugins-official`) load automatically in every gateway session
- Merge stdio MCP servers from `~/.claude/settings.json` (user-scoped) and `~/.claude.json` (project-scoped) into the generated `mcp-config.json` at spawn time
- `"telegram"` is reserved — any telegram entry in user/project config is skipped; gateway always generates its own

## Background

`--strict-mcp-config` was designed to isolate sessions to only the telegram plugin. Testing showed it also blocks all plugin MCP servers (OAuth-based HTTP servers like Figma). Removing it allows plugins to load naturally while `--mcp-config` still provides the telegram server.

## How to use Figma MCP

1. `claude plugin install figma@claude-plugins-official` (if not installed)
2. Authenticate once in terminal: open Claude → `/mcp` → figma → Authenticate
3. Restart gateway — all new sessions will have Figma tools available

## Test plan

- [x] 16 unit tests covering: no `--strict-mcp-config` in args, user/project MCP merge, name collision priority, telegram reservation, corrupt config resilience, API session unchanged
- [x] 505 unit + integration tests pass
- [x] Empirically verified with real Claude subprocess: plugins load with `needs-auth` status when `--strict-mcp-config` is absent