### PR TITLE
feat: agent behavioral guidelines, emoji support, and config migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage/
 .claude
 
 # Planning
+archive/
 planning*.md
 design*.md
 testcase*.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ dist/
 .env.*
 !.env.example
 config.json
-!config.example.json
+!config.template.json
 
 # Logs
 *.log
@@ -36,5 +36,5 @@ planning*.md
 design*.md
 testcase*.md
 feature*.md
-task-imp*.md
+task-*.md
 research*.md

--- a/.gitignore
+++ b/.gitignore
@@ -28,11 +28,13 @@ Thumbs.db
 # Test coverage
 coverage/
 
+.claude-plugin/
+.claude
+
 # Planning
 planning*.md
 design*.md
 testcase*.md
 feature*.md
-
-.claude-plugin/
-.claude
+task-imp*.md
+research*.md

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export
 
 .DEFAULT_GOAL := help
 
-.PHONY: help start create-agent pair plugin-install
+.PHONY: help start create-agent update-agent pair plugin-install
 
 help: ## Show this help message
 	@echo "----------------------------------------"
@@ -17,6 +17,9 @@ start: ## Build and start the gateway
 
 create-agent: ## Run the interactive wizard to create a new agent
 	./node_modules/.bin/ts-node scripts/create-agent.ts
