### PR TITLE
Replace acknowledge rule with infrastructure-driven status reactions

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -40,7 +40,6 @@
         "dangerouslySkipPermissions": true,
         "extraFlags": []
       },
-      "emojiReactionMode": "minimal",
       "signatureEmoji": "",
       "heartbeat": {
         "rateLimitMinutes": 30

--- a/plugins/telegram/server.ts
+++ b/plugins/telegram/server.ts
@@ -90,6 +90,10 @@ const typingManager = createWorkingStateManager(
     sendMessage: (chatId, text) => bot.api.sendMessage(chatId, text),
     editMessageText: (chatId, msgId, text) => bot.api.editMessageText(chatId, msgId, text),
     deleteMessage: (chatId, msgId) => bot.api.deleteMessage(chatId, msgId),
+    setMessageReaction: (chatId, msgId, emoji) =>
+      bot.api.setMessageReaction(chatId, msgId, [
+        { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] }
+      ]),
   },
   { mkdirSync, writeFileSync, existsSync, rmSync, readFileSync, statSync },
 )
@@ -130,6 +134,7 @@ function defaultAccess(): Access {
     allowFrom: [],
     groups: {},
     pending: {},
+    ackReaction: '👀',
   }
 }
 
@@ -694,6 +699,12 @@ async function handleInbound(
         { type: 'emoji', emoji: access.ackReaction as ReactionTypeEmoji['emoji'] },
       ])
       .catch(() => {})
+  }
+
+  // Store message ID for status reaction updates during processing
+  if (msgId != null) {
+    const msgIdPath = join(TYPING_DIR, `${chat_id}.msgid`)
+    try { writeFileSync(msgIdPath, String(msgId)) } catch {}
   }
 
   const imagePath = downloadImage ? await downloadImage() : undefined

--- a/plugins/telegram/typing.ts
+++ b/plugins/telegram/typing.ts
@@ -32,12 +32,22 @@ export const ERROR_MESSAGES: Record<string, string> = {
   SPAWN_FAILED: '❌ Failed to start Claude session. Please try again.',
 }
 
