### PR TITLE
fix: forward image_path and attachment meta fields into channel XML tag

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -124,10 +124,21 @@ export class AgentRunner extends EventEmitter {
     meta?: Record<string, string>;
   }): string {
     const meta = params.meta ?? {};
+    const optionalAttrs = [
+      'image_path',
+      'attachment_file_id',
+      'attachment_kind',
+      'attachment_size',
+      'attachment_mime',
+      'attachment_name',
+    ]
+      .filter(k => meta[k])
+      .map(k => ` ${k}="${meta[k]!.replace(/"/g, '&quot;')}"`)
+      .join('');
     return (
       `<channel source="telegram" chat_id="${meta['chat_id'] ?? ''}" ` +
       `message_id="${meta['message_id'] ?? ''}" user="${meta['user'] ?? ''}" ` +
-      `ts="${meta['ts'] ?? new Date().toISOString()}">${params.content ?? ''}</channel>`
+      `ts="${meta['ts'] ?? new Date().toISOString()}"${optionalAttrs}>${params.content ?? ''}</channel>`
     );
   }
 


### PR DESCRIPTION
## Summary
- Fixed `buildChannelXml` in `agent-runner.ts` to include `image_path` and `attachment_file_id` attributes in the `<channel>` XML tag
- Previously, photo attachments sent via Telegram were not forwarded to the agent, making it impossible to read images from channel messages
- Now agents receive the correct file path and can use `Read` tool to process photos

## Test plan
- [x] Send a photo via Telegram channel
- [x] Verify agent receives `image_path` attribute in `<channel>` tag
- [x] Verify agent can read the image with the `Read` tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)