+
+update-agent: ## Update an existing agent's agent.md with Claude
+	./node_modules/.bin/ts-node scripts/update-agent.ts
 
 pair: ## Approve a Telegram pairing (e.g. make pair agent=alfred code=abc123)
 	./node_modules/.bin/ts-node scripts/pair.ts --agent=$(agent) --code=$(code)

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ See [Quickstart: Using the Agent API](#quickstart-using-the-agent-api) for full 
 ```
 claude-gateway/
 ├── Makefile                            ← make start / create-agent / pair / plugin-install / add-user
-├── config.example.json                 ← config template
+├── config.template.json                ← config template (source of truth for migration)
 ├── src/                                ← gateway source (TypeScript)
 │   ├── index.ts                        ← entrypoint, loads config and starts agents
 │   ├── agent-runner.ts                 ← session pool manager (spawn/evict SessionProcesses)

--- a/config.example.json
+++ b/config.example.json
@@ -33,6 +33,8 @@
         "dangerouslySkipPermissions": true,
         "extraFlags": []
       },
+      "emojiReactionMode": "minimal",
+      "signatureEmoji": "",
       "heartbeat": {
         "rateLimitMinutes": 30
       },

--- a/config.template.json
+++ b/config.template.json
@@ -7,6 +7,7 @@
   },
   "configVersion": "1.0.0",
   "gateway": {
+    "version": "1.0.0",
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "api": {

--- a/config.template.json
+++ b/config.template.json
@@ -7,7 +7,6 @@
   },
   "configVersion": "1.0.0",
   "gateway": {
-    "version": "1.0.0",
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "api": {

--- a/config.template.json
+++ b/config.template.json
@@ -1,4 +1,5 @@
 {
+  "configVersion": "1.0.0",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",

--- a/config.template.json
+++ b/config.template.json
@@ -1,4 +1,10 @@
 {
+  "_migration": {
+    "ignorePaths": [
+      "gateway.api",
+      "gateway.api.keys"
+    ]
+  },
   "configVersion": "1.0.0",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-gateway",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Multi-agent gateway for Claude",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-gateway",
-  "version": "1.0.0",
-  "description": "Multi-agent Telegram gateway for Claude",
+  "version": "1.0.1",
+  "description": "Multi-agent gateway for Claude",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/scripts/create-agent-prompts.ts
+++ b/scripts/create-agent-prompts.ts
@@ -24,8 +24,10 @@ Generate workspace markdown files for this agent. Output each file as:
 Rules:
 - agent.md is REQUIRED. Start with "# Agent: ${name}" on line 1.
   Include: role, rules, what it can/cannot do, language to use.
-  Always include this rule: when a message arrives, send a brief acknowledgement first
-  (e.g. "Got it, let me check…" or "On it!"), then do the work and reply with the result.
+  Always include this rule under ## Rules:
+  "Acknowledge first (mandatory): Every message MUST begin with a short acknowledgement
+   before taking any action or calling any tool. No exceptions.
+   Examples: 'Got it!', 'On it!', 'รับทราบค่ะ!'"
 - soul.md: tone and personality only (not rules). Omit if no distinct style.
 - user.md: target user profile. Omit if public/unknown.
 - tools.md: available tools or capabilities. Omit if none specified.
@@ -69,4 +71,25 @@ export function parseGeneratedFiles(output: string): Map<string, string> {
   }
 
   return files;
+}
+
+/**
+ * Build the Claude update prompt for an existing agent.md file.
+ */
+export function buildUpdatePrompt(name: string, currentContent: string): string {
+  return `You are updating the agent.md file for a Claude Gateway agent named "${name}".
+
+Current agent.md content:
+"""
+${currentContent}
+"""
+
+Update this agent.md to follow current best practices:
+- Preserve the agent's role, purpose, and all existing rules
+- Ensure ## Rules section includes this rule (add if missing, strengthen if weak):
+  "Acknowledge first (mandatory): Every message MUST begin with a short acknowledgement
+   before taking any action or calling any tool. No exceptions.
+   Examples: 'Got it!', 'On it!', 'รับทราบค่ะ!'"
+- Keep the file under 500 words
+- Output ONLY the updated agent.md content, no extra explanation`;
 }

--- a/scripts/create-agent-prompts.ts
+++ b/scripts/create-agent-prompts.ts
@@ -113,5 +113,7 @@ Update this agent.md to follow current best practices:
     - Reactions: React to messages like a human would — use the react tool. Max 1 reaction per message.
     - Signature emoji: preserve any existing signature emoji setting.
 - Keep the file under 500 words
-- Output ONLY the updated agent.md content, no extra explanation`;
+
+Output ONLY the updated agent.md content — no preamble, no explanation, no commentary.
+Start directly with the first line of the agent.md content.`;
 }

--- a/scripts/create-agent-prompts.ts
+++ b/scripts/create-agent-prompts.ts
@@ -34,9 +34,9 @@ Rules:
 - agent.md is REQUIRED. Start with "# Agent: ${name}" on line 1.
   Include: role, rules, what it can/cannot do, language to use.
   Always include this rule under ## Rules:
-  "Acknowledge first (mandatory): Every message MUST begin with a short acknowledgement
-   before taking any action or calling any tool. No exceptions.
-   Examples: 'Got it!', 'On it!', 'Sure thing!'"
+  "Acknowledge first (mandatory): Every message MUST begin with a text reply acknowledgement
+   before taking any action or calling any tool. No exceptions. Emoji reaction alone does NOT count.
+   Examples: 'Got it!', 'On it!', 'Sure thing!', 'Let me check…'"
   Also include an "## Emoji Usage" section in agent.md with these guidelines:
     - Text emoji: Use sparingly in messages. Occasional emoji is fine for warmth, but don't overdo it.
     - Reactions: React to messages like a human would — use the react tool. Max 1 reaction per message.
@@ -106,9 +106,9 @@ ${currentContent}
 Update this agent.md to follow current best practices:
 - Preserve the agent's role, purpose, and all existing rules
 - Ensure ## Rules section includes this rule (add if missing, strengthen if weak):
-  "Acknowledge first (mandatory): Every message MUST begin with a short acknowledgement
-   before taking any action or calling any tool. No exceptions.
-   Examples: 'Got it!', 'On it!', 'Sure thing!'"
+  "Acknowledge first (mandatory): Every message MUST begin with a text reply acknowledgement
+   before taking any action or calling any tool. No exceptions. Emoji reaction alone does NOT count.
+   Examples: 'Got it!', 'On it!', 'Sure thing!', 'Let me check…'"
 - Ensure an "## Emoji Usage" section exists with these guidelines:
     - Text emoji: Use sparingly. Occasional emoji is fine for warmth, but don't overdo it.
     - Reactions: React to messages like a human would — use the react tool. Max 1 reaction per message.

--- a/scripts/create-agent-prompts.ts
+++ b/scripts/create-agent-prompts.ts
@@ -5,7 +5,16 @@
 /**
  * Build the Claude generation prompt for workspace markdown files.
  */
-export function buildGenerationPrompt(name: string, description: string): string {
+export function buildGenerationPrompt(
+  name: string,
+  description: string,
+  options?: { signatureEmoji?: string; emojiReactionMode?: string }
+): string {
+  const signatureNote = options?.signatureEmoji
+    ? `\nThe agent has a signature emoji: ${options.signatureEmoji}. Include it in the Emoji Usage section as the signature emoji.`
+    : '';
+  const reactionMode = options?.emojiReactionMode ?? 'minimal';
+
   return `You are helping configure a Claude Code agent for the claude-gateway multi-bot system.
 
 The user described the agent as:
@@ -26,6 +35,15 @@ Rules:
   Include: role, rules, what it can/cannot do, language to use.
   Always include this rule: when a message arrives, send a brief acknowledgement first
   (e.g. "Got it, let me check…" or "On it!"), then do the work and reply with the result.
+  Also include an "## Emoji Usage" section in agent.md with these guidelines:
+    - Text emoji: Use sparingly in messages. Occasional emoji is fine for warmth, but don't overdo it.
+    - Reactions: React to messages like a human would — use the react tool. Max 1 reaction per message.
+      Reaction mode is "${reactionMode}": ${{
+        minimal: 'only react when the message clearly warrants it (e.g. thanks, celebrations, humor).',
+        extensive: 'react to most messages with an appropriate emoji to show engagement.',
+        none: 'do not use emoji reactions at all.',
+      }[reactionMode] ?? 'only react when the message clearly warrants it.'}
+    - Signature emoji: ${options?.signatureEmoji ? `Use ${options.signatureEmoji} as your signature emoji in greetings or sign-offs.` : 'None assigned.'}${signatureNote}
 - soul.md: tone and personality only (not rules). Omit if no distinct style.
 - user.md: target user profile. Omit if public/unknown.
 - tools.md: available tools or capabilities. Omit if none specified.

--- a/scripts/create-agent-prompts.ts
+++ b/scripts/create-agent-prompts.ts
@@ -52,7 +52,8 @@ Rules:
 - heartbeat.md: only if proactive/scheduled tasks were described. Use YAML tasks format.
 - bootstrap.md: only if a special first-run greeting is appropriate.
 - Keep each file under 500 words.
-- Omit files that are not relevant.`;
+- Omit files that are not relevant.
+- IMPORTANT: On the very FIRST line of your output (before any === markers), output a single emoji that best represents this agent's personality or role. Just the emoji alone on line 1, nothing else.`;
 }
 
 /**

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -949,7 +949,9 @@ async function resumeWizard(state: WizardState): Promise<void> {
   clearWizardState();
 }
 
-main().catch((err) => {
-  console.error('\nFatal error:', (err as Error).message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('\nFatal error:', (err as Error).message);
+    process.exit(1);
+  });
+}

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -22,6 +22,7 @@ import { randomBytes } from 'crypto';
 import { spawnSync } from 'child_process';
 import { loadWorkspace } from '../src/workspace-loader';
 import { buildGenerationPrompt, parseGeneratedFiles } from './create-agent-prompts';
+import { loadCleanTemplate, stripIgnoredPaths } from '../src/config-migrator';
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -146,10 +147,21 @@ function loadOrCreateRawConfig(): RawConfig {
     const raw = fs.readFileSync(cp, 'utf8');
     return JSON.parse(raw) as RawConfig;
   }
-  return {
-    gateway: { logDir: '~/.claude-gateway/logs', timezone: 'UTC' },
-    agents: [],
-  };
+
+  // First run: try to load from template
+  const templatePath = path.join(__dirname, '..', 'config.template.json');
+  try {
+    const { template, ignorePaths } = loadCleanTemplate(templatePath);
+    stripIgnoredPaths(template, ignorePaths);
+    template.agents = [];
+    return template as unknown as RawConfig;
+  } catch {
+    // Template missing or unreadable — use hardcoded fallback
+    return {
+      gateway: { logDir: '~/.claude-gateway/logs', timezone: 'UTC' },
+      agents: [],
+    };
+  }
 }
 
 function saveConfig(config: RawConfig): void {

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -22,6 +22,7 @@ import { randomBytes } from 'crypto';
 import { spawnSync } from 'child_process';
 import { loadWorkspace } from '../src/workspace-loader';
 import { buildGenerationPrompt, parseGeneratedFiles } from './create-agent-prompts';
+import { interactiveSelect } from './interactive-select';
 import { loadCleanTemplate, stripIgnoredPaths } from '../src/config-migrator';
 
 // ---------------------------------------------------------------------------
@@ -261,11 +262,29 @@ function fallbackFiles(agentId: string): Map<string, string> {
   return files;
 }
 
+interface GenerateResult {
+  files: Map<string, string>;
+  suggestedEmoji?: string;
+}
+
+// Extract a single emoji from the first line of text (Claude suggests one)
+function extractLeadingEmoji(text: string): { emoji: string | undefined; rest: string } {
+  const firstLine = text.split('\n')[0].trim();
+  // Match a single emoji (including compound emoji with ZWJ, skin tones, etc.)
+  const emojiMatch = firstLine.match(/^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)(\u200D(\p{Emoji_Presentation}|\p{Emoji}\uFE0F))*$/u);
+  if (emojiMatch) {
+    // Remove the emoji line from content
+    const rest = text.slice(text.indexOf('\n') + 1).trim();
+    return { emoji: firstLine, rest };
+  }
+  return { emoji: undefined, rest: text };
+}
+
 async function generateFiles(
   agentId: string,
   description: string,
   options?: { signatureEmoji?: string; emojiReactionMode?: string }
-): Promise<Map<string, string>> {
+): Promise<GenerateResult> {
   const agentName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
   console.log('\nGenerating workspace files with Claude...');
 
@@ -278,16 +297,39 @@ async function generateFiles(
 
   if (result.error || result.status !== 0 || !result.stdout?.trim()) {
     console.log('  Warning: Claude generation failed. Using minimal fallback templates.');
-    return fallbackFiles(agentId);
+    return { files: fallbackFiles(agentId) };
   }
 
-  const parsed = parseGeneratedFiles(result.stdout);
+  // Strip wrapping code fences that Claude sometimes adds
+  let raw = result.stdout.trim();
+  const fenceMatch = raw.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```\s*$/);
+  if (fenceMatch) {
+    raw = fenceMatch[1].trim();
+  }
+
+  // Extract suggested emoji from first line
+  const { emoji: suggestedEmoji, rest } = extractLeadingEmoji(raw);
+  if (suggestedEmoji) {
+    raw = rest;
+  }
+
+  const parsed = parseGeneratedFiles(raw);
   if (!parsed.has('agent.md')) {
+    // Fallback: if Claude output looks like markdown content without markers, use as agent.md
+    const headingIdx = raw.indexOf('# ');
+    if (headingIdx >= 0) {
+      const content = raw.slice(headingIdx).replace(/\n```\s*$/, '').trim();
+      if (content.length > 50) {
+        console.log('  Note: Claude output had no section markers — treating as agent.md');
+        parsed.set('agent.md', content);
+        return { files: parsed, suggestedEmoji };
+      }
+    }
     console.log('  Warning: agent.md not found in Claude output. Using minimal fallback templates.');
-    return fallbackFiles(agentId);
+    return { files: fallbackFiles(agentId) };
   }
 
-  return parsed;
+  return { files: parsed, suggestedEmoji };
 }
 
 // ---------------------------------------------------------------------------
@@ -814,21 +856,41 @@ async function main(): Promise<void> {
   const agentId = await promptAgentName(rl, existingIds);
   const agentName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
 
-  // Prompt for optional signature emoji
-  const signatureEmojiInput = await prompt(
-    rl,
-    '\nSignature emoji for this agent (optional, press Enter to skip): '
-  );
-  const signatureEmoji = signatureEmojiInput.trim() || undefined;
-
   const state: WizardState = { agentId, agentName, lastCompletedStep: 1 };
   saveWizardState(state);
 
   // ── Step 2 ──────────────────────────────────────────────────────────────
   console.log('\nStep 2/6 · Describe Your Agent\n');
   const description = await promptDescription(rl);
-  const generatedFiles = await generateFiles(agentId, description, { signatureEmoji });
-  const acceptedFiles = await previewAndAccept(rl, generatedFiles);
+  rl.close(); // close rl before interactiveSelect (uses raw stdin)
+
+  const { files: generatedFiles, suggestedEmoji } = await generateFiles(agentId, description);
+
+  // ── Emoji selection (after generation) ────────────────────────────────
+  // interactiveSelect pauses stdin — resume before creating new readline
+  process.stdin.resume();
+
+  const defaultEmoji = suggestedEmoji || '🤖';
+  console.log(`\n  Suggested signature emoji: ${defaultEmoji}`);
+  const rl2 = createRl();
+  const emojiInput = await prompt(
+    rl2,
+    `Signature emoji [${defaultEmoji}] (press Enter to accept, or type a new one): `
+  );
+  const signatureEmoji = emojiInput.trim() || defaultEmoji;
+  console.log(`  ✓ Signature emoji: ${signatureEmoji}`);
+  rl2.close();
+
+  // ── Reaction mode selection ───────────────────────────────────────────
+  const reactionModes = ['minimal — react only when clearly warranted', 'extensive — react to most messages', 'none — no emoji reactions'];
+  const modeIdx = await interactiveSelect(reactionModes, 'Select emoji reaction mode (↑/↓ to move, Enter to select):');
+  const emojiReactionMode = (['minimal', 'extensive', 'none'] as const)[modeIdx];
+  console.log(`  ✓ Reaction mode: ${emojiReactionMode}`);
+
+  // Resume stdin + new readline for file preview
+  process.stdin.resume();
+  const rl3 = createRl();
+  const acceptedFiles = await previewAndAccept(rl3, generatedFiles);
 
   if (!acceptedFiles.has('agent.md')) {
     const fallback = fallbackFiles(agentId);
@@ -841,7 +903,7 @@ async function main(): Promise<void> {
   console.log('\nStep 3/6 · Create Workspace\n');
   const wsDir = await createWorkspace(agentId, acceptedFiles);
   await appendToConfig(agentId, wsDir, acceptedFiles.get('agent.md')!, {
-    emojiReactionMode: 'minimal',
+    emojiReactionMode,
     signatureEmoji,
   });
   state.wsDir = wsDir;
@@ -859,14 +921,14 @@ async function main(): Promise<void> {
   console.log('       123456789:AAHfiqksKZ8WmHPDKxxxxxxxxxxxxxxxx');
   console.log('     Copy the entire token.\n');
 
-  const { token, username: botUsername } = await promptBotToken(rl, agentId);
+  const { token, username: botUsername } = await promptBotToken(rl3, agentId);
   state.token = token;
   state.botUsername = botUsername;
   state.lastCompletedStep = 4;
   saveWizardState(state);
 
   // ── Step 5 ──────────────────────────────────────────────────────────────
-  rl.close();
+  rl3.close();
 
   console.log('\nStep 5/6 · Pair Your Telegram Account\n');
   console.log('The wizard will detect your message and approve pairing automatically.\n');
@@ -893,7 +955,7 @@ async function resumeWizard(state: WizardState): Promise<void> {
     // Need to redo step 2 — files not yet created
     console.log('Step 2/6 · Describe Your Agent\n');
     const description = await promptDescription(rl);
-    const generatedFiles = await generateFiles(agentId, description);
+    const { files: generatedFiles } = await generateFiles(agentId, description);
     const acceptedFiles = await previewAndAccept(rl, generatedFiles);
     if (!acceptedFiles.has('agent.md')) {
       acceptedFiles.set('agent.md', fallbackFiles(agentId).get('agent.md')!);

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -136,6 +136,8 @@ interface RawAgentEntry {
     dangerouslySkipPermissions: boolean;
     extraFlags: string[];
   };
+  emojiReactionMode?: 'minimal' | 'extensive' | 'none';
+  signatureEmoji?: string;
 }
 
 function loadOrCreateRawConfig(): RawConfig {
@@ -247,11 +249,15 @@ function fallbackFiles(agentId: string): Map<string, string> {
   return files;
 }
 
-async function generateFiles(agentId: string, description: string): Promise<Map<string, string>> {
+async function generateFiles(
+  agentId: string,
+  description: string,
+  options?: { signatureEmoji?: string; emojiReactionMode?: string }
+): Promise<Map<string, string>> {
   const agentName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
   console.log('\nGenerating workspace files with Claude...');
 
-  const genPrompt = buildGenerationPrompt(agentName, description);
+  const genPrompt = buildGenerationPrompt(agentName, description, options);
   const result = spawnSync('claude', ['--print'], {
     input: genPrompt,
     encoding: 'utf8',
@@ -380,7 +386,8 @@ export async function createWorkspace(agentId: string, files: Map<string, string
 export async function appendToConfig(
   agentId: string,
   wsDir: string,
-  agentMdContent: string
+  agentMdContent: string,
+  options?: { emojiReactionMode?: 'minimal' | 'extensive' | 'none'; signatureEmoji?: string }
 ): Promise<void> {
   console.log('Updating config.json...');
 
@@ -406,6 +413,13 @@ export async function appendToConfig(
       extraFlags: [],
     },
   };
+
+  if (options?.emojiReactionMode) {
+    newAgent.emojiReactionMode = options.emojiReactionMode;
+  }
+  if (options?.signatureEmoji) {
+    newAgent.signatureEmoji = options.signatureEmoji;
+  }
 
   config.agents.push(newAgent);
   saveConfig(config);
@@ -787,13 +801,21 @@ async function main(): Promise<void> {
   console.log('Step 1/6 · Agent Name\n');
   const agentId = await promptAgentName(rl, existingIds);
   const agentName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
+
+  // Prompt for optional signature emoji
+  const signatureEmojiInput = await prompt(
+    rl,
+    '\nSignature emoji for this agent (optional, press Enter to skip): '
+  );
+  const signatureEmoji = signatureEmojiInput.trim() || undefined;
+
   const state: WizardState = { agentId, agentName, lastCompletedStep: 1 };
   saveWizardState(state);
 
   // ── Step 2 ──────────────────────────────────────────────────────────────
   console.log('\nStep 2/6 · Describe Your Agent\n');
   const description = await promptDescription(rl);
-  const generatedFiles = await generateFiles(agentId, description);
+  const generatedFiles = await generateFiles(agentId, description, { signatureEmoji });
   const acceptedFiles = await previewAndAccept(rl, generatedFiles);
 
   if (!acceptedFiles.has('agent.md')) {
@@ -806,7 +828,10 @@ async function main(): Promise<void> {
   // ── Step 3 ──────────────────────────────────────────────────────────────
   console.log('\nStep 3/6 · Create Workspace\n');
   const wsDir = await createWorkspace(agentId, acceptedFiles);
-  await appendToConfig(agentId, wsDir, acceptedFiles.get('agent.md')!);
+  await appendToConfig(agentId, wsDir, acceptedFiles.get('agent.md')!, {
+    emojiReactionMode: 'minimal',
+    signatureEmoji,
+  });
   state.wsDir = wsDir;
   state.lastCompletedStep = 3;
   saveWizardState(state);

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -279,7 +279,7 @@ async function generateFiles(agentId: string, description: string): Promise<Map<
 const OPTIONAL_FILES = new Set(['soul.md', 'user.md', 'tools.md', 'heartbeat.md', 'bootstrap.md']);
 const SEPARATOR_WIDTH = 42;
 
-function printFilePreview(filename: string, content: string): void {
+export function printFilePreview(filename: string, content: string): void {
   const label = `─── ${filename} `;
   const padding = Math.max(0, SEPARATOR_WIDTH - label.length);
   console.log('\n' + label + '─'.repeat(padding));

--- a/scripts/interactive-select.ts
+++ b/scripts/interactive-select.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared interactive select component for CLI wizards.
+ * Uses arrow keys / j/k to navigate, Enter to confirm, Ctrl+C to cancel.
+ * Renders with reverse video highlight and hides cursor during selection.
+ */
+
+export function interactiveSelect(items: string[], label: string): Promise<number> {
+  return new Promise((resolve) => {
+    let selected = 0;
+    const { stdin, stdout } = process;
+
+    // Pad item text to fixed width for consistent highlight bar
+    const maxLen = Math.max(...items.map((s) => s.length));
+
+    function renderItem(i: number): string {
+      const text = `    ${items[i]}`.padEnd(maxLen + 6);
+      if (i === selected) {
+        // Reverse video — uses terminal's default colors
+        return `\x1b[7m${text}\x1b[0m`;
+      }
+      return text;
+    }
+
+    // Total lines drawn: 1 (label) + 1 (blank) + items.length
+    const totalLines = items.length + 2;
+
+    function render(): void {
+      // Move cursor up to redraw list only (not label)
+      stdout.write(`\x1b[${items.length}A`);
+      for (let i = 0; i < items.length; i++) {
+        stdout.write(`\x1b[2K${renderItem(i)}\n`);
+      }
+    }
+
+    // Hide cursor during selection
+    stdout.write('\x1b[?25l');
+
+    // Initial render: label + blank line + items
+    stdout.write(`${label}\n\n`);
+    for (let i = 0; i < items.length; i++) {
+      stdout.write(`${renderItem(i)}\n`);
+    }
+
+    if (!stdin.isTTY) {
+      resolve(0);
+      return;
+    }
+
+    const wasRaw = stdin.isRaw;
+    stdin.setRawMode(true);
+    stdin.resume();
+
+    function onData(key: Buffer): void {
+      const s = key.toString();
+
+      if (s === '\x1b[A' || s === 'k') {
+        // Up arrow or k
+        selected = (selected - 1 + items.length) % items.length;
+        render();
+      } else if (s === '\x1b[B' || s === 'j') {
+        // Down arrow or j
+        selected = (selected + 1) % items.length;
+        render();
+      } else if (s === '\r' || s === '\n') {
+        // Enter
+        cleanup();
+        resolve(selected);
+      } else if (s === '\x03') {
+        // Ctrl+C
+        cleanup();
+        process.exit(0);
+      }
+    }
+
+    function cleanup(): void {
+      stdin.removeListener('data', onData);
+      stdin.setRawMode(wasRaw ?? false);
+      stdin.pause();
+      // Clear select UI (move up past all lines and clear each)
+      stdout.write(`\x1b[${totalLines}A`);
+      for (let i = 0; i < totalLines; i++) {
+        stdout.write('\x1b[2K\n');
+      }
+      stdout.write(`\x1b[${totalLines}A`);
+      // Restore cursor visibility
+      stdout.write('\x1b[?25h');
+    }
+
+    stdin.on('data', onData);
+  });
+}