+export const STATUS_EMOJI: Record<string, string> = {
+  queued:   '👀',
+  thinking: '🤔',
+  tool:     '🔥',
+  coding:   '👨\u200d💻',
+  done:     '👍',
+  error:    '😱',
+}
+
 export interface WorkingState {
   typingInterval: ReturnType<typeof setInterval>
   statusInterval: ReturnType<typeof setInterval>
   stalledInterval: ReturnType<typeof setInterval>
   statusMessageId: number | null
   startedAt: number
+  currentReaction: string | null
 }
 
 export interface BotApi {
@@ -45,6 +55,7 @@ export interface BotApi {
   sendMessage(chatId: string, text: string): Promise<{ message_id: number }>
   editMessageText(chatId: string, msgId: number, text: string): Promise<unknown>
   deleteMessage(chatId: string, msgId: number): Promise<unknown>
+  setMessageReaction(chatId: string, msgId: number, emoji: string): Promise<unknown>
 }
 
 export interface FsApi {
@@ -75,15 +86,38 @@ export function createWorkingStateManager(
     return `${typingDir}/${chatId}.heartbeat`
   }
 
+  function statusFilePath(chatId: string): string {
+    return `${typingDir}/${chatId}.status`
+  }
+
+  function msgIdFilePath(chatId: string): string {
+    return `${typingDir}/${chatId}.msgid`
+  }
+
   async function stop(chatId: string): Promise<void> {
     const state = states.get(chatId)
     if (!state) return
     clearInterval(state.typingInterval)
     clearInterval(state.statusInterval)
     clearInterval(state.stalledInterval)
+    // Read final status and set done/error reaction before cleanup
+    const statusPath = statusFilePath(chatId)
+    const msgIdPath = msgIdFilePath(chatId)
+    if (fsApi.existsSync(statusPath) && fsApi.existsSync(msgIdPath)) {
+      try {
+        const finalStatus = fsApi.readFileSync(statusPath, 'utf8').trim()
+        const msgId = parseInt(fsApi.readFileSync(msgIdPath, 'utf8').trim(), 10)
+        const emoji = STATUS_EMOJI[finalStatus] ?? STATUS_EMOJI['done']
+        if (!isNaN(msgId) && emoji && state.currentReaction !== emoji) {
+          await botApi.setMessageReaction(chatId, msgId, emoji).catch(() => {})
+        }
+      } catch {}
+    }
     fsApi.rmSync(typingFilePath(chatId), { force: true })
     fsApi.rmSync(errorFilePath(chatId), { force: true })
     fsApi.rmSync(heartbeatFilePath(chatId), { force: true })
+    fsApi.rmSync(statusFilePath(chatId), { force: true })
+    fsApi.rmSync(msgIdFilePath(chatId), { force: true })
     if (state.statusMessageId !== null) {
       await botApi.deleteMessage(chatId, state.statusMessageId).catch(() => {})
     }
@@ -110,6 +144,7 @@ export function createWorkingStateManager(
       stalledInterval: null as unknown as ReturnType<typeof setInterval>,
       statusMessageId: null,
       startedAt,
+      currentReaction: null,
     }
     states.set(chatId, state)
 
@@ -127,6 +162,21 @@ export function createWorkingStateManager(
         return
       }
       void botApi.sendChatAction(chatId, 'typing').catch(() => {})
+      // Read .status + .msgid files and update reaction if state changed
+      const statusPath = statusFilePath(chatId)
+      const msgIdPath = msgIdFilePath(chatId)
+      if (fsApi.existsSync(statusPath) && fsApi.existsSync(msgIdPath)) {
+        try {
+          const status = fsApi.readFileSync(statusPath, 'utf8').trim()
+          const msgId = parseInt(fsApi.readFileSync(msgIdPath, 'utf8').trim(), 10)
+          const emoji = STATUS_EMOJI[status]
+          const s = states.get(chatId)
+          if (emoji && !isNaN(msgId) && s && s.currentReaction !== emoji) {
+            s.currentReaction = emoji
+            void botApi.setMessageReaction(chatId, msgId, emoji).catch(() => {})
+          }
+        } catch {}
+      }
     }, TYPING_INTERVAL_MS)
 
     state.statusInterval = setInterval(async () => {

--- a/scripts/create-agent-prompts.ts
+++ b/scripts/create-agent-prompts.ts
@@ -8,12 +8,11 @@
 export function buildGenerationPrompt(
   name: string,
   description: string,
-  options?: { signatureEmoji?: string; emojiReactionMode?: string }
+  options?: { signatureEmoji?: string }
 ): string {
   const signatureNote = options?.signatureEmoji
     ? `\nThe agent has a signature emoji: ${options.signatureEmoji}. Include it in the Emoji Usage section as the signature emoji.`
     : '';
-  const reactionMode = options?.emojiReactionMode ?? 'minimal';
 
   return `You are helping configure a Claude Code agent for the claude-gateway multi-bot system.
 
@@ -34,20 +33,11 @@ Rules:
 - agent.md is REQUIRED. Start with "# Agent: ${name}" on line 1.
   Include: role, rules, what it can/cannot do, language to use.
   Always include these rules under ## Rules:
-  "Acknowledge first (mandatory): Every message MUST begin with a text reply acknowledgement
-   before taking any action or calling any tool. No exceptions. Emoji reaction alone does NOT count.
-   Examples: 'Got it!', 'On it!', 'Sure thing!', 'Let me check…'"
   "Report completion (mandatory): After finishing any task, ALWAYS send a reply summarising what
    was done before the session ends. Never silently complete work without reporting the result back
    to the user."
   Also include an "## Emoji Usage" section in agent.md with these guidelines:
-    - Text emoji: Use sparingly in messages. Occasional emoji is fine for warmth, but don't overdo it.
-    - Reactions: React to messages like a human would — use the react tool. Max 1 reaction per message.
-      Reaction mode is "${reactionMode}": ${{
-        minimal: 'only react when the message clearly warrants it (e.g. thanks, celebrations, humor).',
-        extensive: 'react to most messages with an appropriate emoji to show engagement.',
-        none: 'do not use emoji reactions at all.',
-      }[reactionMode] ?? 'only react when the message clearly warrants it.'}
+    - React to messages naturally — use the react tool. Max 1 reaction per message.
     - Signature emoji: ${options?.signatureEmoji ? `Use ${options.signatureEmoji} as your signature emoji in greetings or sign-offs.` : 'None assigned.'}${signatureNote}
 - soul.md: tone and personality only (not rules). Omit if no distinct style.
 - user.md: target user profile. Omit if public/unknown.
@@ -108,17 +98,15 @@ ${currentContent}
 
 Update this agent.md to follow current best practices:
 - Preserve the agent's role, purpose, and all existing rules
-- Ensure ## Rules section includes these rules (add if missing, strengthen if weak):
-  "Acknowledge first (mandatory): Every message MUST begin with a text reply acknowledgement
-   before taking any action or calling any tool. No exceptions. Emoji reaction alone does NOT count.
-   Examples: 'Got it!', 'On it!', 'Sure thing!', 'Let me check…'"
+- REMOVE any "Acknowledge first" rule if present — this is now handled at infrastructure level
+- Ensure ## Rules section includes this rule (add if missing, strengthen if weak):
   "Report completion (mandatory): After finishing any task, ALWAYS send a reply summarising what
    was done before the session ends. Never silently complete work without reporting the result back
    to the user."
 - Ensure an "## Emoji Usage" section exists with these guidelines:
-    - Text emoji: Use sparingly. Occasional emoji is fine for warmth, but don't overdo it.
-    - Reactions: React to messages like a human would — use the react tool. Max 1 reaction per message.
+    - React to messages naturally — use the react tool. Max 1 reaction per message.
     - Signature emoji: preserve any existing signature emoji setting.
+- Remove any mention of "emojiReactionMode" if present
 - Keep the file under 500 words
 
 Output ONLY the updated agent.md content — no preamble, no explanation, no commentary.

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -138,7 +138,6 @@ interface RawAgentEntry {
     dangerouslySkipPermissions: boolean;
     extraFlags: string[];
   };
-  emojiReactionMode?: 'minimal' | 'extensive' | 'none';
   signatureEmoji?: string;
 }
 
@@ -283,7 +282,7 @@ function extractLeadingEmoji(text: string): { emoji: string | undefined; rest: s
 async function generateFiles(
   agentId: string,
   description: string,
-  options?: { signatureEmoji?: string; emojiReactionMode?: string }
+  options?: { signatureEmoji?: string }
 ): Promise<GenerateResult> {
   const agentName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
   console.log('\nGenerating workspace files with Claude...');
@@ -441,7 +440,7 @@ export async function appendToConfig(
   agentId: string,
   wsDir: string,
   agentMdContent: string,
-  options?: { emojiReactionMode?: 'minimal' | 'extensive' | 'none'; signatureEmoji?: string }
+  options?: { signatureEmoji?: string }
 ): Promise<void> {
   console.log('Updating config.json...');
 
@@ -468,9 +467,6 @@ export async function appendToConfig(
     },
   };
 
-  if (options?.emojiReactionMode) {
-    newAgent.emojiReactionMode = options.emojiReactionMode;
-  }
   if (options?.signatureEmoji) {
     newAgent.signatureEmoji = options.signatureEmoji;
   }
@@ -881,12 +877,6 @@ async function main(): Promise<void> {
   console.log(`  ✓ Signature emoji: ${signatureEmoji}`);
   rl2.close();
 
-  // ── Reaction mode selection ───────────────────────────────────────────
-  const reactionModes = ['minimal — react only when clearly warranted', 'extensive — react to most messages', 'none — no emoji reactions'];
-  const modeIdx = await interactiveSelect(reactionModes, 'Select emoji reaction mode (↑/↓ to move, Enter to select):');
-  const emojiReactionMode = (['minimal', 'extensive', 'none'] as const)[modeIdx];
-  console.log(`  ✓ Reaction mode: ${emojiReactionMode}`);
-
   // Resume stdin + new readline for file preview
   process.stdin.resume();
   const rl3 = createRl();
@@ -903,7 +893,6 @@ async function main(): Promise<void> {
   console.log('\nStep 3/6 · Create Workspace\n');
   const wsDir = await createWorkspace(agentId, acceptedFiles);
   await appendToConfig(agentId, wsDir, acceptedFiles.get('agent.md')!, {
-    emojiReactionMode,
     signatureEmoji,
   });
   state.wsDir = wsDir;

--- a/scripts/update-agent.ts
+++ b/scripts/update-agent.ts
@@ -41,7 +41,6 @@ interface RawAgentEntry {
   id: string;
   workspace: string;
   signatureEmoji?: string;
-  emojiReactionMode?: 'minimal' | 'extensive' | 'none';
   [key: string]: unknown;
 }
 
@@ -299,19 +298,8 @@ async function main(): Promise<void> {
     console.log(`  ✓ Signature emoji: ${signatureEmoji}`);
   }
 
-  // Step 7 — Reaction mode
-  const reactionModes = ['minimal — react only when clearly warranted', 'extensive — react to most messages', 'none — no emoji reactions'];
-  const modeKeys = ['minimal', 'extensive', 'none'] as const;
-  const currentModeIdx = modeKeys.indexOf((agent.emojiReactionMode ?? 'minimal') as typeof modeKeys[number]);
-  console.log(`\n  Current reaction mode: ${agent.emojiReactionMode ?? 'minimal'}`);
-
-  const modeIdx = await interactiveSelect(reactionModes, 'Select emoji reaction mode (↑/↓ to move, Enter to select):');
-  const emojiReactionMode = modeKeys[modeIdx];
-  console.log(`  ✓ Reaction mode: ${emojiReactionMode}`);
-
-  // Save emoji + reaction mode to config.json
+  // Save emoji to config.json
   agent.signatureEmoji = signatureEmoji;
-  agent.emojiReactionMode = emojiReactionMode;
   saveConfig(config);
   console.log('  ✓ config.json updated');
 

--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -205,9 +205,22 @@ export class SessionProcess extends EventEmitter {
     }
 
     // Capture stdout — emit output events + persist assistant replies
+    const typingDir = path.join(this.agentConfig.workspace, '.telegram-state', 'typing');
     const heartbeatPath = this.source === 'telegram'
-      ? path.join(this.agentConfig.workspace, '.telegram-state', 'typing', `${this.sessionId}.heartbeat`)
+      ? path.join(typingDir, `${this.sessionId}.heartbeat`)
       : null;
+    const statusPath = this.source === 'telegram'
+      ? path.join(typingDir, `${this.sessionId}.status`)
+      : null;
+
+    const writeStatus = (status: string): void => {
+      if (statusPath) {
+        try { fs.writeFileSync(statusPath, status) } catch {}
+      }
+    };
+
+    const CODING_TOOLS = new Set(['Write', 'Edit', 'NotebookEdit', 'MultiEdit']);
+
     let assistantBuffer = '';
     proc.stdout?.on('data', (data: Buffer) => {
       // Update heartbeat so the receiver's stalled detector knows Claude is active
@@ -219,7 +232,7 @@ export class SessionProcess extends EventEmitter {
         if (!line.trim()) continue;
         this.emit('output', line);
         this.logger.debug('session output', { line });
-        // Try to capture assistant text for SessionStore
+        // Try to capture assistant text for SessionStore + update status file
         try {
           const obj = JSON.parse(line);
           // stream-json assistant message
@@ -227,19 +240,31 @@ export class SessionProcess extends EventEmitter {
             for (const block of obj.message.content) {
               if (block.type === 'text') assistantBuffer += block.text;
             }
+            // Detect tool use to write status
+            const toolBlock = obj.message.content.find(
+              (b: { type: string }) => b.type === 'tool_use',
+            );
+            if (toolBlock) {
+              writeStatus(CODING_TOOLS.has(toolBlock.name ?? '') ? 'coding' : 'tool');
+            } else if (obj.message.content.some((b: { type: string }) => b.type === 'text')) {
+              writeStatus('thinking');
+            }
           }
           // text delta
           if (obj.type === 'text') assistantBuffer += obj.text ?? '';
           // result = end of turn
-          if (obj.type === 'result' && assistantBuffer.trim()) {
-            this.sessionStore
-              .appendMessage(this.agentConfig.id, this.sessionId, {
-                role: 'assistant',
-                content: assistantBuffer.trim(),
-                ts: Date.now(),
-              })
-              .catch(() => {});
-            assistantBuffer = '';
+          if (obj.type === 'result') {
+            writeStatus(obj.is_error ? 'error' : 'done');
+            if (assistantBuffer.trim()) {
+              this.sessionStore
+                .appendMessage(this.agentConfig.id, this.sessionId, {
+                  role: 'assistant',
+                  content: assistantBuffer.trim(),
+                  ts: Date.now(),
+                })
+                .catch(() => {});
+              assistantBuffer = '';
+            }
           }
         } catch {
           /* not JSON */
@@ -291,6 +316,16 @@ export class SessionProcess extends EventEmitter {
         sessionId: this.sessionId,
       });
       return;
+    }
+    // Signal queued state so the typing loop can update the reaction immediately
+    if (this.source === 'telegram') {
+      const statusPath = path.join(
+        this.agentConfig.workspace,
+        '.telegram-state',
+        'typing',
+        `${this.sessionId}.status`,
+      );
+      try { fs.writeFileSync(statusPath, 'queued') } catch {}
     }
     this.process.stdin.write(SessionProcess.toStreamJsonTurn(text) + '\n');
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,6 @@ export interface AgentConfig {
   };
   /** Session pool settings */
   session?: SessionConfig;
-  /** Emoji reaction mode for Telegram reactions */
-  emojiReactionMode?: 'minimal' | 'extensive' | 'none';
   /** Agent's signature emoji (used in greetings/sign-offs) */
   signatureEmoji?: string;
 }

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -350,7 +350,7 @@ describe('config-migrator', () => {
           {
             id: 'example',
             telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
-            emojiReactionMode: 'minimal',
+            signatureEmoji: '',
           },
         ],
       };
@@ -361,7 +361,7 @@ describe('config-migrator', () => {
       expect(result.migrated).toBe(true);
       const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
       expect(updated.agents[0].id).toBe('agent-a');
-      expect(updated.agents[0].emojiReactionMode).toBe('minimal');
+      expect(updated.agents[0].signatureEmoji).toBe('');
       expect(updated.agents[0].telegram.botToken).toBe('tok-a');
       expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist');
     });
@@ -440,7 +440,6 @@ describe('config-migrator', () => {
           {
             id: 'example',
             telegram: { botToken: '${TOKEN}', dmPolicy: 'allowlist' },
-            emojiReactionMode: 'minimal',
             signatureEmoji: '',
           },
         ],
@@ -450,16 +449,15 @@ describe('config-migrator', () => {
 
       const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
       expect(updated.agents[0].id).toBe('agent-a');
-      expect(updated.agents[0].emojiReactionMode).toBe('minimal');
       expect(updated.agents[0].signatureEmoji).toBe('');
       expect(updated.agents[0].telegram.botToken).toBe('tok-a');
       expect(updated.agents[0].telegram.dmPolicy).toBe('allowlist');
 
       expect(updated.agents[1].id).toBe('agent-b');
-      expect(updated.agents[1].emojiReactionMode).toBe('minimal');
+      expect(updated.agents[1].signatureEmoji).toBe('');
 
-      expect(result.addedFields).toContain('agents[0].emojiReactionMode');
-      expect(result.addedFields).toContain('agents[1].emojiReactionMode');
+      expect(result.addedFields).toContain('agents[0].signatureEmoji');
+      expect(result.addedFields).toContain('agents[1].signatureEmoji');
     });
 
     it('creates a .bak backup before writing', () => {

--- a/tests/unit/create-agent-prompts.test.ts
+++ b/tests/unit/create-agent-prompts.test.ts
@@ -5,6 +5,7 @@
 import {
   parseGeneratedFiles,
   buildGenerationPrompt,
+  buildUpdatePrompt,
 } from '../../scripts/create-agent-prompts';
 
 describe('create-agent-prompts', () => {
@@ -160,6 +161,37 @@ Line 3.`;
       const prompt = buildGenerationPrompt('Agent', 'Description.');
       expect(typeof prompt).toBe('string');
       expect(prompt.length).toBeGreaterThan(0);
+    });
+
+    // T12: No "Acknowledge first"
+    it('T12: does not contain "Acknowledge first"', () => {
+      const prompt = buildGenerationPrompt('Bot', 'A helpful bot.');
+      expect(prompt).not.toContain('Acknowledge first');
+    });
+
+    // T13: No "emojiReactionMode"
+    it('T13: does not contain "emojiReactionMode"', () => {
+      const prompt = buildGenerationPrompt('Bot', 'A helpful bot.');
+      expect(prompt).not.toContain('emojiReactionMode');
+    });
+
+    // T14: Has "Report completion"
+    it('T14: contains "Report completion"', () => {
+      const prompt = buildGenerationPrompt('Bot', 'A helpful bot.');
+      expect(prompt).toContain('Report completion');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildUpdatePrompt — T15
+  // ---------------------------------------------------------------------------
+  describe('buildUpdatePrompt', () => {
+    // T15: No "Acknowledge first"
+    it('T15: does not contain "Acknowledge first" as a rule to add', () => {
+      const prompt = buildUpdatePrompt('Bot', '# Agent: Bot\n## Rules\nsome rules');
+      // The update prompt should instruct removal, not addition
+      expect(prompt).not.toMatch(/add.*Acknowledge first/i);
+      expect(prompt).toContain('REMOVE');
     });
   });
 

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -456,4 +456,96 @@ describe('SessionProcess', () => {
       fs.rmSync(fakeHome, { recursive: true, force: true });
     }
   });
+
+  // --------------------------------------------------------------------------
+  // T7-T11: Status file writes from stream-json parsing
+  // --------------------------------------------------------------------------
+
+  function statusPath(workspace: string, sessionId: string): string {
+    return path.join(workspace, '.telegram-state', 'typing', `${sessionId}.status`);
+  }
+
+  it('T7: stdout tool_use Write → writes "coding" to status file', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const typingDir = path.join(agentConfig.workspace, '.telegram-state', 'typing');
+    fs.mkdirSync(typingDir, { recursive: true });
+
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [{ type: 'tool_use', name: 'Write' }],
+      },
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
+
+    const sp_path = statusPath(agentConfig.workspace, 'chat:111');
+    expect(fs.existsSync(sp_path)).toBe(true);
+    expect(fs.readFileSync(sp_path, 'utf-8')).toBe('coding');
+  });
+
+  it('T8: stdout tool_use Bash → writes "tool" to status file', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const typingDir = path.join(agentConfig.workspace, '.telegram-state', 'typing');
+    fs.mkdirSync(typingDir, { recursive: true });
+
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [{ type: 'tool_use', name: 'Bash' }],
+      },
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
+
+    const sp_path = statusPath(agentConfig.workspace, 'chat:111');
+    expect(fs.existsSync(sp_path)).toBe(true);
+    expect(fs.readFileSync(sp_path, 'utf-8')).toBe('tool');
+  });
+
+  it('T9: stdout result ok → writes "done" to status file', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const typingDir = path.join(agentConfig.workspace, '.telegram-state', 'typing');
+    fs.mkdirSync(typingDir, { recursive: true });
+
+    const line = JSON.stringify({ type: 'result', is_error: false });
+    lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
+
+    const sp_path = statusPath(agentConfig.workspace, 'chat:111');
+    expect(fs.existsSync(sp_path)).toBe(true);
+    expect(fs.readFileSync(sp_path, 'utf-8')).toBe('done');
+  });
+
+  it('T10: stdout result is_error → writes "error" to status file', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const typingDir = path.join(agentConfig.workspace, '.telegram-state', 'typing');
+    fs.mkdirSync(typingDir, { recursive: true });
+
+    const line = JSON.stringify({ type: 'result', is_error: true });
+    lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
+
+    const sp_path = statusPath(agentConfig.workspace, 'chat:111');
+    expect(fs.existsSync(sp_path)).toBe(true);
+    expect(fs.readFileSync(sp_path, 'utf-8')).toBe('error');
+  });
+
+  it('T11: sendMessage() writes "queued" to status file for telegram source', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const typingDir = path.join(agentConfig.workspace, '.telegram-state', 'typing');
+    fs.mkdirSync(typingDir, { recursive: true });
+
+    sp.sendMessage('hello');
+
+    const sp_path = statusPath(agentConfig.workspace, 'chat:111');
+    expect(fs.existsSync(sp_path)).toBe(true);
+    expect(fs.readFileSync(sp_path, 'utf-8')).toBe('queued');
+  });
 });

