### PR TITLE
feat(multi-session): Telegram multi-session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ testcase*.md
 feature*.md
 task-*.md
 research*.md
+restart.sh
+stop.sh

--- a/README.md
+++ b/README.md
@@ -409,16 +409,32 @@ This switches `dmPolicy` to `pairing`, prints pairing instructions, and reminds 
 
 Once paired, the following bot commands are available in a private chat:
 
+**Session management**
+
+| Command | Description |
+|---------|-------------|
+| `/session` | Show current session info (name, message count, context %) |
+| `/sessions` | List all sessions with inline keyboard — switch or delete |
+| `/new <name>` | Create a new session, optionally with a name |
+| `/rename <name>` | Rename the current session |
+| `/clear` | Clear current session history (with confirmation) |
+| `/compact` | Summarise old history and keep only recent messages |
+| `/restart` | Graceful session restart — shows a confirmation button; confirms and notifies when the session is back online |
+
+**Agent**
+
+| Command | Description |
+|---------|-------------|
+| `/model` | Show the current AI model |
+| `/models` | Switch AI model — shows an inline keyboard; selecting a model triggers a graceful restart and notifies when back online |
+
+**Account**
+
 | Command | Description |
 |---------|-------------|
 | `/start` | Pairing instructions |
-| `/help` | Show available commands |
 | `/status` | Check your pairing state |
-| `/model` | Show the current AI model |
-| `/models` | Switch AI model — shows an inline keyboard; selecting a model triggers a graceful restart and notifies when back online |
-| `/restart` | Graceful session restart — shows a confirmation button; confirms and notifies when the session is back online |
-
-> **Note:** `/model`, `/models`, and `/restart` require the agent to be running in `TELEGRAM_RECEIVER_MODE` with a reachable `CLAUDE_CHANNEL_CALLBACK` endpoint. If no active session exists when switching model or restarting, the change is applied immediately and a success message is shown without a restart.
+| `/help` | Show available commands |
 
 ---
 

--- a/config.template.json
+++ b/config.template.json
@@ -5,10 +5,15 @@
       "gateway.api.keys"
     ]
   },
-  "configVersion": "1.0.1",
+  "configVersion": "1.0.2",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
+    "models": [
+      { "id": "claude-opus-4-6",           "label": "Opus 4.6",   "alias": "opus",   "contextWindow": 1000000 },
+      { "id": "claude-sonnet-4-6",         "label": "Sonnet 4.6", "alias": "sonnet", "contextWindow": 1000000 },
+      { "id": "claude-haiku-4-5-20251001", "label": "Haiku 4.5",  "alias": "haiku",  "contextWindow": 200000 }
+    ],
     "api": {
       "keys": [
         {

--- a/plugins/telegram/server.ts
+++ b/plugins/telegram/server.ts
@@ -637,6 +637,21 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
 const SEND_ONLY = process.env.TELEGRAM_SEND_ONLY === 'true'
 const RECEIVER_MODE = process.env.TELEGRAM_RECEIVER_MODE === 'true'
 
+const BOT_COMMANDS = [
+  { command: 'session', description: 'Show current session info' },
+  { command: 'sessions', description: 'Manage conversation sessions' },
+  { command: 'new', description: 'Create a new session' },
+  { command: 'rename', description: 'Rename current session' },
+  { command: 'clear', description: 'Clear current session history' },
+  { command: 'compact', description: 'Summarize and compress session history' },
+  { command: 'restart', description: 'Graceful restart session' },
+  { command: 'model', description: 'Show current AI model' },
+  { command: 'models', description: 'Switch AI model' },
+  { command: 'start', description: 'Welcome and setup guide' },
+  { command: 'status', description: 'Check your pairing status' },
+  { command: 'help', description: 'What this bot can do' },
+]
+
 // Available AI models for /models command
 const AVAILABLE_MODELS = [
   { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus' },
@@ -851,11 +866,21 @@ bot.command('help', async ctx => {
   await ctx.reply(
     `Messages you send here route to a paired Claude Code session. ` +
     `Text and photos are forwarded; replies and reactions come back.\n\n` +
-    `/start — pairing instructions\n` +
-    `/status — check your pairing state\n` +
+    `*Session management*\n` +
+    `/session — show current session info\n` +    
+    `/sessions — list and switch between sessions\n` +
+    `/new <name> — create a new session\n` +
+    `/rename <name> — rename current session\n` +
+    `/clear — clear current session history\n` +
+    `/compact — summarise and compress session history\n` +
+    `/restart — graceful restart session\n\n` +
+    `*Agent*\n` +
     `/model — show current AI model\n` +
-    `/models — switch AI model\n` +
-    `/restart — graceful restart session`
+    `/models — switch AI model\n\n` +
+    `*Account*\n` +
+    `/start — pairing instructions\n` +
+    `/status — check your pairing state`,
+    { parse_mode: 'Markdown' }
   )
 })
 
@@ -934,6 +959,22 @@ bot.command('models', async ctx => {
   }
 })
 
+// /compact — show compact confirmation keyboard (receiver mode only)
+bot.command('compact', async ctx => {
+  if (ctx.chat?.type !== 'private') return
+  const access = loadAccess()
+  if (!access.allowFrom.includes(String(ctx.from!.id))) return
+
+  const keyboard = new InlineKeyboard()
+    .text('\u2705 Yes, compact', 'compact:confirm')
+    .text('\u274c Cancel', 'compact:cancel')
+
+  await ctx.reply(
+    '🧠 Compact session?\nThis will summarise old messages and keep only recent history.',
+    { reply_markup: keyboard },
+  )
+})
+
 // /restart — show restart confirmation keyboard (receiver mode only)
 bot.command('restart', async ctx => {
   if (ctx.chat?.type !== 'private') return
@@ -948,6 +989,94 @@ bot.command('restart', async ctx => {
     '\u26a0\ufe0f Restart session?\nThis will graceful-restart the current Claude session.',
     { reply_markup: keyboard },
   )
+})
+
+// /session — show current session info (direct command, no typing manager)
+bot.command('session', async ctx => {
+  if (ctx.chat?.type !== 'private') return
+  const access = loadAccess()
+  if (!access.allowFrom.includes(String(ctx.from!.id))) return
+  if (!CALLBACK_URL_BASE) return
+
+  try {
+    const res = await fetch(CALLBACK_URL_BASE + '/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'session_info', chat_id: String(ctx.chat.id) }),
+    })
+    const data = await res.json() as { success: boolean; text?: string }
+    await ctx.reply(data.text ?? '⚠️ Could not get session info.')
+  } catch {
+    await ctx.reply('⚠️ Could not connect to gateway.')
+  }
+})
+
+// /sessions — list sessions with inline keyboard for switching/deleting
+bot.command('sessions', async ctx => {
+  if (ctx.chat?.type !== 'private') return
+  const access = loadAccess()
+  if (!access.allowFrom.includes(String(ctx.from!.id))) return
+  if (!CALLBACK_URL_BASE) return
+
+  try {
+    const res = await fetch(CALLBACK_URL_BASE + '/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'list_sessions', chat_id: String(ctx.chat.id) }),
+    })
+    const data = (await res.json()) as {
+      sessions?: Array<{ id: string; name: string; messageCount: number; lastActive: number }>
+      activeSessionId?: string
+    }
+    const sessions = data.sessions ?? []
+    const activeId = data.activeSessionId ?? ''
+
+    const keyboard = new InlineKeyboard()
+    for (const s of sessions) {
+      const isActive = s.id === activeId
+      const label = isActive ? `\ud83d\udfe2 ${s.name}` : s.name
+      if (sessions.length > 1) {
+        keyboard.text(label, `session_switch:${s.id}`).text('\ud83d\uddd1', `session_delete:${s.id}`).row()
+      } else {
+        keyboard.text(label, `session_switch:${s.id}`).row()
+      }
+    }
+    keyboard.text('\u2795 New Session', 'session_new').row()
+    keyboard.text('Dismiss', 'session_back')
+
+    const lines = [`\ud83d\uddc2 Sessions (${sessions.length})`, '']
+    for (const s of sessions) {
+      const isActive = s.id === activeId
+      const ago = Math.round((Date.now() - s.lastActive) / 60000)
+      const ageStr = ago < 60 ? `${ago}m ago` : `${Math.round(ago / 60)}h ago`
+      lines.push(`${isActive ? '\ud83d\udfe2' : '\u26aa'} ${s.name} \u00b7 ${s.messageCount} msgs \u00b7 ${ageStr}`)
+    }
+    lines.push('')
+    lines.push('Tap a session to switch, \ud83d\uddd1 to delete')
+
+    await ctx.reply(lines.join('\n'), { reply_markup: keyboard })
+  } catch {
+    await ctx.reply('Failed to get sessions.')
+  }
+})
+
+// /clear — show Yes/No confirmation before clearing session history
+bot.command('clear', async ctx => {
+  if (ctx.chat?.type !== 'private') return
+  const access = loadAccess()
+  if (!access.allowFrom.includes(String(ctx.from!.id))) return
+
+  await ctx.reply(
+    '🗑️ Clear session?\n\nThis will delete all message history. This cannot be undone.',
+    {
+      reply_markup: {
+        inline_keyboard: [[
+          { text: '✅ Yes, clear it', callback_data: 'session_clear_confirm' },
+          { text: '❌ Cancel', callback_data: 'session_clear_cancel' },
+        ]],
+      },
+    },
+  ).catch(() => {})
 })
 
 // Inline-button handler for permission requests. Callback data is
@@ -1038,6 +1167,214 @@ bot.on('callback_query:data', async ctx => {
       } else {
         await ctx.answerCallbackQuery({ text: result.error ?? 'Failed' }).catch(() => {})
         await ctx.editMessageText(`Restart failed: ${result.error ?? 'unknown error'}`).catch(() => {})
+      }
+    } catch {
+      await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
+    }
+    return
+  }
+
+  // Handle compact confirmation: compact:confirm | compact:cancel
+  const compactMatch = /^compact:(confirm|cancel)$/.exec(data)
+  if (compactMatch) {
+    const access = loadAccess()
+    if (!access.allowFrom.includes(String(ctx.from.id))) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    if (compactMatch[1] === 'cancel') {
+      await ctx.answerCallbackQuery({ text: 'Cancelled' }).catch(() => {})
+      await ctx.editMessageText('Compact cancelled.').catch(() => {})
+      return
+    }
+    // confirm
+    if (!CALLBACK_URL_BASE) {
+      await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+      return
+    }
+    const chatId = String(ctx.callbackQuery.message?.chat.id)
+    try {
+      await ctx.answerCallbackQuery({ text: 'Compacting...' }).catch(() => {})
+      await ctx.deleteMessage().catch(() => {})
+      await ctx.reply('🧠 Session compacting, please wait...\nThis may take a moment.').catch(() => {})
+      if (RECEIVER_MODE) {
+        typingManager.start(chatId)
+      }
+      await fetch(CALLBACK_URL_BASE + '/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'compact_confirm', chat_id: chatId }),
+      })
+    } catch {
+      await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
+    }
+    return
+  }
+
+  // Handle session switch: session_switch:<sessionId>
+  const switchMatch = /^session_switch:(.+)$/.exec(data)
+  if (switchMatch) {
+    const access = loadAccess()
+    if (!access.allowFrom.includes(String(ctx.from.id))) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    if (!CALLBACK_URL_BASE) {
+      await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+      return
+    }
+    const sessionId = switchMatch[1]
+    const chatId = String(ctx.callbackQuery.message?.chat.id)
+    try {
+      const res = await fetch(CALLBACK_URL_BASE + '/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'switch_session', chat_id: chatId, payload: { session_id: sessionId } }),
+      })
+      const result = (await res.json()) as { success?: boolean; error?: string; sessionName?: string }
+      if (result.success) {
+        await ctx.answerCallbackQuery({ text: 'Switched!' }).catch(() => {})
+        const name = result.sessionName ?? sessionId
+        await ctx.editMessageText(`\u2705 Session switched to "${name}".`).catch(() => {})
+      } else {
+        await ctx.answerCallbackQuery({ text: result.error ?? 'Failed' }).catch(() => {})
+      }
+    } catch {
+      await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
+    }
+    return
+  }
+
+  // Handle session delete prompt: session_delete:<sessionId>
+  const deleteMatch = /^session_delete:(.+)$/.exec(data)
+  if (deleteMatch) {
+    const access = loadAccess()
+    if (!access.allowFrom.includes(String(ctx.from.id))) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    const sessionId = deleteMatch[1]
+    const keyboard = new InlineKeyboard()
+      .text('\u2705 Yes, delete', `session_delete_confirm:${sessionId}`)
+      .text('\u274c Cancel', 'session_delete_cancel')
+    await ctx.answerCallbackQuery().catch(() => {})
+    await ctx.editMessageText('\u26a0\ufe0f Delete this session? This cannot be undone.', {
+      reply_markup: keyboard,
+    }).catch(() => {})
+    return
+  }
+
+  // Handle session delete confirmation: session_delete_confirm:<sessionId>
+  const deleteConfirmMatch = /^session_delete_confirm:(.+)$/.exec(data)
+  if (deleteConfirmMatch) {
+    const access = loadAccess()
+    if (!access.allowFrom.includes(String(ctx.from.id))) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    if (!CALLBACK_URL_BASE) {
+      await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+      return
+    }
+    const sessionId = deleteConfirmMatch[1]
+    const chatId = String(ctx.callbackQuery.message?.chat.id)
+    try {
+      const res = await fetch(CALLBACK_URL_BASE + '/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'delete_session', chat_id: chatId, payload: { session_id: sessionId } }),
+      })
+      const result = (await res.json()) as { success?: boolean; error?: string; sessionName?: string }
+      if (result.success) {
+        await ctx.answerCallbackQuery({ text: 'Deleted' }).catch(() => {})
+        const switchedTo = result.sessionName ? `\n\n↩️ Switched to "${result.sessionName}"` : ''
+        await ctx.editMessageText(`\ud83d\uddd1 Session deleted.${switchedTo}`).catch(() => {})
+      } else {
+        await ctx.answerCallbackQuery({ text: result.error ?? 'Failed' }).catch(() => {})
+        await ctx.editMessageText(`Delete failed: ${result.error ?? 'unknown error'}`).catch(() => {})
+      }
+    } catch {
+      await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
+    }
+    return
+  }
+
+  // Handle session delete cancel
+  if (data === 'session_delete_cancel') {
+    await ctx.answerCallbackQuery({ text: 'Cancelled' }).catch(() => {})
+    await ctx.editMessageText('Delete cancelled.').catch(() => {})
+    return
+  }
+
+  // Handle /clear confirmation: session_clear_confirm | session_clear_cancel
+  if (data === 'session_clear_confirm') {
+    const access = loadAccess()
+    if (!access.allowFrom.includes(String(ctx.from.id))) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    if (!CALLBACK_URL_BASE) {
+      await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+      return
+    }
+    const chatId = String(ctx.callbackQuery.message?.chat.id)
+    try {
+      await ctx.answerCallbackQuery({ text: 'Clearing...' }).catch(() => {})
+      await ctx.editMessageText('\u23f3 Clearing session...').catch(() => {})
+      const res = await fetch(CALLBACK_URL_BASE + '/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'session_clear_confirm', chat_id: chatId }),
+      })
+      const result = (await res.json()) as { success?: boolean; error?: string }
+      if (result.success) {
+        await ctx.reply('\uD83D\uDCA1 Session has been cleared').catch(() => {})
+      } else {
+        await ctx.reply(`\u274C Clear failed: ${result.error ?? 'Unknown error'}`).catch(() => {})
+      }
+    } catch {
+      await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
+    }
+    return
+  }
+
+  if (data === 'session_clear_cancel') {
+    await ctx.answerCallbackQuery({ text: 'Cancelled' }).catch(() => {})
+    await ctx.editMessageText('Clear cancelled.').catch(() => {})
+    return
+  }
+
+  // Handle back button: dismiss the sessions menu
+  if (data === 'session_back') {
+    await ctx.answerCallbackQuery().catch(() => {})
+    await ctx.deleteMessage().catch(() => {})
+    return
+  }
+
+  // Handle new session via keyboard button: session_new
+  if (data === 'session_new') {
+    const access = loadAccess()
+    if (!access.allowFrom.includes(String(ctx.from.id))) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    if (!CALLBACK_URL_BASE) {
+      await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+      return
+    }
+    const chatId = String(ctx.callbackQuery.message?.chat.id)
+    try {
+      const res = await fetch(CALLBACK_URL_BASE + '/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'new_session', chat_id: chatId }),
+      })
+      const result = (await res.json()) as { success?: boolean; error?: string }
+      if (result.success) {
+        await ctx.answerCallbackQuery({ text: 'New session created!' }).catch(() => {})
+        await ctx.editMessageText('\u2705 New session started.').catch(() => {})
+      } else {
+        await ctx.answerCallbackQuery({ text: result.error ?? 'Failed' }).catch(() => {})
       }
     } catch {
       await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
@@ -1237,17 +1574,7 @@ if (RECEIVER_MODE) {
           onStart: info => {
             botUsername = info.username
             process.stderr.write(`telegram channel (receiver): polling as @${info.username}\n`)
-            void bot.api.setMyCommands(
-              [
-                { command: 'start', description: 'Welcome and setup guide' },
-                { command: 'help', description: 'What this bot can do' },
-                { command: 'status', description: 'Check your pairing status' },
-                { command: 'model', description: 'Show current AI model' },
-                { command: 'models', description: 'Switch AI model' },
-                { command: 'restart', description: 'Graceful restart session' },
-              ],
-              { scope: { type: 'all_private_chats' } },
-            ).catch(() => {})
+            void bot.api.setMyCommands(BOT_COMMANDS, { scope: { type: 'all_private_chats' } }).catch(() => {})
           },
         })
         return
