### PR TITLE
fix(typing): use ✅ instead of ☑️ for completed status steps

### DIFF
--- a/plugins/telegram/typing.ts
+++ b/plugins/telegram/typing.ts
@@ -223,11 +223,11 @@ export function createWorkingStateManager(
             : `${secs}s`
         const currentLine = s.lastDetail ?? STATUS_MESSAGES[tick % STATUS_MESSAGES.length]!
         tick++
-        // Build multi-line status: history (☑️) + current (🕐) + elapsed
+        // Build multi-line status: history (✅) + current (🕐) + elapsed
         const historyLines = s.recentDetails.slice(-4);
         const hasHistory = historyLines.length > 0
-        const formattedHistory = hasHistory ? historyLines.map(d => `☑️ : ${d}`) : []
-        const formattedCurrent = hasHistory ? `🕐 : ${currentLine}` : currentLine
+        const formattedHistory = hasHistory ? historyLines.map(d => `✅ ${d}`) : []
+        const formattedCurrent = hasHistory ? `🕐 ${currentLine}` : currentLine
         const lines = [...formattedHistory, formattedCurrent, `(elapsed: ${elapsedStr})`]
         const text = lines.join('\n')
         if (s.statusMessageId === null) {


### PR DESCRIPTION
## Summary
- Change history step emoji from `☑️` to `✅` to match README documentation
- Remove redundant ` : ` separator — format is now `✅ <detail>` not `☑️ : <detail>`
- Same fix for current step: `🕐 <detail>` instead of `🕐 : <detail>`

## Test plan
- [ ] Start gateway and trigger a multi-step agent response
- [ ] Verify status message shows `✅` for completed steps and `🕐` for current step
- [ ] Confirm format matches README Live Status example

🤖 Generated with [Claude Code](https://claude.com/claude-code)