### PR TITLE
fix: remove --strict-mcp-config to allow plugins and MCP servers

### DIFF
--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -101,7 +101,7 @@ export class SessionProcess extends EventEmitter {
     ];
 
     if (mcpConfigPath) {
-      args.unshift('--mcp-config', mcpConfigPath, '--strict-mcp-config');
+      args.unshift('--mcp-config', mcpConfigPath);
     }
 
     if (this.agentConfig.claude.dangerouslySkipPermissions) {


### PR DESCRIPTION
## Summary
- Removes `--strict-mcp-config` flag from `buildArgs()` in `session-process.ts`
- This flag was blocking all Claude Code plugins (Figma, Playwright, etc.) from loading in gateway sessions
- Only the telegram MCP was being loaded — all other user-configured MCP servers and plugins were silently blocked

## Root Cause
PR #3 (`feature/mcp-plugin-support`) was mistakenly merged into `feature/agent-api` instead of `main`, so the fix never landed on the default branch.

## Fix
Single-line change: remove `'--strict-mcp-config'` from the `--mcp-config` argument array.

## Test Plan
- [x] All 510 tests pass (32/33 suites — 1 skipped E2E)
- [x] Plugins (Figma, Playwright) will now load from enabled plugin directories
- [x] User-scoped MCP servers from `~/.claude/settings.json` will now be available in gateway sessions
- [x] Telegram MCP still injected via `--mcp-config` as before