@@ -1298,17 +1625,7 @@ if (RECEIVER_MODE) {
             onStart: info => {
               botUsername = info.username
               process.stderr.write(`telegram channel: polling as @${info.username}\n`)
-              void bot.api.setMyCommands(
-                [
-                  { command: 'start', description: 'Welcome and setup guide' },
-                  { command: 'help', description: 'What this bot can do' },
-                  { command: 'status', description: 'Check your pairing status' },
-                  { command: 'model', description: 'Show current AI model' },
-                  { command: 'models', description: 'Switch AI model' },
-                  { command: 'restart', description: 'Graceful restart session' },
-                ],
-                { scope: { type: 'all_private_chats' } },
-              ).catch(() => {})
+              void bot.api.setMyCommands(BOT_COMMANDS, { scope: { type: 'all_private_chats' } }).catch(() => {})
             },
           })
           return // bot.stop() was called — clean exit from the loop

--- a/plugins/telegram/typing.ts
+++ b/plugins/telegram/typing.ts
@@ -155,17 +155,9 @@ export function createWorkingStateManager(
           forwardText = raw
           parseMode = undefined
         }
-        // Skip if the reply tool already sent the exact same text (content-based dedup)
-        let isDuplicate = false
-        if (fsApi.existsSync(repliedPath)) {
-          try {
-            const repliedText = fsApi.readFileSync(repliedPath, 'utf8').trim()
-            isDuplicate = repliedText === forwardText.trim()
-          } catch {
-            isDuplicate = true  // Unreadable → assume duplicate to avoid double-send
-          }
-        }
-        if (!isDuplicate && forwardText) {
+        // Skip if the reply tool already sent a message (agent already replied)
+        const alreadyReplied = fsApi.existsSync(repliedPath)
+        if (!alreadyReplied && forwardText) {
           const msgOpts = parseMode ? { parse_mode: parseMode } : {}
           await botApi.sendMessage(chatId, forwardText, msgOpts).catch(() => {})
         }
@@ -316,7 +308,7 @@ export function createWorkingStateManager(
       if (Date.now() - lastActivity >= STALLED_TIMEOUT_MS) {
         await botApi.sendMessage(
           chatId,
-          '⚠️ Claude has not responded in 2 minutes. It may be waiting for input or stuck. Please try sending a new message.',
+          '⚠️ Claude has not responded in 5 minutes. It may be waiting for input or stuck. Please try sending a new message.',
         ).catch(() => {})
         await stop(chatId)
       }

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -3,21 +3,22 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as net from 'net';
 import * as path from 'path';
-import { AgentConfig, GatewayConfig, Logger, StreamEvent } from './types';
+import { AgentConfig, GatewayConfig, Logger, ModelConfig, StreamEvent } from './types';
 import { createLogger } from './logger';
 import { SessionProcess } from './session-process';
 import { SessionStore } from './session-store';
+import { SessionCompactor } from './session-compactor';
 import { TelegramReceiver } from './telegram-receiver';
 import { hasMarkdown, toTelegramHtml } from './markdown';
 
 const DEFAULT_IDLE_TIMEOUT_MINUTES = 30;
 const DEFAULT_MAX_CONCURRENT = 20;
 
-const AVAILABLE_MODELS = [
-  { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus' },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', alias: 'sonnet' },
-  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', alias: 'haiku' },
-] as const;
+const DEFAULT_MODELS: ModelConfig[] = [
+  { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus', contextWindow: 1000000 },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', alias: 'sonnet', contextWindow: 1000000 },
+  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', alias: 'haiku', contextWindow: 200000 },
+];
 
 export class AgentRunner extends EventEmitter {
   private readonly agentConfig: AgentConfig;
@@ -102,23 +103,35 @@ export class AgentRunner extends EventEmitter {
           const chatId = meta['chat_id'] ?? '';
           const content = params.content ?? '';
 
-          // Append user message to session store
-          this.sessionStore
-            .appendMessage(this.agentConfig.id, chatId, {
-              role: 'user',
-              content,
-              ts: Date.now(),
-            })
-            .catch(() => {});
+          // Check if this is a session management command
+          const trimmedContent = content.trim();
+          if (this.isSessionCommand(trimmedContent)) {
+            this.handleSessionCommand(chatId, trimmedContent)
+              .then(() => this.writeTypingDone(chatId))
+              .catch((err) => {
+                this.logger.error('Session command failed', { error: (err as Error).message });
+                this.writeTypingDone(chatId);
+              });
+            return;
+          }
 
-          // Route to session, inject as channel XML
-          this.getOrSpawnSession(chatId, 'telegram')
-            .then((session) => {
+          // Get active session ID and route message to it
+          this.sessionStore.getActiveSessionId(this.agentConfig.id, chatId)
+            .then(async (sessionId) => {
+              // Append user message to the active telegram session
+              await this.sessionStore.appendTelegramMessage(this.agentConfig.id, chatId, sessionId, {
+                role: 'user',
+                content,
+                ts: Date.now(),
+              });
+              // Route to session process (map key = chatId, actual sessionId passed separately)
+              const session = await this.getOrSpawnSession(chatId, 'telegram', sessionId);
               const channelXml = AgentRunner.buildChannelXml(params);
               session.sendMessage(channelXml);
               session.touch();
               this.logger.debug('Injected channel turn into session', {
                 chatId,
+                sessionId,
                 user: meta['user'],
               });
             })
@@ -146,7 +159,7 @@ export class AgentRunner extends EventEmitter {
    * Handle POST /command requests from the receiver process.
    * Supports: get_model, set_model, restart.
    */
-  private handleCommandRequest(raw: string, res: http.ServerResponse): void {
+  private async handleCommandRequest(raw: string, res: http.ServerResponse): Promise<void> {
     const respond = (data: Record<string, unknown>, status = 200): void => {
       res.writeHead(status, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(data));
@@ -169,7 +182,8 @@ export class AgentRunner extends EventEmitter {
 
     if (command === 'set_model') {
       const newModel = typeof body.payload?.model === 'string' ? body.payload.model : '';
-      const valid = AVAILABLE_MODELS.find(m => m.id === newModel);
+      const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+      const valid = availableModels.find(m => m.id === newModel);
       if (!valid) {
         respond({ success: false, error: 'Unknown model' });
         return;
@@ -247,6 +261,118 @@ export class AgentRunner extends EventEmitter {
       return;
     }
 
+    if (command === 'session_clear_confirm') {
+      const chatId = body.chat_id ?? '';
+      try {
+        await this.handleCommandClear(this.agentConfig.id, chatId);
+        respond({ success: true });
+      } catch (err) {
+        respond({ success: false, error: String(err) });
+      }
+      return;
+    }
+
+    if (command === 'list_sessions') {
+      const chatId = body.chat_id ?? '';
+      try {
+        const index = await this.sessionStore.listSessions(this.agentConfig.id, chatId);
+        return respond({ sessions: index.sessions, activeSessionId: index.activeSessionId });
+      } catch {
+        return respond({ success: false, error: 'Failed to list sessions' });
+      }
+    }
+
+    if (command === 'session_info') {
+      const chatId = body.chat_id ?? '';
+      try {
+        const index = await this.sessionStore.listSessions(this.agentConfig.id, chatId);
+        const meta = index.sessions.find(s => s.id === index.activeSessionId);
+        if (!meta) {
+          return respond({ success: true, text: 'No active session found.' });
+        }
+        const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+        const modelConfig = availableModels.find(m => m.id === this.agentConfig.claude.model);
+        const contextWindow = modelConfig?.contextWindow ?? 200000;
+        const contextTokens = meta.lastInputTokens ?? 0;
+        const usedPct = Math.round((contextTokens / contextWindow) * 100);
+        let msgs: string;
+        if (meta.messageCount <= 0) {
+          msgs = 'No messages yet';
+        } else if ((meta.archivedCount ?? 0) > 0 && meta.loadedAtSpawn != null && meta.messageCountAtSpawn != null) {
+          const newMessagesSinceSpawn = meta.messageCount - meta.messageCountAtSpawn;
+          const inContext = meta.loadedAtSpawn + Math.max(0, newMessagesSinceSpawn);
+          msgs = `${meta.messageCount} (${inContext} in context / ${meta.archivedCount} archived)`;
+        } else {
+          msgs = `${meta.messageCount}`;
+        }
+        const lines = [
+          `📌 Current Session: ${meta.name}`,
+          '',
+          `📥 Messages: ${msgs}`,
+          `👉 Context: ${usedPct}%`,
+        ];
+        if (usedPct >= 80) {
+          lines.push('', '💡 Near limit — consider /compact');
+        }
+        lines.push('', 'Commands: /sessions /new /rename /clear /compact');
+        return respond({ success: true, text: lines.join('\n') });
+      } catch {
+        return respond({ success: false, text: 'Failed to get session info.' });
+      }
+    }
+
+    if (command === 'switch_session') {
+      const chatId = body.chat_id ?? '';
+      const sessionId = typeof body.payload?.session_id === 'string' ? body.payload.session_id : '';
+      if (!sessionId) {
+        respond({ success: false, error: 'Missing session_id' });
+        return;
+      }
+      this.switchSession(chatId, sessionId)
+        .then(async () => {
+          const index = await this.sessionStore.listSessions(this.agentConfig.id, chatId);
+          const session = index.sessions.find(s => s.id === sessionId);
+          respond({ success: true, sessionName: session?.name ?? sessionId });
+        })
+        .catch(err => respond({ success: false, error: String(err) }));
+      return;
+    }
+
+    if (command === 'delete_session') {
+      const chatId = body.chat_id ?? '';
+      const sessionId = typeof body.payload?.session_id === 'string' ? body.payload.session_id : '';
+      if (!sessionId) {
+        respond({ success: false, error: 'Missing session_id' });
+        return;
+      }
+      this.sessionStore.deleteTelegramSession(this.agentConfig.id, chatId, sessionId)
+        .then(async () => {
+          const newIndex = await this.sessionStore.listSessions(this.agentConfig.id, chatId);
+          await this.restartProcess(chatId);
+          const activeMeta = newIndex.sessions.find(s => s.id === newIndex.activeSessionId);
+          respond({ success: true, sessionName: activeMeta?.name ?? newIndex.activeSessionId });
+        })
+        .catch(err => respond({ success: false, error: String(err) }));
+      return;
+    }
+
+    if (command === 'new_session') {
+      const chatId = body.chat_id ?? '';
+      const name = typeof body.payload?.name === 'string' ? body.payload.name : undefined;
+      this.handleCommandNew(this.agentConfig.id, chatId, name)
+        .then(() => respond({ success: true }))
+        .catch(err => respond({ success: false, error: String(err) }));
+      return;
+    }
+
+    if (command === 'compact_confirm') {
+      const chatId = body.chat_id ?? '';
+      this.handleCommandCompact(this.agentConfig.id, chatId)
+        .then(() => this.writeTypingDone(chatId))
+        .catch(() => this.writeTypingDone(chatId));
+      return respond({ success: true });
+    }
+
     respond({ success: false, error: 'Unknown command' }, 400);
   }
 
@@ -306,10 +432,11 @@ export class AgentRunner extends EventEmitter {
   }
 
   private async getOrSpawnSession(
-    sessionId: string,
+    mapKey: string,              // Map lookup key (chatId for telegram, sessionId for API)
     source: 'telegram' | 'api',
+    sessionId?: string,          // actual session UUID (only for telegram; equals mapKey for API)
   ): Promise<SessionProcess> {
-    const existing = this.sessions.get(sessionId);
+    const existing = this.sessions.get(mapKey);
     if (existing) return existing;
 
     // Evict oldest idle session if at capacity
@@ -327,12 +454,16 @@ export class AgentRunner extends EventEmitter {
       }
     }
 
+    const actualSessionId = sessionId ?? mapKey;
+    const chatId = source === 'telegram' ? mapKey : undefined;
+
     const proc = new SessionProcess(
-      sessionId,
+      actualSessionId,
       source,
       this.agentConfig,
       this.gatewayConfig,
       this.sessionStore,
+      chatId,
     );
     await proc.start();
 
@@ -343,8 +474,8 @@ export class AgentRunner extends EventEmitter {
     // Notify typing indicator when session permanently fails (max restarts exceeded)
     if (source === 'telegram') {
       proc.once('failed', () => {
-        this.writeTypingError(sessionId, 'PROCESS_FAILED');
-        this.sessions.delete(sessionId);
+        this.writeTypingError(mapKey, 'PROCESS_FAILED');
+        this.sessions.delete(mapKey);
       });
       // Stop typing loop when Claude's turn truly ends.
       // Typing done is delayed 3s after result event — if new output arrives within
@@ -382,20 +513,48 @@ export class AgentRunner extends EventEmitter {
             if (resultText.trim()) {
               const text = resultText.trim();
               if (hasMarkdown(text)) {
-                this.writeAutoForward(sessionId, toTelegramHtml(text), 'html');
+                this.writeAutoForward(mapKey, toTelegramHtml(text), 'html');
               } else {
-                this.writeAutoForward(sessionId, text);
+                this.writeAutoForward(mapKey, text);
               }
             }
             replyCalled = false; // reset for next turn
             // Delay typing done — agent may continue with more work
             typingDoneTimer = setTimeout(() => {
-              this.writeTypingDone(sessionId);
+              this.writeTypingDone(mapKey);
               typingDoneTimer = null;
             }, TYPING_DONE_DELAY_MS);
           }
         } catch { /* non-JSON */ }
       });
+
+      // Track token usage and persist to session meta
+      // Use actualSessionId (captured at spawn time) — NOT getActiveSessionId() —
+      // so tokens are attributed to the session that owns this process.
+      proc.on('tokenUsage', async ({ inputTokens, totalTokens }: { inputTokens: number; totalTokens: number }) => {
+        try {
+          const index = await this.sessionStore.listSessions(this.agentConfig.id, mapKey);
+          const meta = index.sessions.find(s => s.id === actualSessionId);
+          const current = meta?.totalTokensUsed ?? 0;
+          await this.sessionStore.updateSessionMeta(this.agentConfig.id, mapKey, actualSessionId, {
+            totalTokensUsed: current + totalTokens,
+            lastInputTokens: inputTokens,
+          });
+        } catch {
+          // Non-fatal — token tracking is best-effort
+        }
+      });
+
+      // Persist spawn context (loaded vs archived message counts).
+      // Read from property instead of event — the event fired during start() before
+      // listeners were registered, causing a race condition.
+      if (proc.spawnContext) {
+        this.sessionStore.updateSessionMeta(this.agentConfig.id, mapKey, actualSessionId, {
+          loadedAtSpawn: proc.spawnContext.loadedAtSpawn,
+          archivedCount: proc.spawnContext.archivedCount,
+          messageCountAtSpawn: proc.spawnContext.messageCountAtSpawn,
+        }).catch(() => { /* Non-fatal */ });
+      }
 
       // Clean up pending typing-done timer when session stops
       proc.once('exit', () => {
@@ -403,17 +562,244 @@ export class AgentRunner extends EventEmitter {
           clearTimeout(typingDoneTimer);
           typingDoneTimer = null;
         }
-        this.writeTypingDone(sessionId);
+        this.writeTypingDone(mapKey);
       });
     }
 
-    this.sessions.set(sessionId, proc);
+    this.sessions.set(mapKey, proc);
     this.logger.info('Spawned session', {
-      sessionId,
+      mapKey,
+      actualSessionId,
       source,
       total: this.sessions.size,
     });
     return proc;
+  }
+
+  /**
+   * Returns true if the message content is a session management command.
+   */
+  private isSessionCommand(content: string): boolean {
+    return /^\/sessions?\b|^\/new(\s|$)|^\/clear\b|^\/compact\b|^\/rename(\s|$)/.test(content);
+  }
+
+  /**
+   * Dispatch a session management command to the appropriate handler.
+   */
+  private async handleSessionCommand(chatId: string, content: string): Promise<void> {
+    const agentId = this.agentConfig.id;
+
+    if (content.startsWith('/sessions')) {
+      await this.handleCommandSessions(agentId, chatId);
+    } else if (content.startsWith('/session') && !content.startsWith('/sessions')) {
+      await this.handleCommandSessionInfo(agentId, chatId);
+    } else if (content.startsWith('/new')) {
+      const name = content.replace('/new', '').trim() || undefined;
+      await this.handleCommandNew(agentId, chatId, name);
+    } else if (content.startsWith('/clear')) {
+      await this.handleCommandClear(agentId, chatId);
+    } else if (content.startsWith('/compact')) {
+      await this.handleCommandCompact(agentId, chatId);
+    } else if (content.startsWith('/rename')) {
+      const name = content.replace('/rename', '').trim();
+      await this.handleCommandRename(agentId, chatId, name);
+    }
+  }
+
+  /**
+   * /sessions — list all sessions for this chat.
+   */
+  private async handleCommandSessions(agentId: string, chatId: string): Promise<void> {
+    const index = await this.sessionStore.listSessions(agentId, chatId);
+    const lines: string[] = [`Sessions (${agentId})`, ''];
+
+    for (const s of index.sessions) {
+      const isActive = s.id === index.activeSessionId;
+      const indicator = isActive ? '🟢 ' : '   ';
+      const age = this.formatAge(s.lastActive);
+      lines.push(`${indicator}${isActive ? `**${s.name}**` : s.name}`);
+      lines.push(`  ${s.messageCount} messages · last active ${age}`);
+      lines.push('');
+    }
+
+    lines.push('Use /new [name] to create a new session');
+    this.writeAutoForward(chatId, lines.join('\n'));
+  }
+
+  /**
+   * /session — show info about the current active session.
+   */
+  private async handleCommandSessionInfo(agentId: string, chatId: string): Promise<void> {
+    const index = await this.sessionStore.listSessions(agentId, chatId);
+    const meta = index.sessions.find(s => s.id === index.activeSessionId);
+    if (!meta) {
+      this.writeAutoForward(chatId, 'No active session found.');
+      return;
+    }
+
+    const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+    const modelConfig = availableModels.find(m => m.id === this.agentConfig.claude.model);
+    const contextWindow = modelConfig?.contextWindow ?? 200000;
+    const contextTokens = meta.lastInputTokens ?? 0;
+    const usedPct = Math.round((contextTokens / contextWindow) * 100);
+
+    let msgs: string;
+    if (meta.messageCount <= 0) {
+      msgs = 'No messages yet';
+    } else if ((meta.archivedCount ?? 0) > 0 && meta.loadedAtSpawn != null && meta.messageCountAtSpawn != null) {
+      const newMessagesSinceSpawn = meta.messageCount - meta.messageCountAtSpawn;
+      const inContext = meta.loadedAtSpawn + Math.max(0, newMessagesSinceSpawn);
+      msgs = `${meta.messageCount} (${inContext} in context / ${meta.archivedCount} archived)`;
+    } else {
+      msgs = `${meta.messageCount}`;
+    }
+
+    const contextLine = `${usedPct}%`;
+
+    const lines = [
+      `📌 Current Session: ${meta.name}`,
+      '',
+      `📥 Messages: ${msgs}`,
+      `👉 Context: ${contextLine}`,
+    ];
+
+    if (usedPct >= 80) {
+      lines.push('', '💡 Near limit — consider /compact');
+    }
+
+    lines.push('', 'Commands: /sessions /new /rename /clear /compact');
+
+    const info = lines.join('\n');
+
+    this.writeAutoForward(chatId, info);
+  }
+
+  /**
+   * /new [name] — create a new session and switch to it.
+   */
+  private async handleCommandNew(agentId: string, chatId: string, name?: string): Promise<void> {
+    const newMeta = await this.sessionStore.createTelegramSession(agentId, chatId, name);
+    await this.switchSession(chatId, newMeta.id);
+    this.writeAutoForward(chatId, `✅ New session created: "${newMeta.name}"\nNow chatting in a fresh context. Use /sessions to switch back.`);
+  }
+
+  /**
+   * /rename <name> — rename the current session.
+   */
+  private async handleCommandRename(agentId: string, chatId: string, name: string): Promise<void> {
+    if (!name) {
+      this.writeAutoForward(chatId, '⚠️ Usage: /rename <new name>\nExample: /rename Design review');
+      return;
+    }
+    const sessionId = await this.sessionStore.getActiveSessionId(agentId, chatId);
+    await this.sessionStore.updateSessionMeta(agentId, chatId, sessionId, { name });
+    this.writeAutoForward(chatId, `✅ Session renamed to "${name}"`);
+  }
+
+  /**
+   * /clear — clear history of the current session and restart the process.
+   */
+  private async handleCommandClear(agentId: string, chatId: string): Promise<void> {
+    const sessionId = await this.sessionStore.getActiveSessionId(agentId, chatId);
+
+    // Clear messages and reset all metadata in-place (preserves session ID and name)
+    await this.sessionStore.clearTelegramSessionHistory(agentId, chatId, sessionId);
+    await this.sessionStore.updateSessionMeta(agentId, chatId, sessionId, {
+      totalTokensUsed: 0,
+      lastInputTokens: 0,
+      archivedCount: 0,
+      loadedAtSpawn: undefined,
+      messageCountAtSpawn: undefined,
+    });
+
+    // Kill old process so next message spawns fresh
+    this.restartProcess(chatId).catch(() => {});
+  }
+
+  /**
+   * /compact — summarise old history and keep only recent messages.
+   */
+  private async handleCommandCompact(agentId: string, chatId: string): Promise<void> {
+    const sessionId = await this.sessionStore.getActiveSessionId(agentId, chatId);
+    const index = await this.sessionStore.listSessions(agentId, chatId);
+    const meta = index.sessions.find(s => s.id === sessionId);
+    const name = meta?.name ?? 'Session';
+
+    const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+    const modelConfig = availableModels.find(m => m.id === this.agentConfig.claude.model);
+    const contextWindow = modelConfig?.contextWindow ?? 200000;
+
+    this.writeAutoForward(chatId, `⏳ Compacting session "${name}"...`);
+
+    try {
+      const compactor = new SessionCompactor(this.sessionStore);
+      const result = await compactor.compact(agentId, chatId, sessionId, this.agentConfig.claude.model, contextWindow);
+      // Reset context tracking — after compaction all messages fit in context
+      await this.sessionStore.updateSessionMeta(agentId, chatId, sessionId, {
+        loadedAtSpawn: undefined,
+        archivedCount: undefined,
+        messageCountAtSpawn: undefined,
+      });
+      await this.restartProcess(chatId);
+
+      const summary = [
+        `✅ Session compacted`,
+        '',
+        `Before: ${result.beforeMessages} messages (~${result.beforeTokens.toLocaleString()} tokens)  →  ${result.contextPctBefore}% of context`,
+        `After:  ${result.afterMessages} messages (~${result.afterTokens.toLocaleString()} tokens)   →  ${result.contextPctAfter}% of context`,
+        `Reduced by: ${result.reductionPct}%`,
+        '',
+        'Summary preserved. Full history before compaction is archived.',
+      ].join('\n');
+      this.writeAutoForward(chatId, summary);
+    } catch (err) {
+      if ((err as Error).name === 'NotEnoughMessagesError') {
+        this.writeAutoForward(chatId, `⚠️ ${(err as Error).message}`);
+      } else {
+        this.logger.error('Compact failed', { error: (err as Error).message });
+        this.writeAutoForward(chatId, `❌ Compact failed: ${(err as Error).message}\n\nYour session history is unchanged.`);
+      }
+    }
+  }
+
+  /**
+   * Switch the active session for a chat: stop the existing process and update the store.
+   * The new process will be lazily spawned on the next incoming message.
+   */
+  private async switchSession(chatId: string, newSessionId: string): Promise<void> {
+    const existing = this.sessions.get(chatId);
+    if (existing) {
+      await existing.stop();
+      this.sessions.delete(chatId);
+    }
+    await this.sessionStore.setActiveSession(this.agentConfig.id, chatId, newSessionId);
+  }
+
+  /**
+   * Restart the process for a given chatId (stop + remove from map).
+   * The process will be lazily re-spawned on the next incoming message.
+   */
+  private async restartProcess(chatId: string): Promise<void> {
+    const existing = this.sessions.get(chatId);
+    if (existing) {
+      await existing.stop();
+      this.sessions.delete(chatId);
+    }
+    // Process will be re-spawned on next incoming message
+  }
+
+  /**
+   * Format a timestamp as a human-readable age string (e.g. "5m ago", "2h ago").
+   */
+  private formatAge(ts: number): string {
+    const diffMs = Date.now() - ts;
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}d ago`;
   }
 
   /**
@@ -472,8 +858,7 @@ export class AgentRunner extends EventEmitter {
     }, 5 * 60 * 1000);
   }
 
-  async start(bootstrapPrompt?: string): Promise<void> {
-    void bootstrapPrompt; // reserved for future use
+  async start(): Promise<void> {
     this.stopping = false;
     await this.startCallbackServer();
     this.receiver = new TelegramReceiver(

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ async function main(): Promise<void> {
     let runner: AgentRunner;
     try {
       runner = new AgentRunner(agentConfig, config, logger);
-      await runner.start(workspace.files.bootstrapMd ?? undefined);
+      await runner.start();
     } catch (err) {
       const reason = (err as Error).message;
       logger.error('Failed to start agent runner', { error: reason });

--- a/src/session-compactor.ts
+++ b/src/session-compactor.ts
@@ -1,0 +1,163 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { Message } from './types';
+import { SessionStore } from './session-store';
+
+export interface CompactionResult {
+  beforeMessages: number;
+  afterMessages: number;
+  beforeTokens: number;
+  afterTokens: number;
+  reductionPct: number;
+  contextPctBefore: number;
+  contextPctAfter: number;
+}
+
+export class NotEnoughMessagesError extends Error {
+  constructor(count: number) {
+    super(`Not enough messages to compact (${count} messages, minimum 5 required)`);
+    this.name = 'NotEnoughMessagesError';
+  }
+}
+
+// Max characters per chunk sent to claude CLI (~100K chars ≈ ~25K tokens, well within 200K limit)
+const CHUNK_CHARS = 100_000;
+// Number of recent messages to keep verbatim; older messages are summarized
+const KEEP_LAST_MESSAGES = 45;
+// Prompt used to merge multiple chunk summaries into one
+const MERGE_SUMMARIES_PROMPT =
+  'These are summaries of sequential parts of a conversation. Merge them into a single concise summary preserving key facts, decisions, context, and any open tasks.';
+// Default instruction for summarizing a single conversation or chunk
+const SINGLE_SUMMARY_INSTRUCTION =
+  'Summarize this conversation concisely, preserving key facts, decisions, context the assistant should remember, and any open questions or unfinished tasks.';
+// System prompt prepended to every claude CLI summarization call
+const COMPACTOR_SYSTEM_PROMPT =
+  'You are a conversation archiver. Your ONLY task is to produce a concise summary of the conversation transcript below. Do NOT respond to the conversation. Do NOT ask questions. Output ONLY the summary.';
+
+// Rough token estimate: ~4 chars per token
+function estimateTokens(messages: Message[]): number {
+  return Math.round(messages.reduce((acc, m) => acc + m.content.length, 0) / 4);
+}
+
+export class SessionCompactor {
+  constructor(private readonly sessionStore: SessionStore) {}
+
+  async compact(
+    agentId: string,
+    chatId: string,
+    sessionId: string,
+    model: string,
+    contextWindow: number,
+  ): Promise<CompactionResult> {
+    // Load current history
+    const messages = await this.sessionStore.loadTelegramSession(agentId, chatId, sessionId);
+
+    if (messages.length < 5) {
+      throw new NotEnoughMessagesError(messages.length);
+    }
+
+    const beforeMessages = messages.length;
+    const beforeTokens = estimateTokens(messages);
+
+    // Archive original before compaction
+    const agentsBaseDir = this.sessionStore.getAgentsBaseDir();
+    const telegramDir = path.join(agentsBaseDir, agentId, 'sessions', `telegram-${chatId}`);
+    fs.mkdirSync(telegramDir, { recursive: true });
+    const archivePath = path.join(telegramDir, `${sessionId}.pre-compact-${Date.now()}.json`);
+    fs.writeFileSync(archivePath, JSON.stringify(messages, null, 2), 'utf-8');
+
+    // Keep last N messages verbatim; summarize only the older portion (or all if < N)
+    const tail = messages.slice(-KEEP_LAST_MESSAGES);
+    const toSummarize = messages.length > KEEP_LAST_MESSAGES ? messages.slice(0, -KEEP_LAST_MESSAGES) : messages;
+    const historyText = toSummarize
+      .map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
+      .join('\n\n');
+
+    const summaryText = await this.summarizeWithChunking(historyText);
+    const compacted: Message[] = [
+      { role: 'system', content: `[Conversation Summary]\n${summaryText}`, ts: Date.now() },
+      ...tail,
+    ];
+
+    // Save compacted history (original already archived above)
+    await this.sessionStore.saveTelegramSession(agentId, chatId, sessionId, compacted);
+
+    const afterMessages = compacted.length;
+    const afterTokens = estimateTokens(compacted);
+    const reductionPct = beforeTokens > 0 ? Math.max(0, Math.round((1 - afterTokens / beforeTokens) * 100)) : 0;
+    const contextPctBefore = Math.round((beforeTokens / contextWindow) * 100);
+    const contextPctAfter = Math.round((afterTokens / contextWindow) * 100);
+
+    return { beforeMessages, afterMessages, beforeTokens, afterTokens, reductionPct, contextPctBefore, contextPctAfter };
+  }
+
+  private async summarizeWithChunking(historyText: string): Promise<string> {
+    // If small enough, summarize directly
+    if (historyText.length <= CHUNK_CHARS) {
+      return this.callClaudeForSummary(historyText);
+    }
+
+    // Split into chunks and summarize each
+    const chunks = this.splitIntoChunks(historyText, CHUNK_CHARS);
+    const chunkSummaries: string[] = [];
+
+    for (let i = 0; i < chunks.length; i++) {
+      const summary = await this.callClaudeForSummary(
+        chunks[i],
+        `This is part ${i + 1} of ${chunks.length} of a longer conversation. Summarize this segment concisely.`,
+      );
+      chunkSummaries.push(`[Part ${i + 1}/${chunks.length}]\n${summary}`);
+    }
+
+    // Merge chunk summaries into final summary
+    const mergedText = chunkSummaries.join('\n\n');
+    return this.callClaudeForSummary(
+      mergedText,
+      MERGE_SUMMARIES_PROMPT,
+    );
+  }
+
+  private splitIntoChunks(text: string, maxChars: number): string[] {
+    const chunks: string[] = [];
+    let start = 0;
+
+    while (start < text.length) {
+      let end = start + maxChars;
+      if (end < text.length) {
+        // Break at a newline boundary to avoid splitting mid-message
+        const boundary = text.lastIndexOf('\n\n', end);
+        if (boundary > start) end = boundary;
+      }
+      chunks.push(text.slice(start, end));
+      start = end;
+    }
+
+    return chunks;
+  }
+
+  private async callClaudeForSummary(
+    text: string,
+    instruction = SINGLE_SUMMARY_INSTRUCTION,
+  ): Promise<string> {
+    // Wrap content in XML tags so claude treats it as data to analyze, not an active conversation
+    const prompt = `${COMPACTOR_SYSTEM_PROMPT}\n\n${instruction}\n\n<transcript>\n${text}\n</transcript>\n\nWrite a concise summary of the above transcript now:`;
+
+    const result = spawnSync('claude', ['--print'], {
+      input: prompt,
+      encoding: 'utf-8',
+      timeout: 300_000,
+      env: process.env,
+    });
+
+    if (result.error) {
+      throw new Error(`claude CLI error: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      const stderr = result.stderr?.trim() ?? '';
+      throw new Error(`claude CLI exited with status ${result.status}: ${stderr}`);
+    }
+
+    return result.stdout?.trim() ?? '';
+  }
+}

--- a/src/session-process.ts
+++ b/src/session-process.ts
@@ -16,8 +16,10 @@ const CHANNELS_ACTIVATION_PROMPT =
 
 export class SessionProcess extends EventEmitter {
   readonly sessionId: string;
+  readonly chatId: string;
   readonly source: 'telegram' | 'api';
   lastActivityAt = Date.now(); // accessible by AgentRunner for eviction sort
+  spawnContext: { loadedAtSpawn: number; archivedCount: number; messageCountAtSpawn: number } | null = null;
   private process: ChildProcess | null = null;
   private stopping = false;
   private restartCount = 0;
@@ -36,10 +38,12 @@ export class SessionProcess extends EventEmitter {
     agentConfig: AgentConfig,
     gatewayConfig: GatewayConfig,
     sessionStore: SessionStore,
+    chatId?: string,  // for telegram: actual chatId; for api: same as sessionId
   ) {
     super();
     this.sessionId = sessionId;
     this.source = source;
+    this.chatId = chatId ?? sessionId;
     this.agentConfig = agentConfig;
     this.gatewayConfig = gatewayConfig;
     this.sessionStore = sessionStore;
@@ -102,30 +106,40 @@ export class SessionProcess extends EventEmitter {
       const marker = notifyPayload
         ? `[System: Graceful restart completed successfully. Do not restart again. IMPORTANT: Send a Telegram reply to chat_id "${notifyPayload.chat_id}" with the message: "${notifyPayload.text}"]`
         : '[System: Graceful restart completed successfully. Do not restart again.]';
-      this.sessionStore.appendMessage(this.agentConfig.id, this.sessionId, {
-        role: 'assistant',
-        content: marker,
-        ts: Date.now(),
-      }).catch(err => this.logger.warn('Failed to write restart marker', { error: err.message }));
+      const restartMsg = { role: 'assistant' as const, content: marker, ts: Date.now() };
+      const appendRestartMarker = this.source === 'telegram'
+        ? this.sessionStore.appendTelegramMessage(this.agentConfig.id, this.chatId, this.sessionId, restartMsg)
+        : this.sessionStore.appendMessage(this.agentConfig.id, this.sessionId, restartMsg);
+      appendRestartMarker.catch(err => this.logger.warn('Failed to write restart marker', { error: err.message }));
       if (this.process) {
         this.process.kill('SIGTERM');
       }
     });
   }
 
-  private async buildInitialPrompt(): Promise<string> {
-    const history = await this.sessionStore.loadSession(this.agentConfig.id, this.sessionId);
+  private async buildInitialPrompt(): Promise<{ prompt: string; loadedAtSpawn: number; archivedCount: number; messageCountAtSpawn: number }> {
+    const history = this.source === 'telegram'
+      ? await this.sessionStore.loadTelegramSession(this.agentConfig.id, this.chatId, this.sessionId)
+      : await this.sessionStore.loadSession(this.agentConfig.id, this.sessionId);
     const recent = history.slice(-MAX_HISTORY_MESSAGES);
+    const loadedAtSpawn = recent.length;
+    const archivedCount = history.length - recent.length;
+    const messageCountAtSpawn = history.length;
 
     if (recent.length === 0) {
-      return CHANNELS_ACTIVATION_PROMPT;
+      return { prompt: CHANNELS_ACTIVATION_PROMPT, loadedAtSpawn, archivedCount, messageCountAtSpawn };
     }
 
     const historyText = recent
       .map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
       .join('\n');
 
-    return `[Conversation history with this user:\n${historyText}]\n\n${CHANNELS_ACTIVATION_PROMPT}`;
+    return {
+      prompt: `[Conversation history with this user:\n${historyText}]\n\n${CHANNELS_ACTIVATION_PROMPT}`,
+      loadedAtSpawn,
+      archivedCount,
+      messageCountAtSpawn,
+    };
   }
 
   /**
@@ -238,7 +252,8 @@ export class SessionProcess extends EventEmitter {
   }
 
   private async spawnProcess(): Promise<void> {
-    const initialPrompt = await this.buildInitialPrompt();
+    const { prompt: initialPrompt, loadedAtSpawn, archivedCount, messageCountAtSpawn } = await this.buildInitialPrompt();
+    this.spawnContext = { loadedAtSpawn, archivedCount, messageCountAtSpawn };
     const mcpConfigPath = this.writeMcpConfig();
     const freshModel = this.readFreshModel();
     const args = this.buildArgs(mcpConfigPath, freshModel);
@@ -277,10 +292,10 @@ export class SessionProcess extends EventEmitter {
     // Capture stdout — emit output events + persist assistant replies
     const typingDir = path.join(this.agentConfig.workspace, '.telegram-state', 'typing');
     const heartbeatPath = this.source === 'telegram'
-      ? path.join(typingDir, `${this.sessionId}.heartbeat`)
+      ? path.join(typingDir, `${this.chatId}.heartbeat`)
       : null;
     const statusPath = this.source === 'telegram'
-      ? path.join(typingDir, `${this.sessionId}.status`)
+      ? path.join(typingDir, `${this.chatId}.status`)
       : null;
 
     const writeStatus = (status: string, detail?: string): void => {
@@ -390,6 +405,9 @@ export class SessionProcess extends EventEmitter {
     // Track partial message text to avoid double-counting when --include-partial-messages is active.
     // Each partial `type: 'assistant'` event contains the FULL text so far, not a delta.
     let lastPartialText = '';
+    // Track context from message_start events (first sub-call of each turn) for accurate context % display.
+    // result.usage is cumulative across all sub-calls; message_start.usage reflects a single API call's context.
+    let lastMessageStartContext = 0;
 
     proc.stdout?.on('data', (data: Buffer) => {
       // Update heartbeat so the receiver's stalled detector knows Claude is active
@@ -460,20 +478,34 @@ export class SessionProcess extends EventEmitter {
           }
           // text delta (standalone, not from assistant messages)
           if (obj.type === 'text') assistantBuffer += obj.text ?? '';
+          // Capture context size from message_start (first sub-call of each turn)
+          if (obj.type === 'stream_event' && obj.event?.type === 'message_start') {
+            const msUsage = obj.event.message?.usage as { input_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } | undefined;
+            if (msUsage) {
+              lastMessageStartContext = (msUsage.input_tokens ?? 0) + (msUsage.cache_read_input_tokens ?? 0) + (msUsage.cache_creation_input_tokens ?? 0);
+            }
+          }
           // result = end of turn
           if (obj.type === 'result') {
             lastPartialText = ''; // reset for next turn
             writeStatus(obj.is_error ? 'error' : 'done');
             if (assistantBuffer.trim()) {
-              this.sessionStore
-                .appendMessage(this.agentConfig.id, this.sessionId, {
-                  role: 'assistant',
-                  content: assistantBuffer.trim(),
-                  ts: Date.now(),
-                })
-                .catch(() => {});
+              const assistantMsg = { role: 'assistant' as const, content: assistantBuffer.trim(), ts: Date.now() };
+              const appendAssistant = this.source === 'telegram'
+                ? this.sessionStore.appendTelegramMessage(this.agentConfig.id, this.chatId, this.sessionId, assistantMsg)
+                : this.sessionStore.appendMessage(this.agentConfig.id, this.sessionId, assistantMsg);
+              appendAssistant.catch(() => {});
               assistantBuffer = '';
             }
+            // Emit tokenUsage using message_start context (accurate per-call context window usage)
+            // rather than result.usage which is cumulative across all sub-calls in the turn.
+            const usage = obj.usage as { output_tokens?: number } | undefined;
+            const outputTokens = usage?.output_tokens ?? 0;
+            const totalTokens = lastMessageStartContext + outputTokens;
+            if (lastMessageStartContext > 0) {
+              this.emit('tokenUsage', { inputTokens: lastMessageStartContext, outputTokens, totalTokens });
+            }
+            lastMessageStartContext = 0;
           }
         } catch {
           /* not JSON */

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 import PQueue from 'p-queue';
-import { Message } from './types';
+import { Message, SessionIndex, SessionMeta } from './types';
 
 export class SessionStore {
   private readonly agentsBaseDir: string;
@@ -12,6 +13,13 @@ export class SessionStore {
   }
 
   /**
+   * Return the base directory where all agents' data is stored.
+   */
+  getAgentsBaseDir(): string {
+    return this.agentsBaseDir;
+  }
+
+  /**
    * Return the session key for a given agent + chat combination.
    */
   resolveKey(agentId: string, chatId: string): string {
@@ -19,7 +27,7 @@ export class SessionStore {
   }
 
   /**
-   * Resolve the file path for a session.
+   * Resolve the file path for a legacy API session (JSONL format).
    */
   private resolvePath(agentId: string, chatId: string): string {
     return path.join(this.agentsBaseDir, agentId, 'sessions', `${chatId}.jsonl`);
@@ -27,9 +35,21 @@ export class SessionStore {
 
   /**
    * Get or create a per-file serialization queue (prevents concurrent write corruption).
+   * For telegram multi-session operations the key is prefixed with 'telegram-'.
    */
   private getQueue(agentId: string, chatId: string): PQueue {
     const key = this.resolveKey(agentId, chatId);
+    if (!this.queues.has(key)) {
+      this.queues.set(key, new PQueue({ concurrency: 1 }));
+    }
+    return this.queues.get(key)!;
+  }
+
+  /**
+   * Get or create a serialization queue keyed on telegram-{chatId} for index operations.
+   */
+  private getTelegramQueue(agentId: string, chatId: string): PQueue {
+    const key = `agent:${agentId}:telegram-index:${chatId}`;
     if (!this.queues.has(key)) {
       this.queues.set(key, new PQueue({ concurrency: 1 }));
     }
@@ -129,5 +149,396 @@ export class SessionStore {
     }
 
     return deleted;
+  }
+
+  // ─── Multi-session Telegram support ──────────────────────────────────────────
+
+  /**
+   * Resolve the directory for a telegram chat's multi-session data.
+   */
+  private resolveTelegramDir(agentId: string, chatId: string): string {
+    return path.join(this.agentsBaseDir, agentId, 'sessions', `telegram-${chatId}`);
+  }
+
+  /**
+   * Resolve the path to the session index file for a telegram chat.
+   */
+  private resolveTelegramIndexPath(agentId: string, chatId: string): string {
+    return path.join(this.resolveTelegramDir(agentId, chatId), 'index.json');
+  }
+
+  /**
+   * Resolve the path to a specific session's message file.
+   */
+  private resolveTelegramSessionPath(agentId: string, chatId: string, sessionId: string): string {
+    return path.join(this.resolveTelegramDir(agentId, chatId), `${sessionId}.json`);
+  }
+
+  /**
+   * Read index.json for a telegram chat. Returns null if file doesn't exist.
+   */
+  async loadIndex(agentId: string, chatId: string): Promise<SessionIndex | null> {
+    const indexPath = this.resolveTelegramIndexPath(agentId, chatId);
+    if (!fs.existsSync(indexPath)) {
+      return null;
+    }
+    try {
+      const raw = fs.readFileSync(indexPath, 'utf-8');
+      return JSON.parse(raw) as SessionIndex;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Write index.json atomically (tmp + rename).
+   */
+  async saveIndex(agentId: string, chatId: string, index: SessionIndex): Promise<void> {
+    const indexPath = this.resolveTelegramIndexPath(agentId, chatId);
+    const dir = path.dirname(indexPath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = indexPath + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(index, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, indexPath);
+  }
+
+  /**
+   * Get or create the session index for a telegram chat.
+   *
+   * Migration logic:
+   * 1. If telegram-{chatId}/index.json exists → return it
+   * 2. If old {chatId}.jsonl exists → migrate to new layout, delete old file
+   * 3. Otherwise → create a fresh index with one empty "Session 1"
+   *
+   * All operations are serialized via the telegram index queue.
+   */
+  /**
+   * Internal (unlocked) version — call this only from WITHIN a getTelegramQueue task
+   * to avoid deadlock. The public getOrCreateIndex wraps this in the queue.
+   */
+  private async loadOrCreateIndexUnlocked(agentId: string, chatId: string): Promise<SessionIndex> {
+    // 1. Check for existing index
+    const existingIndex = await this.loadIndex(agentId, chatId);
+    if (existingIndex !== null) {
+      return existingIndex;
+    }
+
+    // 2. Check for old JSONL file → migrate
+    const oldPath = this.resolvePath(agentId, chatId);
+    if (fs.existsSync(oldPath)) {
+      const raw = fs.readFileSync(oldPath, 'utf-8');
+      const lines = raw.split('\n').filter((l) => l.trim() !== '');
+      const messages: Message[] = [];
+      for (const line of lines) {
+        try {
+          messages.push(JSON.parse(line) as Message);
+        } catch {
+          // Skip corrupted lines during migration
+        }
+      }
+
+      const newId = randomUUID();
+      const now = Date.now();
+      const meta: SessionMeta = {
+        id: newId,
+        name: 'Session 1',
+
+        createdAt: now,
+        lastActive: now,
+        messageCount: messages.length,
+        totalTokensUsed: 0,
+      };
+      const index: SessionIndex = {
+        activeSessionId: newId,
+        sessions: [meta],
+      };
+
+      const telegramDir = this.resolveTelegramDir(agentId, chatId);
+      fs.mkdirSync(telegramDir, { recursive: true });
+      const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, newId);
+      fs.writeFileSync(sessionPath, JSON.stringify(messages, null, 2) + '\n', 'utf-8');
+      await this.saveIndex(agentId, chatId, index);
+      try { fs.unlinkSync(oldPath); } catch { /* non-fatal */ }
+      return index;
+    }
+
+    // 3. Create fresh index with one empty session
+    const newId = randomUUID();
+    const now = Date.now();
+    const meta: SessionMeta = {
+      id: newId,
+      name: 'Session 1',
+      createdAt: now,
+      lastActive: now,
+      messageCount: 0,
+      totalTokensUsed: 0,
+    };
+    const index: SessionIndex = {
+      activeSessionId: newId,
+      sessions: [meta],
+    };
+    const telegramDir = this.resolveTelegramDir(agentId, chatId);
+    fs.mkdirSync(telegramDir, { recursive: true });
+    const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, newId);
+    fs.writeFileSync(sessionPath, JSON.stringify([], null, 2) + '\n', 'utf-8');
+    await this.saveIndex(agentId, chatId, index);
+    return index;
+  }
+
+  async getOrCreateIndex(agentId: string, chatId: string): Promise<SessionIndex> {
+    const queue = this.getTelegramQueue(agentId, chatId);
+    return queue.add(() => this.loadOrCreateIndexUnlocked(agentId, chatId)) as Promise<SessionIndex>;
+  }
+
+  /**
+   * Create a new session for a telegram chat, add it to the index, and return the SessionMeta.
+   * If name is not provided, auto-generates "Session N" based on current session count.
+   */
+  async createTelegramSession(agentId: string, chatId: string, name?: string): Promise<SessionMeta> {
+    const queue = this.getTelegramQueue(agentId, chatId);
+    return queue.add(async () => {
+      const index = await this.loadOrCreateIndexUnlocked(agentId, chatId);
+      const newId = randomUUID();
+      const now = Date.now();
+      const sessionName = name ?? `Session ${index.sessions.length + 1}`;
+      const meta: SessionMeta = {
+        id: newId,
+        name: sessionName,
+
+        createdAt: now,
+        lastActive: now,
+        messageCount: 0,
+        totalTokensUsed: 0,
+      };
+
+      // Write empty messages file
+      const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, newId);
+      const telegramDir = this.resolveTelegramDir(agentId, chatId);
+      fs.mkdirSync(telegramDir, { recursive: true });
+      fs.writeFileSync(sessionPath, JSON.stringify([], null, 2) + '\n', 'utf-8');
+
+      // Update index
+      index.sessions.push(meta);
+      await this.saveIndex(agentId, chatId, index);
+
+      return meta;
+    }) as Promise<SessionMeta>;
+  }
+
+  /**
+   * List all sessions for a telegram chat.
+   */
+  async listSessions(agentId: string, chatId: string): Promise<SessionIndex> {
+    return this.getOrCreateIndex(agentId, chatId);
+  }
+
+  /**
+   * Get the active session ID for a telegram chat.
+   */
+  async getActiveSessionId(agentId: string, chatId: string): Promise<string> {
+    const index = await this.getOrCreateIndex(agentId, chatId);
+    return index.activeSessionId;
+  }
+
+  /**
+   * Set the active session for a telegram chat, updating index.json.
+   */
+  async setActiveSession(agentId: string, chatId: string, sessionId: string): Promise<void> {
+    const queue = this.getTelegramQueue(agentId, chatId);
+    await queue.add(async () => {
+      const index = await this.loadIndex(agentId, chatId);
+      if (!index) {
+        throw new Error(`No session index found for chat ${chatId}`);
+      }
+      const exists = index.sessions.some((s) => s.id === sessionId);
+      if (!exists) {
+        throw new Error(`Session ${sessionId} not found in index for chat ${chatId}`);
+      }
+      index.activeSessionId = sessionId;
+      await this.saveIndex(agentId, chatId, index);
+    });
+  }
+
+  /**
+   * Delete a session for a telegram chat. Cannot delete the last remaining session.
+   */
+  async deleteTelegramSession(agentId: string, chatId: string, sessionId: string): Promise<void> {
+    const queue = this.getTelegramQueue(agentId, chatId);
+    await queue.add(async () => {
+      const index = await this.loadIndex(agentId, chatId);
+      if (!index) {
+        throw new Error(`No session index found for chat ${chatId}`);
+      }
+      if (index.sessions.length <= 1) {
+        throw new Error(`Cannot delete the last session for chat ${chatId}`);
+      }
+
+      const sessionIdx = index.sessions.findIndex((s) => s.id === sessionId);
+      if (sessionIdx === -1) {
+        throw new Error(`Session ${sessionId} not found in index for chat ${chatId}`);
+      }
+
+      // Remove from index
+      index.sessions.splice(sessionIdx, 1);
+
+      // If we deleted the active session, promote the first remaining session
+      if (index.activeSessionId === sessionId) {
+        index.activeSessionId = index.sessions[0]!.id;
+      }
+
+      await this.saveIndex(agentId, chatId, index);
+
+      // Delete the session messages file
+      const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId);
+      try {
+        fs.unlinkSync(sessionPath);
+      } catch {
+        // Non-fatal if file doesn't exist
+      }
+    });
+  }
+
+  /**
+   * Clear the history of a telegram session (reset messages to empty array).
+   * Session meta is preserved and messageCount is reset to 0.
+   */
+  async clearTelegramSessionHistory(agentId: string, chatId: string, sessionId: string): Promise<void> {
+    const queue = this.getTelegramQueue(agentId, chatId);
+    await queue.add(async () => {
+      const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId);
+      fs.mkdirSync(path.dirname(sessionPath), { recursive: true });
+      fs.writeFileSync(sessionPath, JSON.stringify([], null, 2) + '\n', 'utf-8');
+
+      // Update meta: reset messageCount
+      const index = await this.loadIndex(agentId, chatId);
+      if (index) {
+        const meta = index.sessions.find((s) => s.id === sessionId);
+        if (meta) {
+          meta.messageCount = 0;
+          meta.lastActive = Date.now();
+          await this.saveIndex(agentId, chatId, index);
+        }
+      }
+    });
+  }
+
+  /**
+   * Update specific meta fields for a telegram session.
+   */
+  async updateSessionMeta(
+    agentId: string,
+    chatId: string,
+    sessionId: string,
+    meta: Partial<Pick<SessionMeta, 'name' | 'totalTokensUsed' | 'messageCount' | 'lastInputTokens' | 'loadedAtSpawn' | 'archivedCount' | 'messageCountAtSpawn'>>,
+  ): Promise<void> {
+    const queue = this.getTelegramQueue(agentId, chatId);
+    await queue.add(async () => {
+      const index = await this.loadIndex(agentId, chatId);
+      if (!index) {
+        throw new Error(`No session index found for chat ${chatId}`);
+      }
+      const session = index.sessions.find((s) => s.id === sessionId);
+      if (!session) {
+        throw new Error(`Session ${sessionId} not found in index for chat ${chatId}`);
+      }
+      Object.assign(session, meta);
+      session.lastActive = Date.now();
+      await this.saveIndex(agentId, chatId, index);
+    });
+  }
+
+  /**
+   * Load messages for a telegram session. Returns Message[] (JSON array format).
+   */
+  async loadTelegramSession(agentId: string, chatId: string, sessionId: string): Promise<Message[]> {
+    const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId);
+    if (!fs.existsSync(sessionPath)) {
+      return [];
+    }
+    try {
+      const raw = fs.readFileSync(sessionPath, 'utf-8');
+      return JSON.parse(raw) as Message[];
+    } catch {
+      console.error(`[SessionStore] Corrupted telegram session file at ${sessionPath}, returning empty.`);
+      return [];
+    }
+  }
+
+  /**
+   * Save all messages for a telegram session (overwrites the JSON array file).
+   */
+  async saveTelegramSession(
+    agentId: string,
+    chatId: string,
+    sessionId: string,
+    messages: Message[],
+  ): Promise<void> {
+    const queue = this.getTelegramQueue(agentId, chatId);
+    await queue.add(async () => {
+      const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId);
+      const dir = path.dirname(sessionPath);
+      fs.mkdirSync(dir, { recursive: true });
+      const tmp = sessionPath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(messages, null, 2) + '\n', 'utf-8');
+      fs.renameSync(tmp, sessionPath);
+
+      // Update meta messageCount and lastActive
+      await this._updateMessageCountInIndex(agentId, chatId, sessionId, messages.length);
+    });
+  }
+
+  /**
+   * Append a single message to a telegram session.
+   */
+  async appendTelegramMessage(
+    agentId: string,
+    chatId: string,
+    sessionId: string,
+    message: Message,
+  ): Promise<void> {
+    const queue = this.getTelegramQueue(agentId, chatId);
+    await queue.add(async () => {
+      const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId);
+      const dir = path.dirname(sessionPath);
+      fs.mkdirSync(dir, { recursive: true });
+
+      // Load existing messages
+      let messages: Message[] = [];
+      if (fs.existsSync(sessionPath)) {
+        try {
+          const raw = fs.readFileSync(sessionPath, 'utf-8');
+          messages = JSON.parse(raw) as Message[];
+        } catch {
+          messages = [];
+        }
+      }
+
+      messages.push(message);
+
+      // Write atomically
+      const tmp = sessionPath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(messages, null, 2) + '\n', 'utf-8');
+      fs.renameSync(tmp, sessionPath);
+
+      // Update meta
+      await this._updateMessageCountInIndex(agentId, chatId, sessionId, messages.length);
+    });
+  }
+
+  private async _updateMessageCountInIndex(
+    agentId: string,
+    chatId: string,
+    sessionId: string,
+    count: number,
+  ): Promise<void> {
+    const index = await this.loadIndex(agentId, chatId);
+    if (index) {
+      const meta = index.sessions.find((s) => s.id === sessionId);
+      if (meta) {
+        meta.messageCount = count;
+        meta.lastActive = Date.now();
+        await this.saveIndex(agentId, chatId, index);
+      }
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,10 +46,18 @@ export interface ApiKey {
   agents: string[] | '*'; // agent IDs this key can access, or '*' for all
 }
 
+export interface ModelConfig {
+  id: string;
+  label: string;
+  alias: string;
+  contextWindow: number;
+}
+
 export interface GatewayConfig {
   gateway: {
     logDir: string;
     timezone: string;
+    models?: ModelConfig[];
     api?: {
       keys: ApiKey[];
     };
@@ -95,6 +103,24 @@ export interface Message {
   role: 'user' | 'assistant' | 'system';
   content: string;
   ts: number;
+}
+
+export interface SessionMeta {
+  id: string;          // UUID
+  name: string;        // user-set or auto-generated ("Session N")
+  createdAt: number;
+  lastActive: number;
+  messageCount: number;
+  totalTokensUsed: number;
+  lastInputTokens?: number;
+  loadedAtSpawn?: number;   // messages loaded into context at last spawn (≤ MAX_HISTORY_MESSAGES)
+  archivedCount?: number;   // messages not loaded into context (older than loaded window)
+  messageCountAtSpawn?: number; // total messageCount at spawn time, used to derive in-context count
+}
+
+export interface SessionIndex {
+  activeSessionId: string;
+  sessions: SessionMeta[];
 }
 
 export type StreamEvent =

--- a/tests/integration/pipeline-mcp.test.ts
+++ b/tests/integration/pipeline-mcp.test.ts
@@ -205,17 +205,6 @@ describe('Pipeline MCP — Telegram → plugin → Claude Code (step-by-step)', 
 
     mock = startMockTelegramServer(port)
 
-    // Pre-pair USER_ID so messages are delivered (not dropped by gate)
-    const access = {
-      dmPolicy: 'allowlist',
-      allowFrom: [USER_ID],
-      groups: {},
-      pending: {},
-    }
-    const stateDir = path.join(tmpDir, '.telegram-state')
-    fs.mkdirSync(stateDir, { recursive: true })
-    fs.writeFileSync(path.join(stateDir, 'access.json'), JSON.stringify(access, null, 2))
-
     collectedOutput = []
 
     // Use mock-claude-mcp as the Claude binary.
@@ -224,15 +213,31 @@ describe('Pipeline MCP — Telegram → plugin → Claude Code (step-by-step)', 
     process.env.CLAUDE_BIN = `node ${MOCK_CLAUDE_MCP_BIN}`
     process.env.TELEGRAM_API_ROOT = `http://127.0.0.1:${port}`
 
-    const agentCfg = makeAgentConfig(tmpDir, BOT_TOKEN, `http://127.0.0.1:${port}`)
+    // Pre-pair USER_ID so messages are delivered (not dropped by gate)
+    const access = {
+      dmPolicy: 'allowlist',
+      allowFrom: [USER_ID],
+      groups: {},
+      pending: {},
+    }
+
+    // workspace must be <base>/<agentId>/workspace so agentsBaseDir resolves correctly
+    const workspace = path.join(tmpDir, 'pipeline-test-agent', 'workspace')
+    fs.mkdirSync(workspace, { recursive: true })
+    const agentCfg = makeAgentConfig(workspace, BOT_TOKEN, `http://127.0.0.1:${port}`)
     const gatewayCfg = makeGatewayConfig(logDir)
+
+    // Pre-pair USER_ID in workspace state dir
+    const workspaceStateDir = path.join(workspace, '.telegram-state')
+    fs.mkdirSync(workspaceStateDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceStateDir, 'access.json'), JSON.stringify(access, null, 2))
 
     runner = new AgentRunner(agentCfg, gatewayCfg)
     runner.on('output', (line: string) => {
       collectedOutput.push(line)
     })
 
-    await runner.start('Pipeline test: channels mode active')
+    await runner.start()
 
     // Wait for mock-claude-mcp to complete MCP handshake with plugin
     const deadline = Date.now() + 20000
@@ -347,9 +352,17 @@ describe('Pipeline MCP — Telegram → plugin → Claude Code (step-by-step)', 
   // ── MCP config validation ─────────────────────────────────────────────────
 
   test('MCP config written by agent-runner has correct structure', () => {
-    // MCP config is per-session: written at .sessions/<chatId>/mcp-config.json
-    const mcpConfigPath = path.join(tmpDir, '.sessions', USER_ID, 'mcp-config.json')
-    expect(fs.existsSync(mcpConfigPath)).toBe(true)
+    // MCP config is per-session: written at workspace/.sessions/<sessionUUID>/mcp-config.json
+    const workspace = path.join(tmpDir, 'pipeline-test-agent', 'workspace')
+    const sessionsDir = path.join(workspace, '.sessions')
+    expect(fs.existsSync(sessionsDir)).toBe(true)
+    // Scan for mcp-config.json in any session directory
+    const sessionDirs = fs.readdirSync(sessionsDir)
+    const sessionWithConfig = sessionDirs.find(d =>
+      fs.existsSync(path.join(sessionsDir, d, 'mcp-config.json'))
+    )
+    expect(sessionWithConfig).toBeDefined()
+    const mcpConfigPath = path.join(sessionsDir, sessionWithConfig!, 'mcp-config.json')
 
     const config = JSON.parse(fs.readFileSync(mcpConfigPath, 'utf8'))
     expect(config.mcpServers).toBeDefined()
@@ -397,15 +410,6 @@ describe('Pipeline MCP — Step 3b: Claude calls reply tool → sendMessage', ()
 
     mock2 = startMockTelegramServer(port2)
 
-    const stateDir2 = path.join(tmpDir2, '.telegram-state')
-    fs.mkdirSync(stateDir2, { recursive: true })
-    fs.writeFileSync(path.join(stateDir2, 'access.json'), JSON.stringify({
-      dmPolicy: 'allowlist',
-      allowFrom: [USER_ID],
-      groups: {},
-      pending: {},
-    }, null, 2))
-
     collectedOutput2 = []
 
     // Set MOCK_CLAUDE_REPLY=1 BEFORE spawning — the child process inherits env at spawn time
@@ -413,14 +417,27 @@ describe('Pipeline MCP — Step 3b: Claude calls reply tool → sendMessage', ()
     process.env.TELEGRAM_API_ROOT = `http://127.0.0.1:${port2}`
     process.env.MOCK_CLAUDE_REPLY = '1'
 
-    const agentCfg = makeAgentConfig(tmpDir2, BOT_TOKEN + '_2', `http://127.0.0.1:${port2}`)
+    // workspace must be <base>/<agentId>/workspace so agentsBaseDir resolves correctly
+    const workspace2 = path.join(tmpDir2, 'pipeline-test-agent-2', 'workspace')
+    fs.mkdirSync(workspace2, { recursive: true })
+    const agentCfg = makeAgentConfig(workspace2, BOT_TOKEN + '_2', `http://127.0.0.1:${port2}`)
     agentCfg.id = 'pipeline-test-agent-2'
+
+    // Pre-pair USER_ID in workspace state dir
+    const stateDir2 = path.join(workspace2, '.telegram-state')
+    fs.mkdirSync(stateDir2, { recursive: true })
+    fs.writeFileSync(path.join(stateDir2, 'access.json'), JSON.stringify({
+      dmPolicy: 'allowlist',
+      allowFrom: [USER_ID],
+      groups: {},
+      pending: {},
+    }, null, 2))
     const gatewayCfg = makeGatewayConfig(logDir2)
 
     runner2 = new AgentRunner(agentCfg, gatewayCfg)
     runner2.on('output', (line: string) => { collectedOutput2.push(line) })
 
-    await runner2.start('Pipeline test: channels mode active')
+    await runner2.start()
 
     // Wait for ready + bot polling
     const deadline = Date.now() + 20000

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -947,3 +947,155 @@ describe('AgentRunner — typing persistence', () => {
   }, 15000);
 
 });
+
+// ── Session command routing tests ─────────────────────────────────────────────
+
+describe('AgentRunner — session command routing', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-session-cmd-'));
+    agentConfig = makeAgentConfig(path.join(tmpDir, 'workspace'));
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  function getTypingDir(): string {
+    return path.join(agentConfig.workspace, '.telegram-state', 'typing');
+  }
+
+  async function postChannelMessage(port: number, chatId: string, content: string): Promise<void> {
+    await fetch(`http://127.0.0.1:${port}/channel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content,
+        meta: {
+          chat_id: chatId,
+          message_id: '1',
+          user: 'testuser',
+          ts: new Date().toISOString(),
+        },
+      }),
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // U11: /sessions command → not forwarded to SessionProcess, triggers session list
+  // -------------------------------------------------------------------------
+  it('U11: /sessions command is NOT forwarded to SessionProcess but triggers session list handling', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+
+    // Send a /sessions command
+    await postChannelMessage(port, 'chat:session-cmd', '/sessions');
+    await new Promise(r => setTimeout(r, 200));
+
+    // The session process should NOT have been spawned (command handled before getOrSpawnSession)
+    const sessions = getSessions(runner);
+    expect(sessions.has('chat:session-cmd')).toBe(false);
+
+    // A .forward file should have been written (session list response)
+    const forwardFile = path.join(getTypingDir(), 'chat:session-cmd.forward');
+    expect(fs.existsSync(forwardFile)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    expect(typeof content.text).toBe('string');
+    expect(content.text).toContain('Session');
+  }, 15000);
+
+  // -------------------------------------------------------------------------
+  // U12: /new my session → creates session, sends confirmation via auto-forward
+  // -------------------------------------------------------------------------
+  it('U12: /new <name> creates a new session and sends confirmation via auto-forward', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+
+    // Send a /new command with a session name
+    await postChannelMessage(port, 'chat:new-cmd', '/new my session');
+    await new Promise(r => setTimeout(r, 300));
+
+    // A .forward file should contain confirmation
+    const forwardFile = path.join(getTypingDir(), 'chat:new-cmd.forward');
+    expect(fs.existsSync(forwardFile)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    expect(content.text).toContain('my session');
+    expect(content.text).toContain('New session created');
+
+    // The process should NOT be in the session map (new sessions are lazily spawned)
+    const sessions = getSessions(runner);
+    expect(sessions.has('chat:new-cmd')).toBe(false);
+  }, 15000);
+
+  it('U12b: /new without name creates "Session N" and sends confirmation', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+
+    await postChannelMessage(port, 'chat:new-noname', '/new');
+    await new Promise(r => setTimeout(r, 300));
+
+    const forwardFile = path.join(getTypingDir(), 'chat:new-noname.forward');
+    expect(fs.existsSync(forwardFile)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    // Auto-name should follow "Session N" pattern
+    expect(content.text).toMatch(/Session \d/);
+  }, 15000);
+
+  // -------------------------------------------------------------------------
+  // U13: regular message (non-command) → forwarded to Claude normally
+  // -------------------------------------------------------------------------
+  it('U13: regular (non-command) message is forwarded to Claude via SessionProcess', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+
+    // Send a plain message
+    await postChannelMessage(port, 'chat:regular', 'Hello, Claude!');
+    await new Promise(r => setTimeout(r, 200));
+
+    // A SessionProcess should have been spawned for this chat
+    const sessions = getSessions(runner);
+    expect(sessions.has('chat:regular')).toBe(true);
+
+    // The process's stdin should have received the message
+    // Skip TelegramReceiver (0 writes) — find session process with stdin writes
+    const proc = allProcesses.find(p => !p.killed && p.stdin!.write.mock.calls.length > 0);
+    expect(proc).toBeDefined();
+    const writeCallArgs = proc!.stdin!.write.mock.calls.map((c: unknown[]) => c[0] as string);
+    const hasMessage = writeCallArgs.some(s => s.includes('Hello, Claude!'));
+    expect(hasMessage).toBe(true);
+  }, 15000);
+
+  it('U13b: /sessions does not spawn a SessionProcess (only session list command)', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    const spawnMock = require('child_process').spawn as jest.Mock;
+    const spawnCountBefore = spawnMock.mock.calls.length;
+
+    await postChannelMessage(port, 'chat:no-spawn', '/sessions');
+    await new Promise(r => setTimeout(r, 200));
+
+    const spawnCountAfter = spawnMock.mock.calls.length;
+    // spawn should NOT have been called for a session command
+    expect(spawnCountAfter).toBe(spawnCountBefore);
+  }, 15000);
+});

--- a/tests/unit/command-endpoint.test.ts
+++ b/tests/unit/command-endpoint.test.ts
@@ -330,6 +330,8 @@ describe('SessionProcess restart watcher notify payload', () => {
   let sessionStore: jest.Mocked<{
     loadSession: jest.Mock;
     appendMessage: jest.Mock;
+    loadTelegramSession: jest.Mock;
+    appendTelegramMessage: jest.Mock;
   }>;
 
   beforeEach(() => {
@@ -343,6 +345,8 @@ describe('SessionProcess restart watcher notify payload', () => {
     sessionStore = {
       loadSession: jest.fn().mockResolvedValue([]),
       appendMessage: jest.fn().mockResolvedValue(undefined),
+      loadTelegramSession: jest.fn().mockResolvedValue([]),
+      appendTelegramMessage: jest.fn().mockResolvedValue(undefined),
     };
 
     allProcesses.length = 0;
@@ -382,16 +386,17 @@ describe('SessionProcess restart watcher notify payload', () => {
     // Wait for chokidar to detect the file and trigger the handler
     await new Promise(r => setTimeout(r, 1000));
 
-    // Check that appendMessage was called with a marker containing notify instruction
-    const calls = sessionStore.appendMessage.mock.calls;
+    // Check that appendTelegramMessage was called with a marker containing notify instruction
+    // appendTelegramMessage(agentId, chatId, sessionId, message) — message is arg[3]
+    const calls = sessionStore.appendTelegramMessage.mock.calls;
     const restartMarkerCall = calls.find(
-      (c: unknown[]) => typeof c[2] === 'object' && c[2] !== null &&
-        typeof (c[2] as { content?: string }).content === 'string' &&
-        (c[2] as { content: string }).content.includes('Graceful restart completed'),
+      (c: unknown[]) => typeof c[3] === 'object' && c[3] !== null &&
+        typeof (c[3] as { content?: string }).content === 'string' &&
+        (c[3] as { content: string }).content.includes('Graceful restart completed'),
     );
     expect(restartMarkerCall).toBeDefined();
 
-    const markerContent = (restartMarkerCall![2] as { content: string }).content;
+    const markerContent = (restartMarkerCall![3] as { content: string }).content;
     expect(markerContent).toContain('IMPORTANT: Send a Telegram reply to chat_id "chat123"');
     expect(markerContent).toContain('Model changed to claude-sonnet-4-6');
 
@@ -425,16 +430,17 @@ describe('SessionProcess restart watcher notify payload', () => {
     // Wait for chokidar to detect the file and trigger the handler
     await new Promise(r => setTimeout(r, 1000));
 
-    // Check that appendMessage was called with default marker (no notify)
-    const calls = sessionStore.appendMessage.mock.calls;
+    // Check that appendTelegramMessage was called with default marker (no notify)
+    // appendTelegramMessage(agentId, chatId, sessionId, message) — message is arg[3]
+    const calls = sessionStore.appendTelegramMessage.mock.calls;
     const restartMarkerCall = calls.find(
-      (c: unknown[]) => typeof c[2] === 'object' && c[2] !== null &&
-        typeof (c[2] as { content?: string }).content === 'string' &&
-        (c[2] as { content: string }).content.includes('Graceful restart completed'),
+      (c: unknown[]) => typeof c[3] === 'object' && c[3] !== null &&
+        typeof (c[3] as { content?: string }).content === 'string' &&
+        (c[3] as { content: string }).content.includes('Graceful restart completed'),
     );
     expect(restartMarkerCall).toBeDefined();
 
-    const markerContent = (restartMarkerCall![2] as { content: string }).content;
+    const markerContent = (restartMarkerCall![3] as { content: string }).content;
     expect(markerContent).toBe('[System: Graceful restart completed successfully. Do not restart again.]');
     expect(markerContent).not.toContain('IMPORTANT');
 

--- a/tests/unit/session-commands.test.ts
+++ b/tests/unit/session-commands.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for /session info display logic (U22, U23).
+ *
+ * These tests drive the AgentRunner's handleCommandSessionInfo via the HTTP
+ * callback server (same pattern as agent-runner.test.ts) and inspect the
+ * .forward file written by writeAutoForward.
+ */
+
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── Mock child_process ────────────────────────────────────────────────────────
+
+interface MockStdin {
+  writable: boolean;
+  write: jest.Mock;
+}
+
+interface MockChildProcess extends EventEmitter {
+  stdin: MockStdin | null;
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+}
+
+const allProcesses: MockChildProcess[] = [];
+
+function makeMockProcess(): MockChildProcess {
+  const stdin: MockStdin = { writable: true, write: jest.fn() };
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdin = stdin;
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.killed = false;
+  proc.pid = Math.floor(Math.random() * 90000) + 10000;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = true;
+    process.nextTick(() => proc.emit('exit', 0, signal ?? 'SIGTERM'));
+    return true;
+  });
+
+  allProcesses.push(proc);
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn((..._args) => makeMockProcess()),
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { AgentRunner } from '../../src/agent-runner';
+import { AgentConfig, GatewayConfig } from '../../src/types';
+import { SessionStore } from '../../src/session-store';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAgentConfig(workspace: string, overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id: 'test-agent',
+    description: 'test agent',
+    workspace,
+    env: '',
+    telegram: {
+      botToken: 'test-token',
+      allowedUsers: [],
+      dmPolicy: 'allowlist',
+    },
+    claude: {
+      model: 'claude-sonnet-4-6',
+      dangerouslySkipPermissions: false,
+      extraFlags: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeGatewayConfig(contextWindow = 200000): GatewayConfig {
+  return {
+    gateway: {
+      logDir: '/tmp/test-sc-logs',
+      timezone: 'UTC',
+      models: [
+        { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', alias: 'sonnet', contextWindow },
+      ],
+    },
+    agents: [],
+  };
+}
+
+function getCallbackPort(runner: AgentRunner): number {
+  return (runner as unknown as { callbackPort: number }).callbackPort;
+}
+
+async function postChannelMessage(port: number, chatId: string, content: string): Promise<void> {
+  await fetch(`http://127.0.0.1:${port}/channel`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      content,
+      meta: {
+        chat_id: chatId,
+        message_id: '1',
+        user: 'testuser',
+        ts: new Date().toISOString(),
+      },
+    }),
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('AgentRunner — /session info display (U22, U23)', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+  let sessionStore: SessionStore;
+
+  const chatId = 'chat:session-info';
+
+  function getForwardFile(): string {
+    return path.join(agentConfig.workspace, '.telegram-state', 'typing', `${chatId}.forward`);
+  }
+
+  function getForwardText(): string {
+    const forwardFile = getForwardFile();
+    expect(fs.existsSync(forwardFile)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    return content.text as string;
+  }
+
+  async function setupSession(lastInputTokens: number): Promise<void> {
+    // Manually write the session index and set lastInputTokens (used for context % display)
+    const agentsBaseDir = path.resolve(agentConfig.workspace, '..', '..');
+    const store = new SessionStore(agentsBaseDir);
+
+    const index = await store.getOrCreateIndex(agentConfig.id, chatId);
+    const sessionId = index.activeSessionId;
+
+    await store.updateSessionMeta(agentConfig.id, chatId, sessionId, {
+      lastInputTokens,
+      name: 'Test Session',
+      messageCount: 10,
+    });
+  }
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-session-info-'));
+    // AgentRunner resolves agentsBaseDir as workspace/../..
+    // So workspace must be at <tmpDir>/test-agent/workspace
+    const workspace = path.join(tmpDir, 'agents', 'test-agent', 'workspace');
+    agentConfig = makeAgentConfig(workspace);
+    fs.mkdirSync(workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig(200000);
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // U22: session with totalTokensUsed < 50% of contextWindow → "plenty of room"
+  // -------------------------------------------------------------------------
+  it('U22: session with tokens < 50% of contextWindow shows "plenty of room"', async () => {
+    // contextWindow = 200000; 40% = 80000 tokens
+    await setupSession(80000);
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, '/session');
+    await new Promise(r => setTimeout(r, 300));
+
+    const text = getForwardText();
+    expect(text).toContain('Context: 40%');
+    expect(text).not.toContain('Near limit');
+  }, 15000);
+
+  it('U22b: session with 0 tokens also shows low context %', async () => {
+    await setupSession(0);
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, '/session');
+    await new Promise(r => setTimeout(r, 300));
+
+    const text = getForwardText();
+    expect(text).toContain('Context: 0%');
+  }, 15000);
+
+  // -------------------------------------------------------------------------
+  // U23: session with totalTokensUsed > 80% of contextWindow → warning
+  // -------------------------------------------------------------------------
+  it('U23: session with tokens > 80% of contextWindow shows near-limit warning', async () => {
+    // contextWindow = 200000; 85% = 170000 tokens
+    await setupSession(170000);
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, '/session');
+    await new Promise(r => setTimeout(r, 300));
+
+    const text = getForwardText();
+    expect(text).toContain('Near limit');
+    expect(text).toContain('/compact');
+  }, 15000);
+
+  it('U23b: session at exactly 80% boundary shows near-limit warning', async () => {
+    // contextWindow = 200000; 80% = 160000 tokens
+    await setupSession(160000);
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, '/session');
+    await new Promise(r => setTimeout(r, 300));
+
+    const text = getForwardText();
+    expect(text).toContain('Near limit');
+  }, 15000);
+
+  it('U23c: session between 50% and 80% shows just percentage', async () => {
+    // contextWindow = 200000; 65% = 130000 tokens
+    await setupSession(130000);
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, '/session');
+    await new Promise(r => setTimeout(r, 300));
+
+    const text = getForwardText();
+    expect(text).toContain('Context: 65%');
+    expect(text).not.toContain('Near limit');
+  }, 15000);
+
+  // -------------------------------------------------------------------------
+  // Additional: /session info output includes session name and token count
+  // -------------------------------------------------------------------------
+  it('/session info output includes session name and token usage percentage', async () => {
+    await setupSession(50000);
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, '/session');
+    await new Promise(r => setTimeout(r, 300));
+
+    const text = getForwardText();
+    expect(text).toContain('Test Session');
+    expect(text).toContain('Context: 25%');     // 50000/200000 = 25%
+  }, 15000);
+});

--- a/tests/unit/session-compactor.test.ts
+++ b/tests/unit/session-compactor.test.ts
@@ -1,0 +1,257 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SessionStore } from '../../src/session-store';
+import { SessionCompactor, NotEnoughMessagesError } from '../../src/session-compactor';
+import { Message } from '../../src/types';
+
+// ── Mock child_process.spawnSync ─────────────────────────────────────────────
+
+const mockSpawnSync = jest.fn();
+jest.mock('child_process', () => ({
+  spawnSync: (...args: unknown[]) => mockSpawnSync(...args),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeMsg(role: 'user' | 'assistant', content: string, ts = Date.now()): Message {
+  return { role, content, ts };
+}
+
+function makeSpawnSuccess(summaryText: string) {
+  return { status: 0, stdout: summaryText, stderr: '', error: undefined };
+}
+
+function makeSpawnError(status: number, stderr = 'CLI Error') {
+  return { status, stdout: '', stderr, error: undefined };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('SessionCompactor', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+  let compactor: SessionCompactor;
+
+  const agentId = 'test-agent';
+  const chatId = '123456';
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compactor-test-'));
+    sessionStore = new SessionStore(tmpDir);
+    compactor = new SessionCompactor(sessionStore);
+    mockSpawnSync.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // U18: compact with < 5 messages → throws NotEnoughMessagesError
+  // -------------------------------------------------------------------------
+  it('U18: compact with fewer than 5 messages throws NotEnoughMessagesError', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+
+    await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg('user', 'msg 1'));
+    await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg('assistant', 'reply 1'));
+    await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg('user', 'msg 2'));
+
+    await expect(
+      compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
+    ).rejects.toThrow(NotEnoughMessagesError);
+
+    await expect(
+      compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
+    ).rejects.toThrow('3 messages, minimum 5 required');
+  });
+
+  it('U18b: compact with exactly 4 messages throws NotEnoughMessagesError', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+
+    for (let i = 0; i < 4; i++) {
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg('user', `msg ${i}`));
+    }
+
+    await expect(
+      compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
+    ).rejects.toBeInstanceOf(NotEnoughMessagesError);
+
+    // claude CLI should NOT have been called (error thrown before CLI call)
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // U19: successful compact → archive saved at {sessionId}.pre-compact-{ts}.json
+  // -------------------------------------------------------------------------
+  it('U19: successful compact saves archive file named {sessionId}.pre-compact-{ts}.json', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+
+    for (let i = 0; i < 6; i++) {
+      const role = i % 2 === 0 ? 'user' : 'assistant';
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `message ${i}`));
+    }
+
+    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('This is a concise summary of the conversation.'));
+
+    const tsBefore = Date.now();
+    await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+    const tsAfter = Date.now();
+
+    const telegramDir = path.join(tmpDir, agentId, 'sessions', `telegram-${chatId}`);
+    const archiveFiles = fs.readdirSync(telegramDir).filter(f => f.includes('.pre-compact-'));
+    expect(archiveFiles).toHaveLength(1);
+
+    const archiveFile = archiveFiles[0];
+    expect(archiveFile).toMatch(new RegExp(`^${sessionId}\\.pre-compact-\\d+\\.json$`));
+
+    const tsInFile = parseInt(archiveFile.replace(`${sessionId}.pre-compact-`, '').replace('.json', ''), 10);
+    expect(tsInFile).toBeGreaterThanOrEqual(tsBefore);
+    expect(tsInFile).toBeLessThanOrEqual(tsAfter);
+
+    const archivePath = path.join(telegramDir, archiveFile);
+    const archived = JSON.parse(fs.readFileSync(archivePath, 'utf-8')) as Message[];
+    expect(archived).toHaveLength(6);
+  });
+
+  // -------------------------------------------------------------------------
+  // U20: compacted history has summary system message + last 40 verbatim
+  // -------------------------------------------------------------------------
+  it('U20: compacted history has summary system message as first entry plus last 40 verbatim messages', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+
+    // Populate with 7 messages (fewer than 40, so all are kept verbatim)
+    const messages: Message[] = [];
+    for (let i = 0; i < 7; i++) {
+      const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+      const msg = makeMsg(role, `content of message ${i}`, Date.now() + i);
+      messages.push(msg);
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, msg);
+    }
+
+    const summaryText = 'Summary: user asked about 7 things, assistant answered.';
+    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess(summaryText));
+
+    await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+
+    const compacted = await sessionStore.loadTelegramSession(agentId, chatId, sessionId);
+
+    // 7 messages < 40, so all 7 kept + 1 summary = 8
+    expect(compacted).toHaveLength(8);
+
+    // First message is the system summary
+    expect(compacted[0].role).toBe('system');
+    expect(compacted[0].content).toContain('[Conversation Summary]');
+    expect(compacted[0].content).toContain(summaryText);
+
+    // All 7 original messages are verbatim
+    for (let i = 0; i < 7; i++) {
+      expect(compacted[i + 1].content).toBe(messages[i].content);
+    }
+  });
+
+  it('U20b: compact returns correct CompactionResult metadata', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+
+    // 5 messages of known content
+    for (let i = 0; i < 5; i++) {
+      const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, '1234567890'));
+    }
+
+    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('brief summary'));
+
+    const result = await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+
+    expect(result.beforeMessages).toBe(5);
+    expect(result.afterMessages).toBe(6); // 1 summary + 5 verbatim (all < 40)
+    expect(result.beforeTokens).toBeGreaterThan(0);
+    expect(result.afterTokens).toBeGreaterThan(0);
+    expect(result.reductionPct).toBeGreaterThanOrEqual(0);
+    expect(result.contextPctBefore).toBeGreaterThanOrEqual(0);
+    expect(result.contextPctAfter).toBeGreaterThanOrEqual(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // U21: CLI failure mid-compact → original history unchanged
+  // -------------------------------------------------------------------------
+  it('U21: CLI failure mid-compact leaves original history unchanged', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+
+    const originalMessages: Message[] = [];
+    for (let i = 0; i < 5; i++) {
+      const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+      const msg = makeMsg(role, `original message ${i}`);
+      originalMessages.push(msg);
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, msg);
+    }
+
+    // Mock claude CLI returning non-zero exit
+    mockSpawnSync.mockReturnValueOnce(makeSpawnError(1, 'Internal error'));
+
+    await expect(
+      compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
+    ).rejects.toThrow('claude CLI exited with status 1');
+
+    const afterFailure = await sessionStore.loadTelegramSession(agentId, chatId, sessionId);
+    expect(afterFailure).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect(afterFailure[i].content).toBe(originalMessages[i].content);
+      expect(afterFailure[i].role).toBe(originalMessages[i].role);
+    }
+  });
+
+  it('U21b: CLI process error mid-compact leaves original history unchanged', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+
+    const originalMessages: Message[] = [];
+    for (let i = 0; i < 5; i++) {
+      const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+      const msg = makeMsg(role, `message ${i}`);
+      originalMessages.push(msg);
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, msg);
+    }
+
+    // Simulate process spawn error (e.g., claude not found)
+    mockSpawnSync.mockReturnValueOnce({ status: null, stdout: '', stderr: '', error: new Error('spawn ENOENT') });
+
+    await expect(
+      compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
+    ).rejects.toThrow('claude CLI error: spawn ENOENT');
+
+    const afterFailure = await sessionStore.loadTelegramSession(agentId, chatId, sessionId);
+    expect(afterFailure).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect(afterFailure[i].content).toBe(originalMessages[i].content);
+    }
+  });
+
+  it('U21c: CLI failure still saves the archive file before failing', async () => {
+    // Archive write happens BEFORE the CLI call, so it should survive the failure
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+
+    for (let i = 0; i < 5; i++) {
+      const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `msg ${i}`));
+    }
+
+    mockSpawnSync.mockReturnValueOnce(makeSpawnError(1, 'Rate limited'));
+
+    await expect(
+      compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
+    ).rejects.toThrow();
+
+    const telegramDir = path.join(tmpDir, agentId, 'sessions', `telegram-${chatId}`);
+    const archiveFiles = fs.readdirSync(telegramDir).filter(f => f.includes('.pre-compact-'));
+    expect(archiveFiles).toHaveLength(1);
+  });
+});

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -219,12 +219,13 @@ describe('SessionProcess', () => {
   // U-SP-07: History injected into initial prompt when SessionStore has data
   // --------------------------------------------------------------------------
   it('U-SP-07: injects history into initial prompt when session has stored messages', async () => {
-    await sessionStore.appendMessage('alfred', 'chat:111', {
+    // Use new telegram multi-session API: write to telegram-chat:111/chat:111.json
+    await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
       role: 'user',
       content: 'Hello',
       ts: Date.now(),
     });
-    await sessionStore.appendMessage('alfred', 'chat:111', {
+    await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
       role: 'assistant',
       content: 'Hi there!',
       ts: Date.now(),
@@ -262,9 +263,9 @@ describe('SessionProcess', () => {
   // U-SP-09: History truncated to MAX_HISTORY_MESSAGES (50)
   // --------------------------------------------------------------------------
   it('U-SP-09: history is truncated to 50 messages', async () => {
-    // Insert 60 messages
+    // Insert 60 messages using new telegram multi-session API
     for (let i = 0; i < 60; i++) {
-      await sessionStore.appendMessage('alfred', 'chat:111', {
+      await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
         role: 'user',
         content: `Message ${i}`,
         ts: Date.now() + i,
@@ -596,7 +597,7 @@ describe('SessionProcess', () => {
     await new Promise(r => setTimeout(r, 200));
 
     // Load session from store — should contain "Hello world", not "HelloHello world"
-    const messages = await sessionStore.loadSession('alfred', 'chat:partial');
+    const messages = await sessionStore.loadTelegramSession('alfred', 'chat:partial', 'chat:partial');
     const assistantMessages = messages.filter(m => m.role === 'assistant');
     expect(assistantMessages.length).toBeGreaterThanOrEqual(1);
     const lastAssistant = assistantMessages[assistantMessages.length - 1];
@@ -636,6 +637,126 @@ describe('SessionProcess', () => {
       }
     }
     // If status file doesn't exist at all, that's the expected behavior — partial didn't write it
+  });
+
+  // --------------------------------------------------------------------------
+  // U9: stream-json result with usage data → tokenUsage event fired with correct counts
+  // --------------------------------------------------------------------------
+  it('U9: result event with usage data fires tokenUsage event with correct counts', async () => {
+    const sp = new SessionProcess('chat:tok9', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const tokenEvents: Array<{ inputTokens: number; outputTokens: number; totalTokens: number }> = [];
+    sp.on('tokenUsage', (data) => tokenEvents.push(data));
+
+    // Emit message_start first (context is derived from this event now)
+    const messageStart = JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'message_start',
+        message: {
+          usage: {
+            input_tokens: 100,
+            cache_read_input_tokens: 20,
+            cache_creation_input_tokens: 10,
+          },
+        },
+      },
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(messageStart + '\n'));
+
+    const resultLine = JSON.stringify({
+      type: 'result',
+      is_error: false,
+      result: 'Done',
+      usage: { output_tokens: 50 },
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(resultLine + '\n'));
+
+    expect(tokenEvents).toHaveLength(1);
+    // inputTokens = 100 + 20 + 10 = 130 (from message_start)
+    expect(tokenEvents[0].inputTokens).toBe(130);
+    expect(tokenEvents[0].outputTokens).toBe(50);
+    // totalTokens = 130 + 50 = 180
+    expect(tokenEvents[0].totalTokens).toBe(180);
+  });
+
+  it('U9b: result event without usage data does not fire tokenUsage event', async () => {
+    const sp = new SessionProcess('chat:tok9b', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const tokenEvents: unknown[] = [];
+    sp.on('tokenUsage', (data) => tokenEvents.push(data));
+
+    // Result with no usage field
+    const resultLine = JSON.stringify({ type: 'result', is_error: false, result: 'Done' });
+    lastProcess!.stdout!.emit('data', Buffer.from(resultLine + '\n'));
+
+    expect(tokenEvents).toHaveLength(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // U10: cumulative tokens tracked — each turn adds to total
+  // --------------------------------------------------------------------------
+  it('U10: cumulative tokens tracked — each result event fires tokenUsage with that turn count', async () => {
+    const sp = new SessionProcess('chat:tok10', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const tokenEvents: Array<{ totalTokens: number }> = [];
+    sp.on('tokenUsage', (data) => tokenEvents.push(data));
+
+    // Helper to emit a message_start + result pair
+    const emitTurn = (inputTokens: number, outputTokens: number, label: string) => {
+      const ms = JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'message_start', message: { usage: { input_tokens: inputTokens } } },
+      });
+      lastProcess!.stdout!.emit('data', Buffer.from(ms + '\n'));
+      const result = JSON.stringify({
+        type: 'result', is_error: false, result: label,
+        usage: { output_tokens: outputTokens },
+      });
+      lastProcess!.stdout!.emit('data', Buffer.from(result + '\n'));
+    };
+
+    emitTurn(60, 40, 'Turn 1');   // total = 60 + 40 = 100
+    emitTurn(50, 30, 'Turn 2');   // total = 50 + 30 = 80
+    emitTurn(150, 50, 'Turn 3');  // total = 150 + 50 = 200
+
+    // Three separate tokenUsage events emitted, one per turn
+    expect(tokenEvents).toHaveLength(3);
+    expect(tokenEvents[0].totalTokens).toBe(100);  // 60 + 40
+    expect(tokenEvents[1].totalTokens).toBe(80);   // 50 + 30
+    expect(tokenEvents[2].totalTokens).toBe(200);  // 150 + 50
+  });
+
+  it('U10b: tokenUsage correctly handles missing optional cache fields', async () => {
+    const sp = new SessionProcess('chat:tok10b', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const tokenEvents: Array<{ inputTokens: number; outputTokens: number; totalTokens: number }> = [];
+    sp.on('tokenUsage', (data) => tokenEvents.push(data));
+
+    // message_start without cache fields
+    const messageStart = JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { usage: { input_tokens: 200 } } },
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(messageStart + '\n'));
+
+    const resultLine = JSON.stringify({
+      type: 'result',
+      is_error: false,
+      result: 'Done',
+      usage: { output_tokens: 100 },
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(resultLine + '\n'));
+
+    expect(tokenEvents).toHaveLength(1);
+    expect(tokenEvents[0].inputTokens).toBe(200);
+    expect(tokenEvents[0].outputTokens).toBe(100);
+    // totalTokens = 200 + 100 = 300
+    expect(tokenEvents[0].totalTokens).toBe(300);
   });
 
   // --------------------------------------------------------------------------

--- a/tests/unit/session-store.test.ts
+++ b/tests/unit/session-store.test.ts
@@ -177,4 +177,202 @@ describe('session-store', () => {
     expect(alfredMsgs[0].content).toBe('alfred message');
     expect(baerbelMsgs[0].content).toBe('baerbel message');
   });
+
+  // ─── Multi-session Telegram support ──────────────────────────────────────────
+
+  // -------------------------------------------------------------------------
+  // U1: listSessions returns all 3 sessions with correct activeSessionId
+  // -------------------------------------------------------------------------
+  it('U1: listSessions returns all 3 sessions with correct activeSessionId', async () => {
+    // Initialise the index (creates Session 1)
+    const index0 = await store.getOrCreateIndex('test-agent', '123456');
+    // Create two more sessions
+    await store.createTelegramSession('test-agent', '123456', 'Session 2');
+    await store.createTelegramSession('test-agent', '123456', 'Session 3');
+
+    const index = await store.listSessions('test-agent', '123456');
+    expect(index.sessions).toHaveLength(3);
+    expect(index.sessions.map(s => s.name)).toEqual(['Session 1', 'Session 2', 'Session 3']);
+    // activeSessionId must be the first one created
+    expect(index.activeSessionId).toBe(index0.activeSessionId);
+  });
+
+  // -------------------------------------------------------------------------
+  // U2: setActiveSession switches active, verified by getActiveSessionId
+  // -------------------------------------------------------------------------
+  it('U2: setActiveSession switches active session', async () => {
+    await store.getOrCreateIndex('test-agent', '123456');
+    const s2 = await store.createTelegramSession('test-agent', '123456', 'Session 2');
+
+    await store.setActiveSession('test-agent', '123456', s2.id);
+
+    const activeId = await store.getActiveSessionId('test-agent', '123456');
+    expect(activeId).toBe(s2.id);
+  });
+
+  // -------------------------------------------------------------------------
+  // U3: deleteSession removes file and index entry; cannot delete last session
+  // -------------------------------------------------------------------------
+  it('U3: deleteTelegramSession removes file and index entry', async () => {
+    const index = await store.getOrCreateIndex('test-agent', '123456');
+    const s1Id = index.activeSessionId;
+    const s2 = await store.createTelegramSession('test-agent', '123456', 'Session 2');
+
+    await store.deleteTelegramSession('test-agent', '123456', s2.id);
+
+    const updated = await store.listSessions('test-agent', '123456');
+    expect(updated.sessions).toHaveLength(1);
+    expect(updated.sessions[0].id).toBe(s1Id);
+
+    // Session file should be gone
+    const sessionDir = path.join(tmpDir, 'test-agent', 'sessions', 'telegram-123456');
+    const sessionFile = path.join(sessionDir, `${s2.id}.json`);
+    expect(fs.existsSync(sessionFile)).toBe(false);
+  });
+
+  it('U3b: deleteTelegramSession throws when only one session remains', async () => {
+    await store.getOrCreateIndex('test-agent', '123456');
+    const index = await store.listSessions('test-agent', '123456');
+    const onlyId = index.sessions[0].id;
+
+    await expect(
+      store.deleteTelegramSession('test-agent', '123456', onlyId),
+    ).rejects.toThrow('Cannot delete the last session');
+  });
+
+  // -------------------------------------------------------------------------
+  // U4: Migration — existing flat {chatId}.jsonl auto-migrates to new layout
+  // -------------------------------------------------------------------------
+  it('U4: existing flat .jsonl file auto-migrates to new multi-session layout', async () => {
+    // Write an old-style flat JSONL file
+    const sessionsDir = path.join(tmpDir, 'test-agent', 'sessions');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const oldFile = path.join(sessionsDir, 'migrate-chat.jsonl');
+    const msg1 = makeMsg('user', 'old message 1');
+    const msg2 = makeMsg('assistant', 'old reply');
+    fs.writeFileSync(oldFile, JSON.stringify(msg1) + '\n' + JSON.stringify(msg2) + '\n');
+
+    // getOrCreateIndex should detect the old file and migrate it
+    const index = await store.getOrCreateIndex('test-agent', 'migrate-chat');
+
+    expect(index.sessions).toHaveLength(1);
+    expect(index.sessions[0].name).toBe('Session 1');
+    expect(index.sessions[0].messageCount).toBe(2);
+
+    // Old JSONL file should be gone
+    expect(fs.existsSync(oldFile)).toBe(false);
+
+    // New session file should contain the migrated messages
+    const messages = await store.loadTelegramSession('test-agent', 'migrate-chat', index.activeSessionId);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].content).toBe('old message 1');
+    expect(messages[1].content).toBe('old reply');
+  });
+
+  // -------------------------------------------------------------------------
+  // U5: clearTelegramSessionHistory resets messages to [] but keeps SessionMeta
+  // -------------------------------------------------------------------------
+  it('U5: clearTelegramSessionHistory resets messages to [] but preserves SessionMeta', async () => {
+    const index = await store.getOrCreateIndex('test-agent', '123456');
+    const sessionId = index.activeSessionId;
+
+    // Append some messages
+    await store.appendTelegramMessage('test-agent', '123456', sessionId, makeMsg('user', 'hello'));
+    await store.appendTelegramMessage('test-agent', '123456', sessionId, makeMsg('assistant', 'hi'));
+
+    // Verify messages exist
+    const before = await store.loadTelegramSession('test-agent', '123456', sessionId);
+    expect(before).toHaveLength(2);
+
+    // Clear history
+    await store.clearTelegramSessionHistory('test-agent', '123456', sessionId);
+
+    // Messages should be empty
+    const after = await store.loadTelegramSession('test-agent', '123456', sessionId);
+    expect(after).toEqual([]);
+
+    // Meta should still exist with messageCount reset
+    const updatedIndex = await store.listSessions('test-agent', '123456');
+    const meta = updatedIndex.sessions.find(s => s.id === sessionId);
+    expect(meta).toBeDefined();
+    expect(meta!.name).toBe('Session 1');
+    expect(meta!.messageCount).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // U6: createTelegramSession auto-names "Session 1", "Session 2", etc.
+  // -------------------------------------------------------------------------
+  it('U6: createTelegramSession auto-names sessions sequentially', async () => {
+    // First getOrCreateIndex creates "Session 1"
+    const index0 = await store.getOrCreateIndex('test-agent', '123456');
+    expect(index0.sessions[0].name).toBe('Session 1');
+
+    // Explicitly creating further sessions
+    const s2 = await store.createTelegramSession('test-agent', '123456');
+    expect(s2.name).toBe('Session 2');
+
+    const s3 = await store.createTelegramSession('test-agent', '123456');
+    expect(s3.name).toBe('Session 3');
+  });
+
+  it('U6b: createTelegramSession uses provided name when given', async () => {
+    await store.getOrCreateIndex('test-agent', '123456');
+    const s = await store.createTelegramSession('test-agent', '123456', 'My Custom Session');
+    expect(s.name).toBe('My Custom Session');
+  });
+
+  // -------------------------------------------------------------------------
+  // U7: appendTelegramMessage and loadTelegramSession round-trip
+  // -------------------------------------------------------------------------
+  it('U7: appendTelegramMessage and loadTelegramSession round-trip correctly', async () => {
+    const index = await store.getOrCreateIndex('test-agent', '123456');
+    const sessionId = index.activeSessionId;
+
+    const msg1 = makeMsg('user', 'ping');
+    const msg2 = makeMsg('assistant', 'pong');
+    const msg3 = makeMsg('user', 'again');
+
+    await store.appendTelegramMessage('test-agent', '123456', sessionId, msg1);
+    await store.appendTelegramMessage('test-agent', '123456', sessionId, msg2);
+    await store.appendTelegramMessage('test-agent', '123456', sessionId, msg3);
+
+    const loaded = await store.loadTelegramSession('test-agent', '123456', sessionId);
+    expect(loaded).toHaveLength(3);
+    expect(loaded[0].content).toBe('ping');
+    expect(loaded[1].content).toBe('pong');
+    expect(loaded[2].content).toBe('again');
+    expect(loaded[0].role).toBe('user');
+    expect(loaded[1].role).toBe('assistant');
+
+    // messageCount in index should be updated
+    const updatedIndex = await store.listSessions('test-agent', '123456');
+    const meta = updatedIndex.sessions.find(s => s.id === sessionId);
+    expect(meta!.messageCount).toBe(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // U8: updateSessionMeta updates fields without affecting other fields
+  // -------------------------------------------------------------------------
+  it('U8: updateSessionMeta updates specified fields without affecting other fields', async () => {
+    const index = await store.getOrCreateIndex('test-agent', '123456');
+    const sessionId = index.activeSessionId;
+    const originalCreatedAt = index.sessions[0].createdAt;
+
+    // Update name and totalTokensUsed
+    await store.updateSessionMeta('test-agent', '123456', sessionId, {
+      name: 'Renamed Session',
+      totalTokensUsed: 5000,
+    });
+
+    const updated = await store.listSessions('test-agent', '123456');
+    const meta = updated.sessions.find(s => s.id === sessionId);
+    expect(meta).toBeDefined();
+    expect(meta!.name).toBe('Renamed Session');
+    expect(meta!.totalTokensUsed).toBe(5000);
+
+    // Other fields should be unchanged
+    expect(meta!.id).toBe(sessionId);
+    expect(meta!.createdAt).toBe(originalCreatedAt);
+    expect(meta!.messageCount).toBe(0);
+  });
 });

--- a/tests/unit/telegram-plugin/typing.test.ts
+++ b/tests/unit/telegram-plugin/typing.test.ts
@@ -272,7 +272,7 @@ describe('createWorkingStateManager', () => {
 
       expect(bot.sendMessage).toHaveBeenCalledWith(
         CHAT_ID,
-        expect.stringContaining('Claude has not responded in 2 minutes'),
+        expect.stringContaining('Claude has not responded in 5 minutes'),
       )
       expect(mgr.states.has(CHAT_ID)).toBe(false)
     })
@@ -297,7 +297,7 @@ describe('createWorkingStateManager', () => {
 
       expect(bot.sendMessage).not.toHaveBeenCalledWith(
         CHAT_ID,
-        expect.stringContaining('2 minutes'),
+        expect.stringContaining('5 minutes'),
       )
       expect(mgr.states.has(CHAT_ID)).toBe(true)
 
@@ -318,7 +318,7 @@ describe('createWorkingStateManager', () => {
 
       expect(bot.sendMessage).not.toHaveBeenCalledWith(
         CHAT_ID,
-        expect.stringContaining('2 minutes'),
+        expect.stringContaining('5 minutes'),
       )
     })
   })
@@ -689,15 +689,15 @@ describe('createWorkingStateManager', () => {
       expect(bot.sendMessage).toHaveBeenCalledWith(CHAT_ID, 'Plain text fallback', {})
     })
 
-    it('U-TY-08: skips forward when .replied text matches .forward text (content-based dedup)', async () => {
+    it('U-TY-08: skips forward when .replied exists (agent already replied via tool)', async () => {
       const bot = makeBotApi()
       const fsApi = makeFsApi()
       const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
 
       mgr.start(CHAT_ID)
-      // Simulate both .forward and .replied exist with the SAME text (agent already sent it via tool)
+      // Simulate both .forward and .replied exist — agent already sent a reply
       fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'Hello from agent', format: 'text' }))
-      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.replied`, 'Hello from agent')
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.replied`, String(Date.now()))
 
       // Remove signal file to trigger stop on next tick
       fsApi._files.delete(`${TYPING_DIR}/${CHAT_ID}`)
@@ -706,32 +706,11 @@ describe('createWorkingStateManager', () => {
       await Promise.resolve()
       await Promise.resolve()
 
-      // sendMessage should NOT be called with the forward text — it's a duplicate
+      // sendMessage should NOT be called — agent already replied
       const forwardCalls = bot.sendMessage.mock.calls.filter(
         (c: unknown[]) => c[1] === 'Hello from agent'
       )
       expect(forwardCalls).toHaveLength(0)
-    })
-
-    it('U-TY-08b: forwards when .replied text differs from .forward text (different content)', async () => {
-      const bot = makeBotApi()
-      const fsApi = makeFsApi()
-      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
-
-      mgr.start(CHAT_ID)
-      // Agent replied with a status update, but result text is different
-      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'Final result text', format: 'text' }))
-      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.replied`, 'Different earlier reply')
-
-      // Remove signal file to trigger stop on next tick
-      fsApi._files.delete(`${TYPING_DIR}/${CHAT_ID}`)
-      jest.advanceTimersByTime(TYPING_INTERVAL_MS)
-      await Promise.resolve()
-      await Promise.resolve()
-      await Promise.resolve()
-
-      // sendMessage SHOULD be called with forward text — it's not a duplicate
-      expect(bot.sendMessage).toHaveBeenCalledWith(CHAT_ID, 'Final result text', {})
     })
 
     it('U-TY-09: cleans up both .forward and .replied files after stop', async () => {


### PR DESCRIPTION
## Summary

- Add per-chat session management for Telegram: create, switch, rename, clear, compact, restart
- Add `SessionStore` multi-session layer (index.json + per-session JSON files)
- Add `SessionCompactor` for LLM-based history summarization with chunked fallback
- Fix context % calculation to use `message_start` input tokens (not cumulative)
- Fix typing status file path (was using sessionId, should be chatId)
- Extract `BOT_COMMANDS` constant shared between receiver and MCP modes

## New Telegram Commands

| Command | Description |
|---------|-------------|
| `/sessions` | List sessions with inline keyboard for switching |
| `/session` | Show current session info (message counts, context %) |
| `/new [name]` | Create a new session |
| `/rename <name>` | Rename current session |
| `/clear` | Confirm + clear session history in-place |
| `/compact` | Confirm + summarize and compress history via LLM |
| `/restart` | Graceful restart of current session process |

## Test plan

- [ ] All 44 test suites pass (`npm test`)
- [ ] `/sessions` shows inline keyboard; tapping switches active session
- [ ] `/new` creates session and switches to it
- [ ] `/clear` shows Yes/No confirm; Yes clears history and restarts process
- [ ] `/compact` summarizes history and restarts with shorter context
- [ ] Context % shows correct value based on `message_start` tokens
- [ ] Multiline typing status detail updates correctly (chatId path fix)