--- a/tests/unit/telegram-plugin/typing.test.ts
+++ b/tests/unit/telegram-plugin/typing.test.ts
@@ -7,6 +7,7 @@ import {
   createWorkingStateManager,
   STATUS_MESSAGES,
   ERROR_MESSAGES,
+  STATUS_EMOJI,
   TYPING_INTERVAL_MS,
   STATUS_INTERVAL_MS,
   STALLED_TIMEOUT_MS,
@@ -23,6 +24,7 @@ function makeBotApi(): jest.Mocked<BotApi> {
     sendMessage: jest.fn().mockResolvedValue({ message_id: 100 }),
     editMessageText: jest.fn().mockResolvedValue({}),
     deleteMessage: jest.fn().mockResolvedValue(undefined),
+    setMessageReaction: jest.fn().mockResolvedValue(undefined),
   }
 }
 
@@ -342,6 +344,151 @@ describe('createWorkingStateManager', () => {
         CHAT_ID,
         '❌ An error occurred. Please try again.',
       )
+    })
+  })
+
+  // ── T1–T6: Status emoji reaction ─────────────────────────────────────────
+
+  describe('STATUS_EMOJI map', () => {
+    test('T1: covers all required states', () => {
+      const required = ['queued', 'thinking', 'tool', 'coding', 'done', 'error']
+      for (const state of required) {
+        expect(STATUS_EMOJI[state]).toBeDefined()
+        expect(STATUS_EMOJI[state]!.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('status reaction in typingInterval', () => {
+    test('T2: reads .status=thinking and calls setMessageReaction(🤔)', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      // Write status + msgid files (as SessionProcess would)
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.status`, 'thinking')
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.msgid`, '42')
+
+      jest.advanceTimersByTime(TYPING_INTERVAL_MS)
+      await Promise.resolve()
+
+      expect(bot.setMessageReaction).toHaveBeenCalledWith(CHAT_ID, 42, STATUS_EMOJI['thinking'])
+
+      await mgr.stop(CHAT_ID)
+    })
+
+    test('T3: reads .status=done and calls setMessageReaction(👍)', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.status`, 'done')
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.msgid`, '99')
+
+      jest.advanceTimersByTime(TYPING_INTERVAL_MS)
+      await Promise.resolve()
+
+      expect(bot.setMessageReaction).toHaveBeenCalledWith(CHAT_ID, 99, STATUS_EMOJI['done'])
+
+      await mgr.stop(CHAT_ID)
+    })
+
+    test('T4: same reaction twice — setMessageReaction NOT called again', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.status`, 'thinking')
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.msgid`, '42')
+
+      // First tick — should call reaction
+      jest.advanceTimersByTime(TYPING_INTERVAL_MS)
+      await Promise.resolve()
+      expect(bot.setMessageReaction).toHaveBeenCalledTimes(1)
+
+      // Second tick — same status, should NOT call again
+      jest.advanceTimersByTime(TYPING_INTERVAL_MS)
+      await Promise.resolve()
+      expect(bot.setMessageReaction).toHaveBeenCalledTimes(1)
+
+      await mgr.stop(CHAT_ID)
+    })
+
+    test('T6: missing .status or .msgid — no error thrown, reaction unchanged', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      // No .status or .msgid files written
+
+      expect(() => jest.advanceTimersByTime(TYPING_INTERVAL_MS)).not.toThrow()
+      await Promise.resolve()
+
+      expect(bot.setMessageReaction).not.toHaveBeenCalled()
+
+      await mgr.stop(CHAT_ID)
+    })
+  })
+
+  describe('stop() cleans up status files', () => {
+    test('T5: stop() deletes .status and .msgid files', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      // Write the files
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.status`, 'thinking')
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.msgid`, '42')
+
+      await mgr.stop(CHAT_ID)
+
+      expect(fsApi._files.has(`${TYPING_DIR}/${CHAT_ID}.status`)).toBe(false)
+      expect(fsApi._files.has(`${TYPING_DIR}/${CHAT_ID}.msgid`)).toBe(false)
+    })
+
+    test('T5b: stop() sets final reaction before deleting files', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      // Simulate status=done written by session-process before stop is called
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.status`, 'done')
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.msgid`, '55')
+
+      await mgr.stop(CHAT_ID)
+
+      // Should have set the final reaction to 👍 before cleanup
+      expect(bot.setMessageReaction).toHaveBeenCalledWith(CHAT_ID, 55, STATUS_EMOJI['done'])
+      // Files still cleaned up
+      expect(fsApi._files.has(`${TYPING_DIR}/${CHAT_ID}.status`)).toBe(false)
+      expect(fsApi._files.has(`${TYPING_DIR}/${CHAT_ID}.msgid`)).toBe(false)
+    })
+
+    test('T5c: stop() sets error reaction when status=error', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.status`, 'error')
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.msgid`, '77')
+
+      await mgr.stop(CHAT_ID)
+
+      expect(bot.setMessageReaction).toHaveBeenCalledWith(CHAT_ID, 77, STATUS_EMOJI['error'])
     })
   })
 })