--- a/scripts/update-agent.ts
+++ b/scripts/update-agent.ts
@@ -1,0 +1,266 @@
+/**
+ * update-agent: CLI to update an existing agent's agent.md with Claude.
+ *
+ * Steps:
+ *  1. Select agent from config.json
+ *  2. Claude reads current agent.md and generates updated version
+ *  3. Show preview of new content
+ *  4. User confirms: y (save), edit (open editor), n (cancel)
+ *  5. Save agent.md + regenerate CLAUDE.md
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as readline from 'readline';
+import { spawnSync } from 'child_process';
+import { loadWorkspace } from '../src/workspace-loader';
+import { buildUpdatePrompt } from './create-agent-prompts';
+import { expandHome, printFilePreview } from './create-agent';
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+function gatewayDir(): string {
+  return path.join(os.homedir(), '.claude-gateway');
+}
+
+function configPath(): string {
+  const envPath = process.env['GATEWAY_CONFIG'];
+  if (envPath) return expandHome(envPath);
+  return path.join(gatewayDir(), 'config.json');
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+interface RawAgentEntry {
+  id: string;
+  workspace: string;
+}
+
+interface RawConfig {
+  agents: RawAgentEntry[];
+}
+
+function loadConfig(): RawConfig {
+  const cp = configPath();
+  if (!fs.existsSync(cp)) {
+    console.error(`Config not found: ${cp}`);
+    process.exit(1);
+  }
+  return JSON.parse(fs.readFileSync(cp, 'utf8')) as RawConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Readline helpers
+// ---------------------------------------------------------------------------
+
+function createRl(): readline.Interface {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+  });
+}
+
+async function prompt(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      resolve(answer);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Select agent
+// ---------------------------------------------------------------------------
+
+async function selectAgent(rl: readline.Interface): Promise<{ agentId: string; wsDir: string }> {
+  const config = loadConfig();
+  const agents = config.agents;
+
+  if (agents.length === 0) {
+    console.error('No agents found in config.json. Run "make create-agent" first.');
+    process.exit(1);
+  }
+
+  if (agents.length === 1) {
+    const agent = agents[0];
+    const wsDir = expandHome(agent.workspace);
+    console.log(`Using agent: ${agent.id}`);
+    return { agentId: agent.id, wsDir };
+  }
+
+  // Multiple agents — show numbered list
+  console.log('Select an agent:\n');
+  agents.forEach((a, i) => {
+    console.log(`  ${i + 1}. ${a.id}`);
+  });
+  console.log('');
+
+  while (true) {
+    const answer = await prompt(rl, `Enter number (1-${agents.length}): `);
+    const num = parseInt(answer.trim(), 10);
+    if (num >= 1 && num <= agents.length) {
+      const agent = agents[num - 1];
+      const wsDir = expandHome(agent.workspace);
+      return { agentId: agent.id, wsDir };
+    }
+    console.log(`  Please enter a number between 1 and ${agents.length}.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Generate updated agent.md
+// ---------------------------------------------------------------------------
+
+function generateUpdatedAgent(agentId: string, currentContent: string): string | null {
+  const agentName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
+  console.log('\nGenerating updated agent.md with Claude...');
+
+  const updatePrompt = buildUpdatePrompt(agentName, currentContent);
+  const result = spawnSync('claude', ['--print'], {
+    input: updatePrompt,
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+
+  if (result.error || result.status !== 0 || !result.stdout?.trim()) {
+    console.error('  Error: Claude generation failed.');
+    if (result.stderr) console.error(result.stderr);
+    return null;
+  }
+
+  return result.stdout.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — Confirm loop (returns final content or null if cancelled)
+// ---------------------------------------------------------------------------
+
+async function confirmAndSave(
+  rl: readline.Interface,
+  agentMdPath: string,
+  initialContent: string
+): Promise<string | null> {
+  let currentContent = initialContent;
+
+  while (true) {
+    const answer = await prompt(rl, 'Accept? (y/edit/n) [y]: ');
+    const choice = answer.trim().toLowerCase() || 'y';
+
+    if (choice === 'y' || choice === 'yes') {
+      return currentContent;
+    } else if (choice === 'n' || choice === 'no') {
+      console.log('  Cancelled. No changes made.');
+      return null;
+    } else if (choice === 'edit') {
+      const tmpFile = path.join(os.tmpdir(), `claude-gateway-agent.md`);
+      fs.writeFileSync(tmpFile, currentContent, 'utf8');
+
+      const editorCandidates = [
+        process.env['VISUAL'],
+        process.env['EDITOR'],
+        'vim',
+        'vi',
+        'nano',
+      ].filter(Boolean) as string[];
+
+      let editResult: ReturnType<typeof spawnSync> | null = null;
+      let usedEditor = '';
+      for (const candidate of editorCandidates) {
+        const result = spawnSync(candidate, [tmpFile], { stdio: 'inherit' });
+        if (!result.error) {
+          editResult = result;
+          usedEditor = candidate;
+          break;
+        }
+      }
+
+      if (!editResult) {
+        console.log(
+          '  Could not open any editor (tried: ' +
+            editorCandidates.join(', ') +
+            ').\n  Set $EDITOR and try again, or choose y/n.'
+        );
+        if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+      } else {
+        const edited = fs.readFileSync(tmpFile, 'utf8');
+        fs.unlinkSync(tmpFile);
+        currentContent = edited;
+        printFilePreview('agent.md', currentContent);
+        console.log(`  (edited with ${usedEditor})`);
+      }
+    } else {
+      console.log('  Please enter y, edit, or n.');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log('═══════════════════════════════════════');
+  console.log('  Claude Gateway — Update Agent');
+  console.log('═══════════════════════════════════════\n');
+
+  const rl = createRl();
+
+  // Step 1 — Select agent
+  const { agentId, wsDir } = await selectAgent(rl);
+
+  // Check agent.md exists
+  const agentMdPath = path.join(wsDir, 'agent.md');
+  if (!fs.existsSync(agentMdPath)) {
+    console.error(`  Error: agent.md not found at ${agentMdPath}`);
+    rl.close();
+    process.exit(1);
+  }
+
+  const currentContent = fs.readFileSync(agentMdPath, 'utf8');
+
+  // Step 2 — Generate
+  const newContent = generateUpdatedAgent(agentId, currentContent);
+  if (!newContent) {
+    rl.close();
+    process.exit(1);
+  }
+
+  // Step 3 — Preview
+  printFilePreview('agent.md', newContent);
+  console.log('\n  Warning: this will overwrite the existing agent.md');
+
+  // Step 4 — Confirm
+  const finalContent = await confirmAndSave(rl, agentMdPath, newContent);
+  rl.close();
+
+  if (finalContent === null) {
+    process.exit(0);
+  }
+
+  // Step 5 — Save
+  fs.writeFileSync(agentMdPath, finalContent + '\n', 'utf8');
+  console.log('  ✓ agent.md saved');
+
+  // Regenerate CLAUDE.md
+  try {
+    const loaded = await loadWorkspace(wsDir);
+    const claudeMdPath = path.join(wsDir, 'CLAUDE.md');
+    fs.writeFileSync(claudeMdPath, loaded.systemPrompt, 'utf8');
+    console.log('  ✓ CLAUDE.md regenerated');
+  } catch (err) {
+    console.error(`  Warning: Could not regenerate CLAUDE.md: ${(err as Error).message}`);
+  }
+
+  console.log('\nDone! Restart the gateway to apply changes.');
+}
+
+main().catch((err) => {
+  console.error('\nFatal error:', (err as Error).message);
+  process.exit(1);
+});

--- a/scripts/update-agent.ts
+++ b/scripts/update-agent.ts
@@ -78,7 +78,93 @@ async function prompt(rl: readline.Interface, question: string): Promise<string>
 // Step 1 — Select agent
 // ---------------------------------------------------------------------------
 
-async function selectAgent(rl: readline.Interface): Promise<{ agentId: string; wsDir: string }> {
+function interactiveSelect(items: string[], label: string): Promise<number> {
+  return new Promise((resolve) => {
+    let selected = 0;
+    const { stdin, stdout } = process;
+
+    // Pad item text to fixed width for consistent highlight bar
+    const maxLen = Math.max(...items.map((s) => s.length));
+
+    function renderItem(i: number): string {
+      const text = `    ${items[i]}`.padEnd(maxLen + 6);
+      if (i === selected) {
+        // Reverse video — uses terminal's default colors
+        return `\x1b[7m${text}\x1b[0m`;
+      }
+      return text;
+    }
+
+    // Total lines drawn: 1 (label) + 1 (blank) + items.length
+    const totalLines = items.length + 2;
+
+    function render(): void {
+      // Move cursor up to redraw list only (not label)
+      stdout.write(`\x1b[${items.length}A`);
+      for (let i = 0; i < items.length; i++) {
+        stdout.write(`\x1b[2K${renderItem(i)}\n`);
+      }
+    }
+
+    // Hide cursor during selection
+    stdout.write('\x1b[?25l');
+
+    // Initial render: label + blank line + items
+    stdout.write(`${label}\n\n`);
+    for (let i = 0; i < items.length; i++) {
+      stdout.write(`${renderItem(i)}\n`);
+    }
+
+    if (!stdin.isTTY) {
+      resolve(0);
+      return;
+    }
+
+    const wasRaw = stdin.isRaw;
+    stdin.setRawMode(true);
+    stdin.resume();
+
+    function onData(key: Buffer): void {
+      const s = key.toString();
+
+      if (s === '\x1b[A' || s === 'k') {
+        // Up arrow or k
+        selected = (selected - 1 + items.length) % items.length;
+        render();
+      } else if (s === '\x1b[B' || s === 'j') {
+        // Down arrow or j
+        selected = (selected + 1) % items.length;
+        render();
+      } else if (s === '\r' || s === '\n') {
+        // Enter
+        cleanup();
+        resolve(selected);
+      } else if (s === '\x03') {
+        // Ctrl+C
+        cleanup();
+        process.exit(0);
+      }
+    }
+
+    function cleanup(): void {
+      stdin.removeListener('data', onData);
+      stdin.setRawMode(wasRaw ?? false);
+      stdin.pause();
+      // Clear select UI (move up past all lines and clear each)
+      stdout.write(`\x1b[${totalLines}A`);
+      for (let i = 0; i < totalLines; i++) {
+        stdout.write('\x1b[2K\n');
+      }
+      stdout.write(`\x1b[${totalLines}A`);
+      // Restore cursor visibility
+      stdout.write('\x1b[?25h');
+    }
+
+    stdin.on('data', onData);
+  });
+}
+
+async function selectAgent(): Promise<{ agentId: string; wsDir: string }> {
   const config = loadConfig();
   const agents = config.agents;
 
@@ -87,30 +173,12 @@ async function selectAgent(rl: readline.Interface): Promise<{ agentId: string; w
     process.exit(1);
   }
 
-  if (agents.length === 1) {
-    const agent = agents[0];
-    const wsDir = expandHome(agent.workspace);
-    console.log(`Using agent: ${agent.id}`);
-    return { agentId: agent.id, wsDir };
-  }
-
-  // Multiple agents — show numbered list
-  console.log('Select an agent:\n');
-  agents.forEach((a, i) => {
-    console.log(`  ${i + 1}. ${a.id}`);
-  });
-  console.log('');
-
-  while (true) {
-    const answer = await prompt(rl, `Enter number (1-${agents.length}): `);
-    const num = parseInt(answer.trim(), 10);
-    if (num >= 1 && num <= agents.length) {
-      const agent = agents[num - 1];
-      const wsDir = expandHome(agent.workspace);
-      return { agentId: agent.id, wsDir };
-    }
-    console.log(`  Please enter a number between 1 and ${agents.length}.`);
-  }
+  const items = agents.map((a) => a.id);
+  const selected = await interactiveSelect(items, 'Select an agent (↑/↓ to move, Enter to select):');
+  const agent = agents[selected];
+  const wsDir = expandHome(agent.workspace);
+  console.log(`\n  Selected: ${agent.id}\n`);
+  return { agentId: agent.id, wsDir };
 }
 
 // ---------------------------------------------------------------------------
@@ -134,7 +202,17 @@ function generateUpdatedAgent(agentId: string, currentContent: string): string |
     return null;
   }
 
-  return result.stdout.trim();
+  // Claude should output only the agent.md content (no markers).
+  // Strip any accidental preamble by finding the first markdown structure.
+  const raw = result.stdout.trim();
+  const yamlStart = raw.indexOf('---\n');
+  const headingStart = raw.indexOf('# ');
+  const start = yamlStart >= 0 ? yamlStart : headingStart;
+  if (start < 0) {
+    console.error('  Error: Could not parse agent.md from Claude output.');
+    return null;
+  }
+  return raw.slice(start).trim();
 }
 
 // ---------------------------------------------------------------------------
@@ -209,10 +287,12 @@ async function main(): Promise<void> {
   console.log('  Claude Gateway — Update Agent');
   console.log('═══════════════════════════════════════\n');
 
-  const rl = createRl();
+  // Step 1 — Select agent (before creating readline — interactiveSelect uses raw stdin)
+  const { agentId, wsDir } = await selectAgent();
 
-  // Step 1 — Select agent
-  const { agentId, wsDir } = await selectAgent(rl);
+  // interactiveSelect pauses stdin in cleanup — resume it so readline can read
+  process.stdin.resume();
+  const rl = createRl();
 
   // Check agent.md exists
   const agentMdPath = path.join(wsDir, 'agent.md');

--- a/scripts/update-agent.ts
+++ b/scripts/update-agent.ts
@@ -17,6 +17,7 @@ import { spawnSync } from 'child_process';
 import { loadWorkspace } from '../src/workspace-loader';
 import { buildUpdatePrompt } from './create-agent-prompts';
 import { expandHome, printFilePreview } from './create-agent';
+import { interactiveSelect } from './interactive-select';
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -39,10 +40,14 @@ function configPath(): string {
 interface RawAgentEntry {
   id: string;
   workspace: string;
+  signatureEmoji?: string;
+  emojiReactionMode?: 'minimal' | 'extensive' | 'none';
+  [key: string]: unknown;
 }
 
 interface RawConfig {
   agents: RawAgentEntry[];
+  [key: string]: unknown;
 }
 
 function loadConfig(): RawConfig {
@@ -78,93 +83,7 @@ async function prompt(rl: readline.Interface, question: string): Promise<string>
 // Step 1 — Select agent
 // ---------------------------------------------------------------------------
 
-function interactiveSelect(items: string[], label: string): Promise<number> {
-  return new Promise((resolve) => {
-    let selected = 0;
-    const { stdin, stdout } = process;
-
-    // Pad item text to fixed width for consistent highlight bar
-    const maxLen = Math.max(...items.map((s) => s.length));
-
-    function renderItem(i: number): string {
-      const text = `    ${items[i]}`.padEnd(maxLen + 6);
-      if (i === selected) {
-        // Reverse video — uses terminal's default colors
-        return `\x1b[7m${text}\x1b[0m`;
-      }
-      return text;
-    }
-
-    // Total lines drawn: 1 (label) + 1 (blank) + items.length
-    const totalLines = items.length + 2;
-
-    function render(): void {
-      // Move cursor up to redraw list only (not label)
-      stdout.write(`\x1b[${items.length}A`);
-      for (let i = 0; i < items.length; i++) {
-        stdout.write(`\x1b[2K${renderItem(i)}\n`);
-      }
-    }
-
-    // Hide cursor during selection
-    stdout.write('\x1b[?25l');
-
-    // Initial render: label + blank line + items
-    stdout.write(`${label}\n\n`);
-    for (let i = 0; i < items.length; i++) {
-      stdout.write(`${renderItem(i)}\n`);
-    }
-
-    if (!stdin.isTTY) {
-      resolve(0);
-      return;
-    }
-
-    const wasRaw = stdin.isRaw;
-    stdin.setRawMode(true);
-    stdin.resume();
-
-    function onData(key: Buffer): void {
-      const s = key.toString();
-
-      if (s === '\x1b[A' || s === 'k') {
-        // Up arrow or k
-        selected = (selected - 1 + items.length) % items.length;
-        render();
-      } else if (s === '\x1b[B' || s === 'j') {
-        // Down arrow or j
-        selected = (selected + 1) % items.length;
-        render();
-      } else if (s === '\r' || s === '\n') {
-        // Enter
-        cleanup();
-        resolve(selected);
-      } else if (s === '\x03') {
-        // Ctrl+C
-        cleanup();
-        process.exit(0);
-      }
-    }
-
-    function cleanup(): void {
-      stdin.removeListener('data', onData);
-      stdin.setRawMode(wasRaw ?? false);
-      stdin.pause();
-      // Clear select UI (move up past all lines and clear each)
-      stdout.write(`\x1b[${totalLines}A`);
-      for (let i = 0; i < totalLines; i++) {
-        stdout.write('\x1b[2K\n');
-      }
-      stdout.write(`\x1b[${totalLines}A`);
-      // Restore cursor visibility
-      stdout.write('\x1b[?25h');
-    }
-
-    stdin.on('data', onData);
-  });
-}
-
-async function selectAgent(): Promise<{ agentId: string; wsDir: string }> {
+async function selectAgent(): Promise<{ agentId: string; wsDir: string; agent: RawAgentEntry; config: RawConfig }> {
   const config = loadConfig();
   const agents = config.agents;
 
@@ -178,7 +97,12 @@ async function selectAgent(): Promise<{ agentId: string; wsDir: string }> {
   const agent = agents[selected];
   const wsDir = expandHome(agent.workspace);
   console.log(`\n  Selected: ${agent.id}\n`);
-  return { agentId: agent.id, wsDir };
+  return { agentId: agent.id, wsDir, agent, config };
+}
+
+function saveConfig(config: RawConfig): void {
+  const cp = configPath();
+  fs.writeFileSync(cp, JSON.stringify(config, null, 2), 'utf8');
 }
 
 // ---------------------------------------------------------------------------
@@ -204,7 +128,14 @@ function generateUpdatedAgent(agentId: string, currentContent: string): string |
 
   // Claude should output only the agent.md content (no markers).
   // Strip any accidental preamble by finding the first markdown structure.
-  const raw = result.stdout.trim();
+  let raw = result.stdout.trim();
+
+  // Strip wrapping code fences (```markdown ... ``` or ``` ... ```)
+  const fenceMatch = raw.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```\s*$/);
+  if (fenceMatch) {
+    raw = fenceMatch[1].trim();
+  }
+
   const yamlStart = raw.indexOf('---\n');
   const headingStart = raw.indexOf('# ');
   const start = yamlStart >= 0 ? yamlStart : headingStart;
@@ -212,7 +143,8 @@ function generateUpdatedAgent(agentId: string, currentContent: string): string |
     console.error('  Error: Could not parse agent.md from Claude output.');
     return null;
   }
-  return raw.slice(start).trim();
+  // Also strip any trailing code fence that wasn't caught above
+  return raw.slice(start).replace(/\n```\s*$/, '').trim();
 }
 
 // ---------------------------------------------------------------------------
@@ -288,7 +220,7 @@ async function main(): Promise<void> {
   console.log('═══════════════════════════════════════\n');
 
   // Step 1 — Select agent (before creating readline — interactiveSelect uses raw stdin)
-  const { agentId, wsDir } = await selectAgent();
+  const { agentId, wsDir, agent, config } = await selectAgent();
 
   // interactiveSelect pauses stdin in cleanup — resume it so readline can read
   process.stdin.resume();
@@ -323,9 +255,65 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // Step 5 — Save
+  // Step 5 — Save agent.md
   fs.writeFileSync(agentMdPath, finalContent + '\n', 'utf8');
   console.log('  ✓ agent.md saved');
+
+  // Step 6 — Signature emoji
+  const currentEmoji = agent.signatureEmoji;
+  let signatureEmoji: string | undefined = currentEmoji;
+
+  if (!currentEmoji) {
+    // No emoji yet — ask Claude to suggest one
+    console.log('\n  No signature emoji set. Generating suggestion...');
+    const emojiResult = spawnSync('claude', ['--print'], {
+      input: `Based on this agent description, suggest a single emoji that best represents the agent's personality or role. Output ONLY the emoji, nothing else.\n\n${finalContent.slice(0, 500)}`,
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    const suggested = emojiResult.stdout?.trim() || '🤖';
+    // Take only first emoji-like character(s)
+    const defaultEmoji = suggested.length <= 8 ? suggested : '🤖';
+
+    process.stdin.resume();
+    const rlEmoji = createRl();
+    const emojiInput = await prompt(
+      rlEmoji,
+      `  Signature emoji [${defaultEmoji}] (Enter to accept, or type a new one): `
+    );
+    signatureEmoji = emojiInput.trim() || defaultEmoji;
+    rlEmoji.close();
+    console.log(`  ✓ Signature emoji: ${signatureEmoji}`);
+  } else {
+    console.log(`\n  Current signature emoji: ${currentEmoji}`);
+    process.stdin.resume();
+    const rlEmoji = createRl();
+    const emojiInput = await prompt(
+      rlEmoji,
+      `  Change emoji? [${currentEmoji}] (Enter to keep, or type a new one): `
+    );
+    if (emojiInput.trim()) {
+      signatureEmoji = emojiInput.trim();
+    }
+    rlEmoji.close();
+    console.log(`  ✓ Signature emoji: ${signatureEmoji}`);
+  }
+
+  // Step 7 — Reaction mode
+  const reactionModes = ['minimal — react only when clearly warranted', 'extensive — react to most messages', 'none — no emoji reactions'];
+  const modeKeys = ['minimal', 'extensive', 'none'] as const;
+  const currentModeIdx = modeKeys.indexOf((agent.emojiReactionMode ?? 'minimal') as typeof modeKeys[number]);
+  console.log(`\n  Current reaction mode: ${agent.emojiReactionMode ?? 'minimal'}`);
+
+  const modeIdx = await interactiveSelect(reactionModes, 'Select emoji reaction mode (↑/↓ to move, Enter to select):');
+  const emojiReactionMode = modeKeys[modeIdx];
+  console.log(`  ✓ Reaction mode: ${emojiReactionMode}`);
+
+  // Save emoji + reaction mode to config.json
+  agent.signatureEmoji = signatureEmoji;
+  agent.emojiReactionMode = emojiReactionMode;
+  saveConfig(config);
+  console.log('  ✓ config.json updated');
 
   // Regenerate CLAUDE.md
   try {

--- a/src/config-migrator.ts
+++ b/src/config-migrator.ts
@@ -161,7 +161,7 @@ export function stripIgnoredPaths(
 export function detectMigration(
   configPath: string,
   templatePath: string,
-  currentVersion: string,
+  templateVersion: string,
 ): DetectMigrationResult {
   const noMigration = (
     config: Record<string, unknown>,
@@ -170,7 +170,7 @@ export function detectMigration(
   ): DetectMigrationResult => ({
     needed: false,
     fromVersion,
-    toVersion: currentVersion,
+    toVersion: templateVersion,
     addedFields: [],
     config,
     template,
@@ -201,7 +201,7 @@ export function detectMigration(
 
   // Version check
   const configVersion = (config.configVersion as string) ?? '0.0.0';
-  if (compareSemver(configVersion, currentVersion) >= 0) {
+  if (compareSemver(configVersion, templateVersion) >= 0) {
     return noMigration(config, template, configVersion);
   }
 
@@ -232,7 +232,7 @@ export function detectMigration(
   return {
     needed: true,
     fromVersion: configVersion,
-    toVersion: currentVersion,
+    toVersion: templateVersion,
     addedFields: added,
     config,
     template,
@@ -247,7 +247,7 @@ export function applyMigration(
   configPath: string,
   config: Record<string, unknown>,
   template: Record<string, unknown>,
-  currentVersion: string,
+  templateVersion: string,
   ignorePaths?: Set<string>,
 ): MigrationResult {
   const added: string[] = [];
@@ -268,7 +268,7 @@ export function applyMigration(
   }
 
   // Update configVersion
-  config.configVersion = currentVersion;
+  config.configVersion = templateVersion;
   if (!added.includes('configVersion')) {
     added.push('configVersion');
   }
@@ -294,9 +294,9 @@ export function applyMigration(
 export function migrateConfig(
   configPath: string,
   templatePath: string,
-  currentVersion: string,
+  templateVersion: string,
 ): MigrationResult {
-  const detection = detectMigration(configPath, templatePath, currentVersion);
+  const detection = detectMigration(configPath, templatePath, templateVersion);
 
   if (!detection.needed) {
     return { migrated: false, addedFields: [] };
@@ -315,7 +315,7 @@ export function migrateConfig(
     configPath,
     detection.config,
     detection.template,
-    currentVersion,
+    templateVersion,
     ignorePaths,
   );
 }

--- a/src/config-migrator.ts
+++ b/src/config-migrator.ts
@@ -6,18 +6,40 @@ export interface MigrationResult {
   addedFields: string[];
 }
 
+export interface DetectMigrationResult {
+  needed: boolean;
+  fromVersion: string;
+  toVersion: string;
+  addedFields: string[];
+  config: Record<string, unknown>;
+  template: Record<string, unknown>;
+}
+
+export interface CleanTemplateResult {
+  template: Record<string, unknown>;
+  ignorePaths: Set<string>;
+}
+
 /**
  * Deep-merge template into target, adding missing keys only.
  * Never overwrites existing values. Returns list of added field paths.
+ * Keys whose full path is in ignorePaths are skipped entirely.
  */
 function deepMerge(
   target: Record<string, unknown>,
   template: Record<string, unknown>,
   prefix: string,
   added: string[],
+  ignorePaths?: Set<string>,
 ): void {
   for (const key of Object.keys(template)) {
     const fullPath = prefix ? `${prefix}.${key}` : key;
+
+    // Skip paths that are in the ignorePaths set
+    if (ignorePaths && ignorePaths.has(fullPath)) {
+      continue;
+    }
+
     if (!(key in target)) {
       target[key] = structuredClone(template[key]);
       added.push(fullPath);
@@ -34,6 +56,7 @@ function deepMerge(
         template[key] as Record<string, unknown>,
         fullPath,
         added,
+        ignorePaths,
       );
     }
   }
@@ -47,11 +70,12 @@ function mergeAgentArrays(
   userAgents: Array<Record<string, unknown>>,
   templateAgents: Array<Record<string, unknown>>,
   added: string[],
+  ignorePaths?: Set<string>,
 ): void {
   if (templateAgents.length === 0) return;
   const schema = templateAgents[0];
   for (let i = 0; i < userAgents.length; i++) {
-    deepMerge(userAgents[i], schema, `agents[${i}]`, added);
+    deepMerge(userAgents[i], schema, `agents[${i}]`, added, ignorePaths);
   }
 }
 
@@ -72,25 +96,93 @@ function compareSemver(a: string, b: string): number {
 }
 
 /**
- * Migrate config.json by adding missing fields from the template.
- * - Never overwrites existing values
- * - Creates a .bak backup before writing
- * - Skips migration if config file does not exist (first run)
+ * Load a template file, extract the _migration metadata, strip it,
+ * and return the clean template along with the ignorePaths set.
  */
-export function migrateConfig(
+export function loadCleanTemplate(templatePath: string): CleanTemplateResult {
+  if (!fs.existsSync(templatePath)) {
+    throw new Error(`Config template not found at "${templatePath}". Cannot load.`);
+  }
+
+  const templateRaw = fs.readFileSync(templatePath, 'utf-8');
+  const template = JSON.parse(templateRaw) as Record<string, unknown>;
+
+  // Extract ignorePaths from _migration metadata
+  let ignorePaths = new Set<string>();
+  if (
+    template._migration &&
+    typeof template._migration === 'object' &&
+    !Array.isArray(template._migration)
+  ) {
+    const migration = template._migration as Record<string, unknown>;
+    if (Array.isArray(migration.ignorePaths)) {
+      ignorePaths = new Set(
+        (migration.ignorePaths as unknown[]).filter(
+          (p): p is string => typeof p === 'string',
+        ),
+      );
+    }
+  }
+
+  // Strip _migration from the template
+  delete template._migration;
+
+  return { template, ignorePaths };
+}
+
+/**
+ * Recursively delete keys from obj whose full dotted path matches any entry
+ * in ignorePaths. The prefix parameter tracks the current path during recursion.
+ */
+export function stripIgnoredPaths(
+  obj: Record<string, unknown>,
+  ignorePaths: Set<string>,
+  prefix = '',
+): void {
+  for (const key of Object.keys(obj)) {
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+
+    if (ignorePaths.has(fullPath)) {
+      delete obj[key];
+    } else if (
+      typeof obj[key] === 'object' &&
+      obj[key] !== null &&
+      !Array.isArray(obj[key])
+    ) {
+      stripIgnoredPaths(obj[key] as Record<string, unknown>, ignorePaths, fullPath);
+    }
+  }
+}
+
+/**
+ * Detect whether a config migration is needed (dry-run, no writes).
+ * Returns migration metadata including the fields that would be added.
+ */
+export function detectMigration(
   configPath: string,
   templatePath: string,
   currentVersion: string,
-): MigrationResult {
+): DetectMigrationResult {
+  const noMigration = (
+    config: Record<string, unknown>,
+    template: Record<string, unknown>,
+    fromVersion: string,
+  ): DetectMigrationResult => ({
+    needed: false,
+    fromVersion,
+    toVersion: currentVersion,
+    addedFields: [],
+    config,
+    template,
+  });
+
   // Config file missing = first run, create-agent handles it
   if (!fs.existsSync(configPath)) {
-    return { migrated: false, addedFields: [] };
+    return noMigration({}, {}, '0.0.0');
   }
 
-  // Template must exist
-  if (!fs.existsSync(templatePath)) {
-    throw new Error(`Config template not found at "${templatePath}". Cannot migrate.`);
-  }
+  // Template must exist — load and strip _migration
+  const { template, ignorePaths } = loadCleanTemplate(templatePath);
 
   // Read and parse config
   let configRaw: string;
@@ -107,25 +199,63 @@ export function migrateConfig(
     throw new Error(`Config file is not valid JSON: ${(err as Error).message}`);
   }
 
-  // Read template
-  const templateRaw = fs.readFileSync(templatePath, 'utf-8');
-  const template = JSON.parse(templateRaw) as Record<string, unknown>;
-
   // Version check
   const configVersion = (config.configVersion as string) ?? '0.0.0';
   if (compareSemver(configVersion, currentVersion) >= 0) {
-    return { migrated: false, addedFields: [] };
+    return noMigration(config, template, configVersion);
   }
 
-  // Perform migration
+  // Dry-run merge on a clone to detect what would be added
+  const configClone = structuredClone(config);
   const added: string[] = [];
 
   // Deep-merge top-level keys (except agents which need special handling)
   const templateWithoutAgents = { ...template };
   delete templateWithoutAgents.agents;
-  const configWithoutAgents = { ...config };
-  delete configWithoutAgents.agents;
-  deepMerge(config, templateWithoutAgents, '', added);
+  deepMerge(configClone, templateWithoutAgents, '', added, ignorePaths);
+
+  // Merge agent arrays
+  if (Array.isArray(configClone.agents) && Array.isArray(template.agents)) {
+    mergeAgentArrays(
+      configClone.agents as Array<Record<string, unknown>>,
+      template.agents as Array<Record<string, unknown>>,
+      added,
+      ignorePaths,
+    );
+  }
+
+  // configVersion will always be updated
+  if (!added.includes('configVersion')) {
+    added.push('configVersion');
+  }
+
+  return {
+    needed: true,
+    fromVersion: configVersion,
+    toVersion: currentVersion,
+    addedFields: added,
+    config,
+    template,
+  };
+}
+
+/**
+ * Apply a config migration: deep-merge missing fields, update version,
+ * create backup, and write the updated config.
+ */
+export function applyMigration(
+  configPath: string,
+  config: Record<string, unknown>,
+  template: Record<string, unknown>,
+  currentVersion: string,
+  ignorePaths?: Set<string>,
+): MigrationResult {
+  const added: string[] = [];
+
+  // Deep-merge top-level keys (except agents)
+  const templateWithoutAgents = { ...template };
+  delete templateWithoutAgents.agents;
+  deepMerge(config, templateWithoutAgents, '', added, ignorePaths);
 
   // Merge agent arrays
   if (Array.isArray(config.agents) && Array.isArray(template.agents)) {
@@ -133,6 +263,7 @@ export function migrateConfig(
       config.agents as Array<Record<string, unknown>>,
       template.agents as Array<Record<string, unknown>>,
       added,
+      ignorePaths,
     );
   }
 
@@ -152,6 +283,41 @@ export function migrateConfig(
   fs.renameSync(tmpPath, configPath);
 
   return { migrated: true, addedFields: added };
+}
+
+/**
+ * Migrate config.json by adding missing fields from the template.
+ * - Never overwrites existing values
+ * - Creates a .bak backup before writing
+ * - Skips migration if config file does not exist (first run)
+ */
+export function migrateConfig(
+  configPath: string,
+  templatePath: string,
+  currentVersion: string,
+): MigrationResult {
+  const detection = detectMigration(configPath, templatePath, currentVersion);
+
+  if (!detection.needed) {
+    return { migrated: false, addedFields: [] };
+  }
+
+  // Load ignorePaths again for the actual merge
+  let ignorePaths: Set<string> | undefined;
+  try {
+    const clean = loadCleanTemplate(templatePath);
+    ignorePaths = clean.ignorePaths;
+  } catch {
+    // If template can't be loaded again, proceed without ignorePaths
+  }
+
+  return applyMigration(
+    configPath,
+    detection.config,
+    detection.template,
+    currentVersion,
+    ignorePaths,
+  );
 }
 
 // Exported for testing

--- a/src/config-migrator.ts
+++ b/src/config-migrator.ts
@@ -1,0 +1,158 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface MigrationResult {
+  migrated: boolean;
+  addedFields: string[];
+}
+
+/**
+ * Deep-merge template into target, adding missing keys only.
+ * Never overwrites existing values. Returns list of added field paths.
+ */
+function deepMerge(
+  target: Record<string, unknown>,
+  template: Record<string, unknown>,
+  prefix: string,
+  added: string[],
+): void {
+  for (const key of Object.keys(template)) {
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+    if (!(key in target)) {
+      target[key] = structuredClone(template[key]);
+      added.push(fullPath);
+    } else if (
+      typeof target[key] === 'object' &&
+      target[key] !== null &&
+      !Array.isArray(target[key]) &&
+      typeof template[key] === 'object' &&
+      template[key] !== null &&
+      !Array.isArray(template[key])
+    ) {
+      deepMerge(
+        target[key] as Record<string, unknown>,
+        template[key] as Record<string, unknown>,
+        fullPath,
+        added,
+      );
+    }
+  }
+}
+
+/**
+ * Merge missing fields from template agent into each user agent.
+ * Uses the first agent in the template as the schema source.
+ */
+function mergeAgentArrays(
+  userAgents: Array<Record<string, unknown>>,
+  templateAgents: Array<Record<string, unknown>>,
+  added: string[],
+): void {
+  if (templateAgents.length === 0) return;
+  const schema = templateAgents[0];
+  for (let i = 0; i < userAgents.length; i++) {
+    deepMerge(userAgents[i], schema, `agents[${i}]`, added);
+  }
+}
+
+/**
+ * Compare two semver strings. Returns:
+ *  -1 if a < b, 0 if equal, 1 if a > b
+ */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va < vb) return -1;
+    if (va > vb) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Migrate config.json by adding missing fields from the template.
+ * - Never overwrites existing values
+ * - Creates a .bak backup before writing
+ * - Skips migration if config file does not exist (first run)
+ */
+export function migrateConfig(
+  configPath: string,
+  templatePath: string,
+  currentVersion: string,
+): MigrationResult {
+  // Config file missing = first run, create-agent handles it
+  if (!fs.existsSync(configPath)) {
+    return { migrated: false, addedFields: [] };
+  }
+
+  // Template must exist
+  if (!fs.existsSync(templatePath)) {
+    throw new Error(`Config template not found at "${templatePath}". Cannot migrate.`);
+  }
+
+  // Read and parse config
+  let configRaw: string;
+  try {
+    configRaw = fs.readFileSync(configPath, 'utf-8');
+  } catch (err) {
+    throw new Error(`Cannot read config file: ${(err as Error).message}`);
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(configRaw) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(`Config file is not valid JSON: ${(err as Error).message}`);
+  }
+
+  // Read template
+  const templateRaw = fs.readFileSync(templatePath, 'utf-8');
+  const template = JSON.parse(templateRaw) as Record<string, unknown>;
+
+  // Version check
+  const configVersion = (config.configVersion as string) ?? '0.0.0';
+  if (compareSemver(configVersion, currentVersion) >= 0) {
+    return { migrated: false, addedFields: [] };
+  }
+
+  // Perform migration
+  const added: string[] = [];
+
+  // Deep-merge top-level keys (except agents which need special handling)
+  const templateWithoutAgents = { ...template };
+  delete templateWithoutAgents.agents;
+  const configWithoutAgents = { ...config };
+  delete configWithoutAgents.agents;
+  deepMerge(config, templateWithoutAgents, '', added);
+
+  // Merge agent arrays
+  if (Array.isArray(config.agents) && Array.isArray(template.agents)) {
+    mergeAgentArrays(
+      config.agents as Array<Record<string, unknown>>,
+      template.agents as Array<Record<string, unknown>>,
+      added,
+    );
+  }
+
+  // Update configVersion
+  config.configVersion = currentVersion;
+  if (!added.includes('configVersion')) {
+    added.push('configVersion');
+  }
+
+  // Backup before writing
+  const backupPath = configPath + '.bak';
+  fs.copyFileSync(configPath, backupPath);
+
+  // Write atomically via temp file
+  const tmpPath = configPath + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmpPath, configPath);
+
+  return { migrated: true, addedFields: added };
+}
+
+// Exported for testing
+export { compareSemver, deepMerge };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as readline from 'readline';
 
 function expandTilde(p: string): string {
   if (p === '~' || p.startsWith('~/')) {
@@ -9,7 +10,7 @@ function expandTilde(p: string): string {
   return p;
 }
 import { loadConfig } from './config-loader';
-import { migrateConfig } from './config-migrator';
+import { detectMigration, applyMigration, loadCleanTemplate } from './config-migrator';
 import { loadWorkspace, watchWorkspace, markBootstrapComplete } from './workspace-loader';
 import { AgentRunner } from './agent-runner';
 import { CronScheduler } from './cron-scheduler';
@@ -128,9 +129,43 @@ async function main(): Promise<void> {
   const pkgPath = path.join(__dirname, '..', 'package.json');
   const pkgVersion: string = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
   try {
-    const migration = migrateConfig(CONFIG_PATH, templatePath, pkgVersion);
-    if (migration.migrated) {
-      console.log(`[gateway] Config migrated to v${pkgVersion}. Added: ${migration.addedFields.join(', ')}`);
+    const detection = detectMigration(CONFIG_PATH, templatePath, pkgVersion);
+    if (detection.needed) {
+      let shouldMigrate = false;
+
+      if (args['auto-migrate']) {
+        shouldMigrate = true;
+      } else {
+        // Prompt user for confirmation
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        const answer = await new Promise<string>((resolve) => {
+          rl.question(
+            `[gateway] Config migration available (v${detection.fromVersion} -> v${detection.toVersion}). Migrate config? (y/n) [y]: `,
+            (ans) => {
+              rl.close();
+              resolve(ans.trim().toLowerCase());
+            },
+          );
+        });
+        shouldMigrate = answer === '' || answer === 'y' || answer === 'yes';
+      }
+
+      if (shouldMigrate) {
+        const { ignorePaths } = loadCleanTemplate(templatePath);
+        const migration = applyMigration(
+          CONFIG_PATH,
+          detection.config,
+          detection.template,
+          pkgVersion,
+          ignorePaths,
+        );
+        console.log(`[gateway] Config migrated to v${pkgVersion}. Added: ${migration.addedFields.join(', ')}`);
+      } else {
+        console.warn(`[gateway] Config migration skipped by user. Running with current config.`);
+      }
     }
   } catch (err) {
     console.warn(`[gateway] Config migration skipped: ${(err as Error).message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,10 +126,10 @@ async function main(): Promise<void> {
 
   // ── Auto-migrate config (add missing fields from template) ────────────────
   const templatePath = path.join(__dirname, '..', 'config.template.json');
-  const pkgPath = path.join(__dirname, '..', 'package.json');
-  const pkgVersion: string = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+  const templateJson = JSON.parse(fs.readFileSync(templatePath, 'utf-8'));
+  const templateVersion: string = templateJson.configVersion ?? '0.0.0';
   try {
-    const detection = detectMigration(CONFIG_PATH, templatePath, pkgVersion);
+    const detection = detectMigration(CONFIG_PATH, templatePath, templateVersion);
     if (detection.needed) {
       let shouldMigrate = false;
 
@@ -159,10 +159,10 @@ async function main(): Promise<void> {
           CONFIG_PATH,
           detection.config,
           detection.template,
-          pkgVersion,
+          templateVersion,
           ignorePaths,
         );
-        console.log(`[gateway] Config migrated to v${pkgVersion}. Added: ${migration.addedFields.join(', ')}`);
+        console.log(`[gateway] Config migrated to v${templateVersion}. Added: ${migration.addedFields.join(', ')}`);
       } else {
         console.warn(`[gateway] Config migration skipped by user. Running with current config.`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ function expandTilde(p: string): string {
   return p;
 }
 import { loadConfig } from './config-loader';
+import { migrateConfig } from './config-migrator';
 import { loadWorkspace, watchWorkspace, markBootstrapComplete } from './workspace-loader';
 import { AgentRunner } from './agent-runner';
 import { CronScheduler } from './cron-scheduler';
@@ -121,6 +122,19 @@ async function main(): Promise<void> {
   // Load agent .env files before config interpolation so ${TOKEN} vars resolve
   const gatewayAgentsDir = path.join(path.dirname(CONFIG_PATH), 'agents');
   loadAgentEnvFiles(gatewayAgentsDir);
+
+  // ── Auto-migrate config (add missing fields from template) ────────────────
+  const templatePath = path.join(__dirname, '..', 'config.template.json');
+  const pkgPath = path.join(__dirname, '..', 'package.json');
+  const pkgVersion: string = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+  try {
+    const migration = migrateConfig(CONFIG_PATH, templatePath, pkgVersion);
+    if (migration.migrated) {
+      console.log(`[gateway] Config migrated to v${pkgVersion}. Added: ${migration.addedFields.join(', ')}`);
+    }
+  } catch (err) {
+    console.warn(`[gateway] Config migration skipped: ${(err as Error).message}`);
+  }
 
   console.log(`[gateway] Loading config from ${CONFIG_PATH}`);
   const config: GatewayConfig = loadConfig(CONFIG_PATH);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,10 @@ export interface AgentConfig {
   };
   /** Session pool settings */
   session?: SessionConfig;
+  /** Emoji reaction mode for Telegram reactions */
+  emojiReactionMode?: 'minimal' | 'extensive' | 'none';
+  /** Agent's signature emoji (used in greetings/sign-offs) */
+  signatureEmoji?: string;
 }
 
 export interface AgentStats {

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -1,7 +1,15 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { migrateConfig, compareSemver } from '../../src/config-migrator';
+import {
+  migrateConfig,
+  compareSemver,
+  deepMerge,
+  detectMigration,
+  applyMigration,
+  loadCleanTemplate,
+  stripIgnoredPaths,
+} from '../../src/config-migrator';
 
 describe('config-migrator', () => {
   let tmpDir: string;
@@ -40,196 +48,530 @@ describe('config-migrator', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Config file missing (first run)
+  // deepMerge with ignorePaths
   // ---------------------------------------------------------------------------
-  it('returns migrated:false when config file does not exist', () => {
-    const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
-    const configPath = path.join(tmpDir, 'nonexistent.json');
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(false);
-    expect(result.addedFields).toEqual([]);
-  });
+  describe('deepMerge with ignorePaths', () => {
+    it('skips fields whose path is in ignorePaths', () => {
+      const target: Record<string, unknown> = { gateway: { logDir: '/logs' } };
+      const template: Record<string, unknown> = {
+        gateway: { logDir: '/default', api: { keys: ['key1'] } },
+      };
+      const added: string[] = [];
+      const ignorePaths = new Set(['gateway.api']);
 
-  // ---------------------------------------------------------------------------
-  // Template file missing
-  // ---------------------------------------------------------------------------
-  it('throws when template file does not exist', () => {
-    const configPath = writeJson('config.json', { configVersion: '0.0.0' });
-    const templatePath = path.join(tmpDir, 'missing-template.json');
-    expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
-      /Config template not found/,
-    );
-  });
+      deepMerge(target, template, '', added, ignorePaths);
 
-  // ---------------------------------------------------------------------------
-  // Same version => no migration
-  // ---------------------------------------------------------------------------
-  it('returns migrated:false when configVersion matches currentVersion', () => {
-    const configPath = writeJson('config.json', { configVersion: '1.0.0', gateway: {} });
-    const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(false);
-  });
-
-  // ---------------------------------------------------------------------------
-  // Missing configVersion treats as 0.0.0 => migrates
-  // ---------------------------------------------------------------------------
-  it('treats missing configVersion as 0.0.0 and migrates', () => {
-    const configPath = writeJson('config.json', { gateway: { logDir: '/logs' } });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { logDir: '/default', timezone: 'UTC' },
+      expect((target.gateway as Record<string, unknown>).api).toBeUndefined();
+      expect(added).not.toContain('gateway.api');
     });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(true);
-    expect(result.addedFields).toContain('configVersion');
 
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(updated.configVersion).toBe('1.0.0');
+    it('works normally when ignorePaths is undefined', () => {
+      const target: Record<string, unknown> = {};
+      const template: Record<string, unknown> = { newField: 'value' };
+      const added: string[] = [];
+
+      deepMerge(target, template, '', added);
+
+      expect(target.newField).toBe('value');
+      expect(added).toContain('newField');
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Never overwrites existing values
+  // loadCleanTemplate
   // ---------------------------------------------------------------------------
-  it('never overwrites existing values', () => {
-    const configPath = writeJson('config.json', {
-      configVersion: '0.0.1',
-      gateway: { logDir: '/my/logs', timezone: 'Asia/Bangkok' },
-    });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { logDir: '/default/logs', timezone: 'UTC', newField: 'hello' },
-    });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(true);
-
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    // Existing values preserved
-    expect(updated.gateway.logDir).toBe('/my/logs');
-    expect(updated.gateway.timezone).toBe('Asia/Bangkok');
-    // New field added
-    expect(updated.gateway.newField).toBe('hello');
-    expect(result.addedFields).toContain('gateway.newField');
-  });
-
-  // ---------------------------------------------------------------------------
-  // Agent array: adds missing fields to each agent
-  // ---------------------------------------------------------------------------
-  it('adds missing fields to each agent from template schema', () => {
-    const configPath = writeJson('config.json', {
-      agents: [
-        { id: 'agent-a', telegram: { botToken: 'tok-a' } },
-        { id: 'agent-b', telegram: { botToken: 'tok-b' } },
-      ],
-    });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      agents: [
-        {
-          id: 'example',
-          telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
-          emojiReactionMode: 'minimal',
-          signatureEmoji: '',
+  describe('loadCleanTemplate', () => {
+    it('returns clean template without _migration key and extracts ignorePaths', () => {
+      const templatePath = writeJson('template.json', {
+        _migration: {
+          ignorePaths: ['gateway.api', 'gateway.api.keys'],
         },
-      ],
+        configVersion: '1.0.0',
+        gateway: { logDir: '/logs', api: { keys: [] } },
+      });
+
+      const result = loadCleanTemplate(templatePath);
+
+      // _migration stripped
+      expect(result.template._migration).toBeUndefined();
+      // ignorePaths extracted
+      expect(result.ignorePaths).toBeInstanceOf(Set);
+      expect(result.ignorePaths.has('gateway.api')).toBe(true);
+      expect(result.ignorePaths.has('gateway.api.keys')).toBe(true);
+      // Rest of template intact
+      expect(result.template.configVersion).toBe('1.0.0');
+      expect(result.template.gateway).toBeDefined();
     });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(true);
 
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    // Agent A
-    expect(updated.agents[0].id).toBe('agent-a'); // not overwritten
-    expect(updated.agents[0].emojiReactionMode).toBe('minimal');
-    expect(updated.agents[0].signatureEmoji).toBe('');
-    expect(updated.agents[0].telegram.botToken).toBe('tok-a'); // not overwritten
-    expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist'); // added
+    it('returns empty ignorePaths when _migration is absent', () => {
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: {},
+      });
 
-    // Agent B
-    expect(updated.agents[1].id).toBe('agent-b');
-    expect(updated.agents[1].emojiReactionMode).toBe('minimal');
+      const result = loadCleanTemplate(templatePath);
 
-    expect(result.addedFields).toContain('agents[0].emojiReactionMode');
-    expect(result.addedFields).toContain('agents[1].emojiReactionMode');
+      expect(result.ignorePaths.size).toBe(0);
+      expect(result.template._migration).toBeUndefined();
+    });
+
+    it('throws when template file does not exist', () => {
+      const templatePath = path.join(tmpDir, 'nonexistent.json');
+      expect(() => loadCleanTemplate(templatePath)).toThrow(/Config template not found/);
+    });
+
+    it('handles _migration with no ignorePaths array gracefully', () => {
+      const templatePath = writeJson('template.json', {
+        _migration: { someOtherKey: true },
+        configVersion: '1.0.0',
+      });
+
+      const result = loadCleanTemplate(templatePath);
+
+      expect(result.ignorePaths.size).toBe(0);
+      expect(result.template._migration).toBeUndefined();
+    });
+
+    it('filters out non-string entries in ignorePaths', () => {
+      const templatePath = writeJson('template.json', {
+        _migration: {
+          ignorePaths: ['gateway.api', 42, null, 'gateway.secret'],
+        },
+        configVersion: '1.0.0',
+      });
+
+      const result = loadCleanTemplate(templatePath);
+
+      expect(result.ignorePaths.size).toBe(2);
+      expect(result.ignorePaths.has('gateway.api')).toBe(true);
+      expect(result.ignorePaths.has('gateway.secret')).toBe(true);
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Backup is created before migration
+  // stripIgnoredPaths
   // ---------------------------------------------------------------------------
-  it('creates a .bak backup before writing', () => {
-    const original = { gateway: { logDir: '/logs' } };
-    const configPath = writeJson('config.json', original);
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { logDir: '/default', newField: true },
+  describe('stripIgnoredPaths', () => {
+    it('removes keys matching ignorePaths', () => {
+      const obj: Record<string, unknown> = {
+        gateway: {
+          logDir: '/logs',
+          api: { keys: ['k1'], rateLimit: 100 },
+        },
+      };
+      const ignorePaths = new Set(['gateway.api']);
+
+      stripIgnoredPaths(obj, ignorePaths);
+
+      const gw = obj.gateway as Record<string, unknown>;
+      expect(gw.api).toBeUndefined();
+      expect(gw.logDir).toBe('/logs');
     });
 
-    migrateConfig(configPath, templatePath, '1.0.0');
+    it('removes nested keys matching ignorePaths', () => {
+      const obj: Record<string, unknown> = {
+        gateway: {
+          api: { keys: ['k1'], rateLimit: 100 },
+        },
+      };
+      const ignorePaths = new Set(['gateway.api.keys']);
 
-    const backup = JSON.parse(fs.readFileSync(configPath + '.bak', 'utf-8'));
-    expect(backup).toEqual(original);
+      stripIgnoredPaths(obj, ignorePaths);
+
+      const api = (obj.gateway as Record<string, unknown>).api as Record<string, unknown>;
+      expect(api.keys).toBeUndefined();
+      expect(api.rateLimit).toBe(100);
+    });
+
+    it('does nothing when ignorePaths is empty', () => {
+      const obj = { a: 1, b: { c: 2 } };
+      const original = structuredClone(obj);
+      stripIgnoredPaths(obj, new Set());
+      expect(obj).toEqual(original);
+    });
+
+    it('supports custom prefix for recursive calls', () => {
+      const obj: Record<string, unknown> = {
+        keys: ['k1'],
+        rateLimit: 100,
+      };
+      const ignorePaths = new Set(['gateway.api.keys']);
+
+      stripIgnoredPaths(obj, ignorePaths, 'gateway.api');
+
+      expect(obj.keys).toBeUndefined();
+      expect(obj.rateLimit).toBe(100);
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Invalid JSON in config => throws
+  // detectMigration
   // ---------------------------------------------------------------------------
-  it('throws on invalid JSON in config file', () => {
-    const configPath = path.join(tmpDir, 'bad.json');
-    fs.writeFileSync(configPath, '{ invalid json }', 'utf-8');
-    const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+  describe('detectMigration', () => {
+    it('returns needed:false when config file does not exist', () => {
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+      const configPath = path.join(tmpDir, 'nonexistent.json');
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+      expect(result.needed).toBe(false);
+      expect(result.addedFields).toEqual([]);
+    });
 
-    expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
-      /Config file is not valid JSON/,
-    );
+    it('returns needed:false when configVersion matches currentVersion', () => {
+      const configPath = writeJson('config.json', { configVersion: '1.0.0', gateway: {} });
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+      expect(result.needed).toBe(false);
+    });
+
+    it('returns needed:true with correct addedFields without writing', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: { logDir: '/logs' },
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', timezone: 'UTC' },
+      });
+
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+
+      expect(result.needed).toBe(true);
+      expect(result.fromVersion).toBe('0.0.1');
+      expect(result.toVersion).toBe('1.0.0');
+      expect(result.addedFields).toContain('gateway.timezone');
+      expect(result.addedFields).toContain('configVersion');
+
+      // Verify no writes occurred
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(onDisk.configVersion).toBe('0.0.1');
+      expect(onDisk.gateway.timezone).toBeUndefined();
+    });
+
+    it('strips _migration from template before detecting', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: {},
+      });
+      const templatePath = writeJson('template.json', {
+        _migration: { ignorePaths: ['gateway.api'] },
+        configVersion: '1.0.0',
+        gateway: { newField: 'x' },
+      });
+
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+
+      expect(result.needed).toBe(true);
+      expect(result.template._migration).toBeUndefined();
+      expect(result.addedFields).not.toContain('_migration');
+    });
+
+    it('throws on invalid JSON in config file', () => {
+      const configPath = path.join(tmpDir, 'bad.json');
+      fs.writeFileSync(configPath, '{ invalid json }', 'utf-8');
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+
+      expect(() => detectMigration(configPath, templatePath, '1.0.0')).toThrow(
+        /Config file is not valid JSON/,
+      );
+    });
+
+    it('treats missing configVersion as 0.0.0', () => {
+      const configPath = writeJson('config.json', { gateway: {} });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { newField: 'x' },
+      });
+
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+
+      expect(result.needed).toBe(true);
+      expect(result.fromVersion).toBe('0.0.0');
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Preserves extra custom fields
+  // applyMigration
   // ---------------------------------------------------------------------------
-  it('preserves extra custom fields not in template', () => {
-    const configPath = writeJson('config.json', {
-      configVersion: '0.0.1',
-      gateway: { logDir: '/logs' },
-      customSection: { foo: 'bar' },
-    });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { logDir: '/default', newField: 'x' },
+  describe('applyMigration', () => {
+    it('writes updated config with backup', () => {
+      const original = { configVersion: '0.0.1', gateway: { logDir: '/logs' } };
+      const configPath = writeJson('config.json', original);
+      const template: Record<string, unknown> = {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', timezone: 'UTC' },
+      };
+      const config = structuredClone(original) as Record<string, unknown>;
+
+      const result = applyMigration(configPath, config, template, '1.0.0');
+
+      expect(result.migrated).toBe(true);
+      expect(result.addedFields).toContain('gateway.timezone');
+      expect(result.addedFields).toContain('configVersion');
+
+      // Verify file was written
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.configVersion).toBe('1.0.0');
+      expect(updated.gateway.timezone).toBe('UTC');
+      expect(updated.gateway.logDir).toBe('/logs'); // not overwritten
+
+      // Verify backup was created
+      const backup = JSON.parse(fs.readFileSync(configPath + '.bak', 'utf-8'));
+      expect(backup).toEqual(original);
     });
 
-    migrateConfig(configPath, templatePath, '1.0.0');
+    it('respects ignorePaths during merge', () => {
+      const original = { configVersion: '0.0.1', gateway: { logDir: '/logs' } };
+      const configPath = writeJson('config.json', original);
+      const template: Record<string, unknown> = {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', api: { keys: ['key1'] }, timezone: 'UTC' },
+      };
+      const config = structuredClone(original) as Record<string, unknown>;
+      const ignorePaths = new Set(['gateway.api']);
 
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(updated.customSection).toEqual({ foo: 'bar' });
+      const result = applyMigration(configPath, config, template, '1.0.0', ignorePaths);
+
+      expect(result.migrated).toBe(true);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.api).toBeUndefined();
+      expect(updated.gateway.timezone).toBe('UTC');
+      expect(result.addedFields).not.toContain('gateway.api');
+    });
+
+    it('merges agent arrays correctly', () => {
+      const original = {
+        configVersion: '0.0.1',
+        agents: [{ id: 'agent-a', telegram: { botToken: 'tok-a' } }],
+      };
+      const configPath = writeJson('config.json', original);
+      const template: Record<string, unknown> = {
+        configVersion: '1.0.0',
+        agents: [
+          {
+            id: 'example',
+            telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
+            emojiReactionMode: 'minimal',
+          },
+        ],
+      };
+      const config = structuredClone(original) as Record<string, unknown>;
+
+      const result = applyMigration(configPath, config, template, '1.0.0');
+
+      expect(result.migrated).toBe(true);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.agents[0].id).toBe('agent-a');
+      expect(updated.agents[0].emojiReactionMode).toBe('minimal');
+      expect(updated.agents[0].telegram.botToken).toBe('tok-a');
+      expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist');
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Nested object merge
+  // migrateConfig (integration — backward compat)
   // ---------------------------------------------------------------------------
-  it('recursively adds nested missing fields', () => {
-    const configPath = writeJson('config.json', {
-      gateway: { api: { keys: [] } },
+  describe('migrateConfig', () => {
+    it('returns migrated:false when config file does not exist', () => {
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+      const configPath = path.join(tmpDir, 'nonexistent.json');
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(false);
+      expect(result.addedFields).toEqual([]);
     });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { api: { keys: [], rateLimit: 100 }, timezone: 'UTC' },
+
+    it('throws when template file does not exist', () => {
+      const configPath = writeJson('config.json', { configVersion: '0.0.0' });
+      const templatePath = path.join(tmpDir, 'missing-template.json');
+      expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
+        /Config template not found/,
+      );
     });
 
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    it('returns migrated:false when configVersion matches currentVersion', () => {
+      const configPath = writeJson('config.json', { configVersion: '1.0.0', gateway: {} });
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(false);
+    });
 
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(updated.gateway.api.rateLimit).toBe(100);
-    expect(updated.gateway.timezone).toBe('UTC');
-    expect(result.addedFields).toContain('gateway.api.rateLimit');
-    expect(result.addedFields).toContain('gateway.timezone');
-  });
+    it('treats missing configVersion as 0.0.0 and migrates', () => {
+      const configPath = writeJson('config.json', { gateway: { logDir: '/logs' } });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', timezone: 'UTC' },
+      });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(true);
+      expect(result.addedFields).toContain('configVersion');
 
-  // ---------------------------------------------------------------------------
-  // Newer config version => no migration
-  // ---------------------------------------------------------------------------
-  it('skips migration when config version is already newer', () => {
-    const configPath = writeJson('config.json', { configVersion: '2.0.0', gateway: {} });
-    const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(false);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.configVersion).toBe('1.0.0');
+    });
+
+    it('never overwrites existing values', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: { logDir: '/my/logs', timezone: 'Asia/Bangkok' },
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default/logs', timezone: 'UTC', newField: 'hello' },
+      });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(true);
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.logDir).toBe('/my/logs');
+      expect(updated.gateway.timezone).toBe('Asia/Bangkok');
+      expect(updated.gateway.newField).toBe('hello');
+      expect(result.addedFields).toContain('gateway.newField');
+    });
+
+    it('adds missing fields to each agent from template schema', () => {
+      const configPath = writeJson('config.json', {
+        agents: [
+          { id: 'agent-a', telegram: { botToken: 'tok-a' } },
+          { id: 'agent-b', telegram: { botToken: 'tok-b' } },
+        ],
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        agents: [
+          {
+            id: 'example',
+            telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
+            emojiReactionMode: 'minimal',
+            signatureEmoji: '',
+          },
+        ],
+      });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(true);
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.agents[0].id).toBe('agent-a');
+      expect(updated.agents[0].emojiReactionMode).toBe('minimal');
+      expect(updated.agents[0].signatureEmoji).toBe('');
+      expect(updated.agents[0].telegram.botToken).toBe('tok-a');
+      expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist');
+
+      expect(updated.agents[1].id).toBe('agent-b');
+      expect(updated.agents[1].emojiReactionMode).toBe('minimal');
+
+      expect(result.addedFields).toContain('agents[0].emojiReactionMode');
+      expect(result.addedFields).toContain('agents[1].emojiReactionMode');
+    });
+
+    it('creates a .bak backup before writing', () => {
+      const original = { gateway: { logDir: '/logs' } };
+      const configPath = writeJson('config.json', original);
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', newField: true },
+      });
+
+      migrateConfig(configPath, templatePath, '1.0.0');
+
+      const backup = JSON.parse(fs.readFileSync(configPath + '.bak', 'utf-8'));
+      expect(backup).toEqual(original);
+    });
+
+    it('throws on invalid JSON in config file', () => {
+      const configPath = path.join(tmpDir, 'bad.json');
+      fs.writeFileSync(configPath, '{ invalid json }', 'utf-8');
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+
+      expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
+        /Config file is not valid JSON/,
+      );
+    });
+
+    it('preserves extra custom fields not in template', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: { logDir: '/logs' },
+        customSection: { foo: 'bar' },
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', newField: 'x' },
+      });
+
+      migrateConfig(configPath, templatePath, '1.0.0');
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.customSection).toEqual({ foo: 'bar' });
+    });
+
+    it('recursively adds nested missing fields', () => {
+      const configPath = writeJson('config.json', {
+        gateway: { api: { keys: [] } },
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { api: { keys: [], rateLimit: 100 }, timezone: 'UTC' },
+      });
+
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.api.rateLimit).toBe(100);
+      expect(updated.gateway.timezone).toBe('UTC');
+      expect(result.addedFields).toContain('gateway.api.rateLimit');
+      expect(result.addedFields).toContain('gateway.timezone');
+    });
+
+    it('skips migration when config version is already newer', () => {
+      const configPath = writeJson('config.json', { configVersion: '2.0.0', gateway: {} });
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(false);
+    });
+
+    it('does not merge fields in ignorePaths from _migration', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: { logDir: '/logs' },
+      });
+      const templatePath = writeJson('template.json', {
+        _migration: { ignorePaths: ['gateway.api'] },
+        configVersion: '1.0.0',
+        gateway: {
+          logDir: '/default',
+          timezone: 'UTC',
+          api: { keys: ['key1'], rateLimit: 100 },
+        },
+      });
+
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+
+      expect(result.migrated).toBe(true);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      // api should NOT be merged because it is in ignorePaths
+      expect(updated.gateway.api).toBeUndefined();
+      // timezone should be merged normally
+      expect(updated.gateway.timezone).toBe('UTC');
+      expect(result.addedFields).not.toContain('gateway.api');
+      expect(result.addedFields).toContain('gateway.timezone');
+    });
+
+    it('strips _migration key from template before merge', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: {},
+      });
+      const templatePath = writeJson('template.json', {
+        _migration: { ignorePaths: [] },
+        configVersion: '1.0.0',
+        gateway: { newField: 'x' },
+      });
+
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      // _migration should NOT appear in the migrated config
+      expect(updated._migration).toBeUndefined();
+      expect(result.addedFields).not.toContain('_migration');
+    });
   });
 });

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -1,0 +1,235 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { migrateConfig, compareSemver } from '../../src/config-migrator';
+
+describe('config-migrator', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeJson(name: string, data: unknown): string {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(p, JSON.stringify(data, null, 2), 'utf-8');
+    return p;
+  }
+
+  // ---------------------------------------------------------------------------
+  // compareSemver
+  // ---------------------------------------------------------------------------
+  describe('compareSemver', () => {
+    it('returns 0 for equal versions', () => {
+      expect(compareSemver('1.0.0', '1.0.0')).toBe(0);
+    });
+
+    it('returns -1 when a < b', () => {
+      expect(compareSemver('1.0.0', '1.1.0')).toBe(-1);
+      expect(compareSemver('0.9.9', '1.0.0')).toBe(-1);
+    });
+
+    it('returns 1 when a > b', () => {
+      expect(compareSemver('2.0.0', '1.9.9')).toBe(1);
+      expect(compareSemver('1.0.1', '1.0.0')).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Config file missing (first run)
+  // ---------------------------------------------------------------------------
+  it('returns migrated:false when config file does not exist', () => {
+    const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+    const configPath = path.join(tmpDir, 'nonexistent.json');
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(false);
+    expect(result.addedFields).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Template file missing
+  // ---------------------------------------------------------------------------
+  it('throws when template file does not exist', () => {
+    const configPath = writeJson('config.json', { configVersion: '0.0.0' });
+    const templatePath = path.join(tmpDir, 'missing-template.json');
+    expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
+      /Config template not found/,
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Same version => no migration
+  // ---------------------------------------------------------------------------
+  it('returns migrated:false when configVersion matches currentVersion', () => {
+    const configPath = writeJson('config.json', { configVersion: '1.0.0', gateway: {} });
+    const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Missing configVersion treats as 0.0.0 => migrates
+  // ---------------------------------------------------------------------------
+  it('treats missing configVersion as 0.0.0 and migrates', () => {
+    const configPath = writeJson('config.json', { gateway: { logDir: '/logs' } });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { logDir: '/default', timezone: 'UTC' },
+    });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(true);
+    expect(result.addedFields).toContain('configVersion');
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(updated.configVersion).toBe('1.0.0');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Never overwrites existing values
+  // ---------------------------------------------------------------------------
+  it('never overwrites existing values', () => {
+    const configPath = writeJson('config.json', {
+      configVersion: '0.0.1',
+      gateway: { logDir: '/my/logs', timezone: 'Asia/Bangkok' },
+    });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { logDir: '/default/logs', timezone: 'UTC', newField: 'hello' },
+    });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(true);
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // Existing values preserved
+    expect(updated.gateway.logDir).toBe('/my/logs');
+    expect(updated.gateway.timezone).toBe('Asia/Bangkok');
+    // New field added
+    expect(updated.gateway.newField).toBe('hello');
+    expect(result.addedFields).toContain('gateway.newField');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Agent array: adds missing fields to each agent
+  // ---------------------------------------------------------------------------
+  it('adds missing fields to each agent from template schema', () => {
+    const configPath = writeJson('config.json', {
+      agents: [
+        { id: 'agent-a', telegram: { botToken: 'tok-a' } },
+        { id: 'agent-b', telegram: { botToken: 'tok-b' } },
+      ],
+    });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      agents: [
+        {
+          id: 'example',
+          telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
+          emojiReactionMode: 'minimal',
+          signatureEmoji: '',
+        },
+      ],
+    });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(true);
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // Agent A
+    expect(updated.agents[0].id).toBe('agent-a'); // not overwritten
+    expect(updated.agents[0].emojiReactionMode).toBe('minimal');
+    expect(updated.agents[0].signatureEmoji).toBe('');
+    expect(updated.agents[0].telegram.botToken).toBe('tok-a'); // not overwritten
+    expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist'); // added
+
+    // Agent B
+    expect(updated.agents[1].id).toBe('agent-b');
+    expect(updated.agents[1].emojiReactionMode).toBe('minimal');
+
+    expect(result.addedFields).toContain('agents[0].emojiReactionMode');
+    expect(result.addedFields).toContain('agents[1].emojiReactionMode');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Backup is created before migration
+  // ---------------------------------------------------------------------------
+  it('creates a .bak backup before writing', () => {
+    const original = { gateway: { logDir: '/logs' } };
+    const configPath = writeJson('config.json', original);
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { logDir: '/default', newField: true },
+    });
+
+    migrateConfig(configPath, templatePath, '1.0.0');
+
+    const backup = JSON.parse(fs.readFileSync(configPath + '.bak', 'utf-8'));
+    expect(backup).toEqual(original);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Invalid JSON in config => throws
+  // ---------------------------------------------------------------------------
+  it('throws on invalid JSON in config file', () => {
+    const configPath = path.join(tmpDir, 'bad.json');
+    fs.writeFileSync(configPath, '{ invalid json }', 'utf-8');
+    const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+
+    expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
+      /Config file is not valid JSON/,
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Preserves extra custom fields
+  // ---------------------------------------------------------------------------
+  it('preserves extra custom fields not in template', () => {
+    const configPath = writeJson('config.json', {
+      configVersion: '0.0.1',
+      gateway: { logDir: '/logs' },
+      customSection: { foo: 'bar' },
+    });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { logDir: '/default', newField: 'x' },
+    });
+
+    migrateConfig(configPath, templatePath, '1.0.0');
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(updated.customSection).toEqual({ foo: 'bar' });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Nested object merge
+  // ---------------------------------------------------------------------------
+  it('recursively adds nested missing fields', () => {
+    const configPath = writeJson('config.json', {
+      gateway: { api: { keys: [] } },
+    });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { api: { keys: [], rateLimit: 100 }, timezone: 'UTC' },
+    });
+
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(updated.gateway.api.rateLimit).toBe(100);
+    expect(updated.gateway.timezone).toBe('UTC');
+    expect(result.addedFields).toContain('gateway.api.rateLimit');
+    expect(result.addedFields).toContain('gateway.timezone');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Newer config version => no migration
+  // ---------------------------------------------------------------------------
+  it('skips migration when config version is already newer', () => {
+    const configPath = writeJson('config.json', { configVersion: '2.0.0', gateway: {} });
+    const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(false);
+  });
+});

--- a/tests/unit/update-agent.test.ts
+++ b/tests/unit/update-agent.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for update-agent feature (buildUpdatePrompt and strengthened acknowledge rule).
+ */
+
+import {
+  buildUpdatePrompt,
+  buildGenerationPrompt,
+} from '../../scripts/create-agent-prompts';
+
+describe('buildUpdatePrompt', () => {
+  // U-UA-01: agent.md already has the acknowledge rule — output should still include it (no duplicate instruction needed)
+  it('U-UA-01: includes acknowledge rule instruction when rule already exists in current content', () => {
+    const currentContent = `# Agent: MyBot
+
+## Rules
+- Acknowledge first (mandatory): Every message MUST begin with a short acknowledgement before taking any action or calling any tool. No exceptions.
+- Be helpful.`;
+
+    const prompt = buildUpdatePrompt('MyBot', currentContent);
+
+    expect(prompt).toContain('Acknowledge first (mandatory)');
+    expect(prompt).toContain('Every message MUST begin with a short acknowledgement');
+  });
+
+  // U-UA-02: agent.md has no acknowledge rule — output must include instruction to add it
+  it('U-UA-02: includes acknowledge rule instruction when rule is missing from current content', () => {
+    const currentContent = `# Agent: MyBot
+
+## Rules
+- Be helpful.
+- Never reveal secrets.`;
+
+    const prompt = buildUpdatePrompt('MyBot', currentContent);
+
+    expect(prompt).toContain('Acknowledge first (mandatory)');
+    expect(prompt).toContain('add if missing, strengthen if weak');
+  });
+
+  // U-UA-03: buildUpdatePrompt preserves the existing role section by embedding currentContent
+  it('U-UA-03: embeds the current agent.md content in the prompt', () => {
+    const currentContent = `# Agent: Analyst
+
+## Role
+Senior data analyst specialized in Python and SQL.`;
+
+    const prompt = buildUpdatePrompt('Analyst', currentContent);
+
+    expect(prompt).toContain('# Agent: Analyst');
+    expect(prompt).toContain('Senior data analyst specialized in Python and SQL.');
+  });
+
+  // U-UA-04: output is plain text — no === wrapper format (unlike buildGenerationPrompt)
+  it('U-UA-04: prompt instructs to output only the agent.md content without === wrapper format', () => {
+    const currentContent = `# Agent: Simple\n\nA simple agent.`;
+    const prompt = buildUpdatePrompt('Simple', currentContent);
+
+    // The update prompt should NOT tell Claude to use === file === wrapper sections
+    expect(prompt).not.toContain('=== agent.md ===');
+    // It should instruct output-only content
+    expect(prompt).toContain('Output ONLY the updated agent.md content');
+  });
+
+  it('includes the agent name in the prompt', () => {
+    const prompt = buildUpdatePrompt('Jeeves', '# Agent: Jeeves\nA butler.');
+    expect(prompt).toContain('"Jeeves"');
+  });
+
+  it('includes the under 500 words constraint', () => {
+    const prompt = buildUpdatePrompt('Bot', '# Agent: Bot\nA bot.');
+    expect(prompt).toContain('500 words');
+  });
+
+  it('instructs to preserve the existing role and purpose', () => {
+    const prompt = buildUpdatePrompt('Bot', '# Agent: Bot\nA bot.');
+    expect(prompt).toContain("Preserve the agent's role, purpose, and all existing rules");
+  });
+});
+
+describe('buildGenerationPrompt — strengthened acknowledge rule', () => {
+  it('contains the mandatory acknowledge rule wording', () => {
+    const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
+    expect(prompt).toContain('Acknowledge first (mandatory)');
+  });
+
+  it('states that every message MUST begin with acknowledgement', () => {
+    const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
+    expect(prompt).toContain('Every message MUST begin with a short acknowledgement');
+  });
+
+  it('states no exceptions', () => {
+    const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
+    expect(prompt).toContain('No exceptions.');
+  });
+
+  it('references the ## Rules section placement', () => {
+    const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
+    expect(prompt).toContain('## Rules');
+  });
+
+  it('does not use the old weak wording', () => {
+    const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
+    expect(prompt).not.toContain('send a brief acknowledgement first');
+  });
+});


### PR DESCRIPTION
## Summary

- **update-agent command** — `make update-agent` interactive script to regenerate agent.md with Claude, includes arrow-key select UI and content validation
- **Mandatory acknowledge rule** — strengthened "acknowledge first" rule in agent prompts (mandatory, no exceptions)
- **Emoji guideline** — added `## Emoji Usage` section in agent.md template with reaction modes (minimal/extensive/none), signature emoji, and text emoji guidelines
- **Emoji config fields** — `emojiReactionMode` and `signatureEmoji` in config.json + create-agent wizard support
- **Config migration system** — auto-migrate config.json on startup:
  - Renamed `config.example.json` → `config.template.json`
  - Deep-merge new fields without overwriting existing values
  - `_migration.ignorePaths` to skip placeholder fields (e.g. `api.keys`)
  - Confirmation prompt before migrating + `.bak` backup
  - `loadCleanTemplate()` + `stripIgnoredPaths()` shared by both create-agent and migrator
- **Bug fixes** — `require.main === module` guard in create-agent, interactive select using reverse video, stdin resume after select, Claude text leak prevention in update-agent

## Test plan
- [x] 557 tests passing
- [ ] Manual test: `make update-agent` — verify arrow-key select, emoji section in output
- [ ] Manual test: `make create-agent` — verify signature emoji prompt, config template used
- [ ] Manual test: `npm start` with outdated config.json — verify migration prompt and backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)