### PR TITLE
feat: cron agent integration, schedule types, delivery, and auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ curl -X POST \
 
 See [Quickstart: Using the Agent API](#quickstart-using-the-agent-api) for full examples with request/response JSON.
 
+#### Agent API
+
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/api/v1/agents/:agentId/messages` | Send a message — sync JSON or SSE stream |
@@ -367,6 +369,72 @@ See [Quickstart: Using the Agent API](#quickstart-using-the-agent-api) for full 
 | 409 | Session is busy processing another request |
 | 504 | Agent did not respond within 60s |
 | 500 | Internal error |
+
+#### Cron API
+
+Manage persistent scheduled jobs via REST. All routes require the same API key auth as the Agent API. Write operations (`POST`, `PUT`, `DELETE`) additionally verify the key has access to the job's `agentId`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/crons` | List jobs (filtered to key's accessible agents) |
+| `GET` | `/api/v1/crons/status` | Scheduler status (total, enabled, running) |
+| `POST` | `/api/v1/crons` | Create a new job |
+| `GET` | `/api/v1/crons/:id` | Get a single job |
+| `PUT` | `/api/v1/crons/:id` | Update a job |
+| `DELETE` | `/api/v1/crons/:id` | Delete a job |
+| `POST` | `/api/v1/crons/:id/run` | Trigger a job manually |
+| `GET` | `/api/v1/crons/:id/runs` | Get run history (last 20 by default) |
+
+**Create job — request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `agentId` | Yes | Agent to associate this job with |
+| `name` | Yes | Human-readable job name |
+| `scheduleKind` | No | `"cron"` (default), `"at"`, or `"every"` |
+| `schedule` | If `scheduleKind=cron` | 5-field cron expression e.g. `"0 9 * * *"` |
+| `scheduleAt` | If `scheduleKind=at` | ISO 8601 timestamp for one-shot run |
+| `everyMs` | If `scheduleKind=every` | Interval in milliseconds |
+| `payloadKind` | No | `"command"` (default) or `"agentTurn"` |
+| `command` | If `payloadKind=command` | Shell command to run |
+| `agentTurnMessage` | If `payloadKind=agentTurn` | Prompt sent to the agent as a new turn |
+| `notify` | No | `{ "telegram": { "chatId": "..." } }` — deliver result to Telegram |
+| `failureAlert` | No | `{ "telegram": { "chatId": "...", "consecutiveErrors": 3 } }` |
+| `deleteAfterRun` | No | `true` to auto-delete after first run (one-shot jobs) |
+| `enabled` | No | `true` (default) / `false` to create disabled |
+
+**Examples:**
+
+```bash
+# Create a daily cron that sends a prompt to an agent
+curl -X POST -H "X-Api-Key: my-key" -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "alfred",
+    "name": "morning-brief",
+    "scheduleKind": "cron",
+    "schedule": "0 9 * * *",
+    "payloadKind": "agentTurn",
+    "agentTurnMessage": "Give me a morning summary."
+  }' http://localhost:3000/api/v1/crons
+
+# Schedule a one-shot command
+curl -X POST -H "X-Api-Key: my-key" -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "alfred",
+    "name": "deploy",
+    "scheduleKind": "at",
+    "scheduleAt": "2026-04-10T10:00:00Z",
+    "payloadKind": "command",
+    "command": "make deploy",
+    "deleteAfterRun": true
+  }' http://localhost:3000/api/v1/crons
+
+# Trigger a job immediately
+curl -X POST -H "X-Api-Key: my-key" \
+  http://localhost:3000/api/v1/crons/<id>/run
+```
+
+Jobs are persisted to `~/.claude-gateway/crons.json` and survive gateway restarts.
 
 ---
 
@@ -428,6 +496,8 @@ claude-gateway/
 │   ├── api-auth.ts                     ← API key auth middleware (timing-safe)
 │   ├── config-loader.ts                ← load + validate config.json
 │   ├── config-migrator.ts              ← auto-migration for config schema changes
+│   ├── cron-manager.ts                 ← persistent cron job manager (REST + agentTurn)
+│   ├── cron-router.ts                  ← Cron API router (auth + agent-scoped access)
 │   ├── cron-scheduler.ts               ← heartbeat task scheduler
 │   ├── heartbeat-parser.ts             ← parse heartbeat.md YAML
 │   ├── heartbeat-history.ts            ← track scheduled task execution
@@ -571,6 +641,8 @@ The gateway runs an HTTP server on port 3000 (set `PORT` env var to change):
 | `GET /ui` | Live HTML dashboard (auto-refreshes every 5s) |
 | `POST /api/v1/agents/:id/messages` | Send a message to an agent (requires API key) |
 | `GET /api/v1/agents` | List accessible agents (requires API key) |
+| `GET /api/v1/crons` | List cron jobs accessible by key (requires API key) |
+| `POST /api/v1/crons` | Create a scheduled job (requires API key + agent access) |
 
 ---
 

--- a/src/cron-manager.ts
+++ b/src/cron-manager.ts
@@ -1,0 +1,383 @@
+import { EventEmitter } from 'events';
+import * as nodeCron from 'node-cron';
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { exec } from 'child_process';
+import { CronJob, CronJobCreate, CronJobUpdate, CronRunLog, CronManagerConfig, Logger } from './types';
+
+const DEFAULT_STORE_PATH = path.join(
+  process.env.HOME ?? '/tmp',
+  '.claude-gateway',
+  'crons.json',
+);
+
+const DEFAULT_RUNS_DIR = path.join(
+  process.env.HOME ?? '/tmp',
+  '.claude-gateway',
+  'cron-runs',
+);
+
+const MAX_RUN_LOGS_PER_JOB = 100;
+
+interface StoreFormat {
+  version: 1;
+  jobs: CronJob[];
+}
+
+export class CronManager extends EventEmitter {
+  private readonly storePath: string;
+  private readonly runsDir: string;
+  private readonly logger: Logger;
+  private jobs: Map<string, CronJob> = new Map();
+  private scheduledTasks: Map<string, nodeCron.ScheduledTask> = new Map();
+
+  constructor(config?: CronManagerConfig, logger?: Logger) {
+    super();
+    this.storePath = config?.storePath ?? DEFAULT_STORE_PATH;
+    this.runsDir = config?.runsDir ?? DEFAULT_RUNS_DIR;
+    this.logger = logger ?? console;
+  }
+
+  /**
+   * Load persisted jobs from disk and schedule them.
+   */
+  async start(): Promise<void> {
+    // Ensure directories exist
+    const storeDir = path.dirname(this.storePath);
+    await fs.promises.mkdir(storeDir, { recursive: true });
+    await fs.promises.mkdir(this.runsDir, { recursive: true });
+
+    // Load existing jobs
+    if (fs.existsSync(this.storePath)) {
+      try {
+        const raw = await fs.promises.readFile(this.storePath, 'utf8');
+        const store: StoreFormat = JSON.parse(raw);
+        if (store.version === 1 && Array.isArray(store.jobs)) {
+          for (const job of store.jobs) {
+            this.jobs.set(job.id, job);
+            if (job.enabled) {
+              this.scheduleJob(job);
+            }
+          }
+          this.logger.info(`Loaded ${store.jobs.length} cron job(s) from disk`);
+        }
+      } catch (err) {
+        this.logger.error('Failed to load crons.json', { error: (err as Error).message });
+      }
+    } else {
+      this.logger.info('No existing crons.json — starting fresh');
+    }
+
+    // Check for missed jobs on startup
+    await this.catchUpMissedJobs();
+  }
+
+  /**
+   * Stop all scheduled tasks.
+   */
+  stop(): void {
+    for (const [id, task] of this.scheduledTasks) {
+      task.stop();
+    }
+    this.scheduledTasks.clear();
+    this.logger.info('All cron jobs stopped');
+  }
+
+  // ─── CRUD Operations ─────────────────────────────────────────────────────
+
+  /**
+   * Create a new cron job.
+   */
+  async create(input: CronJobCreate): Promise<CronJob> {
+    // Validate cron expression
+    if (!nodeCron.validate(input.schedule)) {
+      throw new Error(`Invalid cron expression: "${input.schedule}"`);
+    }
+
+    const now = Date.now();
+    const job: CronJob = {
+      id: randomUUID(),
+      agentId: input.agentId,
+      name: input.name,
+      schedule: input.schedule,
+      command: input.command,
+      enabled: input.enabled ?? true,
+      createdAt: now,
+      updatedAt: now,
+      notify: input.notify,
+      state: {
+        lastRunAt: null,
+        lastStatus: null,
+        lastError: null,
+        consecutiveErrors: 0,
+        runCount: 0,
+      },
+    };
+
+    this.jobs.set(job.id, job);
+
+    if (job.enabled) {
+      this.scheduleJob(job);
+    }
+
+    await this.persist();
+    this.logger.info(`Created cron job "${job.name}"`, { id: job.id, schedule: job.schedule });
+    this.emit('job:created', job);
+
+    return job;
+  }
+
+  /**
+   * Update an existing cron job.
+   */
+  async update(id: string, input: CronJobUpdate): Promise<CronJob> {
+    const job = this.jobs.get(id);
+    if (!job) throw new Error(`Job not found: ${id}`);
+
+    // Validate new schedule if provided
+    if (input.schedule !== undefined) {
+      if (!nodeCron.validate(input.schedule)) {
+        throw new Error(`Invalid cron expression: "${input.schedule}"`);
+      }
+      job.schedule = input.schedule;
+    }
+
+    if (input.name !== undefined) job.name = input.name;
+    if (input.command !== undefined) job.command = input.command;
+    if (input.notify !== undefined) job.notify = input.notify;
+
+    if (input.enabled !== undefined) {
+      job.enabled = input.enabled;
+    }
+
+    job.updatedAt = Date.now();
+
+    // Reschedule
+    this.unscheduleJob(id);
+    if (job.enabled) {
+      this.scheduleJob(job);
+    }
+
+    await this.persist();
+    this.logger.info(`Updated cron job "${job.name}"`, { id });
+    this.emit('job:updated', job);
+
+    return job;
+  }
+
+  /**
+   * Delete a cron job.
+   */
+  async remove(id: string): Promise<void> {
+    const job = this.jobs.get(id);
+    if (!job) throw new Error(`Job not found: ${id}`);
+
+    this.unscheduleJob(id);
+    this.jobs.delete(id);
+
+    await this.persist();
+    this.logger.info(`Removed cron job "${job.name}"`, { id });
+    this.emit('job:removed', id);
+  }
+
+  /**
+   * Get a job by ID.
+   */
+  get(id: string): CronJob | undefined {
+    return this.jobs.get(id);
+  }
+
+  /**
+   * List all jobs, optionally filtered by agentId.
+   */
+  list(agentId?: string): CronJob[] {
+    const all = [...this.jobs.values()];
+    if (agentId) return all.filter((j) => j.agentId === agentId);
+    return all;
+  }
+
+  /**
+   * Manually trigger a job immediately.
+   */
+  async run(id: string): Promise<CronRunLog> {
+    const job = this.jobs.get(id);
+    if (!job) throw new Error(`Job not found: ${id}`);
+    return this.executeJob(job);
+  }
+
+  /**
+   * Get run history for a job.
+   */
+  async getRuns(id: string, limit = 20): Promise<CronRunLog[]> {
+    const logFile = path.join(this.runsDir, `${id}.jsonl`);
+    if (!fs.existsSync(logFile)) return [];
+
+    const content = await fs.promises.readFile(logFile, 'utf8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    return lines
+      .slice(-limit)
+      .map((line) => {
+        try {
+          return JSON.parse(line) as CronRunLog;
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean) as CronRunLog[];
+  }
+
+  /**
+   * Get overall status.
+   */
+  status(): {
+    totalJobs: number;
+    enabledJobs: number;
+    disabledJobs: number;
+    jobs: CronJob[];
+  } {
+    const all = [...this.jobs.values()];
+    return {
+      totalJobs: all.length,
+      enabledJobs: all.filter((j) => j.enabled).length,
+      disabledJobs: all.filter((j) => !j.enabled).length,
+      jobs: all,
+    };
+  }
+
+  // ─── Internal ─────────────────────────────────────────────────────────────
+
+  private scheduleJob(job: CronJob): void {
+    const task = nodeCron.schedule(job.schedule, async () => {
+      await this.executeJob(job);
+    });
+    this.scheduledTasks.set(job.id, task);
+    this.logger.info(`Scheduled "${job.name}" [${job.schedule}]`, { id: job.id });
+  }
+
+  private unscheduleJob(id: string): void {
+    const task = this.scheduledTasks.get(id);
+    if (task) {
+      task.stop();
+      this.scheduledTasks.delete(id);
+    }
+  }
+
+  private async executeJob(job: CronJob): Promise<CronRunLog> {
+    const startedAt = Date.now();
+    this.logger.info(`Executing cron job "${job.name}"`, { id: job.id });
+
+    let status: 'ok' | 'error' = 'ok';
+    let output = '';
+    let error: string | null = null;
+
+    try {
+      output = await this.runCommand(job.command, job.agentId);
+      job.state.consecutiveErrors = 0;
+    } catch (err) {
+      status = 'error';
+      error = (err as Error).message;
+      output = error;
+      job.state.consecutiveErrors++;
+      this.logger.error(`Cron job "${job.name}" failed`, { id: job.id, error });
+    }
+
+    const durationMs = Date.now() - startedAt;
+    job.state.lastRunAt = startedAt;
+    job.state.lastStatus = status;
+    job.state.lastError = error;
+    job.state.runCount++;
+    job.updatedAt = Date.now();
+
+    const runLog: CronRunLog = {
+      jobId: job.id,
+      startedAt,
+      durationMs,
+      status,
+      output: output.slice(0, 5000), // cap output size
+      error,
+    };
+
+    // Persist state and log
+    await Promise.all([
+      this.persist(),
+      this.appendRunLog(job.id, runLog),
+    ]);
+
+    this.emit('job:executed', job, runLog);
+    return runLog;
+  }
+
+  private runCommand(command: string, agentId: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const env = {
+        ...process.env,
+        CRON_AGENT_ID: agentId,
+      };
+
+      exec(command, { timeout: 120_000, env, maxBuffer: 1024 * 1024 }, (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(`${err.message}\n${stderr}`.trim()));
+        } else {
+          resolve(stdout.trim());
+        }
+      });
+    });
+  }
+
+  private async persist(): Promise<void> {
+    const store: StoreFormat = {
+      version: 1,
+      jobs: [...this.jobs.values()],
+    };
+
+    // Write atomically (write to temp, then rename)
+    const tmpPath = this.storePath + '.tmp';
+    await fs.promises.writeFile(tmpPath, JSON.stringify(store, null, 2), 'utf8');
+    await fs.promises.rename(tmpPath, this.storePath);
+  }
+
+  private async appendRunLog(jobId: string, log: CronRunLog): Promise<void> {
+    const logFile = path.join(this.runsDir, `${jobId}.jsonl`);
+    await fs.promises.appendFile(logFile, JSON.stringify(log) + '\n', 'utf8');
+
+    // Prune old entries
+    try {
+      const content = await fs.promises.readFile(logFile, 'utf8');
+      const lines = content.trim().split('\n');
+      if (lines.length > MAX_RUN_LOGS_PER_JOB) {
+        const pruned = lines.slice(-MAX_RUN_LOGS_PER_JOB).join('\n') + '\n';
+        await fs.promises.writeFile(logFile, pruned, 'utf8');
+      }
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  /**
+   * On startup, check for jobs that should have run while we were down.
+   * Run them once to catch up (max 5 missed jobs).
+   */
+  private async catchUpMissedJobs(): Promise<void> {
+    const MAX_CATCHUP = 5;
+    let caught = 0;
+
+    for (const job of this.jobs.values()) {
+      if (!job.enabled || caught >= MAX_CATCHUP) continue;
+      if (!job.state.lastRunAt) continue;
+
+      // Simple heuristic: if lastRunAt is more than 2x the cron interval ago, run it
+      const ageMs = Date.now() - job.state.lastRunAt;
+      if (ageMs > 30 * 60 * 1000) { // more than 30 min stale
+        this.logger.info(`Catching up missed job "${job.name}"`, { id: job.id, ageMs });
+        // Stagger catchup runs
+        setTimeout(() => this.executeJob(job), caught * 5000);
+        caught++;
+      }
+    }
+
+    if (caught > 0) {
+      this.logger.info(`Catching up ${caught} missed job(s)`);
+    }
+  }
+}

--- a/src/cron-manager.ts
+++ b/src/cron-manager.ts
@@ -4,7 +4,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { exec } from 'child_process';
-import { CronJob, CronJobCreate, CronJobUpdate, CronRunLog, CronManagerConfig, Logger } from './types';
+import {
+  CronJob,
+  CronJobCreate,
+  CronJobUpdate,
+  CronRunLog,
+  CronManagerConfig,
+  Logger,
+  AgentConfig,
+} from './types';
+import type { AgentRunner } from './agent-runner';
 
 const DEFAULT_STORE_PATH = path.join(
   process.env.HOME ?? '/tmp',
@@ -19,6 +28,9 @@ const DEFAULT_RUNS_DIR = path.join(
 );
 
 const MAX_RUN_LOGS_PER_JOB = 100;
+const DEFAULT_AGENT_TURN_TIMEOUT_MS = 120_000;
+const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 3_600_000; // 1 hour
+const TELEGRAM_API_BASE = 'https://api.telegram.org';
 
 interface StoreFormat {
   version: 1;
@@ -29,13 +41,22 @@ export class CronManager extends EventEmitter {
   private readonly storePath: string;
   private readonly runsDir: string;
   private readonly logger: Logger;
+  private readonly agentRunners: Map<string, AgentRunner>;
+  private readonly agentConfigs: Map<string, AgentConfig>;
   private jobs: Map<string, CronJob> = new Map();
-  private scheduledTasks: Map<string, nodeCron.ScheduledTask> = new Map();
+  private scheduledTasks: Map<string, nodeCron.ScheduledTask | NodeJS.Timeout> = new Map();
 
-  constructor(config?: CronManagerConfig, logger?: Logger) {
+  constructor(
+    config?: CronManagerConfig,
+    agentRunners?: Map<string, AgentRunner>,
+    agentConfigs?: Map<string, AgentConfig>,
+    logger?: Logger,
+  ) {
     super();
     this.storePath = config?.storePath ?? DEFAULT_STORE_PATH;
     this.runsDir = config?.runsDir ?? DEFAULT_RUNS_DIR;
+    this.agentRunners = agentRunners ?? new Map();
+    this.agentConfigs = agentConfigs ?? new Map();
     this.logger = logger ?? console;
   }
 
@@ -43,12 +64,10 @@ export class CronManager extends EventEmitter {
    * Load persisted jobs from disk and schedule them.
    */
   async start(): Promise<void> {
-    // Ensure directories exist
     const storeDir = path.dirname(this.storePath);
     await fs.promises.mkdir(storeDir, { recursive: true });
     await fs.promises.mkdir(this.runsDir, { recursive: true });
 
-    // Load existing jobs
     if (fs.existsSync(this.storePath)) {
       try {
         const raw = await fs.promises.readFile(this.storePath, 'utf8');
@@ -69,7 +88,6 @@ export class CronManager extends EventEmitter {
       this.logger.info('No existing crons.json — starting fresh');
     }
 
-    // Check for missed jobs on startup
     await this.catchUpMissedJobs();
   }
 
@@ -77,41 +95,54 @@ export class CronManager extends EventEmitter {
    * Stop all scheduled tasks.
    */
   stop(): void {
-    for (const [id, task] of this.scheduledTasks) {
-      task.stop();
+    for (const task of this.scheduledTasks.values()) {
+      if (typeof (task as nodeCron.ScheduledTask).stop === 'function') {
+        (task as nodeCron.ScheduledTask).stop();
+      } else {
+        clearInterval(task as NodeJS.Timeout);
+      }
     }
     this.scheduledTasks.clear();
     this.logger.info('All cron jobs stopped');
   }
 
-  // ─── CRUD Operations ─────────────────────────────────────────────────────
+  // ─── CRUD Operations ───────────────────────────────────────────────────────
 
-  /**
-   * Create a new cron job.
-   */
   async create(input: CronJobCreate): Promise<CronJob> {
-    // Validate cron expression
-    if (!nodeCron.validate(input.schedule)) {
-      throw new Error(`Invalid cron expression: "${input.schedule}"`);
-    }
+    this.validateSchedule(input);
+    this.validatePayload(input);
 
     const now = Date.now();
+    const scheduleKind = input.scheduleKind ?? 'cron';
+    const payloadKind = input.payloadKind ?? 'command';
+
     const job: CronJob = {
       id: randomUUID(),
       agentId: input.agentId,
       name: input.name,
+      scheduleKind,
       schedule: input.schedule,
+      scheduleAt: input.scheduleAt,
+      everyMs: input.everyMs,
+      anchorMs: input.anchorMs,
+      payloadKind,
       command: input.command,
+      agentTurnMessage: input.agentTurnMessage,
+      agentTurnSessionId: input.agentTurnSessionId,
+      agentTurnTimeoutMs: input.agentTurnTimeoutMs,
+      deleteAfterRun: input.deleteAfterRun,
       enabled: input.enabled ?? true,
       createdAt: now,
       updatedAt: now,
       notify: input.notify,
+      failureAlert: input.failureAlert,
       state: {
         lastRunAt: null,
         lastStatus: null,
         lastError: null,
         consecutiveErrors: 0,
         runCount: 0,
+        lastAlertAt: null,
       },
     };
 
@@ -122,30 +153,47 @@ export class CronManager extends EventEmitter {
     }
 
     await this.persist();
-    this.logger.info(`Created cron job "${job.name}"`, { id: job.id, schedule: job.schedule });
+    this.logger.info(`Created cron job "${job.name}"`, { id: job.id, scheduleKind });
     this.emit('job:created', job);
 
     return job;
   }
 
-  /**
-   * Update an existing cron job.
-   */
   async update(id: string, input: CronJobUpdate): Promise<CronJob> {
     const job = this.jobs.get(id);
     if (!job) throw new Error(`Job not found: ${id}`);
 
-    // Validate new schedule if provided
-    if (input.schedule !== undefined) {
-      if (!nodeCron.validate(input.schedule)) {
-        throw new Error(`Invalid cron expression: "${input.schedule}"`);
-      }
-      job.schedule = input.schedule;
+    // Validate schedule if any schedule fields are being updated
+    if (
+      input.scheduleKind !== undefined ||
+      input.schedule !== undefined ||
+      input.scheduleAt !== undefined ||
+      input.everyMs !== undefined
+    ) {
+      const merged = { ...job, ...input };
+      this.validateSchedule(merged);
     }
 
-    if (input.name !== undefined) job.name = input.name;
+    // Validate payload if payload fields are being updated
+    if (input.payloadKind !== undefined || input.command !== undefined || input.agentTurnMessage !== undefined) {
+      const merged = { ...job, ...input };
+      this.validatePayload(merged);
+    }
+
+    if (input.scheduleKind !== undefined) job.scheduleKind = input.scheduleKind;
+    if (input.schedule !== undefined) job.schedule = input.schedule;
+    if (input.scheduleAt !== undefined) job.scheduleAt = input.scheduleAt;
+    if (input.everyMs !== undefined) job.everyMs = input.everyMs;
+    if (input.anchorMs !== undefined) job.anchorMs = input.anchorMs;
+    if (input.payloadKind !== undefined) job.payloadKind = input.payloadKind;
     if (input.command !== undefined) job.command = input.command;
+    if (input.agentTurnMessage !== undefined) job.agentTurnMessage = input.agentTurnMessage;
+    if (input.agentTurnSessionId !== undefined) job.agentTurnSessionId = input.agentTurnSessionId;
+    if (input.agentTurnTimeoutMs !== undefined) job.agentTurnTimeoutMs = input.agentTurnTimeoutMs;
+    if (input.deleteAfterRun !== undefined) job.deleteAfterRun = input.deleteAfterRun;
+    if (input.name !== undefined) job.name = input.name;
     if (input.notify !== undefined) job.notify = input.notify;
+    if (input.failureAlert !== undefined) job.failureAlert = input.failureAlert;
 
     if (input.enabled !== undefined) {
       job.enabled = input.enabled;
@@ -153,7 +201,6 @@ export class CronManager extends EventEmitter {
 
     job.updatedAt = Date.now();
 
-    // Reschedule
     this.unscheduleJob(id);
     if (job.enabled) {
       this.scheduleJob(job);
@@ -166,9 +213,6 @@ export class CronManager extends EventEmitter {
     return job;
   }
 
-  /**
-   * Delete a cron job.
-   */
   async remove(id: string): Promise<void> {
     const job = this.jobs.get(id);
     if (!job) throw new Error(`Job not found: ${id}`);
@@ -181,34 +225,22 @@ export class CronManager extends EventEmitter {
     this.emit('job:removed', id);
   }
 
-  /**
-   * Get a job by ID.
-   */
   get(id: string): CronJob | undefined {
     return this.jobs.get(id);
   }
 
-  /**
-   * List all jobs, optionally filtered by agentId.
-   */
   list(agentId?: string): CronJob[] {
     const all = [...this.jobs.values()];
     if (agentId) return all.filter((j) => j.agentId === agentId);
     return all;
   }
 
-  /**
-   * Manually trigger a job immediately.
-   */
   async run(id: string): Promise<CronRunLog> {
     const job = this.jobs.get(id);
     if (!job) throw new Error(`Job not found: ${id}`);
     return this.executeJob(job);
   }
 
-  /**
-   * Get run history for a job.
-   */
   async getRuns(id: string, limit = 20): Promise<CronRunLog[]> {
     const logFile = path.join(this.runsDir, `${id}.jsonl`);
     if (!fs.existsSync(logFile)) return [];
@@ -227,9 +259,6 @@ export class CronManager extends EventEmitter {
       .filter(Boolean) as CronRunLog[];
   }
 
-  /**
-   * Get overall status.
-   */
   status(): {
     totalJobs: number;
     enabledJobs: number;
@@ -245,34 +274,146 @@ export class CronManager extends EventEmitter {
     };
   }
 
-  // ─── Internal ─────────────────────────────────────────────────────────────
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private validateSchedule(input: { scheduleKind?: string; schedule?: string; scheduleAt?: string; everyMs?: number }): void {
+    const kind = input.scheduleKind ?? 'cron';
+    if (kind === 'cron') {
+      if (!input.schedule) throw new Error('schedule is required for scheduleKind=cron');
+      if (!nodeCron.validate(input.schedule)) {
+        throw new Error(`Invalid cron expression: "${input.schedule}"`);
+      }
+    } else if (kind === 'at') {
+      if (!input.scheduleAt) throw new Error('scheduleAt is required for scheduleKind=at');
+      const ts = Date.parse(input.scheduleAt);
+      if (isNaN(ts)) throw new Error(`Invalid ISO-8601 timestamp: "${input.scheduleAt}"`);
+    } else if (kind === 'every') {
+      if (input.everyMs === undefined || input.everyMs === null) {
+        throw new Error('everyMs is required for scheduleKind=every');
+      }
+      if (typeof input.everyMs !== 'number' || input.everyMs <= 0) {
+        throw new Error('everyMs must be a positive number');
+      }
+    }
+  }
+
+  private validatePayload(input: { payloadKind?: string; command?: string; agentTurnMessage?: string }): void {
+    const kind = input.payloadKind ?? 'command';
+    if (kind === 'command') {
+      if (!input.command) throw new Error('command is required for payloadKind=command');
+    } else if (kind === 'agentTurn') {
+      if (!input.agentTurnMessage) throw new Error('agentTurnMessage is required for payloadKind=agentTurn');
+    }
+  }
 
   private scheduleJob(job: CronJob): void {
-    const task = nodeCron.schedule(job.schedule, async () => {
-      await this.executeJob(job);
-    });
-    this.scheduledTasks.set(job.id, task);
-    this.logger.info(`Scheduled "${job.name}" [${job.schedule}]`, { id: job.id });
+    const kind = job.scheduleKind ?? 'cron';
+
+    if (kind === 'cron') {
+      const task = nodeCron.schedule(job.schedule!, async () => {
+        await this.executeJob(job);
+      });
+      this.scheduledTasks.set(job.id, task);
+      this.logger.info(`Scheduled "${job.name}" [cron: ${job.schedule}]`, { id: job.id });
+
+    } else if (kind === 'at') {
+      const targetMs = Date.parse(job.scheduleAt!);
+      const delayMs = targetMs - Date.now();
+
+      const fireAt = async () => {
+        try {
+          this.scheduledTasks.delete(job.id);
+          await this.executeJob(job);
+          await this.disableOrDeleteJob(job);
+        } catch (err) {
+          this.logger.error(`at-job "${job.name}" post-run cleanup failed`, { id: job.id, error: (err as Error).message });
+        }
+      };
+
+      if (delayMs <= 0) {
+        this.logger.info(`Scheduling "${job.name}" [at: ${job.scheduleAt}] — past, running now`, { id: job.id });
+        const t = setTimeout(fireAt, 0);
+        this.scheduledTasks.set(job.id, t);
+      } else {
+        this.logger.info(`Scheduled "${job.name}" [at: ${job.scheduleAt}] in ${Math.round(delayMs / 1000)}s`, { id: job.id });
+        const t = setTimeout(fireAt, delayMs);
+        this.scheduledTasks.set(job.id, t);
+      }
+
+    } else if (kind === 'every') {
+      const everyMs = job.everyMs!;
+      let firstDelay = 0;
+
+      if (job.anchorMs !== undefined) {
+        const elapsed = (Date.now() - job.anchorMs) % everyMs;
+        firstDelay = everyMs - elapsed;
+        if (firstDelay >= everyMs) firstDelay = 0;
+      }
+
+      const startInterval = () => {
+        const t = setInterval(async () => {
+          await this.executeJob(job);
+        }, everyMs);
+        this.scheduledTasks.set(job.id, t);
+      };
+
+      if (firstDelay > 0) {
+        this.logger.info(`Scheduled "${job.name}" [every: ${everyMs}ms] first run in ${firstDelay}ms`, { id: job.id });
+        const initialTimer = setTimeout(() => {
+          startInterval();
+          this.executeJob(job).catch(() => {});
+        }, firstDelay);
+        this.scheduledTasks.set(job.id, initialTimer);
+      } else {
+        this.logger.info(`Scheduled "${job.name}" [every: ${everyMs}ms]`, { id: job.id });
+        startInterval();
+      }
+    }
   }
 
   private unscheduleJob(id: string): void {
     const task = this.scheduledTasks.get(id);
     if (task) {
-      task.stop();
+      if (typeof (task as nodeCron.ScheduledTask).stop === 'function') {
+        (task as nodeCron.ScheduledTask).stop();
+      } else {
+        clearTimeout(task as NodeJS.Timeout);
+        clearInterval(task as NodeJS.Timeout);
+      }
       this.scheduledTasks.delete(id);
+    }
+  }
+
+  private async disableOrDeleteJob(job: CronJob): Promise<void> {
+    if (job.deleteAfterRun) {
+      this.jobs.delete(job.id);
+      await this.persist();
+      this.logger.info(`Auto-deleted one-shot job "${job.name}"`, { id: job.id });
+      this.emit('job:removed', job.id);
+    } else {
+      job.enabled = false;
+      job.updatedAt = Date.now();
+      await this.persist();
+      this.logger.info(`Auto-disabled one-shot job "${job.name}"`, { id: job.id });
+      this.emit('job:updated', job);
     }
   }
 
   private async executeJob(job: CronJob): Promise<CronRunLog> {
     const startedAt = Date.now();
-    this.logger.info(`Executing cron job "${job.name}"`, { id: job.id });
+    this.logger.info(`Executing cron job "${job.name}"`, { id: job.id, payloadKind: job.payloadKind ?? 'command' });
 
     let status: 'ok' | 'error' = 'ok';
     let output = '';
     let error: string | null = null;
 
     try {
-      output = await this.runCommand(job.command, job.agentId);
+      const payloadKind = job.payloadKind ?? 'command';
+      if (payloadKind === 'agentTurn') {
+        output = await this.runAgentTurn(job);
+      } else {
+        output = await this.runCommand(job.command!, job.agentId);
+      }
       job.state.consecutiveErrors = 0;
     } catch (err) {
       status = 'error';
@@ -294,15 +435,22 @@ export class CronManager extends EventEmitter {
       startedAt,
       durationMs,
       status,
-      output: output.slice(0, 5000), // cap output size
+      output: output.slice(0, 5000),
       error,
     };
 
-    // Persist state and log
     await Promise.all([
       this.persist(),
       this.appendRunLog(job.id, runLog),
     ]);
+
+    // Deliver notification
+    await this.deliverNotify(job, runLog);
+
+    // Check failure alert
+    if (status === 'error') {
+      await this.checkFailureAlert(job);
+    }
 
     this.emit('job:executed', job, runLog);
     return runLog;
@@ -325,13 +473,133 @@ export class CronManager extends EventEmitter {
     });
   }
 
+  private async runAgentTurn(job: CronJob): Promise<string> {
+    const runner = this.agentRunners.get(job.agentId);
+    if (!runner) {
+      throw new Error(`AgentRunner not found for agentId: "${job.agentId}"`);
+    }
+
+    const sessionId = job.agentTurnSessionId ?? `cron-${job.id}`;
+    const timeoutMs = job.agentTurnTimeoutMs ?? DEFAULT_AGENT_TURN_TIMEOUT_MS;
+
+    return runner.sendApiMessage(sessionId, job.agentTurnMessage!, { timeoutMs });
+  }
+
+  private async deliverNotify(job: CronJob, runLog: CronRunLog): Promise<void> {
+    const notify = job.notify;
+    if (!notify) return;
+
+    const isSuccess = runLog.status === 'ok';
+    const shouldNotify = isSuccess
+      ? (notify.onSuccess !== false)
+      : (notify.onError !== false);
+
+    if (!shouldNotify) return;
+
+    const icon = isSuccess ? '✅' : '❌';
+    const detail = isSuccess
+      ? runLog.output.slice(0, 500)
+      : (runLog.error ?? runLog.output).slice(0, 500);
+    const text = `${icon} ${job.name}\n${detail}`.trim();
+
+    if (notify.telegram) {
+      await this.sendTelegram(job.agentId, notify.telegram, text);
+    }
+
+    if (notify.webhook) {
+      await this.sendWebhook(notify.webhook, {
+        jobId: job.id,
+        jobName: job.name,
+        agentId: job.agentId,
+        status: runLog.status,
+        output: runLog.output,
+        error: runLog.error,
+        startedAt: runLog.startedAt,
+        durationMs: runLog.durationMs,
+      });
+    }
+  }
+
+  private async checkFailureAlert(job: CronJob): Promise<void> {
+    const alert = job.failureAlert;
+    if (!alert) return;
+
+    if (job.state.consecutiveErrors < alert.after) return;
+
+    const cooldownMs = alert.cooldownMs ?? DEFAULT_FAILURE_ALERT_COOLDOWN_MS;
+    const lastAlertAt = job.state.lastAlertAt ?? 0;
+    if (Date.now() - lastAlertAt < cooldownMs) return;
+
+    const text = `⚠️ Cron alert: ${job.name} failed ${job.state.consecutiveErrors} times in a row\nLast error: ${job.state.lastError ?? 'unknown'}`;
+
+    if (alert.telegram) {
+      await this.sendTelegram(job.agentId, alert.telegram, text);
+    }
+
+    if (alert.webhook) {
+      await this.sendWebhook(alert.webhook, {
+        jobId: job.id,
+        jobName: job.name,
+        agentId: job.agentId,
+        alertKind: 'failure',
+        consecutiveErrors: job.state.consecutiveErrors,
+        lastError: job.state.lastError,
+      });
+    }
+
+    job.state.lastAlertAt = Date.now();
+    await this.persist();
+  }
+
+  private async sendTelegram(agentId: string, chatId: string, text: string): Promise<void> {
+    const agentConfig = this.agentConfigs.get(agentId);
+    const botToken = agentConfig?.telegram?.botToken;
+
+    if (!botToken) {
+      this.logger.warn(`Cannot send Telegram notify: no botToken for agent "${agentId}"`);
+      return;
+    }
+
+    try {
+      const url = `${TELEGRAM_API_BASE}/bot${botToken}/sendMessage`;
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, text }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        this.logger.warn(`Telegram notify failed: ${resp.status} ${body}`, { chatId });
+      }
+    } catch (err) {
+      this.logger.warn(`Telegram notify error: ${(err as Error).message}`, { chatId });
+    }
+  }
+
+  private async sendWebhook(url: string, payload: Record<string, unknown>): Promise<void> {
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        this.logger.warn(`Webhook notify failed: ${resp.status} ${body}`, { url });
+      }
+    } catch (err) {
+      this.logger.warn(`Webhook notify error: ${(err as Error).message}`, { url });
+    }
+  }
+
   private async persist(): Promise<void> {
     const store: StoreFormat = {
       version: 1,
       jobs: [...this.jobs.values()],
     };
 
-    // Write atomically (write to temp, then rename)
     const tmpPath = this.storePath + '.tmp';
     await fs.promises.writeFile(tmpPath, JSON.stringify(store, null, 2), 'utf8');
     await fs.promises.rename(tmpPath, this.storePath);
@@ -341,7 +609,6 @@ export class CronManager extends EventEmitter {
     const logFile = path.join(this.runsDir, `${jobId}.jsonl`);
     await fs.promises.appendFile(logFile, JSON.stringify(log) + '\n', 'utf8');
 
-    // Prune old entries
     try {
       const content = await fs.promises.readFile(logFile, 'utf8');
       const lines = content.trim().split('\n');
@@ -354,23 +621,24 @@ export class CronManager extends EventEmitter {
     }
   }
 
-  /**
-   * On startup, check for jobs that should have run while we were down.
-   * Run them once to catch up (max 5 missed jobs).
-   */
   private async catchUpMissedJobs(): Promise<void> {
     const MAX_CATCHUP = 5;
     let caught = 0;
 
     for (const job of this.jobs.values()) {
       if (!job.enabled || caught >= MAX_CATCHUP) continue;
+      const kind = job.scheduleKind ?? 'cron';
+
+      if (kind === 'at') {
+        // Already handled in scheduleJob (past at-jobs run immediately)
+        continue;
+      }
+
       if (!job.state.lastRunAt) continue;
 
-      // Simple heuristic: if lastRunAt is more than 2x the cron interval ago, run it
       const ageMs = Date.now() - job.state.lastRunAt;
-      if (ageMs > 30 * 60 * 1000) { // more than 30 min stale
+      if (ageMs > 30 * 60 * 1000) {
         this.logger.info(`Catching up missed job "${job.name}"`, { id: job.id, ageMs });
-        // Stagger catchup runs
         setTimeout(() => this.executeJob(job), caught * 5000);
         caught++;
       }

--- a/src/cron-router.ts
+++ b/src/cron-router.ts
@@ -1,12 +1,19 @@
 import { Router, Request, Response } from 'express';
 import { CronManager } from './cron-manager';
-import { CronJobCreate, CronJobUpdate } from './types';
+import { ApiKey, CronJobCreate, CronJobUpdate } from './types';
+import { createApiAuthMiddleware, canAccessAgent } from './api-auth';
+
+type AuthedRequest = Request & { apiKey: ApiKey };
 
 /**
  * Creates Express routes for managing persistent cron jobs.
  *
+ * All routes require a valid API key (Authorization: Bearer or X-Api-Key header).
+ * Write operations (create/update/delete/run) additionally verify that the key
+ * has access to the job's agentId via canAccessAgent().
+ *
  * Routes:
- *   GET    /v1/crons           — List all jobs (optional ?agent= filter)
+ *   GET    /v1/crons           — List jobs accessible by this key
  *   GET    /v1/crons/status    — Overall scheduler status
  *   POST   /v1/crons           — Create a new job
  *   GET    /v1/crons/:id       — Get a single job
@@ -15,13 +22,39 @@ import { CronJobCreate, CronJobUpdate } from './types';
  *   POST   /v1/crons/:id/run   — Trigger a job manually
  *   GET    /v1/crons/:id/runs  — Get run history
  */
-export function createCronRouter(manager: CronManager): Router {
+export function createCronRouter(manager: CronManager, apiKeys?: ApiKey[]): Router {
   const router = Router();
 
-  // List jobs
+  // Apply auth middleware if apiKeys are provided
+  if (apiKeys?.length) {
+    router.use(createApiAuthMiddleware(apiKeys));
+  }
+
+  // Helper: check agent access for jobs retrieved by id
+  function checkJobAccess(req: Request, res: Response, agentId: string): boolean {
+    if (!apiKeys?.length) return true; // no auth configured — allow all
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return false;
+    }
+    return true;
+  }
+
+  // List jobs — filtered to agents this key can access
   router.get('/v1/crons', (_req: Request, res: Response) => {
     const agentId = _req.query.agent as string | undefined;
-    const jobs = manager.list(agentId);
+    let jobs = manager.list(agentId);
+
+    // Filter by key's agent scope
+    if (apiKeys?.length) {
+      const apiKey = (_req as AuthedRequest).apiKey;
+      if (apiKey.agents !== '*') {
+        const allowed = apiKey.agents as string[];
+        jobs = jobs.filter((j) => allowed.includes(j.agentId));
+      }
+    }
+
     res.json({ jobs });
   });
 
@@ -34,10 +67,37 @@ export function createCronRouter(manager: CronManager): Router {
   router.post('/v1/crons', async (req: Request, res: Response) => {
     const body = req.body as Partial<CronJobCreate>;
 
-    if (!body.agentId || !body.name || !body.schedule || !body.command) {
-      res.status(400).json({
-        error: 'Required fields: agentId, name, schedule, command',
-      });
+    if (!body.agentId || !body.name) {
+      res.status(400).json({ error: 'Required fields: agentId, name' });
+      return;
+    }
+
+    if (!checkJobAccess(req, res, body.agentId)) return;
+
+    const scheduleKind = body.scheduleKind ?? 'cron';
+    const payloadKind = body.payloadKind ?? 'command';
+
+    // Schedule validation
+    if (scheduleKind === 'cron' && !body.schedule) {
+      res.status(400).json({ error: 'schedule is required for scheduleKind=cron' });
+      return;
+    }
+    if (scheduleKind === 'at' && !body.scheduleAt) {
+      res.status(400).json({ error: 'scheduleAt is required for scheduleKind=at' });
+      return;
+    }
+    if (scheduleKind === 'every' && (body.everyMs === undefined || body.everyMs === null)) {
+      res.status(400).json({ error: 'everyMs is required for scheduleKind=every' });
+      return;
+    }
+
+    // Payload validation
+    if (payloadKind === 'command' && !body.command) {
+      res.status(400).json({ error: 'command is required for payloadKind=command' });
+      return;
+    }
+    if (payloadKind === 'agentTurn' && !body.agentTurnMessage) {
+      res.status(400).json({ error: 'agentTurnMessage is required for payloadKind=agentTurn' });
       return;
     }
 
@@ -56,14 +116,21 @@ export function createCronRouter(manager: CronManager): Router {
       res.status(404).json({ error: 'Job not found' });
       return;
     }
+    if (!checkJobAccess(req, res, job.agentId)) return;
     res.json({ job });
   });
 
   // Update job
   router.put('/v1/crons/:id', async (req: Request, res: Response) => {
+    const job = manager.get(req.params.id);
+    if (!job) {
+      res.status(404).json({ error: 'Job not found' });
+      return;
+    }
+    if (!checkJobAccess(req, res, job.agentId)) return;
     try {
-      const job = await manager.update(req.params.id, req.body as CronJobUpdate);
-      res.json({ job });
+      const updated = await manager.update(req.params.id, req.body as CronJobUpdate);
+      res.json({ job: updated });
     } catch (err) {
       const message = (err as Error).message;
       if (message.includes('not found')) {
@@ -76,36 +143,46 @@ export function createCronRouter(manager: CronManager): Router {
 
   // Delete job
   router.delete('/v1/crons/:id', async (req: Request, res: Response) => {
+    const job = manager.get(req.params.id);
+    if (!job) {
+      res.status(404).json({ error: 'Job not found' });
+      return;
+    }
+    if (!checkJobAccess(req, res, job.agentId)) return;
     try {
       await manager.remove(req.params.id);
       res.json({ ok: true });
     } catch (err) {
       const message = (err as Error).message;
-      if (message.includes('not found')) {
-        res.status(404).json({ error: message });
-      } else {
-        res.status(500).json({ error: message });
-      }
+      res.status(500).json({ error: message });
     }
   });
 
   // Manual trigger
   router.post('/v1/crons/:id/run', async (req: Request, res: Response) => {
+    const job = manager.get(req.params.id);
+    if (!job) {
+      res.status(404).json({ error: 'Job not found' });
+      return;
+    }
+    if (!checkJobAccess(req, res, job.agentId)) return;
     try {
       const log = await manager.run(req.params.id);
       res.json({ run: log });
     } catch (err) {
       const message = (err as Error).message;
-      if (message.includes('not found')) {
-        res.status(404).json({ error: message });
-      } else {
-        res.status(500).json({ error: message });
-      }
+      res.status(500).json({ error: message });
     }
   });
 
   // Run history
   router.get('/v1/crons/:id/runs', async (req: Request, res: Response) => {
+    const job = manager.get(req.params.id);
+    if (!job) {
+      res.status(404).json({ error: 'Job not found' });
+      return;
+    }
+    if (!checkJobAccess(req, res, job.agentId)) return;
     const limit = parseInt(req.query.limit as string) || 20;
     try {
       const runs = await manager.getRuns(req.params.id, limit);

--- a/src/cron-router.ts
+++ b/src/cron-router.ts
@@ -1,0 +1,119 @@
+import { Router, Request, Response } from 'express';
+import { CronManager } from './cron-manager';
+import { CronJobCreate, CronJobUpdate } from './types';
+
+/**
+ * Creates Express routes for managing persistent cron jobs.
+ *
+ * Routes:
+ *   GET    /v1/crons           — List all jobs (optional ?agent= filter)
+ *   GET    /v1/crons/status    — Overall scheduler status
+ *   POST   /v1/crons           — Create a new job
+ *   GET    /v1/crons/:id       — Get a single job
+ *   PUT    /v1/crons/:id       — Update a job
+ *   DELETE /v1/crons/:id       — Delete a job
+ *   POST   /v1/crons/:id/run   — Trigger a job manually
+ *   GET    /v1/crons/:id/runs  — Get run history
+ */
+export function createCronRouter(manager: CronManager): Router {
+  const router = Router();
+
+  // List jobs
+  router.get('/v1/crons', (_req: Request, res: Response) => {
+    const agentId = _req.query.agent as string | undefined;
+    const jobs = manager.list(agentId);
+    res.json({ jobs });
+  });
+
+  // Overall status
+  router.get('/v1/crons/status', (_req: Request, res: Response) => {
+    res.json(manager.status());
+  });
+
+  // Create job
+  router.post('/v1/crons', async (req: Request, res: Response) => {
+    const body = req.body as Partial<CronJobCreate>;
+
+    if (!body.agentId || !body.name || !body.schedule || !body.command) {
+      res.status(400).json({
+        error: 'Required fields: agentId, name, schedule, command',
+      });
+      return;
+    }
+
+    try {
+      const job = await manager.create(body as CronJobCreate);
+      res.status(201).json({ job });
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  // Get single job
+  router.get('/v1/crons/:id', (req: Request, res: Response) => {
+    const job = manager.get(req.params.id);
+    if (!job) {
+      res.status(404).json({ error: 'Job not found' });
+      return;
+    }
+    res.json({ job });
+  });
+
+  // Update job
+  router.put('/v1/crons/:id', async (req: Request, res: Response) => {
+    try {
+      const job = await manager.update(req.params.id, req.body as CronJobUpdate);
+      res.json({ job });
+    } catch (err) {
+      const message = (err as Error).message;
+      if (message.includes('not found')) {
+        res.status(404).json({ error: message });
+      } else {
+        res.status(400).json({ error: message });
+      }
+    }
+  });
+
+  // Delete job
+  router.delete('/v1/crons/:id', async (req: Request, res: Response) => {
+    try {
+      await manager.remove(req.params.id);
+      res.json({ ok: true });
+    } catch (err) {
+      const message = (err as Error).message;
+      if (message.includes('not found')) {
+        res.status(404).json({ error: message });
+      } else {
+        res.status(500).json({ error: message });
+      }
+    }
+  });
+
+  // Manual trigger
+  router.post('/v1/crons/:id/run', async (req: Request, res: Response) => {
+    try {
+      const log = await manager.run(req.params.id);
+      res.json({ run: log });
+    } catch (err) {
+      const message = (err as Error).message;
+      if (message.includes('not found')) {
+        res.status(404).json({ error: message });
+      } else {
+        res.status(500).json({ error: message });
+      }
+    }
+  });
+
+  // Run history
+  router.get('/v1/crons/:id/runs', async (req: Request, res: Response) => {
+    const limit = parseInt(req.query.limit as string) || 20;
+    try {
+      const runs = await manager.getRuns(req.params.id, limit);
+      res.json({ runs });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  return router;
+}

--- a/src/gateway-router.ts
+++ b/src/gateway-router.ts
@@ -86,9 +86,9 @@ export class GatewayRouter {
       this.app.use('/api', apiRouter);
     }
 
-    // Mount cron manager routes (no auth required for now — add API key auth later)
+    // Mount cron manager routes with same API key auth as agent router
     if (this.cronManager) {
-      const cronRouter = createCronRouter(this.cronManager);
+      const cronRouter = createCronRouter(this.cronManager, this.gatewayConfig?.gateway?.api?.keys);
       this.app.use('/api', cronRouter);
     }
 

--- a/src/gateway-router.ts
+++ b/src/gateway-router.ts
@@ -3,8 +3,10 @@ import { Server } from 'http';
 import { AgentRunner } from './agent-runner';
 import { AgentConfig, AgentStats, ApiKey, GatewayConfig, HeartbeatResult } from './types';
 import { CronScheduler } from './cron-scheduler';
+import { CronManager } from './cron-manager';
 import { generateDashboardHtml } from './web-ui';
 import { createApiRouter } from './api-router';
+import { createCronRouter } from './cron-router';
 
 export class GatewayRouter {
   private readonly agents: Map<string, AgentRunner>;
@@ -31,15 +33,20 @@ export class GatewayRouter {
   /** Optional gateway config (used to mount API router) */
   private readonly gatewayConfig?: GatewayConfig;
 
+  /** Optional persistent cron manager */
+  private readonly cronManager?: CronManager;
+
   constructor(
     agents: Map<string, AgentRunner>,
     configs: Map<string, AgentConfig>,
     schedulers?: Map<string, CronScheduler>,
     gatewayConfig?: GatewayConfig,
+    cronManager?: CronManager,
   ) {
     this.agents = agents;
     this.configs = configs;
     this.gatewayConfig = gatewayConfig;
+    this.cronManager = cronManager;
     this.app = express();
 
     // Initialise counters for all known agents
@@ -77,6 +84,12 @@ export class GatewayRouter {
         this.gatewayConfig.gateway.api.keys,
       );
       this.app.use('/api', apiRouter);
+    }
+
+    // Mount cron manager routes (no auth required for now — add API key auth later)
+    if (this.cronManager) {
+      const cronRouter = createCronRouter(this.cronManager);
+      this.app.use('/api', cronRouter);
     }
 
     // Health check

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { detectMigration, applyMigration, loadCleanTemplate } from './config-mig
 import { loadWorkspace, watchWorkspace, markBootstrapComplete } from './workspace-loader';
 import { AgentRunner } from './agent-runner';
 import { CronScheduler } from './cron-scheduler';
+import { CronManager } from './cron-manager';
 import { GatewayRouter } from './gateway-router';
 import { ContextIsolationGuard } from './context-isolation';
 import { createLogger } from './logger';
@@ -294,8 +295,18 @@ async function main(): Promise<void> {
   // Print startup summary table
   printStartupTable(startupResults);
 
+  // Start persistent cron manager
+  const cronManager = new CronManager(
+    {
+      storePath: path.join(path.dirname(CONFIG_PATH), 'crons.json'),
+      runsDir: path.join(path.dirname(CONFIG_PATH), 'cron-runs'),
+    },
+    createLogger('cron-manager', expandTilde(config.gateway.logDir)),
+  );
+  await cronManager.start();
+
   // Start gateway router
-  const router = new GatewayRouter(agentRunners, agentConfigs, undefined, config);
+  const router = new GatewayRouter(agentRunners, agentConfigs, undefined, config, cronManager);
   await router.start(PORT);
   console.log(`[gateway] Listening on port ${PORT}`);
 
@@ -346,6 +357,7 @@ async function main(): Promise<void> {
       scheduler.stop();
     }
 
+    cronManager.stop();
     configWatcher.stop();
 
     await router.stop();

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,6 +301,8 @@ async function main(): Promise<void> {
       storePath: path.join(path.dirname(CONFIG_PATH), 'crons.json'),
       runsDir: path.join(path.dirname(CONFIG_PATH), 'cron-runs'),
     },
+    agentRunners,
+    agentConfigs,
     createLogger('cron-manager', expandTilde(config.gateway.logDir)),
   );
   await cronManager.start();

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,3 +109,62 @@ export interface Logger {
   error(message: string, data?: Record<string, unknown>): void;
   debug(message: string, data?: Record<string, unknown>): void;
 }
+
+// ─── Cron Manager Types ───────────────────────────────────────────────────────
+
+export interface CronJobState {
+  lastRunAt: number | null;
+  lastStatus: 'ok' | 'error' | null;
+  lastError: string | null;
+  consecutiveErrors: number;
+  runCount: number;
+}
+
+export interface CronJobNotify {
+  telegram?: string; // chat_id
+  webhook?: string;  // URL
+}
+
+export interface CronJob {
+  id: string;
+  agentId: string;
+  name: string;
+  schedule: string; // 5-field cron expression
+  command: string;  // shell command to execute
+  enabled: boolean;
+  createdAt: number;
+  updatedAt: number;
+  notify?: CronJobNotify;
+  state: CronJobState;
+}
+
+export interface CronJobCreate {
+  agentId: string;
+  name: string;
+  schedule: string;
+  command: string;
+  enabled?: boolean;
+  notify?: CronJobNotify;
+}
+
+export interface CronJobUpdate {
+  name?: string;
+  schedule?: string;
+  command?: string;
+  enabled?: boolean;
+  notify?: CronJobNotify;
+}
+
+export interface CronRunLog {
+  jobId: string;
+  startedAt: number;
+  durationMs: number;
+  status: 'ok' | 'error';
+  output: string;
+  error: string | null;
+}
+
+export interface CronManagerConfig {
+  storePath?: string;
+  runsDir?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,47 +112,96 @@ export interface Logger {
 
 // ─── Cron Manager Types ───────────────────────────────────────────────────────
 
+export type CronScheduleKind = 'cron' | 'at' | 'every';
+export type CronPayloadKind = 'command' | 'agentTurn';
+
 export interface CronJobState {
   lastRunAt: number | null;
   lastStatus: 'ok' | 'error' | null;
   lastError: string | null;
   consecutiveErrors: number;
   runCount: number;
+  lastAlertAt?: number | null;
 }
 
 export interface CronJobNotify {
   telegram?: string; // chat_id
   webhook?: string;  // URL
+  onSuccess?: boolean; // default true
+  onError?: boolean;   // default true
+}
+
+export interface CronJobFailureAlert {
+  after: number;       // trigger after N consecutive errors
+  telegram?: string;   // chat_id
+  webhook?: string;    // URL
+  cooldownMs?: number; // default 3600000 (1h)
 }
 
 export interface CronJob {
   id: string;
   agentId: string;
   name: string;
-  schedule: string; // 5-field cron expression
-  command: string;  // shell command to execute
+  // Schedule fields
+  scheduleKind?: CronScheduleKind;  // default: 'cron'
+  schedule?: string;                // cron expression (kind=cron)
+  scheduleAt?: string;              // ISO-8601 timestamp (kind=at)
+  everyMs?: number;                 // interval in ms (kind=every)
+  anchorMs?: number;                // optional anchor timestamp (kind=every)
+  // Payload fields
+  payloadKind?: CronPayloadKind;    // default: 'command'
+  command?: string;                 // shell command (payloadKind=command)
+  agentTurnMessage?: string;        // prompt for agent (payloadKind=agentTurn)
+  agentTurnSessionId?: string;      // session id (auto-generated if omitted)
+  agentTurnTimeoutMs?: number;      // default 120000
+  // Lifecycle
+  deleteAfterRun?: boolean;         // auto-delete after first successful run
   enabled: boolean;
   createdAt: number;
   updatedAt: number;
   notify?: CronJobNotify;
+  failureAlert?: CronJobFailureAlert;
   state: CronJobState;
 }
 
 export interface CronJobCreate {
   agentId: string;
   name: string;
-  schedule: string;
-  command: string;
+  // Schedule
+  scheduleKind?: CronScheduleKind;
+  schedule?: string;
+  scheduleAt?: string;
+  everyMs?: number;
+  anchorMs?: number;
+  // Payload
+  payloadKind?: CronPayloadKind;
+  command?: string;
+  agentTurnMessage?: string;
+  agentTurnSessionId?: string;
+  agentTurnTimeoutMs?: number;
+  // Lifecycle
+  deleteAfterRun?: boolean;
   enabled?: boolean;
   notify?: CronJobNotify;
+  failureAlert?: CronJobFailureAlert;
 }
 
 export interface CronJobUpdate {
   name?: string;
+  scheduleKind?: CronScheduleKind;
   schedule?: string;
+  scheduleAt?: string;
+  everyMs?: number;
+  anchorMs?: number;
+  payloadKind?: CronPayloadKind;
   command?: string;
+  agentTurnMessage?: string;
+  agentTurnSessionId?: string;
+  agentTurnTimeoutMs?: number;
+  deleteAfterRun?: boolean;
   enabled?: boolean;
   notify?: CronJobNotify;
+  failureAlert?: CronJobFailureAlert;
 }
 
 export interface CronRunLog {

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -1,0 +1,623 @@
+/**
+ * Unit tests for CronManager (Planning-27: Agent Integration & OpenClaw Feature Parity)
+ *
+ * T1-T5:   Schedule types (at / every / cron)
+ * T6-T10:  Agent turn payload
+ * T11-T15: Delivery (notify)
+ * T16-T20: Failure alert
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { CronManager } from '../../src/cron-manager';
+import { CronJobCreate, AgentConfig } from '../../src/types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cron-test-'));
+}
+
+function makeRunner(response = 'agent ok') {
+  return {
+    sendApiMessage: jest.fn().mockResolvedValue(response),
+  };
+}
+
+function makeAgentConfig(agentId: string, botToken = 'bot-token-123'): AgentConfig {
+  return {
+    id: agentId,
+    description: 'test agent',
+    workspace: '/tmp/workspace',
+    env: '',
+    telegram: {
+      botToken,
+      allowedUsers: [],
+      dmPolicy: 'allowlist',
+    },
+    claude: {
+      model: 'claude-opus-4-6',
+      dangerouslySkipPermissions: false,
+      extraFlags: [],
+    },
+  };
+}
+
+function makeManager(opts: {
+  agentId?: string;
+  runner?: ReturnType<typeof makeRunner>;
+  botToken?: string;
+  tmpDir?: string;
+} = {}) {
+  const agentId = opts.agentId ?? 'test-agent';
+  const tmpDir = opts.tmpDir ?? makeTmpDir();
+  const agentRunners = new Map<string, any>();
+  const agentConfigs = new Map<string, AgentConfig>();
+
+  if (opts.runner) {
+    agentRunners.set(agentId, opts.runner);
+  }
+  agentConfigs.set(agentId, makeAgentConfig(agentId, opts.botToken ?? 'bot-token-123'));
+
+  const manager = new CronManager(
+    { storePath: path.join(tmpDir, 'crons.json'), runsDir: path.join(tmpDir, 'runs') },
+    agentRunners,
+    agentConfigs,
+    makeLogger(),
+  );
+
+  return { manager, tmpDir, agentId, agentRunners, agentConfigs };
+}
+
+// ─── T1-T5: Schedule types ────────────────────────────────────────────────────
+
+describe('T1-T5: Schedule types', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('T1: at job schedules with setTimeout for future timestamp', async () => {
+    jest.useFakeTimers();
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const futureTs = new Date(Date.now() + 60_000).toISOString();
+    const job = await manager.create({
+      agentId,
+      name: 'one-shot',
+      scheduleKind: 'at',
+      scheduleAt: futureTs,
+      payloadKind: 'command',
+      command: 'echo hi',
+    });
+
+    expect(job.scheduleKind).toBe('at');
+    expect(job.scheduleAt).toBe(futureTs);
+    expect(job.enabled).toBe(true);
+
+    manager.stop();
+  });
+
+  it('T2: at job with past timestamp auto-disables after run', async () => {
+    const tmpDir = makeTmpDir();
+    const { manager, agentId } = makeManager({ tmpDir });
+    await manager.start();
+
+    // Use a signal file to know when exec completed
+    const signalFile = path.join(tmpDir, 'at-ran.txt');
+    const pastTs = new Date(Date.now() - 1000).toISOString();
+    const job = await manager.create({
+      agentId,
+      name: 'past-shot',
+      scheduleKind: 'at',
+      scheduleAt: pastTs,
+      payloadKind: 'command',
+      command: `touch "${signalFile}"`,
+    });
+
+    // Poll until enabled=false (disableOrDeleteJob completed after exec)
+    const deadline = Date.now() + 20_000;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100));
+      if (fs.existsSync(signalFile) && manager.get(job.id)?.enabled === false) break;
+    }
+
+    expect(fs.existsSync(signalFile)).toBe(true);
+    const updated = manager.get(job.id);
+    expect(updated?.enabled).toBe(false);
+    expect(updated?.state.runCount).toBe(1);
+
+    manager.stop();
+  }, 25000);
+
+  it('T3: every job schedules with setInterval', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'interval-job',
+      scheduleKind: 'every',
+      everyMs: 5000,
+      payloadKind: 'command',
+      command: 'echo interval',
+    });
+
+    expect(job.scheduleKind).toBe('every');
+    expect(job.everyMs).toBe(5000);
+
+    manager.stop();
+  });
+
+  it('T4: at job with invalid ISO string throws error', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    await expect(manager.create({
+      agentId,
+      name: 'bad-at',
+      scheduleKind: 'at',
+      scheduleAt: 'not-a-date',
+      payloadKind: 'command',
+      command: 'echo x',
+    })).rejects.toThrow(/Invalid ISO-8601/);
+
+    manager.stop();
+  });
+
+  it('T5: every job with everyMs <= 0 throws error', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    await expect(manager.create({
+      agentId,
+      name: 'bad-every',
+      scheduleKind: 'every',
+      everyMs: -1,
+      payloadKind: 'command',
+      command: 'echo x',
+    })).rejects.toThrow(/positive/);
+
+    manager.stop();
+  });
+});
+
+// ─── T6-T10: Agent turn payload ───────────────────────────────────────────────
+
+describe('T6-T10: Agent turn payload', () => {
+  it('T6: agentTurn job calls sendApiMessage on run', async () => {
+    const runner = makeRunner('agent response text');
+    const { manager, agentId } = makeManager({ runner });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'agent-job',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'hello agent',
+    });
+
+    const log = await manager.run(job.id);
+
+    expect(runner.sendApiMessage).toHaveBeenCalledWith(
+      expect.stringContaining('cron-'),
+      'hello agent',
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
+    expect(log.status).toBe('ok');
+    expect(log.output).toContain('agent response text');
+
+    manager.stop();
+  });
+
+  it('T7: agent response captured in runLog.output', async () => {
+    const runner = makeRunner('my specific output');
+    const { manager, agentId } = makeManager({ runner });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'capture-test',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'ping',
+    });
+
+    const log = await manager.run(job.id);
+    expect(log.output).toBe('my specific output');
+
+    manager.stop();
+  });
+
+  it('T8: agentTurnSessionId defaults to cron-{jobId}', async () => {
+    const runner = makeRunner();
+    const { manager, agentId } = makeManager({ runner });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'session-default',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'test',
+      // no agentTurnSessionId
+    });
+
+    await manager.run(job.id);
+
+    const [sessionId] = (runner.sendApiMessage as jest.Mock).mock.calls[0];
+    expect(sessionId).toBe(`cron-${job.id}`);
+
+    manager.stop();
+  });
+
+  it('T9: agentTurn timeout → status=error', async () => {
+    const runner = {
+      sendApiMessage: jest.fn().mockRejectedValue(Object.assign(new Error('timeout'), { code: 'TIMEOUT' })),
+    };
+    const { manager, agentId } = makeManager({ runner });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'timeout-job',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'slow prompt',
+    });
+
+    const log = await manager.run(job.id);
+    expect(log.status).toBe('error');
+    expect(log.error).toContain('timeout');
+
+    manager.stop();
+  });
+
+  it('T10: payloadKind=command still uses exec (regression)', async () => {
+    const runner = makeRunner();
+    const { manager, agentId } = makeManager({ runner });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'command-regression',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'command',
+      command: 'echo regression-ok',
+    });
+
+    const log = await manager.run(job.id);
+    expect(log.status).toBe('ok');
+    expect(log.output).toContain('regression-ok');
+    // runner should NOT have been called
+    expect(runner.sendApiMessage).not.toHaveBeenCalled();
+
+    manager.stop();
+  });
+});
+
+// ─── T11-T15: Delivery (notify) ───────────────────────────────────────────────
+
+describe('T11-T15: Delivery (notify)', () => {
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      text: async () => '',
+    } as Response);
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  it('T11: success + notify.telegram → fetch with ✅', async () => {
+    const runner = makeRunner('done');
+    const { manager, agentId } = makeManager({ runner, botToken: 'TOKEN123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'notify-success',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'hi',
+      notify: { telegram: '12345' },
+    });
+
+    await manager.run(job.id);
+
+    const telegramCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('sendMessage'),
+    );
+    expect(telegramCalls.length).toBe(1);
+    const body = JSON.parse(telegramCalls[0][1].body);
+    expect(body.chat_id).toBe('12345');
+    expect(body.text).toContain('✅');
+
+    manager.stop();
+  });
+
+  it('T12: error + notify.telegram → fetch with ❌', async () => {
+    const runner = {
+      sendApiMessage: jest.fn().mockRejectedValue(new Error('agent failed')),
+    };
+    const { manager, agentId } = makeManager({ runner, botToken: 'TOKEN123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'notify-error',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'hi',
+      notify: { telegram: '99999' },
+    });
+
+    await manager.run(job.id);
+
+    const telegramCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('sendMessage'),
+    );
+    expect(telegramCalls.length).toBe(1);
+    const body = JSON.parse(telegramCalls[0][1].body);
+    expect(body.text).toContain('❌');
+
+    manager.stop();
+  });
+
+  it('T13: onSuccess=false + success → Telegram not called', async () => {
+    const runner = makeRunner('ok');
+    const { manager, agentId } = makeManager({ runner, botToken: 'TOKEN123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'no-success-notify',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'hi',
+      notify: { telegram: '12345', onSuccess: false },
+    });
+
+    await manager.run(job.id);
+
+    const telegramCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('sendMessage'),
+    );
+    expect(telegramCalls.length).toBe(0);
+
+    manager.stop();
+  });
+
+  it('T14: notify.webhook → fetch POST with JSON body', async () => {
+    const runner = makeRunner('webhook-output');
+    const { manager, agentId } = makeManager({ runner });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'webhook-job',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'hi',
+      notify: { webhook: 'https://hooks.example.com/test' },
+    });
+
+    await manager.run(job.id);
+
+    const webhookCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('hooks.example.com'),
+    );
+    expect(webhookCalls.length).toBe(1);
+    const [, opts] = webhookCalls[0];
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body.status).toBe('ok');
+    expect(body.output).toBe('webhook-output');
+
+    manager.stop();
+  });
+
+  it('T15: Telegram API error → job status still ok, warn logged', async () => {
+    fetchMock.mockRejectedValue(new Error('network error'));
+
+    const runner = makeRunner('ok');
+    const logger = makeLogger();
+    const agentId = 'test-agent';
+    const tmpDir = makeTmpDir();
+    const agentRunners = new Map<string, any>([[agentId, runner]]);
+    const agentConfigs = new Map<string, AgentConfig>([[agentId, makeAgentConfig(agentId)]]);
+
+    const manager = new CronManager(
+      { storePath: path.join(tmpDir, 'crons.json'), runsDir: path.join(tmpDir, 'runs') },
+      agentRunners,
+      agentConfigs,
+      logger,
+    );
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'network-fail',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'agentTurn',
+      agentTurnMessage: 'hi',
+      notify: { telegram: '12345' },
+    });
+
+    const log = await manager.run(job.id);
+    expect(log.status).toBe('ok'); // job itself succeeded
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Telegram notify error'),
+      expect.anything(),
+    );
+
+    manager.stop();
+  });
+});
+
+// ─── T16-T20: Failure alert ───────────────────────────────────────────────────
+
+describe('T16-T20: Failure alert', () => {
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      text: async () => '',
+    } as Response);
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  async function makeFailingJob(manager: CronManager, agentId: string, alertAfter = 3) {
+    return manager.create({
+      agentId,
+      name: 'failing-job',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'command',
+      command: 'exit 1',
+      failureAlert: { after: alertAfter, telegram: '55555' },
+    });
+  }
+
+  it('T16: 3rd error triggers alert when failureAlert.after=3', async () => {
+    const { manager, agentId } = makeManager({ botToken: 'TOKEN' });
+    await manager.start();
+
+    const job = await makeFailingJob(manager, agentId, 3);
+
+    // Force 3 consecutive errors
+    for (let i = 0; i < 3; i++) {
+      await manager.run(job.id).catch(() => {});
+    }
+
+    const alertCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('sendMessage'),
+    );
+    expect(alertCalls.length).toBe(1);
+    const body = JSON.parse(alertCalls[0][1].body);
+    expect(body.text).toContain('⚠️');
+    expect(body.text).toContain('3 times');
+
+    manager.stop();
+  });
+
+  it('T17: 2nd error does not trigger alert when failureAlert.after=3', async () => {
+    const { manager, agentId } = makeManager({ botToken: 'TOKEN' });
+    await manager.start();
+
+    const job = await makeFailingJob(manager, agentId, 3);
+
+    for (let i = 0; i < 2; i++) {
+      await manager.run(job.id).catch(() => {});
+    }
+
+    const alertCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('sendMessage'),
+    );
+    expect(alertCalls.length).toBe(0);
+
+    manager.stop();
+  });
+
+  it('T18: alert within cooldown is not sent again', async () => {
+    const { manager, agentId } = makeManager({ botToken: 'TOKEN' });
+    await manager.start();
+
+    const job = await makeFailingJob(manager, agentId, 1);
+
+    // First error → alert
+    await manager.run(job.id).catch(() => {});
+    // Second error → within cooldown, no second alert
+    await manager.run(job.id).catch(() => {});
+
+    const alertCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('sendMessage'),
+    );
+    expect(alertCalls.length).toBe(1);
+
+    manager.stop();
+  });
+
+  it('T19: alert is sent again after cooldown expires', async () => {
+    const { manager, agentId } = makeManager({ botToken: 'TOKEN' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'cooldown-expired',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'command',
+      command: 'exit 1',
+      failureAlert: { after: 1, telegram: '55555', cooldownMs: 1 }, // 1ms cooldown
+    });
+
+    await manager.run(job.id).catch(() => {});
+    // Wait for cooldown (1ms)
+    await new Promise((r) => setTimeout(r, 10));
+    await manager.run(job.id).catch(() => {});
+
+    const alertCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('sendMessage'),
+    );
+    expect(alertCalls.length).toBe(2);
+
+    manager.stop();
+  });
+
+  it('T20: success after error resets consecutiveErrors', async () => {
+    const { manager, agentId } = makeManager({ botToken: 'TOKEN' });
+    await manager.start();
+
+    // Create a job that initially fails then succeeds
+    const job = await manager.create({
+      agentId,
+      name: 'recover-job',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      payloadKind: 'command',
+      command: 'exit 1',
+      failureAlert: { after: 2, telegram: '55555' },
+    });
+
+    // Fail once
+    await manager.run(job.id).catch(() => {});
+    expect(manager.get(job.id)!.state.consecutiveErrors).toBe(1);
+
+    // Change command to succeed
+    await manager.update(job.id, { command: 'echo ok' });
+    await manager.run(job.id);
+
+    expect(manager.get(job.id)!.state.consecutiveErrors).toBe(0);
+
+    manager.stop();
+  });
+});

--- a/tests/unit/cron-router-v2.test.ts
+++ b/tests/unit/cron-router-v2.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for cron-router (Planning-27 Task 5 + Auth)
+ *
+ * T21-T23: Router validation for new schedule/payload fields
+ * T24-T28: API key auth + agent-scoped access control
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { CronManager } from '../../src/cron-manager';
+import { createCronRouter } from '../../src/cron-router';
+import { ApiKey } from '../../src/types';
+
+function makeLogger() {
+  return { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+}
+
+const VALID_KEY = 'test-key-abc';
+const apiKeys: ApiKey[] = [
+  { key: VALID_KEY, description: 'test', agents: ['agent-1'] },
+  { key: 'admin-key', description: 'admin', agents: '*' },
+];
+
+function makeApp(withAuth = false) {
+  const manager = new CronManager(
+    { storePath: '/tmp/crons-router-test.json', runsDir: '/tmp/crons-router-runs' },
+    new Map(),
+    new Map(),
+    makeLogger(),
+  );
+  // Mock create to avoid actual filesystem/scheduling
+  manager.create = jest.fn().mockImplementation(async (input) => ({
+    id: 'mock-id',
+    ...input,
+    scheduleKind: input.scheduleKind ?? 'cron',
+    payloadKind: input.payloadKind ?? 'command',
+    enabled: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    state: { lastRunAt: null, lastStatus: null, lastError: null, consecutiveErrors: 0, runCount: 0 },
+  }));
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCronRouter(manager, withAuth ? apiKeys : undefined));
+  return { app, manager };
+}
+
+describe('T21-T23: Router validation for new fields', () => {
+  it('T21: POST with scheduleKind=at + valid scheduleAt → 201', async () => {
+    const { app } = makeApp();
+
+    const futureTs = new Date(Date.now() + 60_000).toISOString();
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .send({
+        agentId: 'agent-1',
+        name: 'one-shot',
+        scheduleKind: 'at',
+        scheduleAt: futureTs,
+        payloadKind: 'command',
+        command: 'echo hi',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.job).toBeDefined();
+  });
+
+  it('T22: POST with scheduleKind=at + missing scheduleAt → 400', async () => {
+    const { app } = makeApp();
+
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .send({
+        agentId: 'agent-1',
+        name: 'bad-at',
+        scheduleKind: 'at',
+        // no scheduleAt
+        payloadKind: 'command',
+        command: 'echo hi',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('scheduleAt');
+  });
+
+  it('T23: POST with payloadKind=agentTurn + missing agentTurnMessage → 400', async () => {
+    const { app } = makeApp();
+
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .send({
+        agentId: 'agent-1',
+        name: 'agent-job',
+        scheduleKind: 'cron',
+        schedule: '* * * * *',
+        payloadKind: 'agentTurn',
+        // no agentTurnMessage
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('agentTurnMessage');
+  });
+});
+
+describe('T24-T28: Auth + agent-scoped access control', () => {
+  it('T24: missing API key → 401', async () => {
+    const { app } = makeApp(true);
+
+    const res = await request(app).get('/api/v1/crons');
+    expect(res.status).toBe(401);
+  });
+
+  it('T25: invalid API key → 403', async () => {
+    const { app } = makeApp(true);
+
+    const res = await request(app)
+      .get('/api/v1/crons')
+      .set('X-Api-Key', 'wrong-key');
+    expect(res.status).toBe(403);
+  });
+
+  it('T26: valid key → GET /v1/crons returns 200', async () => {
+    const { app } = makeApp(true);
+
+    const res = await request(app)
+      .get('/api/v1/crons')
+      .set('X-Api-Key', VALID_KEY);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.jobs)).toBe(true);
+  });
+
+  it('T27: key scoped to agent-1 cannot create cron for agent-2 → 403', async () => {
+    const { app } = makeApp(true);
+
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .set('X-Api-Key', VALID_KEY)
+      .send({
+        agentId: 'agent-2',
+        name: 'forbidden-job',
+        scheduleKind: 'cron',
+        schedule: '* * * * *',
+        payloadKind: 'command',
+        command: 'echo hi',
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('agent-2');
+  });
+
+  it('T28: admin key (*) can create cron for any agent → 201', async () => {
+    const { app } = makeApp(true);
+
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .set('X-Api-Key', 'admin-key')
+      .send({
+        agentId: 'agent-99',
+        name: 'admin-job',
+        scheduleKind: 'cron',
+        schedule: '* * * * *',
+        payloadKind: 'command',
+        command: 'echo hi',
+      });
+
+    expect(res.status).toBe(201);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the cron manager (PR #18) with full agent integration, flexible scheduling, result delivery, and API key authentication. Branched from `feat/cron-manager` (PR #18).

- **3 schedule types** — `cron` (existing), `at` (one-shot at ISO timestamp), `every` (fixed interval in ms)
- **2 payload types** — `command` (shell exec) and `agentTurn` (send prompt to Claude agent)
- **Post-run delivery** — Telegram chat or webhook notification after each run
- **Failure alerting** — Telegram alert after N consecutive errors
- **Cron API auth** — same API key auth as Agent API; list filtered by key scope; write ops check `canAccessAgent(apiKey, body.agentId)`
- **README** — full Cron API reference with request body schema and curl examples

## Test plan

- [ ] T1-T20: CronManager unit tests (schedule types, agentTurn, delivery, failure alert, auto-disable)
- [ ] T21-T23: Router validation (at/every/agentTurn fields)
- [ ] T24-T28: Auth middleware — missing key (401), invalid key (403), valid key (200), scoped key forbidden (403), admin key allowed (201)
- [ ] 699 pass / 0 fail (8 pre-existing skips)

> Depends on PR #18 (`feat/cron-manager`) — merge that first.