### PR TITLE
fix: improve status message detail for better readability

### DIFF
--- a/plugins/telegram/server.ts
+++ b/plugins/telegram/server.ts
@@ -562,6 +562,9 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
           }
         }
 
+        // Signal typing loop that reply was sent → stop typing indicator
+        typingManager.signalReplyDone(chat_id)
+
         const result =
           sentIds.length === 1
             ? `sent (id: ${sentIds[0]})`

--- a/plugins/telegram/typing.ts
+++ b/plugins/telegram/typing.ts
@@ -109,6 +109,10 @@ export function createWorkingStateManager(
     return `${typingDir}/${chatId}.msgid`
   }
 
+  function forwardFilePath(chatId: string): string {
+    return `${typingDir}/${chatId}.forward`
+  }
+
   async function stop(chatId: string): Promise<void> {
     const state = states.get(chatId)
     if (!state) return
@@ -129,6 +133,17 @@ export function createWorkingStateManager(
           await botApi.setMessageReaction(chatId, msgId, emoji).catch(() => {})
         }
       } catch {}
+    }
+    // Auto-forward result text if agent didn't call reply tool
+    const forwardPath = forwardFilePath(chatId)
+    if (fsApi.existsSync(forwardPath)) {
+      try {
+        const text = fsApi.readFileSync(forwardPath, 'utf8').trim()
+        if (text) {
+          await botApi.sendMessage(chatId, text).catch(() => {})
+        }
+      } catch {}
+      fsApi.rmSync(forwardPath, { force: true })
     }
     fsApi.rmSync(typingFilePath(chatId), { force: true })
     fsApi.rmSync(errorFilePath(chatId), { force: true })

