### PR TITLE
feat: forward replied-message context (text + image) into channel XML

### DIFF
--- a/plugins/telegram/server.ts
+++ b/plugins/telegram/server.ts
@@ -681,6 +681,28 @@ async function handleInbound(
 
   const imagePath = downloadImage ? await downloadImage() : undefined
 
+  // Download photo from replied-to message if present
+  const replyMsg = ctx.message?.reply_to_message
+  let repliedImagePath: string | undefined
+  if (replyMsg?.photo) {
+    try {
+      const largest = replyMsg.photo[replyMsg.photo.length - 1]!
+      const file = await bot.api.getFile(largest.file_id)
+      if (file.file_path) {
+        const url = `https://api.telegram.org/file/bot${TOKEN}/${file.file_path}`
+        const res = await fetch(url)
+        if (res.ok) {
+          const buf = Buffer.from(await res.arrayBuffer())
+          const ext = file.file_path.split('.').pop()?.replace(/[^a-zA-Z0-9]/g, '') || 'jpg'
+          const uniqueId = (largest.file_unique_id ?? '').replace(/[^a-zA-Z0-9_-]/g, '') || 'reply'
+          repliedImagePath = join(INBOX_DIR, `${Date.now()}-reply-${uniqueId}.${ext}`)
+          mkdirSync(INBOX_DIR, { recursive: true })
+          writeFileSync(repliedImagePath, buf)
+        }
+      }
+    } catch {}
+  }
+
   // image_path goes in meta only — an in-content "[image attached — read: PATH]"
   // annotation is forgeable by any allowlisted sender typing that string.
   const channelParams = {
@@ -698,6 +720,12 @@ async function handleInbound(
         ...(attachment.size != null ? { attachment_size: String(attachment.size) } : {}),
         ...(attachment.mime ? { attachment_mime: attachment.mime } : {}),
         ...(attachment.name ? { attachment_name: attachment.name } : {}),
+      } : {}),
+      ...(replyMsg ? {
+        replied_message_id: String(replyMsg.message_id),
+        replied_user: replyMsg.from?.username ?? String(replyMsg.from?.id ?? ''),
+        ...(replyMsg.text ? { replied_text: replyMsg.text } : {}),
+        ...(repliedImagePath ? { replied_image_path: repliedImagePath } : {}),
       } : {}),
     },
   }

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -135,10 +135,27 @@ export class AgentRunner extends EventEmitter {
       .filter(k => meta[k])
       .map(k => ` ${k}="${meta[k]!.replace(/"/g, '&quot;')}"`)
       .join('');
+
+    // Build nested <replied> block if this message is a reply to another
+    let repliedBlock = '';
+    if (meta['replied_message_id']) {
+      const repliedAttrs = [
+        'replied_image_path',
+      ]
+        .filter(k => meta[k])
+        .map(k => ` ${k}="${meta[k]!.replace(/"/g, '&quot;')}"`)
+        .join('');
+      repliedBlock =
+        `<replied message_id="${meta['replied_message_id']}" ` +
+        `user="${(meta['replied_user'] ?? '').replace(/"/g, '&quot;')}"${repliedAttrs}>` +
+        `${(meta['replied_text'] ?? '').replace(/</g, '&lt;').replace(/>/g, '&gt;')}` +
+        `</replied>`;
+    }
+
     return (
       `<channel source="telegram" chat_id="${meta['chat_id'] ?? ''}" ` +
       `message_id="${meta['message_id'] ?? ''}" user="${meta['user'] ?? ''}" ` +
-      `ts="${meta['ts'] ?? new Date().toISOString()}"${optionalAttrs}>${params.content ?? ''}</channel>`
+      `ts="${meta['ts'] ?? new Date().toISOString()}"${optionalAttrs}>${repliedBlock}${params.content ?? ''}</channel>`
     );
   }
 


### PR DESCRIPTION
## Summary
- Download and save photos from replied-to Telegram messages into INBOX_DIR
- Forward `replied_message_id`, `replied_user`, `replied_text`, `replied_image_path` through channel metadata
- Render nested `<replied>` block inside `<channel>` XML tag in `buildChannelXml`

## Test plan
- [x] Reply to a text message → `<replied>` block contains original text
- [x] Reply to a photo → `replied_image_path` points to downloaded file, agent can Read it
- [x] Reply to a message with both text and image → both fields present

🤖 Generated with [Claude Code](https://claude.com/claude-code)