--- a/tests/unit/update-agent.test.ts
+++ b/tests/unit/update-agent.test.ts
@@ -8,8 +8,8 @@ import {
 } from '../../scripts/create-agent-prompts';
 
 describe('buildUpdatePrompt', () => {
-  // U-UA-01: agent.md already has the acknowledge rule — output should still include it (no duplicate instruction needed)
-  it('U-UA-01: includes acknowledge rule instruction when rule already exists in current content', () => {
+  // U-UA-01: update prompt instructs to REMOVE acknowledge rule (now infra-driven)
+  it('U-UA-01: instructs to REMOVE "Acknowledge first" rule (infra-driven now)', () => {
     const currentContent = `# Agent: MyBot
 
 ## Rules
@@ -18,12 +18,12 @@ describe('buildUpdatePrompt', () => {
 
     const prompt = buildUpdatePrompt('MyBot', currentContent);
 
-    expect(prompt).toContain('Acknowledge first (mandatory)');
-    expect(prompt).toContain('Every message MUST begin with a short acknowledgement');
+    expect(prompt).toContain('REMOVE');
+    expect(prompt).not.toMatch(/add.*Acknowledge first/i);
   });
 
-  // U-UA-02: agent.md has no acknowledge rule — output must include instruction to add it
-  it('U-UA-02: includes acknowledge rule instruction when rule is missing from current content', () => {
+  // U-UA-02: update prompt includes Report completion rule
+  it('U-UA-02: includes Report completion rule instruction', () => {
     const currentContent = `# Agent: MyBot
 
 ## Rules
@@ -32,8 +32,7 @@ describe('buildUpdatePrompt', () => {
 
     const prompt = buildUpdatePrompt('MyBot', currentContent);
 
-    expect(prompt).toContain('Acknowledge first (mandatory)');
-    expect(prompt).toContain('add if missing, strengthen if weak');
+    expect(prompt).toContain('Report completion');
   });
 
   // U-UA-03: buildUpdatePrompt preserves the existing role section by embedding currentContent
@@ -76,20 +75,20 @@ Senior data analyst specialized in Python and SQL.`;
   });
 });
 
-describe('buildGenerationPrompt — strengthened acknowledge rule', () => {
-  it('contains the mandatory acknowledge rule wording', () => {
+describe('buildGenerationPrompt — report completion rule (no acknowledge)', () => {
+  it('does not contain "Acknowledge first" (infra handles it now)', () => {
     const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
-    expect(prompt).toContain('Acknowledge first (mandatory)');
+    expect(prompt).not.toContain('Acknowledge first');
   });
 
-  it('states that every message MUST begin with acknowledgement', () => {
+  it('does not contain "Every message MUST begin with acknowledgement"', () => {
     const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
-    expect(prompt).toContain('Every message MUST begin with a text reply acknowledgement');
+    expect(prompt).not.toContain('Every message MUST begin with a text reply acknowledgement');
   });
 
-  it('states no exceptions', () => {
+  it('contains "Report completion (mandatory)"', () => {
     const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
-    expect(prompt).toContain('No exceptions.');
+    expect(prompt).toContain('Report completion');
   });
 
   it('references the ## Rules section placement', () => {
@@ -97,8 +96,8 @@ describe('buildGenerationPrompt — strengthened acknowledge rule', () => {
     expect(prompt).toContain('## Rules');
   });
 
-  it('does not use the old weak wording', () => {
+  it('does not contain emojiReactionMode', () => {
     const prompt = buildGenerationPrompt('TestAgent', 'A test agent.');
-    expect(prompt).not.toContain('send a brief acknowledgement first');
+    expect(prompt).not.toContain('emojiReactionMode');
   });
 });


### PR DESCRIPTION
## Summary
- Remove LLM-dependent "Acknowledge first" rule and replace with infrastructure-level emoji status reactions that automatically track session lifecycle
- Status flow: queued (👀) → thinking (🤔) → tool (🔥) → coding (👨‍💻) → done (👍) / error (😱)
- Remove deprecated `emojiReactionMode` config from types, scripts, and template
- Add `writeStatus()` in session-process to emit status via `.status` file
- Add status reading in typing interval + final status read in `stop()` to prevent race condition

## Motivation
Follows openclaw philosophy: acknowledgment should be handled at infrastructure level (guaranteed, code-driven) rather than relying on LLM to follow a text rule (can be missed).

## Files changed (13)
| Area | Files |
|---|---|
| Core | `session-process.ts`, `types.ts` |
| Plugin | `server.ts`, `typing.ts` |
| Scripts | `create-agent-prompts.ts`, `create-agent.ts`, `update-agent.ts` |
| Config | `config.template.json` |
| Tests | `typing.test.ts`, `session-process.test.ts`, `create-agent-prompts.test.ts`, `update-agent.test.ts`, `config-migrator.test.ts` |

## Test plan
- [x] All 597 tests pass (0 fail)
- [x] T1-T6: typing status reaction tests (read status, emoji mapping, final status in stop)
- [x] T7-T11: session-process writeStatus tests (queued/thinking/tool/coding/done/error)
- [x] T12-T15: prompt generation tests (no acknowledge rule, no emojiReactionMode)
- [x] Updated legacy tests for removed emojiReactionMode
- [x] Manual test: gateway restart, emoji flow verified