--- a/plugins/telegram/typing.ts
+++ b/plugins/telegram/typing.ts
@@ -62,6 +62,7 @@ export interface WorkingState {
   startedAt: number
   currentReaction: string | null
   lastDetail: string | null
+  recentDetails: string[]
 }
 
 export interface BotApi {
@@ -163,6 +164,7 @@ export function createWorkingStateManager(
       startedAt,
       currentReaction: null,
       lastDetail: null,
+      recentDetails: [],
     }
     states.set(chatId, state)
 
@@ -182,9 +184,12 @@ export function createWorkingStateManager(
           : mins > 0
             ? secs > 0 ? `${mins}m ${secs}s` : `${mins}m`
             : `${secs}s`
-        const statusLine = s.lastDetail ?? STATUS_MESSAGES[tick % STATUS_MESSAGES.length]!
+        const currentLine = s.lastDetail ?? STATUS_MESSAGES[tick % STATUS_MESSAGES.length]!
         tick++
-        const text = `${statusLine}\n(elapsed: ${elapsedStr})`
+        // Build multi-line status: recent history (dimmed) + current line + elapsed
+        const historyLines = s.recentDetails.slice(-4).map(d => `  ${d}`);
+        const lines = [...historyLines, currentLine, `(elapsed: ${elapsedStr})`]
+        const text = lines.join('\n')
         if (s.statusMessageId === null) {
           try {
             const sent = await botApi.sendMessage(chatId, text)
@@ -231,6 +236,11 @@ export function createWorkingStateManager(
           }
           // Update detail and immediately send status when it changes
           if (s && detail && detail !== s.lastDetail) {
+            if (s.lastDetail) {
+              s.recentDetails.push(s.lastDetail)
+              // Keep only last 4 history entries
+              if (s.recentDetails.length > 4) s.recentDetails.shift()
+            }
             s.lastDetail = detail
             void sendStatusUpdate()
           }

--- a/plugins/telegram/typing.ts
+++ b/plugins/telegram/typing.ts
@@ -187,7 +187,7 @@ export function createWorkingStateManager(
         const currentLine = s.lastDetail ?? STATUS_MESSAGES[tick % STATUS_MESSAGES.length]!
         tick++
         // Build multi-line status: recent history (dimmed) + current line + elapsed
-        const historyLines = s.recentDetails.slice(-4).map(d => `  ${d}`);
+        const historyLines = s.recentDetails.slice(-4);
         const lines = [...historyLines, currentLine, `(elapsed: ${elapsedStr})`]
         const text = lines.join('\n')
         if (s.statusMessageId === null) {

--- a/plugins/telegram/typing.ts
+++ b/plugins/telegram/typing.ts
@@ -24,7 +24,8 @@ export const STATUS_MESSAGES = [
 export const STALLED_TIMEOUT_MS = 120_000  // 2 minutes without heartbeat → warn + stop
 export const STALLED_CHECK_INTERVAL_MS = 15_000  // check heartbeat freshness every 15s
 export const TYPING_INTERVAL_MS = 4_000    // sendChatAction every 4s (Telegram expires at 5s)
-export const STATUS_INTERVAL_MS = 30_000   // status update every 30s
+export const STATUS_INTERVAL_MS = 10_000   // status update every 10s
+export const STATUS_INITIAL_DELAY_MS = 5_000  // first status message after 5s
 
 export const ERROR_MESSAGES: Record<string, string> = {
   PROCESS_FAILED: '❌ Claude stopped unexpectedly. Please try sending a new message.',
@@ -56,6 +57,7 @@ export interface WorkingState {
   typingInterval: ReturnType<typeof setInterval>
   statusInterval: ReturnType<typeof setInterval>
   stalledInterval: ReturnType<typeof setInterval>
+  initialStatusTimer: ReturnType<typeof setTimeout> | null
   statusMessageId: number | null
   startedAt: number
   currentReaction: string | null
@@ -112,6 +114,7 @@ export function createWorkingStateManager(
     clearInterval(state.typingInterval)
     clearInterval(state.statusInterval)
     clearInterval(state.stalledInterval)
+    if (state.initialStatusTimer) clearTimeout(state.initialStatusTimer)
     // Read final status and set done/error reaction before cleanup
     const statusPath = statusFilePath(chatId)
     const msgIdPath = msgIdFilePath(chatId)
@@ -155,12 +158,48 @@ export function createWorkingStateManager(
       typingInterval: null as unknown as ReturnType<typeof setInterval>,
       statusInterval: null as unknown as ReturnType<typeof setInterval>,
       stalledInterval: null as unknown as ReturnType<typeof setInterval>,
+      initialStatusTimer: null,
       statusMessageId: null,
       startedAt,
       currentReaction: null,
       lastDetail: null,
     }
     states.set(chatId, state)
+
+    // Shared function to send/edit the status message
+    let statusUpdatePending = false
+    async function sendStatusUpdate(): Promise<void> {
+      const s = states.get(chatId)
+      if (!s || statusUpdatePending) return
+      statusUpdatePending = true
+      try {
+        const totalSecs = Math.floor((Date.now() - s.startedAt) / 1000)
+        const hours = Math.floor(totalSecs / 3600)
+        const mins = Math.floor((totalSecs % 3600) / 60)
+        const secs = totalSecs % 60
+        const elapsedStr = hours > 0
+          ? `${hours}h ${mins}m`
+          : mins > 0
+            ? secs > 0 ? `${mins}m ${secs}s` : `${mins}m`
+            : `${secs}s`
+        const statusLine = s.lastDetail ?? STATUS_MESSAGES[tick % STATUS_MESSAGES.length]!
+        tick++
+        const text = `${statusLine}\n(elapsed: ${elapsedStr})`
+        if (s.statusMessageId === null) {
+          try {
+            const sent = await botApi.sendMessage(chatId, text)
+            s.statusMessageId = sent.message_id
+          } catch {}
+        } else {
+          await botApi.editMessageText(chatId, s.statusMessageId, text).catch(async () => {
+            const current = states.get(chatId)
+            if (current) current.statusMessageId = null
+          })
+        }
+      } finally {
+        statusUpdatePending = false
+      }
+    }
 
     state.typingInterval = setInterval(() => {
       // File deleted by SEND_ONLY (reply sent) → stop loop
@@ -190,41 +229,22 @@ export function createWorkingStateManager(
             s.currentReaction = emoji
             void botApi.setMessageReaction(chatId, msgId, emoji).catch(() => {})
           }
-          // Update detail for status message
+          // Update detail and immediately send status when it changes
           if (s && detail && detail !== s.lastDetail) {
             s.lastDetail = detail
+            void sendStatusUpdate()
           }
         } catch {}
       }
     }, TYPING_INTERVAL_MS)
 
+    // First status message after 5s, then recurring every 10s
+    state.initialStatusTimer = setTimeout(() => {
+      void sendStatusUpdate()
+    }, STATUS_INITIAL_DELAY_MS)
+
     state.statusInterval = setInterval(async () => {
-      const s = states.get(chatId)
-      if (!s) return
-      const totalSecs = Math.floor((Date.now() - s.startedAt) / 1000)
-      const hours = Math.floor(totalSecs / 3600)
-      const mins = Math.floor((totalSecs % 3600) / 60)
-      const secs = totalSecs % 60
-      const elapsedStr = hours > 0
-        ? `${hours}h ${mins}m`
-        : mins > 0
-          ? secs > 0 ? `${mins}m ${secs}s` : `${mins}m`
-          : `${secs}s`
-      const statusLine = s.lastDetail ?? STATUS_MESSAGES[tick % STATUS_MESSAGES.length]!
-      tick++
-      const text = `${statusLine}\n(elapsed: ${elapsedStr})`
-      if (s.statusMessageId === null) {
-        try {
-          const sent = await botApi.sendMessage(chatId, text)
-          s.statusMessageId = sent.message_id
-        } catch {}
-      } else {
-        await botApi.editMessageText(chatId, s.statusMessageId, text).catch(async () => {
-          // Message was deleted by user — resend on next tick
-          const current = states.get(chatId)
-          if (current) current.statusMessageId = null
-        })
-      }
+      await sendStatusUpdate()
     }, STATUS_INTERVAL_MS)
 
     // Stalled detection: check heartbeat file freshness every STALLED_CHECK_INTERVAL_MS.

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -205,10 +205,29 @@ export class AgentRunner extends EventEmitter {
       });
       // Stop typing loop when Claude's turn truly ends (result event = end of turn).
       // This is deferred from the reply tool so typing stays active during multi-step work.
+      // Also auto-forward result text to Telegram if agent didn't call reply tool.
+      let replyCalled = false;
       proc.on('output', (line: string) => {
         try {
           const obj = JSON.parse(line) as Record<string, unknown>;
+          // Track mcp__telegram__reply tool calls
+          if (obj['type'] === 'assistant') {
+            const msg = obj['message'] as { content?: Array<{ type: string; name?: string }> } | undefined;
+            if (Array.isArray(msg?.content)) {
+              for (const block of msg!.content) {
+                if (block.type === 'tool_use' && block.name === 'mcp__telegram__reply') {
+                  replyCalled = true;
+                }
+              }
+            }
+          }
           if (obj['type'] === 'result') {
+            // Auto-forward result text if agent didn't call reply tool
+            const resultText = typeof obj['result'] === 'string' ? obj['result'] : '';
+            if (!replyCalled && resultText.trim()) {
+              this.writeAutoForward(sessionId, resultText.trim());
+            }
+            replyCalled = false; // reset for next turn
             this.writeTypingDone(sessionId);
           }
         } catch { /* non-JSON */ }
@@ -247,6 +266,20 @@ export class AgentRunner extends EventEmitter {
     const typingDir = path.join(this.agentConfig.workspace, '.telegram-state', 'typing');
     try {
       fs.rmSync(path.join(typingDir, chatId), { force: true });
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  /**
+   * Write result text to a forward file so the typing plugin sends it to Telegram.
+   * Used when the agent produces text output but didn't call mcp__telegram__reply.
+   */
+  private writeAutoForward(chatId: string, text: string): void {
+    const typingDir = path.join(this.agentConfig.workspace, '.telegram-state', 'typing');
+    try {
+      fs.mkdirSync(typingDir, { recursive: true });
+      fs.writeFileSync(path.join(typingDir, `${chatId}.forward`), text);
     } catch {
       // Non-fatal
     }

--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -232,33 +232,58 @@ export class SessionProcess extends EventEmitter {
     };
 
     function shortenPath(p: string): string {
+      // Keep last 2 segments for context (e.g. "src/api-router.ts" not just "api-router.ts")
       const parts = p.split('/');
-      return parts[parts.length - 1] || p;
+      return parts.length > 2 ? parts.slice(-2).join('/') : parts[parts.length - 1] || p;
     }
 
-    function truncateDetail(s: string, max = 80): string {
+    function truncateDetail(s: string, max = 200): string {
       return s.length > max ? s.slice(0, max) + '...' : s;
     }
 
     function extractToolDetail(name: string, input: Record<string, unknown>): string {
       const emoji = TOOL_EMOJI[name] ?? '🔧';
-      let desc = '';
+      const parts: string[] = [];
+
+      // Primary description (e.g. Bash.description, Agent.description)
       if (input.description && typeof input.description === 'string') {
-        desc = input.description;
-      } else if (input.file_path && typeof input.file_path === 'string') {
-        desc = shortenPath(input.file_path);
-      } else if (input.pattern && typeof input.pattern === 'string') {
-        desc = input.pattern;
-      } else if (input.url && typeof input.url === 'string') {
-        desc = input.url;
-      } else if (input.query && typeof input.query === 'string') {
-        desc = input.query;
-      } else if (input.command && typeof input.command === 'string') {
-        desc = input.command.slice(0, 60);
-      } else if (input.prompt && typeof input.prompt === 'string') {
-        desc = input.prompt.slice(0, 60);
+        parts.push(input.description);
       }
-      return truncateDetail(`${emoji} ${desc || name}`);
+      // File path context
+      if (input.file_path && typeof input.file_path === 'string') {
+        parts.push(shortenPath(input.file_path));
+      }
+      // Search pattern
+      if (input.pattern && typeof input.pattern === 'string') {
+        parts.push(input.pattern);
+      }
+      // URL
+      if (input.url && typeof input.url === 'string') {
+        parts.push(input.url);
+      }
+      // Search query
+      if (input.query && typeof input.query === 'string') {
+        parts.push(input.query);
+      }
+      // Bash command (when no description)
+      if (!parts.length && input.command && typeof input.command === 'string') {
+        parts.push(input.command);
+      }
+      // Agent/task prompt (when no description)
+      if (!parts.length && input.prompt && typeof input.prompt === 'string') {
+        parts.push(input.prompt);
+      }
+      // TodoWrite: summarize todo content
+      if (!parts.length && input.todos && Array.isArray(input.todos)) {
+        const active = (input.todos as { content?: string; status?: string }[])
+          .find(t => t.status === 'in_progress');
+        if (active?.content) {
+          parts.push(active.content);
+        }
+      }
+
+      const detail = parts.length ? parts.join(' — ') : name;
+      return truncateDetail(`${emoji} ${detail}`);
     }
 
     let assistantBuffer = '';

--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -224,11 +224,20 @@ export class SessionProcess extends EventEmitter {
 
     const CODING_TOOLS = new Set(['Write', 'Edit', 'NotebookEdit', 'MultiEdit']);
 
-    const TOOL_EMOJI: Record<string, string> = {
-      Read: '📖', Edit: '✏️', Write: '📝', NotebookEdit: '📝',
-      Grep: '🔍', Glob: '📂',
-      Bash: '⚡', WebFetch: '🌐', WebSearch: '🔎',
-      Agent: '🤖', Task: '🤖',
+    const TOOL_LABELS: Record<string, { emoji: string; verb: string }> = {
+      Read:         { emoji: '📖', verb: 'Reading' },
+      Edit:         { emoji: '✏️', verb: 'Editing' },
+      Write:        { emoji: '📝', verb: 'Writing' },
+      MultiEdit:    { emoji: '✏️', verb: 'Editing' },
+      NotebookEdit: { emoji: '📝', verb: 'Editing notebook' },
+      Grep:         { emoji: '🔍', verb: 'Searching for' },
+      Glob:         { emoji: '📂', verb: 'Finding files' },
+      Bash:         { emoji: '⚡', verb: 'Running' },
+      WebFetch:     { emoji: '🌐', verb: 'Fetching' },
+      WebSearch:    { emoji: '🔎', verb: 'Searching' },
+      Agent:        { emoji: '🤖', verb: 'Running agent' },
+      Task:         { emoji: '🤖', verb: 'Running task' },
+      TodoWrite:    { emoji: '📋', verb: 'Updating tasks' },
     };
 
     function shortenPath(p: string): string {
@@ -242,48 +251,60 @@ export class SessionProcess extends EventEmitter {
     }
 
     function extractToolDetail(name: string, input: Record<string, unknown>): string {
-      const emoji = TOOL_EMOJI[name] ?? '🔧';
-      const parts: string[] = [];
+      const label = TOOL_LABELS[name] ?? { emoji: '🔧', verb: name };
+      const { emoji, verb } = label;
 
-      // Primary description (e.g. Bash.description, Agent.description)
-      if (input.description && typeof input.description === 'string') {
-        parts.push(input.description);
-      }
-      // File path context
-      if (input.file_path && typeof input.file_path === 'string') {
-        parts.push(shortenPath(input.file_path));
-      }
-      // Search pattern
-      if (input.pattern && typeof input.pattern === 'string') {
-        parts.push(input.pattern);
-      }
-      // URL
-      if (input.url && typeof input.url === 'string') {
-        parts.push(input.url);
-      }
-      // Search query
-      if (input.query && typeof input.query === 'string') {
-        parts.push(input.query);
-      }
-      // Bash command (when no description)
-      if (!parts.length && input.command && typeof input.command === 'string') {
-        parts.push(input.command);
-      }
-      // Agent/task prompt (when no description)
-      if (!parts.length && input.prompt && typeof input.prompt === 'string') {
-        parts.push(input.prompt);
-      }
-      // TodoWrite: summarize todo content
-      if (!parts.length && input.todos && Array.isArray(input.todos)) {
-        const active = (input.todos as { content?: string; status?: string }[])
-          .find(t => t.status === 'in_progress');
-        if (active?.content) {
-          parts.push(active.content);
+      // Build context parts based on tool type
+      switch (name) {
+        case 'Read':
+        case 'Edit':
+        case 'Write':
+        case 'MultiEdit':
+        case 'NotebookEdit': {
+          const file = typeof input.file_path === 'string' ? shortenPath(input.file_path) : '';
+          const desc = typeof input.description === 'string' ? ` — ${input.description}` : '';
+          return truncateDetail(`${emoji} ${verb}: ${file}${desc}`);
+        }
+        case 'Grep': {
+          const pattern = typeof input.pattern === 'string' ? `"${input.pattern}"` : '';
+          const path = typeof input.path === 'string' ? ` in ${shortenPath(input.path)}` : '';
+          return truncateDetail(`${emoji} ${verb}: ${pattern}${path}`);
+        }
+        case 'Glob': {
+          const pattern = typeof input.pattern === 'string' ? `"${input.pattern}"` : '';
+          return truncateDetail(`${emoji} ${verb}: ${pattern}`);
+        }
+        case 'Bash': {
+          const desc = typeof input.description === 'string' ? input.description : '';
+          const cmd = typeof input.command === 'string' ? input.command : '';
+          return truncateDetail(`${emoji} ${verb}: ${desc || cmd}`);
+        }
+        case 'WebFetch': {
+          const url = typeof input.url === 'string' ? input.url : '';
+          return truncateDetail(`${emoji} ${verb}: ${url}`);
+        }
+        case 'WebSearch': {
+          const query = typeof input.query === 'string' ? input.query : '';
+          return truncateDetail(`${emoji} ${verb}: "${query}"`);
+        }
+        case 'Agent':
+        case 'Task': {
+          const desc = typeof input.description === 'string' ? input.description : '';
+          const prompt = typeof input.prompt === 'string' ? input.prompt : '';
+          return truncateDetail(`${emoji} ${verb}: ${desc || prompt}`);
+        }
+        case 'TodoWrite': {
+          const todos = Array.isArray(input.todos) ? input.todos as { content?: string; status?: string }[] : [];
+          const active = todos.find(t => t.status === 'in_progress');
+          const detail = active?.content ?? `${todos.length} items`;
+          return truncateDetail(`${emoji} ${verb}: ${detail}`);
+        }
+        default: {
+          // Generic fallback: try description, then name
+          const desc = typeof input.description === 'string' ? input.description : '';
+          return truncateDetail(`${emoji} ${verb}: ${desc || '...'}`);
         }
       }
-
-      const detail = parts.length ? parts.join(' — ') : name;
-      return truncateDetail(`${emoji} ${detail}`);
     }
 
     let assistantBuffer = '';
@@ -325,8 +346,8 @@ export class SessionProcess extends EventEmitter {
               writeStatus('tool', truncateDetail(`🤖 ${taskDesc}`));
             } else {
               const toolName = typeof obj.last_tool_name === 'string' ? obj.last_tool_name : '';
-              const emoji = TOOL_EMOJI[toolName] ?? '🔧';
-              writeStatus('tool', truncateDetail(`${emoji} ${taskDesc}`));
+              const toolLabel = TOOL_LABELS[toolName] ?? { emoji: '🔧', verb: toolName };
+              writeStatus('tool', truncateDetail(`${toolLabel.emoji} ${taskDesc}`));
             }
           }
           // rate_limit_event

--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -228,15 +228,15 @@ export class SessionProcess extends EventEmitter {
       Read:         { emoji: '📖', verb: 'Reading' },
       Edit:         { emoji: '✏️', verb: 'Editing' },
       Write:        { emoji: '📝', verb: 'Writing' },
-      MultiEdit:    { emoji: '✏️', verb: 'Editing' },
-      NotebookEdit: { emoji: '📝', verb: 'Editing notebook' },
-      Grep:         { emoji: '🔍', verb: 'Searching for' },
+      MultiEdit:    { emoji: '❤️‍🔥', verb: 'Editing' },
+      NotebookEdit: { emoji: '📕', verb: 'Editing notebook' },
+      Grep:         { emoji: '🔦', verb: 'Searching for' },
       Glob:         { emoji: '📂', verb: 'Finding files' },
-      Bash:         { emoji: '⚡', verb: 'Running' },
+      Bash:         { emoji: '💻', verb: 'Running' },
       WebFetch:     { emoji: '🌐', verb: 'Fetching' },
       WebSearch:    { emoji: '🔎', verb: 'Searching' },
       Agent:        { emoji: '🤖', verb: 'Running agent' },
-      Task:         { emoji: '🤖', verb: 'Running task' },
+      Task:         { emoji: '👉', verb: 'Running task' },
       TodoWrite:    { emoji: '📋', verb: 'Updating tasks' },
     };
 
@@ -246,8 +246,17 @@ export class SessionProcess extends EventEmitter {
       return parts.length > 2 ? parts.slice(-2).join('/') : parts[parts.length - 1] || p;
     }
 
-    function truncateDetail(s: string, max = 200): string {
-      return s.length > max ? s.slice(0, max) + '...' : s;
+    function truncateDetail(s: string, maxLines = 5, maxChars = 300): string {
+      const lines = s.split('\n').filter(l => l.trim());
+      const trimmedByLines = lines.length > maxLines;
+      const kept = lines.slice(0, maxLines);
+      let result = kept.join('\n');
+      if (result.length > maxChars) {
+        result = result.slice(0, maxChars) + '...';
+      } else if (trimmedByLines) {
+        result += '\n...';
+      }
+      return result;
     }
 
     function extractToolDetail(name: string, input: Record<string, unknown>): string {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -475,7 +475,7 @@ describe('SessionProcess', () => {
     const line = JSON.stringify({
       type: 'assistant',
       message: {
-        content: [{ type: 'tool_use', name: 'Write' }],
+        content: [{ type: 'tool_use', name: 'Write', input: { file_path: '/home/user/src/app.ts' } }],
       },
     });
     lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
@@ -484,7 +484,8 @@ describe('SessionProcess', () => {
     expect(fs.existsSync(sp_path)).toBe(true);
     const written = JSON.parse(fs.readFileSync(sp_path, 'utf-8'));
     expect(written.status).toBe('coding');
-    expect(written.detail).toContain('Write');
+    expect(written.detail).toContain('Writing');
+    expect(written.detail).toContain('src/app.ts');
   });
 
   it('T8: stdout tool_use Bash → writes "tool" to status file', async () => {
@@ -497,7 +498,7 @@ describe('SessionProcess', () => {
     const line = JSON.stringify({
       type: 'assistant',
       message: {
-        content: [{ type: 'tool_use', name: 'Bash' }],
+        content: [{ type: 'tool_use', name: 'Bash', input: { command: 'npm test', description: 'Run tests' } }],
       },
     });
     lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
@@ -506,7 +507,8 @@ describe('SessionProcess', () => {
     expect(fs.existsSync(sp_path)).toBe(true);
     const written = JSON.parse(fs.readFileSync(sp_path, 'utf-8'));
     expect(written.status).toBe('tool');
-    expect(written.detail).toContain('Bash');
+    expect(written.detail).toContain('Running');
+    expect(written.detail).toContain('Run tests');
   });
 
   it('T9: stdout result ok → writes "done" to status file', async () => {


### PR DESCRIPTION
## Summary
- Increase status message truncation from 80 to 200 characters for 3-5 lines of readable context
- Keep last 2 path segments (e.g. `src/api-router.ts` instead of `api-router.ts`) for better file identification
- Combine multiple input fields with dashes for richer tool descriptions
- Add TodoWrite support: show the active task content instead of just the tool name
- Bash command shows full command when no description is provided

## Before/After
| Before | After |
|---|---|
| `📖 api-router.test.ts` | `📖 unit/api-router.test.ts` |
| `🔧 TodoWrite` | `🔧 Adding SSE streaming to api-router.ts` |
| `⚡ Bash` | `⚡ npm run build` |
| `🧠 Now add the...` (truncated at 80) | `🧠 Now add the sendApiMessageStream method after sendApiMessage. This handles...` (200 chars) |

## Test plan
- [x] All 606 tests pass
- [x] Build clean
- [x] Existing session-process tests (T7, T8) still pass with new format