### PR TITLE
feat: add emoji guideline support for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ dist/
 .env.*
 !.env.example
 config.json
-!config.example.json
+!config.template.json
 
 # Logs
 *.log
@@ -36,5 +36,5 @@ planning*.md
 design*.md
 testcase*.md
 feature*.md
-task-imp*.md
+task-*.md
 research*.md

--- a/.gitignore
+++ b/.gitignore
@@ -28,11 +28,13 @@ Thumbs.db
 # Test coverage
 coverage/
 
+.claude-plugin/
+.claude
+
 # Planning
 planning*.md
 design*.md
 testcase*.md
 feature*.md
-
-.claude-plugin/
-.claude
+task-imp*.md
+research*.md

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ See [Quickstart: Using the Agent API](#quickstart-using-the-agent-api) for full 
 ```
 claude-gateway/
 ├── Makefile                            ← make start / create-agent / pair / plugin-install / add-user
-├── config.example.json                 ← config template
+├── config.template.json                ← config template (source of truth for migration)
 ├── src/                                ← gateway source (TypeScript)
 │   ├── index.ts                        ← entrypoint, loads config and starts agents
 │   ├── agent-runner.ts                 ← session pool manager (spawn/evict SessionProcesses)

--- a/config.example.json
+++ b/config.example.json
@@ -33,6 +33,8 @@
         "dangerouslySkipPermissions": true,
         "extraFlags": []
       },
+      "emojiReactionMode": "minimal",
+      "signatureEmoji": "",
       "heartbeat": {
         "rateLimitMinutes": 30
       },

--- a/config.template.json
+++ b/config.template.json
@@ -1,4 +1,5 @@
 {
+  "configVersion": "1.0.0",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",

--- a/config.template.json
+++ b/config.template.json
@@ -1,4 +1,10 @@
 {
+  "_migration": {
+    "ignorePaths": [
+      "gateway.api",
+      "gateway.api.keys"
+    ]
+  },
   "configVersion": "1.0.0",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",

--- a/scripts/create-agent-prompts.ts
+++ b/scripts/create-agent-prompts.ts
@@ -5,7 +5,16 @@
 /**
  * Build the Claude generation prompt for workspace markdown files.
  */
-export function buildGenerationPrompt(name: string, description: string): string {
+export function buildGenerationPrompt(
+  name: string,
+  description: string,
+  options?: { signatureEmoji?: string; emojiReactionMode?: string }
+): string {
+  const signatureNote = options?.signatureEmoji
+    ? `\nThe agent has a signature emoji: ${options.signatureEmoji}. Include it in the Emoji Usage section as the signature emoji.`
+    : '';
+  const reactionMode = options?.emojiReactionMode ?? 'minimal';
+
   return `You are helping configure a Claude Code agent for the claude-gateway multi-bot system.
 
 The user described the agent as:
@@ -26,6 +35,15 @@ Rules:
   Include: role, rules, what it can/cannot do, language to use.
   Always include this rule: when a message arrives, send a brief acknowledgement first
   (e.g. "Got it, let me check…" or "On it!"), then do the work and reply with the result.
+  Also include an "## Emoji Usage" section in agent.md with these guidelines:
+    - Text emoji: Use sparingly in messages. Occasional emoji is fine for warmth, but don't overdo it.
+    - Reactions: React to messages like a human would — use the react tool. Max 1 reaction per message.
+      Reaction mode is "${reactionMode}": ${{
+        minimal: 'only react when the message clearly warrants it (e.g. thanks, celebrations, humor).',
+        extensive: 'react to most messages with an appropriate emoji to show engagement.',
+        none: 'do not use emoji reactions at all.',
+      }[reactionMode] ?? 'only react when the message clearly warrants it.'}
+    - Signature emoji: ${options?.signatureEmoji ? `Use ${options.signatureEmoji} as your signature emoji in greetings or sign-offs.` : 'None assigned.'}${signatureNote}
 - soul.md: tone and personality only (not rules). Omit if no distinct style.
 - user.md: target user profile. Omit if public/unknown.
 - tools.md: available tools or capabilities. Omit if none specified.

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -22,6 +22,7 @@ import { randomBytes } from 'crypto';
 import { spawnSync } from 'child_process';
 import { loadWorkspace } from '../src/workspace-loader';
 import { buildGenerationPrompt, parseGeneratedFiles } from './create-agent-prompts';
+import { loadCleanTemplate, stripIgnoredPaths } from '../src/config-migrator';
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -146,10 +147,21 @@ function loadOrCreateRawConfig(): RawConfig {
     const raw = fs.readFileSync(cp, 'utf8');
     return JSON.parse(raw) as RawConfig;
   }
-  return {
-    gateway: { logDir: '~/.claude-gateway/logs', timezone: 'UTC' },
-    agents: [],
-  };
+
+  // First run: try to load from template
+  const templatePath = path.join(__dirname, '..', 'config.template.json');
+  try {
+    const { template, ignorePaths } = loadCleanTemplate(templatePath);
+    stripIgnoredPaths(template, ignorePaths);
+    template.agents = [];
+    return template as unknown as RawConfig;
+  } catch {
+    // Template missing or unreadable — use hardcoded fallback
+    return {
+      gateway: { logDir: '~/.claude-gateway/logs', timezone: 'UTC' },
+      agents: [],
+    };
+  }
 }
 
 function saveConfig(config: RawConfig): void {

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -136,6 +136,8 @@ interface RawAgentEntry {
     dangerouslySkipPermissions: boolean;
     extraFlags: string[];
   };
+  emojiReactionMode?: 'minimal' | 'extensive' | 'none';
+  signatureEmoji?: string;
 }
 
 function loadOrCreateRawConfig(): RawConfig {
@@ -247,11 +249,15 @@ function fallbackFiles(agentId: string): Map<string, string> {
   return files;
 }
 
-async function generateFiles(agentId: string, description: string): Promise<Map<string, string>> {
+async function generateFiles(
+  agentId: string,
+  description: string,
+  options?: { signatureEmoji?: string; emojiReactionMode?: string }
+): Promise<Map<string, string>> {
   const agentName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
   console.log('\nGenerating workspace files with Claude...');
 
-  const genPrompt = buildGenerationPrompt(agentName, description);
+  const genPrompt = buildGenerationPrompt(agentName, description, options);
   const result = spawnSync('claude', ['--print'], {
     input: genPrompt,
     encoding: 'utf8',
@@ -380,7 +386,8 @@ export async function createWorkspace(agentId: string, files: Map<string, string
 export async function appendToConfig(
   agentId: string,
   wsDir: string,
-  agentMdContent: string
+  agentMdContent: string,
+  options?: { emojiReactionMode?: 'minimal' | 'extensive' | 'none'; signatureEmoji?: string }
 ): Promise<void> {
   console.log('Updating config.json...');
 
@@ -406,6 +413,13 @@ export async function appendToConfig(
       extraFlags: [],
     },
   };
+
+  if (options?.emojiReactionMode) {
+    newAgent.emojiReactionMode = options.emojiReactionMode;
+  }
+  if (options?.signatureEmoji) {
+    newAgent.signatureEmoji = options.signatureEmoji;
+  }
 
   config.agents.push(newAgent);
   saveConfig(config);
@@ -787,13 +801,21 @@ async function main(): Promise<void> {
   console.log('Step 1/6 · Agent Name\n');
   const agentId = await promptAgentName(rl, existingIds);
   const agentName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
+
+  // Prompt for optional signature emoji
+  const signatureEmojiInput = await prompt(
+    rl,
+    '\nSignature emoji for this agent (optional, press Enter to skip): '
+  );
+  const signatureEmoji = signatureEmojiInput.trim() || undefined;
+
   const state: WizardState = { agentId, agentName, lastCompletedStep: 1 };
   saveWizardState(state);
 
   // ── Step 2 ──────────────────────────────────────────────────────────────
   console.log('\nStep 2/6 · Describe Your Agent\n');
   const description = await promptDescription(rl);
-  const generatedFiles = await generateFiles(agentId, description);
+  const generatedFiles = await generateFiles(agentId, description, { signatureEmoji });
   const acceptedFiles = await previewAndAccept(rl, generatedFiles);
 
   if (!acceptedFiles.has('agent.md')) {
@@ -806,7 +828,10 @@ async function main(): Promise<void> {
   // ── Step 3 ──────────────────────────────────────────────────────────────
   console.log('\nStep 3/6 · Create Workspace\n');
   const wsDir = await createWorkspace(agentId, acceptedFiles);
-  await appendToConfig(agentId, wsDir, acceptedFiles.get('agent.md')!);
+  await appendToConfig(agentId, wsDir, acceptedFiles.get('agent.md')!, {
+    emojiReactionMode: 'minimal',
+    signatureEmoji,
+  });
   state.wsDir = wsDir;
   state.lastCompletedStep = 3;
   saveWizardState(state);

--- a/src/config-migrator.ts
+++ b/src/config-migrator.ts
@@ -6,18 +6,40 @@ export interface MigrationResult {
   addedFields: string[];
 }
 
+export interface DetectMigrationResult {
+  needed: boolean;
+  fromVersion: string;
+  toVersion: string;
+  addedFields: string[];
+  config: Record<string, unknown>;
+  template: Record<string, unknown>;
+}
+
+export interface CleanTemplateResult {
+  template: Record<string, unknown>;
+  ignorePaths: Set<string>;
+}
+
 /**
  * Deep-merge template into target, adding missing keys only.
  * Never overwrites existing values. Returns list of added field paths.
+ * Keys whose full path is in ignorePaths are skipped entirely.
  */
 function deepMerge(
   target: Record<string, unknown>,
   template: Record<string, unknown>,
   prefix: string,
   added: string[],
+  ignorePaths?: Set<string>,
 ): void {
   for (const key of Object.keys(template)) {
     const fullPath = prefix ? `${prefix}.${key}` : key;
+
+    // Skip paths that are in the ignorePaths set
+    if (ignorePaths && ignorePaths.has(fullPath)) {
+      continue;
+    }
+
     if (!(key in target)) {
       target[key] = structuredClone(template[key]);
       added.push(fullPath);
@@ -34,6 +56,7 @@ function deepMerge(
         template[key] as Record<string, unknown>,
         fullPath,
         added,
+        ignorePaths,
       );
     }
   }
@@ -47,11 +70,12 @@ function mergeAgentArrays(
   userAgents: Array<Record<string, unknown>>,
   templateAgents: Array<Record<string, unknown>>,
   added: string[],
+  ignorePaths?: Set<string>,
 ): void {
   if (templateAgents.length === 0) return;
   const schema = templateAgents[0];
   for (let i = 0; i < userAgents.length; i++) {
-    deepMerge(userAgents[i], schema, `agents[${i}]`, added);
+    deepMerge(userAgents[i], schema, `agents[${i}]`, added, ignorePaths);
   }
 }
 
@@ -72,25 +96,93 @@ function compareSemver(a: string, b: string): number {
 }
 
 /**
- * Migrate config.json by adding missing fields from the template.
- * - Never overwrites existing values
- * - Creates a .bak backup before writing
- * - Skips migration if config file does not exist (first run)
+ * Load a template file, extract the _migration metadata, strip it,
+ * and return the clean template along with the ignorePaths set.
  */
-export function migrateConfig(
+export function loadCleanTemplate(templatePath: string): CleanTemplateResult {
+  if (!fs.existsSync(templatePath)) {
+    throw new Error(`Config template not found at "${templatePath}". Cannot load.`);
+  }
+
+  const templateRaw = fs.readFileSync(templatePath, 'utf-8');
+  const template = JSON.parse(templateRaw) as Record<string, unknown>;
+
+  // Extract ignorePaths from _migration metadata
+  let ignorePaths = new Set<string>();
+  if (
+    template._migration &&
+    typeof template._migration === 'object' &&
+    !Array.isArray(template._migration)
+  ) {
+    const migration = template._migration as Record<string, unknown>;
+    if (Array.isArray(migration.ignorePaths)) {
+      ignorePaths = new Set(
+        (migration.ignorePaths as unknown[]).filter(
+          (p): p is string => typeof p === 'string',
+        ),
+      );
+    }
+  }
+
+  // Strip _migration from the template
+  delete template._migration;
+
+  return { template, ignorePaths };
+}
+
+/**
+ * Recursively delete keys from obj whose full dotted path matches any entry
+ * in ignorePaths. The prefix parameter tracks the current path during recursion.
+ */
+export function stripIgnoredPaths(
+  obj: Record<string, unknown>,
+  ignorePaths: Set<string>,
+  prefix = '',
+): void {
+  for (const key of Object.keys(obj)) {
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+
+    if (ignorePaths.has(fullPath)) {
+      delete obj[key];
+    } else if (
+      typeof obj[key] === 'object' &&
+      obj[key] !== null &&
+      !Array.isArray(obj[key])
+    ) {
+      stripIgnoredPaths(obj[key] as Record<string, unknown>, ignorePaths, fullPath);
+    }
+  }
+}
+
+/**
+ * Detect whether a config migration is needed (dry-run, no writes).
+ * Returns migration metadata including the fields that would be added.
+ */
+export function detectMigration(
   configPath: string,
   templatePath: string,
   currentVersion: string,
-): MigrationResult {
+): DetectMigrationResult {
+  const noMigration = (
+    config: Record<string, unknown>,
+    template: Record<string, unknown>,
+    fromVersion: string,
+  ): DetectMigrationResult => ({
+    needed: false,
+    fromVersion,
+    toVersion: currentVersion,
+    addedFields: [],
+    config,
+    template,
+  });
+
   // Config file missing = first run, create-agent handles it
   if (!fs.existsSync(configPath)) {
-    return { migrated: false, addedFields: [] };
+    return noMigration({}, {}, '0.0.0');
   }
 
-  // Template must exist
-  if (!fs.existsSync(templatePath)) {
-    throw new Error(`Config template not found at "${templatePath}". Cannot migrate.`);
-  }
+  // Template must exist — load and strip _migration
+  const { template, ignorePaths } = loadCleanTemplate(templatePath);
 
   // Read and parse config
   let configRaw: string;
@@ -107,25 +199,63 @@ export function migrateConfig(
     throw new Error(`Config file is not valid JSON: ${(err as Error).message}`);
   }
 
-  // Read template
-  const templateRaw = fs.readFileSync(templatePath, 'utf-8');
-  const template = JSON.parse(templateRaw) as Record<string, unknown>;
-
   // Version check
   const configVersion = (config.configVersion as string) ?? '0.0.0';
   if (compareSemver(configVersion, currentVersion) >= 0) {
-    return { migrated: false, addedFields: [] };
+    return noMigration(config, template, configVersion);
   }
 
-  // Perform migration
+  // Dry-run merge on a clone to detect what would be added
+  const configClone = structuredClone(config);
   const added: string[] = [];
 
   // Deep-merge top-level keys (except agents which need special handling)
   const templateWithoutAgents = { ...template };
   delete templateWithoutAgents.agents;
-  const configWithoutAgents = { ...config };
-  delete configWithoutAgents.agents;
-  deepMerge(config, templateWithoutAgents, '', added);
+  deepMerge(configClone, templateWithoutAgents, '', added, ignorePaths);
+
+  // Merge agent arrays
+  if (Array.isArray(configClone.agents) && Array.isArray(template.agents)) {
+    mergeAgentArrays(
+      configClone.agents as Array<Record<string, unknown>>,
+      template.agents as Array<Record<string, unknown>>,
+      added,
+      ignorePaths,
+    );
+  }
+
+  // configVersion will always be updated
+  if (!added.includes('configVersion')) {
+    added.push('configVersion');
+  }
+
+  return {
+    needed: true,
+    fromVersion: configVersion,
+    toVersion: currentVersion,
+    addedFields: added,
+    config,
+    template,
+  };
+}
+
+/**
+ * Apply a config migration: deep-merge missing fields, update version,
+ * create backup, and write the updated config.
+ */
+export function applyMigration(
+  configPath: string,
+  config: Record<string, unknown>,
+  template: Record<string, unknown>,
+  currentVersion: string,
+  ignorePaths?: Set<string>,
+): MigrationResult {
+  const added: string[] = [];
+
+  // Deep-merge top-level keys (except agents)
+  const templateWithoutAgents = { ...template };
+  delete templateWithoutAgents.agents;
+  deepMerge(config, templateWithoutAgents, '', added, ignorePaths);
 
   // Merge agent arrays
   if (Array.isArray(config.agents) && Array.isArray(template.agents)) {
@@ -133,6 +263,7 @@ export function migrateConfig(
       config.agents as Array<Record<string, unknown>>,
       template.agents as Array<Record<string, unknown>>,
       added,
+      ignorePaths,
     );
   }
 
@@ -152,6 +283,41 @@ export function migrateConfig(
   fs.renameSync(tmpPath, configPath);
 
   return { migrated: true, addedFields: added };
+}
+
+/**
+ * Migrate config.json by adding missing fields from the template.
+ * - Never overwrites existing values
+ * - Creates a .bak backup before writing
+ * - Skips migration if config file does not exist (first run)
+ */
+export function migrateConfig(
+  configPath: string,
+  templatePath: string,
+  currentVersion: string,
+): MigrationResult {
+  const detection = detectMigration(configPath, templatePath, currentVersion);
+
+  if (!detection.needed) {
+    return { migrated: false, addedFields: [] };
+  }
+
+  // Load ignorePaths again for the actual merge
+  let ignorePaths: Set<string> | undefined;
+  try {
+    const clean = loadCleanTemplate(templatePath);
+    ignorePaths = clean.ignorePaths;
+  } catch {
+    // If template can't be loaded again, proceed without ignorePaths
+  }
+
+  return applyMigration(
+    configPath,
+    detection.config,
+    detection.template,
+    currentVersion,
+    ignorePaths,
+  );
 }
 
 // Exported for testing

--- a/src/config-migrator.ts
+++ b/src/config-migrator.ts
@@ -1,0 +1,158 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface MigrationResult {
+  migrated: boolean;
+  addedFields: string[];
+}
+
+/**
+ * Deep-merge template into target, adding missing keys only.
+ * Never overwrites existing values. Returns list of added field paths.
+ */
+function deepMerge(
+  target: Record<string, unknown>,
+  template: Record<string, unknown>,
+  prefix: string,
+  added: string[],
+): void {
+  for (const key of Object.keys(template)) {
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+    if (!(key in target)) {
+      target[key] = structuredClone(template[key]);
+      added.push(fullPath);
+    } else if (
+      typeof target[key] === 'object' &&
+      target[key] !== null &&
+      !Array.isArray(target[key]) &&
+      typeof template[key] === 'object' &&
+      template[key] !== null &&
+      !Array.isArray(template[key])
+    ) {
+      deepMerge(
+        target[key] as Record<string, unknown>,
+        template[key] as Record<string, unknown>,
+        fullPath,
+        added,
+      );
+    }
+  }
+}
+
+/**
+ * Merge missing fields from template agent into each user agent.
+ * Uses the first agent in the template as the schema source.
+ */
+function mergeAgentArrays(
+  userAgents: Array<Record<string, unknown>>,
+  templateAgents: Array<Record<string, unknown>>,
+  added: string[],
+): void {
+  if (templateAgents.length === 0) return;
+  const schema = templateAgents[0];
+  for (let i = 0; i < userAgents.length; i++) {
+    deepMerge(userAgents[i], schema, `agents[${i}]`, added);
+  }
+}
+
+/**
+ * Compare two semver strings. Returns:
+ *  -1 if a < b, 0 if equal, 1 if a > b
+ */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va < vb) return -1;
+    if (va > vb) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Migrate config.json by adding missing fields from the template.
+ * - Never overwrites existing values
+ * - Creates a .bak backup before writing
+ * - Skips migration if config file does not exist (first run)
+ */
+export function migrateConfig(
+  configPath: string,
+  templatePath: string,
+  currentVersion: string,
+): MigrationResult {
+  // Config file missing = first run, create-agent handles it
+  if (!fs.existsSync(configPath)) {
+    return { migrated: false, addedFields: [] };
+  }
+
+  // Template must exist
+  if (!fs.existsSync(templatePath)) {
+    throw new Error(`Config template not found at "${templatePath}". Cannot migrate.`);
+  }
+
+  // Read and parse config
+  let configRaw: string;
+  try {
+    configRaw = fs.readFileSync(configPath, 'utf-8');
+  } catch (err) {
+    throw new Error(`Cannot read config file: ${(err as Error).message}`);
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(configRaw) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(`Config file is not valid JSON: ${(err as Error).message}`);
+  }
+
+  // Read template
+  const templateRaw = fs.readFileSync(templatePath, 'utf-8');
+  const template = JSON.parse(templateRaw) as Record<string, unknown>;
+
+  // Version check
+  const configVersion = (config.configVersion as string) ?? '0.0.0';
+  if (compareSemver(configVersion, currentVersion) >= 0) {
+    return { migrated: false, addedFields: [] };
+  }
+
+  // Perform migration
+  const added: string[] = [];
+
+  // Deep-merge top-level keys (except agents which need special handling)
+  const templateWithoutAgents = { ...template };
+  delete templateWithoutAgents.agents;
+  const configWithoutAgents = { ...config };
+  delete configWithoutAgents.agents;
+  deepMerge(config, templateWithoutAgents, '', added);
+
+  // Merge agent arrays
+  if (Array.isArray(config.agents) && Array.isArray(template.agents)) {
+    mergeAgentArrays(
+      config.agents as Array<Record<string, unknown>>,
+      template.agents as Array<Record<string, unknown>>,
+      added,
+    );
+  }
+
+  // Update configVersion
+  config.configVersion = currentVersion;
+  if (!added.includes('configVersion')) {
+    added.push('configVersion');
+  }
+
+  // Backup before writing
+  const backupPath = configPath + '.bak';
+  fs.copyFileSync(configPath, backupPath);
+
+  // Write atomically via temp file
+  const tmpPath = configPath + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmpPath, configPath);
+
+  return { migrated: true, addedFields: added };
+}
+
+// Exported for testing
+export { compareSemver, deepMerge };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as readline from 'readline';
 
 function expandTilde(p: string): string {
   if (p === '~' || p.startsWith('~/')) {
@@ -9,7 +10,7 @@ function expandTilde(p: string): string {
   return p;
 }
 import { loadConfig } from './config-loader';
-import { migrateConfig } from './config-migrator';
+import { detectMigration, applyMigration, loadCleanTemplate } from './config-migrator';
 import { loadWorkspace, watchWorkspace, markBootstrapComplete } from './workspace-loader';
 import { AgentRunner } from './agent-runner';
 import { CronScheduler } from './cron-scheduler';
@@ -128,9 +129,43 @@ async function main(): Promise<void> {
   const pkgPath = path.join(__dirname, '..', 'package.json');
   const pkgVersion: string = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
   try {
-    const migration = migrateConfig(CONFIG_PATH, templatePath, pkgVersion);
-    if (migration.migrated) {
-      console.log(`[gateway] Config migrated to v${pkgVersion}. Added: ${migration.addedFields.join(', ')}`);
+    const detection = detectMigration(CONFIG_PATH, templatePath, pkgVersion);
+    if (detection.needed) {
+      let shouldMigrate = false;
+
+      if (args['auto-migrate']) {
+        shouldMigrate = true;
+      } else {
+        // Prompt user for confirmation
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        const answer = await new Promise<string>((resolve) => {
+          rl.question(
+            `[gateway] Config migration available (v${detection.fromVersion} -> v${detection.toVersion}). Migrate config? (y/n) [y]: `,
+            (ans) => {
+              rl.close();
+              resolve(ans.trim().toLowerCase());
+            },
+          );
+        });
+        shouldMigrate = answer === '' || answer === 'y' || answer === 'yes';
+      }
+
+      if (shouldMigrate) {
+        const { ignorePaths } = loadCleanTemplate(templatePath);
+        const migration = applyMigration(
+          CONFIG_PATH,
+          detection.config,
+          detection.template,
+          pkgVersion,
+          ignorePaths,
+        );
+        console.log(`[gateway] Config migrated to v${pkgVersion}. Added: ${migration.addedFields.join(', ')}`);
+      } else {
+        console.warn(`[gateway] Config migration skipped by user. Running with current config.`);
+      }
     }
   } catch (err) {
     console.warn(`[gateway] Config migration skipped: ${(err as Error).message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ function expandTilde(p: string): string {
   return p;
 }
 import { loadConfig } from './config-loader';
+import { migrateConfig } from './config-migrator';
 import { loadWorkspace, watchWorkspace, markBootstrapComplete } from './workspace-loader';
 import { AgentRunner } from './agent-runner';
 import { CronScheduler } from './cron-scheduler';
@@ -121,6 +122,19 @@ async function main(): Promise<void> {
   // Load agent .env files before config interpolation so ${TOKEN} vars resolve
   const gatewayAgentsDir = path.join(path.dirname(CONFIG_PATH), 'agents');
   loadAgentEnvFiles(gatewayAgentsDir);
+
+  // ── Auto-migrate config (add missing fields from template) ────────────────
+  const templatePath = path.join(__dirname, '..', 'config.template.json');
+  const pkgPath = path.join(__dirname, '..', 'package.json');
+  const pkgVersion: string = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+  try {
+    const migration = migrateConfig(CONFIG_PATH, templatePath, pkgVersion);
+    if (migration.migrated) {
+      console.log(`[gateway] Config migrated to v${pkgVersion}. Added: ${migration.addedFields.join(', ')}`);
+    }
+  } catch (err) {
+    console.warn(`[gateway] Config migration skipped: ${(err as Error).message}`);
+  }
 
   console.log(`[gateway] Loading config from ${CONFIG_PATH}`);
   const config: GatewayConfig = loadConfig(CONFIG_PATH);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,10 @@ export interface AgentConfig {
   };
   /** Session pool settings */
   session?: SessionConfig;
+  /** Emoji reaction mode for Telegram reactions */
+  emojiReactionMode?: 'minimal' | 'extensive' | 'none';
+  /** Agent's signature emoji (used in greetings/sign-offs) */
+  signatureEmoji?: string;
 }
 
 export interface AgentStats {

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -1,7 +1,15 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { migrateConfig, compareSemver } from '../../src/config-migrator';
+import {
+  migrateConfig,
+  compareSemver,
+  deepMerge,
+  detectMigration,
+  applyMigration,
+  loadCleanTemplate,
+  stripIgnoredPaths,
+} from '../../src/config-migrator';
 
 describe('config-migrator', () => {
   let tmpDir: string;
@@ -40,196 +48,530 @@ describe('config-migrator', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Config file missing (first run)
+  // deepMerge with ignorePaths
   // ---------------------------------------------------------------------------
-  it('returns migrated:false when config file does not exist', () => {
-    const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
-    const configPath = path.join(tmpDir, 'nonexistent.json');
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(false);
-    expect(result.addedFields).toEqual([]);
-  });
+  describe('deepMerge with ignorePaths', () => {
+    it('skips fields whose path is in ignorePaths', () => {
+      const target: Record<string, unknown> = { gateway: { logDir: '/logs' } };
+      const template: Record<string, unknown> = {
+        gateway: { logDir: '/default', api: { keys: ['key1'] } },
+      };
+      const added: string[] = [];
+      const ignorePaths = new Set(['gateway.api']);
 
-  // ---------------------------------------------------------------------------
-  // Template file missing
-  // ---------------------------------------------------------------------------
-  it('throws when template file does not exist', () => {
-    const configPath = writeJson('config.json', { configVersion: '0.0.0' });
-    const templatePath = path.join(tmpDir, 'missing-template.json');
-    expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
-      /Config template not found/,
-    );
-  });
+      deepMerge(target, template, '', added, ignorePaths);
 
-  // ---------------------------------------------------------------------------
-  // Same version => no migration
-  // ---------------------------------------------------------------------------
-  it('returns migrated:false when configVersion matches currentVersion', () => {
-    const configPath = writeJson('config.json', { configVersion: '1.0.0', gateway: {} });
-    const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(false);
-  });
-
-  // ---------------------------------------------------------------------------
-  // Missing configVersion treats as 0.0.0 => migrates
-  // ---------------------------------------------------------------------------
-  it('treats missing configVersion as 0.0.0 and migrates', () => {
-    const configPath = writeJson('config.json', { gateway: { logDir: '/logs' } });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { logDir: '/default', timezone: 'UTC' },
+      expect((target.gateway as Record<string, unknown>).api).toBeUndefined();
+      expect(added).not.toContain('gateway.api');
     });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(true);
-    expect(result.addedFields).toContain('configVersion');
 
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(updated.configVersion).toBe('1.0.0');
+    it('works normally when ignorePaths is undefined', () => {
+      const target: Record<string, unknown> = {};
+      const template: Record<string, unknown> = { newField: 'value' };
+      const added: string[] = [];
+
+      deepMerge(target, template, '', added);
+
+      expect(target.newField).toBe('value');
+      expect(added).toContain('newField');
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Never overwrites existing values
+  // loadCleanTemplate
   // ---------------------------------------------------------------------------
-  it('never overwrites existing values', () => {
-    const configPath = writeJson('config.json', {
-      configVersion: '0.0.1',
-      gateway: { logDir: '/my/logs', timezone: 'Asia/Bangkok' },
-    });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { logDir: '/default/logs', timezone: 'UTC', newField: 'hello' },
-    });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(true);
-
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    // Existing values preserved
-    expect(updated.gateway.logDir).toBe('/my/logs');
-    expect(updated.gateway.timezone).toBe('Asia/Bangkok');
-    // New field added
-    expect(updated.gateway.newField).toBe('hello');
-    expect(result.addedFields).toContain('gateway.newField');
-  });
-
-  // ---------------------------------------------------------------------------
-  // Agent array: adds missing fields to each agent
-  // ---------------------------------------------------------------------------
-  it('adds missing fields to each agent from template schema', () => {
-    const configPath = writeJson('config.json', {
-      agents: [
-        { id: 'agent-a', telegram: { botToken: 'tok-a' } },
-        { id: 'agent-b', telegram: { botToken: 'tok-b' } },
-      ],
-    });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      agents: [
-        {
-          id: 'example',
-          telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
-          emojiReactionMode: 'minimal',
-          signatureEmoji: '',
+  describe('loadCleanTemplate', () => {
+    it('returns clean template without _migration key and extracts ignorePaths', () => {
+      const templatePath = writeJson('template.json', {
+        _migration: {
+          ignorePaths: ['gateway.api', 'gateway.api.keys'],
         },
-      ],
+        configVersion: '1.0.0',
+        gateway: { logDir: '/logs', api: { keys: [] } },
+      });
+
+      const result = loadCleanTemplate(templatePath);
+
+      // _migration stripped
+      expect(result.template._migration).toBeUndefined();
+      // ignorePaths extracted
+      expect(result.ignorePaths).toBeInstanceOf(Set);
+      expect(result.ignorePaths.has('gateway.api')).toBe(true);
+      expect(result.ignorePaths.has('gateway.api.keys')).toBe(true);
+      // Rest of template intact
+      expect(result.template.configVersion).toBe('1.0.0');
+      expect(result.template.gateway).toBeDefined();
     });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(true);
 
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    // Agent A
-    expect(updated.agents[0].id).toBe('agent-a'); // not overwritten
-    expect(updated.agents[0].emojiReactionMode).toBe('minimal');
-    expect(updated.agents[0].signatureEmoji).toBe('');
-    expect(updated.agents[0].telegram.botToken).toBe('tok-a'); // not overwritten
-    expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist'); // added
+    it('returns empty ignorePaths when _migration is absent', () => {
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: {},
+      });
 
-    // Agent B
-    expect(updated.agents[1].id).toBe('agent-b');
-    expect(updated.agents[1].emojiReactionMode).toBe('minimal');
+      const result = loadCleanTemplate(templatePath);
 
-    expect(result.addedFields).toContain('agents[0].emojiReactionMode');
-    expect(result.addedFields).toContain('agents[1].emojiReactionMode');
+      expect(result.ignorePaths.size).toBe(0);
+      expect(result.template._migration).toBeUndefined();
+    });
+
+    it('throws when template file does not exist', () => {
+      const templatePath = path.join(tmpDir, 'nonexistent.json');
+      expect(() => loadCleanTemplate(templatePath)).toThrow(/Config template not found/);
+    });
+
+    it('handles _migration with no ignorePaths array gracefully', () => {
+      const templatePath = writeJson('template.json', {
+        _migration: { someOtherKey: true },
+        configVersion: '1.0.0',
+      });
+
+      const result = loadCleanTemplate(templatePath);
+
+      expect(result.ignorePaths.size).toBe(0);
+      expect(result.template._migration).toBeUndefined();
+    });
+
+    it('filters out non-string entries in ignorePaths', () => {
+      const templatePath = writeJson('template.json', {
+        _migration: {
+          ignorePaths: ['gateway.api', 42, null, 'gateway.secret'],
+        },
+        configVersion: '1.0.0',
+      });
+
+      const result = loadCleanTemplate(templatePath);
+
+      expect(result.ignorePaths.size).toBe(2);
+      expect(result.ignorePaths.has('gateway.api')).toBe(true);
+      expect(result.ignorePaths.has('gateway.secret')).toBe(true);
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Backup is created before migration
+  // stripIgnoredPaths
   // ---------------------------------------------------------------------------
-  it('creates a .bak backup before writing', () => {
-    const original = { gateway: { logDir: '/logs' } };
-    const configPath = writeJson('config.json', original);
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { logDir: '/default', newField: true },
+  describe('stripIgnoredPaths', () => {
+    it('removes keys matching ignorePaths', () => {
+      const obj: Record<string, unknown> = {
+        gateway: {
+          logDir: '/logs',
+          api: { keys: ['k1'], rateLimit: 100 },
+        },
+      };
+      const ignorePaths = new Set(['gateway.api']);
+
+      stripIgnoredPaths(obj, ignorePaths);
+
+      const gw = obj.gateway as Record<string, unknown>;
+      expect(gw.api).toBeUndefined();
+      expect(gw.logDir).toBe('/logs');
     });
 
-    migrateConfig(configPath, templatePath, '1.0.0');
+    it('removes nested keys matching ignorePaths', () => {
+      const obj: Record<string, unknown> = {
+        gateway: {
+          api: { keys: ['k1'], rateLimit: 100 },
+        },
+      };
+      const ignorePaths = new Set(['gateway.api.keys']);
 
-    const backup = JSON.parse(fs.readFileSync(configPath + '.bak', 'utf-8'));
-    expect(backup).toEqual(original);
+      stripIgnoredPaths(obj, ignorePaths);
+
+      const api = (obj.gateway as Record<string, unknown>).api as Record<string, unknown>;
+      expect(api.keys).toBeUndefined();
+      expect(api.rateLimit).toBe(100);
+    });
+
+    it('does nothing when ignorePaths is empty', () => {
+      const obj = { a: 1, b: { c: 2 } };
+      const original = structuredClone(obj);
+      stripIgnoredPaths(obj, new Set());
+      expect(obj).toEqual(original);
+    });
+
+    it('supports custom prefix for recursive calls', () => {
+      const obj: Record<string, unknown> = {
+        keys: ['k1'],
+        rateLimit: 100,
+      };
+      const ignorePaths = new Set(['gateway.api.keys']);
+
+      stripIgnoredPaths(obj, ignorePaths, 'gateway.api');
+
+      expect(obj.keys).toBeUndefined();
+      expect(obj.rateLimit).toBe(100);
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Invalid JSON in config => throws
+  // detectMigration
   // ---------------------------------------------------------------------------
-  it('throws on invalid JSON in config file', () => {
-    const configPath = path.join(tmpDir, 'bad.json');
-    fs.writeFileSync(configPath, '{ invalid json }', 'utf-8');
-    const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+  describe('detectMigration', () => {
+    it('returns needed:false when config file does not exist', () => {
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+      const configPath = path.join(tmpDir, 'nonexistent.json');
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+      expect(result.needed).toBe(false);
+      expect(result.addedFields).toEqual([]);
+    });
 
-    expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
-      /Config file is not valid JSON/,
-    );
+    it('returns needed:false when configVersion matches currentVersion', () => {
+      const configPath = writeJson('config.json', { configVersion: '1.0.0', gateway: {} });
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+      expect(result.needed).toBe(false);
+    });
+
+    it('returns needed:true with correct addedFields without writing', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: { logDir: '/logs' },
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', timezone: 'UTC' },
+      });
+
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+
+      expect(result.needed).toBe(true);
+      expect(result.fromVersion).toBe('0.0.1');
+      expect(result.toVersion).toBe('1.0.0');
+      expect(result.addedFields).toContain('gateway.timezone');
+      expect(result.addedFields).toContain('configVersion');
+
+      // Verify no writes occurred
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(onDisk.configVersion).toBe('0.0.1');
+      expect(onDisk.gateway.timezone).toBeUndefined();
+    });
+
+    it('strips _migration from template before detecting', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: {},
+      });
+      const templatePath = writeJson('template.json', {
+        _migration: { ignorePaths: ['gateway.api'] },
+        configVersion: '1.0.0',
+        gateway: { newField: 'x' },
+      });
+
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+
+      expect(result.needed).toBe(true);
+      expect(result.template._migration).toBeUndefined();
+      expect(result.addedFields).not.toContain('_migration');
+    });
+
+    it('throws on invalid JSON in config file', () => {
+      const configPath = path.join(tmpDir, 'bad.json');
+      fs.writeFileSync(configPath, '{ invalid json }', 'utf-8');
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+
+      expect(() => detectMigration(configPath, templatePath, '1.0.0')).toThrow(
+        /Config file is not valid JSON/,
+      );
+    });
+
+    it('treats missing configVersion as 0.0.0', () => {
+      const configPath = writeJson('config.json', { gateway: {} });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { newField: 'x' },
+      });
+
+      const result = detectMigration(configPath, templatePath, '1.0.0');
+
+      expect(result.needed).toBe(true);
+      expect(result.fromVersion).toBe('0.0.0');
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Preserves extra custom fields
+  // applyMigration
   // ---------------------------------------------------------------------------
-  it('preserves extra custom fields not in template', () => {
-    const configPath = writeJson('config.json', {
-      configVersion: '0.0.1',
-      gateway: { logDir: '/logs' },
-      customSection: { foo: 'bar' },
-    });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { logDir: '/default', newField: 'x' },
+  describe('applyMigration', () => {
+    it('writes updated config with backup', () => {
+      const original = { configVersion: '0.0.1', gateway: { logDir: '/logs' } };
+      const configPath = writeJson('config.json', original);
+      const template: Record<string, unknown> = {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', timezone: 'UTC' },
+      };
+      const config = structuredClone(original) as Record<string, unknown>;
+
+      const result = applyMigration(configPath, config, template, '1.0.0');
+
+      expect(result.migrated).toBe(true);
+      expect(result.addedFields).toContain('gateway.timezone');
+      expect(result.addedFields).toContain('configVersion');
+
+      // Verify file was written
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.configVersion).toBe('1.0.0');
+      expect(updated.gateway.timezone).toBe('UTC');
+      expect(updated.gateway.logDir).toBe('/logs'); // not overwritten
+
+      // Verify backup was created
+      const backup = JSON.parse(fs.readFileSync(configPath + '.bak', 'utf-8'));
+      expect(backup).toEqual(original);
     });
 
-    migrateConfig(configPath, templatePath, '1.0.0');
+    it('respects ignorePaths during merge', () => {
+      const original = { configVersion: '0.0.1', gateway: { logDir: '/logs' } };
+      const configPath = writeJson('config.json', original);
+      const template: Record<string, unknown> = {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', api: { keys: ['key1'] }, timezone: 'UTC' },
+      };
+      const config = structuredClone(original) as Record<string, unknown>;
+      const ignorePaths = new Set(['gateway.api']);
 
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(updated.customSection).toEqual({ foo: 'bar' });
+      const result = applyMigration(configPath, config, template, '1.0.0', ignorePaths);
+
+      expect(result.migrated).toBe(true);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.api).toBeUndefined();
+      expect(updated.gateway.timezone).toBe('UTC');
+      expect(result.addedFields).not.toContain('gateway.api');
+    });
+
+    it('merges agent arrays correctly', () => {
+      const original = {
+        configVersion: '0.0.1',
+        agents: [{ id: 'agent-a', telegram: { botToken: 'tok-a' } }],
+      };
+      const configPath = writeJson('config.json', original);
+      const template: Record<string, unknown> = {
+        configVersion: '1.0.0',
+        agents: [
+          {
+            id: 'example',
+            telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
+            emojiReactionMode: 'minimal',
+          },
+        ],
+      };
+      const config = structuredClone(original) as Record<string, unknown>;
+
+      const result = applyMigration(configPath, config, template, '1.0.0');
+
+      expect(result.migrated).toBe(true);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.agents[0].id).toBe('agent-a');
+      expect(updated.agents[0].emojiReactionMode).toBe('minimal');
+      expect(updated.agents[0].telegram.botToken).toBe('tok-a');
+      expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist');
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Nested object merge
+  // migrateConfig (integration — backward compat)
   // ---------------------------------------------------------------------------
-  it('recursively adds nested missing fields', () => {
-    const configPath = writeJson('config.json', {
-      gateway: { api: { keys: [] } },
+  describe('migrateConfig', () => {
+    it('returns migrated:false when config file does not exist', () => {
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+      const configPath = path.join(tmpDir, 'nonexistent.json');
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(false);
+      expect(result.addedFields).toEqual([]);
     });
-    const templatePath = writeJson('template.json', {
-      configVersion: '1.0.0',
-      gateway: { api: { keys: [], rateLimit: 100 }, timezone: 'UTC' },
+
+    it('throws when template file does not exist', () => {
+      const configPath = writeJson('config.json', { configVersion: '0.0.0' });
+      const templatePath = path.join(tmpDir, 'missing-template.json');
+      expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
+        /Config template not found/,
+      );
     });
 
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    it('returns migrated:false when configVersion matches currentVersion', () => {
+      const configPath = writeJson('config.json', { configVersion: '1.0.0', gateway: {} });
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(false);
+    });
 
-    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(updated.gateway.api.rateLimit).toBe(100);
-    expect(updated.gateway.timezone).toBe('UTC');
-    expect(result.addedFields).toContain('gateway.api.rateLimit');
-    expect(result.addedFields).toContain('gateway.timezone');
-  });
+    it('treats missing configVersion as 0.0.0 and migrates', () => {
+      const configPath = writeJson('config.json', { gateway: { logDir: '/logs' } });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', timezone: 'UTC' },
+      });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(true);
+      expect(result.addedFields).toContain('configVersion');
 
-  // ---------------------------------------------------------------------------
-  // Newer config version => no migration
-  // ---------------------------------------------------------------------------
-  it('skips migration when config version is already newer', () => {
-    const configPath = writeJson('config.json', { configVersion: '2.0.0', gateway: {} });
-    const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
-    const result = migrateConfig(configPath, templatePath, '1.0.0');
-    expect(result.migrated).toBe(false);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.configVersion).toBe('1.0.0');
+    });
+
+    it('never overwrites existing values', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: { logDir: '/my/logs', timezone: 'Asia/Bangkok' },
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default/logs', timezone: 'UTC', newField: 'hello' },
+      });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(true);
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.logDir).toBe('/my/logs');
+      expect(updated.gateway.timezone).toBe('Asia/Bangkok');
+      expect(updated.gateway.newField).toBe('hello');
+      expect(result.addedFields).toContain('gateway.newField');
+    });
+
+    it('adds missing fields to each agent from template schema', () => {
+      const configPath = writeJson('config.json', {
+        agents: [
+          { id: 'agent-a', telegram: { botToken: 'tok-a' } },
+          { id: 'agent-b', telegram: { botToken: 'tok-b' } },
+        ],
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        agents: [
+          {
+            id: 'example',
+            telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
+            emojiReactionMode: 'minimal',
+            signatureEmoji: '',
+          },
+        ],
+      });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(true);
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.agents[0].id).toBe('agent-a');
+      expect(updated.agents[0].emojiReactionMode).toBe('minimal');
+      expect(updated.agents[0].signatureEmoji).toBe('');
+      expect(updated.agents[0].telegram.botToken).toBe('tok-a');
+      expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist');
+
+      expect(updated.agents[1].id).toBe('agent-b');
+      expect(updated.agents[1].emojiReactionMode).toBe('minimal');
+
+      expect(result.addedFields).toContain('agents[0].emojiReactionMode');
+      expect(result.addedFields).toContain('agents[1].emojiReactionMode');
+    });
+
+    it('creates a .bak backup before writing', () => {
+      const original = { gateway: { logDir: '/logs' } };
+      const configPath = writeJson('config.json', original);
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', newField: true },
+      });
+
+      migrateConfig(configPath, templatePath, '1.0.0');
+
+      const backup = JSON.parse(fs.readFileSync(configPath + '.bak', 'utf-8'));
+      expect(backup).toEqual(original);
+    });
+
+    it('throws on invalid JSON in config file', () => {
+      const configPath = path.join(tmpDir, 'bad.json');
+      fs.writeFileSync(configPath, '{ invalid json }', 'utf-8');
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+
+      expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
+        /Config file is not valid JSON/,
+      );
+    });
+
+    it('preserves extra custom fields not in template', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: { logDir: '/logs' },
+        customSection: { foo: 'bar' },
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', newField: 'x' },
+      });
+
+      migrateConfig(configPath, templatePath, '1.0.0');
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.customSection).toEqual({ foo: 'bar' });
+    });
+
+    it('recursively adds nested missing fields', () => {
+      const configPath = writeJson('config.json', {
+        gateway: { api: { keys: [] } },
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.0',
+        gateway: { api: { keys: [], rateLimit: 100 }, timezone: 'UTC' },
+      });
+
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.api.rateLimit).toBe(100);
+      expect(updated.gateway.timezone).toBe('UTC');
+      expect(result.addedFields).toContain('gateway.api.rateLimit');
+      expect(result.addedFields).toContain('gateway.timezone');
+    });
+
+    it('skips migration when config version is already newer', () => {
+      const configPath = writeJson('config.json', { configVersion: '2.0.0', gateway: {} });
+      const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+      expect(result.migrated).toBe(false);
+    });
+
+    it('does not merge fields in ignorePaths from _migration', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: { logDir: '/logs' },
+      });
+      const templatePath = writeJson('template.json', {
+        _migration: { ignorePaths: ['gateway.api'] },
+        configVersion: '1.0.0',
+        gateway: {
+          logDir: '/default',
+          timezone: 'UTC',
+          api: { keys: ['key1'], rateLimit: 100 },
+        },
+      });
+
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+
+      expect(result.migrated).toBe(true);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      // api should NOT be merged because it is in ignorePaths
+      expect(updated.gateway.api).toBeUndefined();
+      // timezone should be merged normally
+      expect(updated.gateway.timezone).toBe('UTC');
+      expect(result.addedFields).not.toContain('gateway.api');
+      expect(result.addedFields).toContain('gateway.timezone');
+    });
+
+    it('strips _migration key from template before merge', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '0.0.1',
+        gateway: {},
+      });
+      const templatePath = writeJson('template.json', {
+        _migration: { ignorePaths: [] },
+        configVersion: '1.0.0',
+        gateway: { newField: 'x' },
+      });
+
+      const result = migrateConfig(configPath, templatePath, '1.0.0');
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      // _migration should NOT appear in the migrated config
+      expect(updated._migration).toBeUndefined();
+      expect(result.addedFields).not.toContain('_migration');
+    });
   });
 });

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -1,0 +1,235 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { migrateConfig, compareSemver } from '../../src/config-migrator';
+
+describe('config-migrator', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeJson(name: string, data: unknown): string {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(p, JSON.stringify(data, null, 2), 'utf-8');
+    return p;
+  }
+
+  // ---------------------------------------------------------------------------
+  // compareSemver
+  // ---------------------------------------------------------------------------
+  describe('compareSemver', () => {
+    it('returns 0 for equal versions', () => {
+      expect(compareSemver('1.0.0', '1.0.0')).toBe(0);
+    });
+
+    it('returns -1 when a < b', () => {
+      expect(compareSemver('1.0.0', '1.1.0')).toBe(-1);
+      expect(compareSemver('0.9.9', '1.0.0')).toBe(-1);
+    });
+
+    it('returns 1 when a > b', () => {
+      expect(compareSemver('2.0.0', '1.9.9')).toBe(1);
+      expect(compareSemver('1.0.1', '1.0.0')).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Config file missing (first run)
+  // ---------------------------------------------------------------------------
+  it('returns migrated:false when config file does not exist', () => {
+    const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+    const configPath = path.join(tmpDir, 'nonexistent.json');
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(false);
+    expect(result.addedFields).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Template file missing
+  // ---------------------------------------------------------------------------
+  it('throws when template file does not exist', () => {
+    const configPath = writeJson('config.json', { configVersion: '0.0.0' });
+    const templatePath = path.join(tmpDir, 'missing-template.json');
+    expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
+      /Config template not found/,
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Same version => no migration
+  // ---------------------------------------------------------------------------
+  it('returns migrated:false when configVersion matches currentVersion', () => {
+    const configPath = writeJson('config.json', { configVersion: '1.0.0', gateway: {} });
+    const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Missing configVersion treats as 0.0.0 => migrates
+  // ---------------------------------------------------------------------------
+  it('treats missing configVersion as 0.0.0 and migrates', () => {
+    const configPath = writeJson('config.json', { gateway: { logDir: '/logs' } });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { logDir: '/default', timezone: 'UTC' },
+    });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(true);
+    expect(result.addedFields).toContain('configVersion');
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(updated.configVersion).toBe('1.0.0');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Never overwrites existing values
+  // ---------------------------------------------------------------------------
+  it('never overwrites existing values', () => {
+    const configPath = writeJson('config.json', {
+      configVersion: '0.0.1',
+      gateway: { logDir: '/my/logs', timezone: 'Asia/Bangkok' },
+    });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { logDir: '/default/logs', timezone: 'UTC', newField: 'hello' },
+    });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(true);
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // Existing values preserved
+    expect(updated.gateway.logDir).toBe('/my/logs');
+    expect(updated.gateway.timezone).toBe('Asia/Bangkok');
+    // New field added
+    expect(updated.gateway.newField).toBe('hello');
+    expect(result.addedFields).toContain('gateway.newField');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Agent array: adds missing fields to each agent
+  // ---------------------------------------------------------------------------
+  it('adds missing fields to each agent from template schema', () => {
+    const configPath = writeJson('config.json', {
+      agents: [
+        { id: 'agent-a', telegram: { botToken: 'tok-a' } },
+        { id: 'agent-b', telegram: { botToken: 'tok-b' } },
+      ],
+    });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      agents: [
+        {
+          id: 'example',
+          telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
+          emojiReactionMode: 'minimal',
+          signatureEmoji: '',
+        },
+      ],
+    });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(true);
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // Agent A
+    expect(updated.agents[0].id).toBe('agent-a'); // not overwritten
+    expect(updated.agents[0].emojiReactionMode).toBe('minimal');
+    expect(updated.agents[0].signatureEmoji).toBe('');
+    expect(updated.agents[0].telegram.botToken).toBe('tok-a'); // not overwritten
+    expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist'); // added
+
+    // Agent B
+    expect(updated.agents[1].id).toBe('agent-b');
+    expect(updated.agents[1].emojiReactionMode).toBe('minimal');
+
+    expect(result.addedFields).toContain('agents[0].emojiReactionMode');
+    expect(result.addedFields).toContain('agents[1].emojiReactionMode');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Backup is created before migration
+  // ---------------------------------------------------------------------------
+  it('creates a .bak backup before writing', () => {
+    const original = { gateway: { logDir: '/logs' } };
+    const configPath = writeJson('config.json', original);
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { logDir: '/default', newField: true },
+    });
+
+    migrateConfig(configPath, templatePath, '1.0.0');
+
+    const backup = JSON.parse(fs.readFileSync(configPath + '.bak', 'utf-8'));
+    expect(backup).toEqual(original);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Invalid JSON in config => throws
+  // ---------------------------------------------------------------------------
+  it('throws on invalid JSON in config file', () => {
+    const configPath = path.join(tmpDir, 'bad.json');
+    fs.writeFileSync(configPath, '{ invalid json }', 'utf-8');
+    const templatePath = writeJson('template.json', { configVersion: '1.0.0' });
+
+    expect(() => migrateConfig(configPath, templatePath, '1.0.0')).toThrow(
+      /Config file is not valid JSON/,
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Preserves extra custom fields
+  // ---------------------------------------------------------------------------
+  it('preserves extra custom fields not in template', () => {
+    const configPath = writeJson('config.json', {
+      configVersion: '0.0.1',
+      gateway: { logDir: '/logs' },
+      customSection: { foo: 'bar' },
+    });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { logDir: '/default', newField: 'x' },
+    });
+
+    migrateConfig(configPath, templatePath, '1.0.0');
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(updated.customSection).toEqual({ foo: 'bar' });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Nested object merge
+  // ---------------------------------------------------------------------------
+  it('recursively adds nested missing fields', () => {
+    const configPath = writeJson('config.json', {
+      gateway: { api: { keys: [] } },
+    });
+    const templatePath = writeJson('template.json', {
+      configVersion: '1.0.0',
+      gateway: { api: { keys: [], rateLimit: 100 }, timezone: 'UTC' },
+    });
+
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+
+    const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(updated.gateway.api.rateLimit).toBe(100);
+    expect(updated.gateway.timezone).toBe('UTC');
+    expect(result.addedFields).toContain('gateway.api.rateLimit');
+    expect(result.addedFields).toContain('gateway.timezone');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Newer config version => no migration
+  // ---------------------------------------------------------------------------
+  it('skips migration when config version is already newer', () => {
+    const configPath = writeJson('config.json', { configVersion: '2.0.0', gateway: {} });
+    const templatePath = writeJson('template.json', { configVersion: '1.0.0', gateway: {} });
+    const result = migrateConfig(configPath, templatePath, '1.0.0');
+    expect(result.migrated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add emoji usage section to agent.md template generation with guidance on text emoji (sparse), reactions (1 per message max), and signature emoji
- Add `emojiReactionMode` and `signatureEmoji` fields to AgentConfig type and config.example.json
- Add signature emoji prompt to create-agent wizard (optional, after agent name step)
- Pass emoji options through to prompt builder so generated agent.md includes tailored emoji guidance

## Test plan
- [x] All 509 tests pass, 0 failures
- [ ] Run `make create-agent` and verify signature emoji prompt appears
- [ ] Verify generated agent.md contains Emoji Usage section