### PR TITLE
fix+refactor: skills hot-reload with deferred restart, unified watcher, and shared-skill sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ Thumbs.db
 
 # Test coverage
 coverage/
-
 .claude
 
 # Planning
@@ -40,3 +39,4 @@ task-*.md
 research*.md
 restart.sh
 stop.sh
+.skills

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ While an agent is working, the gateway sends real-time status updates to Telegra
 ```
 
 - **Tool tracking** — each tool call is displayed with a descriptive label (e.g. `📖 Reading: config.ts`, `⚡ Running: npm test`)
-- **History** — previous steps shown with ✅, current step with 🕐
+- **History** — previous steps shown with ☑️, current step with 🕐
 - **Thinking** — agent's reasoning shown with 🧠
 - **Elapsed time** — total time since the agent started working
 - **Auto-cleanup** — status message is deleted when the agent finishes

--- a/README.md
+++ b/README.md
@@ -413,6 +413,9 @@ claude-gateway/
 ├── logs/
 │   ├── alfred.log
 │   └── warrior.log
+├── shared-skills/                      ← shared skills (synced to ~/.claude/skills/ on boot and on change)
+│   └── <skill-name>/
+│       └── SKILL.md                    ← skill definition (same format as agent skills)
 └── agents/
     └── alfred/
         ├── .env                        ← bot token (auto-created by wizard)
@@ -470,6 +473,7 @@ Skills are reusable capabilities defined as `SKILL.md` files with YAML frontmatt
 | Location | Scope | Description |
 |----------|-------|-------------|
 | `workspace/skills/<name>/SKILL.md` | Per-agent | Agent-specific skills |
+| `~/.claude-gateway/shared-skills/<name>/SKILL.md` | All agents | Shared skills — synced to `~/.claude/skills/` at boot and on change |
 | `mcp/tools/<channel>/skills/<name>/SKILL.md` | All agents | Built-in channel skills (e.g. `/telegram:access`) |
 
 ### SKILL.md format
@@ -497,6 +501,16 @@ Agents can manage skills at runtime via MCP tools:
 | `skill_install` | Install a skill from a GitHub URL or raw URL |
 
 Skills are **hot-reloaded** — changes to skill files are detected automatically and the skill registry is updated without restarting the session.
+
+### Shared skills sync
+
+Skills placed in `~/.claude-gateway/shared-skills/` are automatically synced to `~/.claude/skills/` — the user-level directory that Claude Code scans for every session:
+
+- **At boot** — gateway copies all shared skills before spawning any agent
+- **On change** — any add, edit, or delete under `shared-skills/` triggers a re-sync
+- **Cleanup** — each synced skill is tagged with a `.shared` marker file; if a skill is removed from `shared-skills/`, the marker is used to delete the stale copy from `~/.claude/skills/` automatically (user-installed skills without the marker are never touched)
+
+This means adding a skill to `shared-skills/` makes it available to **all agents** without per-agent setup or a gateway restart.
 
 ---
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -150,6 +150,7 @@ export class AgentRunner extends EventEmitter {
                 });
               }
 
+              session.setProcessing(true);
               session.sendMessage(channelXml);
               session.touch();
               this.logger.debug('Injected channel turn into session', {
@@ -530,6 +531,7 @@ export class AgentRunner extends EventEmitter {
             }
           }
           if (obj['type'] === 'result') {
+            proc.setProcessing(false);
             // Always forward result text — it contains the agent's completion summary.
             // If the agent also called reply tool, this summary still reaches the user.
             const resultText = typeof obj['result'] === 'string' ? obj['result'] : '';
@@ -581,11 +583,19 @@ export class AgentRunner extends EventEmitter {
 
       // Clean up pending typing-done timer when session stops
       proc.once('exit', () => {
+        proc.setProcessing(false);
         if (typingDoneTimer) {
           clearTimeout(typingDoneTimer);
           typingDoneTimer = null;
         }
         this.writeTypingDone(mapKey);
+      });
+
+      // Deferred restart: stop session after its current turn completes
+      proc.once('deferredRestartReady', async () => {
+        this.logger.info('Deferred restart: stopping session after turn completed', { mapKey });
+        await proc.stop();
+        this.sessions.delete(mapKey);
       });
     }
 
@@ -823,24 +833,26 @@ export class AgentRunner extends EventEmitter {
    * Used by the skills hot-reload path so that SKILL.md changes take effect
    * without kicking users out of in-flight turns.
    */
-  async restartIdleSessions(): Promise<void> {
-    const IDLE_THRESHOLD_MS = 1000;
-    const toStop: string[] = [];
+  async restartOrDefer(): Promise<void> {
+    let immediate = 0;
+    let deferred = 0;
+    const toStopNow: string[] = [];
     for (const [id, proc] of this.sessions) {
-      if (proc.isIdle(IDLE_THRESHOLD_MS)) {
-        toStop.push(id);
+      if (proc.isProcessing) {
+        proc.markPendingRestart();
+        deferred++;
+      } else {
+        toStopNow.push(id);
       }
     }
-    for (const id of toStop) {
+    for (const id of toStopNow) {
       const proc = this.sessions.get(id);
       if (!proc) continue;
       await proc.stop();
       this.sessions.delete(id);
+      immediate++;
     }
-    this.logger.info('Restarted idle sessions for skill reload', {
-      stopped: toStop.length,
-      skipped: this.sessions.size,
-    });
+    this.logger.info('restartOrDefer: sessions restarted', { immediate, deferred });
   }
 
   /**
@@ -1060,6 +1072,7 @@ export class AgentRunner extends EventEmitter {
 
           // result event = end of turn
           if (obj['type'] === 'result') {
+            session.setProcessing(false);
             const resultText = (obj['result'] as string | undefined) ?? buffer.join('');
             done(resultText);
           }
@@ -1069,10 +1082,12 @@ export class AgentRunner extends EventEmitter {
       };
 
       const globalTimer = setTimeout(() => {
+        session.setProcessing(false);
         fail(Object.assign(new Error('Agent response timeout'), { code: 'TIMEOUT' }));
       }, opts.timeoutMs);
 
       session.on('output', onOutput);
+      session.setProcessing(true);
       session.sendMessage(channelXml);
       // Do NOT call resetQuiet() here — the quiet timer should only start
       // after the first output line arrives, otherwise it fires before the
@@ -1227,6 +1242,7 @@ export class AgentRunner extends EventEmitter {
 
         // Result = end of turn
         if (obj['type'] === 'result') {
+          session.setProcessing(false);
           lastPartialText = ''; // reset for next turn
           const resultText = (obj['result'] as string | undefined) ?? buffer.join('');
           done(resultText);
@@ -1237,6 +1253,7 @@ export class AgentRunner extends EventEmitter {
     };
 
     const globalTimer = setTimeout(() => {
+      session.setProcessing(false);
       fail(Object.assign(new Error('Agent response timeout'), { code: 'TIMEOUT' }));
     }, opts.timeoutMs);
 
@@ -1249,6 +1266,7 @@ export class AgentRunner extends EventEmitter {
       `Do NOT call any tools. Your text output will be returned directly to the caller.]\n` +
       `</channel>`;
 
+    session.setProcessing(true);
     session.sendMessage(channelXml);
 
     // Return cleanup function for client disconnect

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -812,6 +812,38 @@ export class AgentRunner extends EventEmitter {
   }
 
   /**
+   * Stop all idle session subprocesses so they re-spawn with the latest
+   * system prompt on the next incoming message.
+   *
+   * - "Idle" = no activity for {@link IDLE_THRESHOLD_MS}ms (enough to exclude an in-flight turn).
+   * - Busy sessions are left alone; they will be picked up by the idle cleaner
+   *   (every 5m) or naturally on the next spawn after timeout.
+   * - Does NOT stop the receiver; incoming messages keep flowing.
+   *
+   * Used by the skills hot-reload path so that SKILL.md changes take effect
+   * without kicking users out of in-flight turns.
+   */
+  async restartIdleSessions(): Promise<void> {
+    const IDLE_THRESHOLD_MS = 1000;
+    const toStop: string[] = [];
+    for (const [id, proc] of this.sessions) {
+      if (proc.isIdle(IDLE_THRESHOLD_MS)) {
+        toStop.push(id);
+      }
+    }
+    for (const id of toStop) {
+      const proc = this.sessions.get(id);
+      if (!proc) continue;
+      await proc.stop();
+      this.sessions.delete(id);
+    }
+    this.logger.info('Restarted idle sessions for skill reload', {
+      stopped: toStop.length,
+      skipped: this.sessions.size,
+    });
+  }
+
+  /**
    * Format a timestamp as a human-readable age string (e.g. "5m ago", "2h ago").
    */
   private formatAge(ts: number): string {

--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import chokidar from 'chokidar';
 import { WorkspaceFiles, LoadedWorkspace, WatchHandle } from '../types';
+import { createWatcher } from '../watch/factory';
 import { loadSkills, renderSkillsSection } from '../skills';
 
 export class MissingRequiredFileError extends Error {
@@ -174,47 +174,25 @@ const WATCH_DEBOUNCE_MS = 300;
  * Returns a WatchHandle with a close() method.
  */
 export function watchWorkspace(workspaceDir: string, onChange: () => void): WatchHandle {
-  const watcher = chokidar.watch(path.join(workspaceDir, '*.md'), {
-    persistent: true,
-    ignoreInitial: true,
-    ignored: path.join(workspaceDir, 'CLAUDE.md'),
-  });
-
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  const debouncedOnChange = () => {
-    if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(onChange, WATCH_DEBOUNCE_MS);
-  };
-
-  watcher.on('change', debouncedOnChange);
-  watcher.on('add', (filePath: string) => {
-    const filename = path.basename(filePath);
-    const upperName = LOWERCASE_TO_UPPERCASE[filename];
-    if (upperName) {
-      // Auto-rename lowercase file to uppercase canonical name
-      const upperPath = path.join(workspaceDir, upperName);
-      try {
-        fs.renameSync(filePath, upperPath);
-        console.log(`[workspace] Auto-renamed: ${filename} → ${upperName}`);
-      } catch {
-        // Ignore rename errors (file may have already been renamed)
+  return createWatcher({
+    paths: [path.join(workspaceDir, '*.md')],
+    debounceMs: WATCH_DEBOUNCE_MS,
+    chokidarOpts: { ignored: path.join(workspaceDir, 'CLAUDE.md') },
+    onAddSync: (filePath: string) => {
+      const filename = path.basename(filePath);
+      const upperName = LOWERCASE_TO_UPPERCASE[filename];
+      if (upperName) {
+        const upperPath = path.join(workspaceDir, upperName);
+        try {
+          fs.renameSync(filePath, upperPath);
+          console.log(`[workspace] Auto-renamed: ${filename} → ${upperName}`);
+        } catch {
+          // Ignore rename errors (file may have already been renamed)
+        }
       }
-    }
-    debouncedOnChange();
-  });
-  watcher.on('unlink', debouncedOnChange);
-
-  return {
-    close(): void {
-      if (debounceTimer) {
-        clearTimeout(debounceTimer);
-        debounceTimer = null;
-      }
-      watcher.close().catch(() => {
-        // Ignore errors during close
-      });
     },
-  };
+    onChange,
+  });
 }
 
 /**

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
-import chokidar from 'chokidar';
 import { loadConfig } from './loader';
 import { AgentConfig, GatewayConfig, Logger } from '../types';
+import { createWatcher, WatchHandle } from '../watch/factory';
 
 // Fields that can be hot-reloaded without restarting the gateway
 const HOT_RELOADABLE_AGENT_FIELDS: string[] = [
@@ -22,9 +22,8 @@ export interface ConfigChange {
 }
 
 export class ConfigWatcher extends EventEmitter {
-  private watcher: chokidar.FSWatcher | null = null;
+  private watchHandle: WatchHandle | null = null;
   private currentConfig: GatewayConfig;
-  private debounceTimer: NodeJS.Timeout | null = null;
 
   constructor(
     private readonly configPath: string,
@@ -36,27 +35,22 @@ export class ConfigWatcher extends EventEmitter {
   }
 
   start(): void {
-    this.watcher = chokidar.watch(this.configPath, {
-      ignoreInitial: true,
-      awaitWriteFinish: { stabilityThreshold: 300 },
+    this.watchHandle = createWatcher({
+      paths: [this.configPath],
+      debounceMs: 500,
+      chokidarOpts: { awaitWriteFinish: { stabilityThreshold: 300 } },
+      onChange: () => this.reload(),
     });
-    this.watcher.on('change', () => this.onConfigChange());
   }
 
   stop(): void {
-    if (this.debounceTimer) clearTimeout(this.debounceTimer);
-    this.watcher?.close();
-    this.watcher = null;
+    void this.watchHandle?.close();
+    this.watchHandle = null;
   }
 
   /** Get current config snapshot */
   getConfig(): GatewayConfig {
     return this.currentConfig;
-  }
-
-  private onConfigChange(): void {
-    if (this.debounceTimer) clearTimeout(this.debounceTimer);
-    this.debounceTimer = setTimeout(() => this.reload(), 500);
   }
 
   reload(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,6 +336,11 @@ async function main(): Promise<void> {
             updated.systemPrompt,
             'utf8',
           );
+          // Stop idle subprocesses so the next incoming message picks up the
+          // refreshed system prompt. Busy sessions are left running and will
+          // pick up the change after their current turn completes and they
+          // idle out via the idle cleaner.
+          await runner.restartIdleSessions();
           logger.info('Skills registry updated', {
             count: updated.skillRegistry?.skills.size ?? 0,
           });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { loadConfig } from './config/loader';
 import { detectMigration, applyMigration, loadCleanTemplate } from './config/migrator';
 import { loadWorkspace, watchWorkspace, markBootstrapComplete, migrateWorkspaceFiles } from './agent/workspace-loader';
 import { watchSkills } from './skills';
+import { syncSharedSkills } from './skills/sync';
+import { createWatcher } from './watch/factory';
 import { AgentRunner } from './agent/runner';
 import { CronScheduler } from './cron/scheduler';
 import { CronManager } from './cron/manager';
@@ -187,6 +189,23 @@ async function main(): Promise<void> {
   const schedulers: CronScheduler[] = [];
   const startupResults: StartupResult[] = [];
 
+  const sharedSkillsDir = path.join(os.homedir(), '.claude-gateway', 'shared-skills');
+  const personalSkillsDir = path.join(os.homedir(), '.claude', 'skills');
+  const globalLogger = createLogger('gateway', expandTilde(config.gateway.logDir));
+
+  // Initial sync: copy shared skills to ~/.claude/skills/ so the Skill tool sees them
+  syncSharedSkills(sharedSkillsDir, personalSkillsDir, globalLogger);
+
+  // Watch shared-skills for changes and re-sync to ~/.claude/skills/ on any update
+  createWatcher({
+    paths: [`${sharedSkillsDir}/**/SKILL.md`],
+    debounceMs: 250,
+    chokidarOpts: { depth: 2 },
+    onChange: () => {
+      syncSharedSkills(sharedSkillsDir, personalSkillsDir, globalLogger);
+    },
+  });
+
   for (const agentConfig of config.agents) {
     // Expand ~ in workspace path so all downstream code uses absolute paths
     agentConfig.workspace = expandTilde(agentConfig.workspace);
@@ -214,7 +233,6 @@ async function main(): Promise<void> {
 
     // Load workspace
     const mcpToolsDir = path.resolve(__dirname, '..', 'mcp', 'tools');
-    const sharedSkillsDir = path.join(os.homedir(), '.claude-gateway', 'shared-skills');
     let workspace;
     try {
       workspace = await loadWorkspace(agentConfig.workspace, {
@@ -304,11 +322,11 @@ async function main(): Promise<void> {
           updated.systemPrompt,
           'utf8',
         );
-        logger.info('Updated CLAUDE.md, restarting runner');
+        logger.info('Updated CLAUDE.md, restarting sessions');
         if (updated.skillRegistry) {
           runner.setSkillRegistry(updated.skillRegistry);
         }
-        await runner.restart();
+        await runner.restartOrDefer();
         scheduler.load(updated.files.heartbeatMd);
       } catch (err) {
         logger.error('Failed to reload workspace', { error: (err as Error).message });
@@ -336,11 +354,9 @@ async function main(): Promise<void> {
             updated.systemPrompt,
             'utf8',
           );
-          // Stop idle subprocesses so the next incoming message picks up the
-          // refreshed system prompt. Busy sessions are left running and will
-          // pick up the change after their current turn completes and they
-          // idle out via the idle cleaner.
-          await runner.restartIdleSessions();
+          // Stop idle subprocesses now; busy sessions are deferred until
+          // their current turn completes, then restarted automatically.
+          await runner.restartOrDefer();
           logger.info('Skills registry updated', {
             count: updated.skillRegistry?.skills.size ?? 0,
           });
@@ -374,7 +390,6 @@ async function main(): Promise<void> {
   console.log(`[gateway] Listening on port ${PORT}`);
 
   // ── Config hot-reload watcher ──────────────────────────────────────────────
-  const globalLogger = createLogger('gateway', expandTilde(config.gateway.logDir));
   const configWatcher = new ConfigWatcher(CONFIG_PATH, config, globalLogger);
 
   configWatcher.on('changes', (changes: ConfigChange[], newConfig: GatewayConfig) => {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -24,6 +24,8 @@ export class SessionProcess extends EventEmitter {
   private stopping = false;
   private restartCount = 0;
   private restartRequested = false;
+  private _processing = false;
+  private _pendingRestart = false;
   private restartWatcher: chokidar.FSWatcher | null = null;
   private readonly sessionStore: SessionStore;
   private readonly agentConfig: AgentConfig;
@@ -121,7 +123,21 @@ export class SessionProcess extends EventEmitter {
     const history = this.source === 'telegram'
       ? await this.sessionStore.loadTelegramSession(this.agentConfig.id, this.chatId, this.sessionId)
       : await this.sessionStore.loadSession(this.agentConfig.id, this.sessionId);
-    const recent = history.slice(-MAX_HISTORY_MESSAGES);
+
+    // If history exceeds the limit and history[0] is a compaction summary, rescue it
+    // so the model retains context from before the truncation window.
+    const SUMMARY_MARKER = '[Conversation Summary]';
+    const firstMsg = history[0];
+    const hasSummary =
+      history.length > MAX_HISTORY_MESSAGES &&
+      firstMsg?.role === 'system' &&
+      typeof firstMsg.content === 'string' &&
+      firstMsg.content.trimStart().startsWith(SUMMARY_MARKER);
+
+    const recent = hasSummary
+      ? [firstMsg, ...history.slice(-(MAX_HISTORY_MESSAGES - 1))]
+      : history.slice(-MAX_HISTORY_MESSAGES);
+
     const loadedAtSpawn = recent.length;
     const archivedCount = history.length - recent.length;
     const messageCountAtSpawn = history.length;
@@ -589,6 +605,26 @@ export class SessionProcess extends EventEmitter {
       try { fs.writeFileSync(statusPath, 'queued') } catch {}
     }
     this.process.stdin.write(SessionProcess.toStreamJsonTurn(text) + '\n');
+  }
+
+  get isProcessing(): boolean { return this._processing; }
+
+  setProcessing(active: boolean): void {
+    if (this._processing !== active) {
+      this._processing = active;
+      this.emit('processingChange', active);
+      if (!active && this._pendingRestart) {
+        this.emit('deferredRestartReady');
+      }
+    }
+  }
+
+  markPendingRestart(): void {
+    if (!this._processing) {
+      this.emit('deferredRestartReady');
+    } else {
+      this._pendingRestart = true;
+    }
   }
 
   touch(): void {

--- a/src/skills/sync.ts
+++ b/src/skills/sync.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Syncs shared skills to the personal Claude skills directory (~/.claude/skills/).
+ * Skills synced from shared are marked with a .shared sentinel file so stale
+ * entries can be cleaned up when they are removed from shared-skills.
+ */
+export function syncSharedSkills(
+  sharedSkillsDir: string,
+  personalSkillsDir: string,
+  logger?: { info: (msg: string, meta?: Record<string, unknown>) => void; warn: (msg: string, meta?: Record<string, unknown>) => void },
+): void {
+  // Enumerate skills currently in shared-skills/
+  const sharedNames = new Set<string>();
+  if (fs.existsSync(sharedSkillsDir)) {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(sharedSkillsDir);
+    } catch {
+      entries = [];
+    }
+    for (const entry of entries) {
+      if (entry.startsWith('.') || entry === 'node_modules') continue;
+      const skillMd = path.join(sharedSkillsDir, entry, 'SKILL.md');
+      if (fs.existsSync(skillMd)) {
+        sharedNames.add(entry);
+      }
+    }
+  }
+
+  // Ensure personal skills directory exists
+  try {
+    fs.mkdirSync(personalSkillsDir, { recursive: true });
+  } catch {
+    logger?.warn('syncSharedSkills: failed to create personalSkillsDir', { personalSkillsDir });
+    return;
+  }
+
+  // Remove stale synced entries (those with .shared marker no longer in shared-skills)
+  let existingEntries: string[] = [];
+  try {
+    existingEntries = fs.readdirSync(personalSkillsDir);
+  } catch {
+    // ignore
+  }
+  for (const entry of existingEntries) {
+    if (entry.startsWith('.')) continue;
+    const markerFile = path.join(personalSkillsDir, entry, '.shared');
+    if (fs.existsSync(markerFile) && !sharedNames.has(entry)) {
+      try {
+        fs.rmSync(path.join(personalSkillsDir, entry), { recursive: true, force: true });
+        logger?.info('syncSharedSkills: removed stale skill', { name: entry });
+      } catch {
+        logger?.warn('syncSharedSkills: failed to remove stale skill', { name: entry });
+      }
+    }
+  }
+
+  // Copy/update skills from shared-skills to personal skills dir
+  for (const skillName of sharedNames) {
+    const srcFile = path.join(sharedSkillsDir, skillName, 'SKILL.md');
+    const destDir = path.join(personalSkillsDir, skillName);
+    const destFile = path.join(destDir, 'SKILL.md');
+    const markerFile = path.join(destDir, '.shared');
+
+    try {
+      fs.mkdirSync(destDir, { recursive: true });
+
+      // Only write if content differs (avoids spurious mtime updates)
+      const newContent = fs.readFileSync(srcFile, 'utf-8');
+      let existing = '';
+      try {
+        existing = fs.readFileSync(destFile, 'utf-8');
+      } catch {
+        // file doesn't exist yet
+      }
+
+      if (newContent !== existing) {
+        const tmp = destFile + '.tmp';
+        fs.writeFileSync(tmp, newContent, 'utf-8');
+        fs.renameSync(tmp, destFile);
+        logger?.info('syncSharedSkills: synced skill', { name: skillName });
+      }
+
+      // Ensure .shared marker exists
+      if (!fs.existsSync(markerFile)) {
+        fs.writeFileSync(markerFile, '', 'utf-8');
+      }
+    } catch (err) {
+      logger?.warn('syncSharedSkills: failed to sync skill', {
+        name: skillName,
+        error: (err as Error).message,
+      });
+    }
+  }
+}

--- a/src/skills/watcher.ts
+++ b/src/skills/watcher.ts
@@ -1,4 +1,4 @@
-import chokidar from 'chokidar';
+import { createWatcher, WatchHandle } from '../watch/factory';
 
 export interface SkillWatcherOptions {
   /** Directories to watch for SKILL.md changes */
@@ -14,7 +14,7 @@ export interface SkillWatcherOptions {
  * Debounces rapid changes to avoid excessive rebuilds.
  * Returns a close() handle to stop watching.
  */
-export function watchSkills(opts: SkillWatcherOptions): { close: () => Promise<void> | void } {
+export function watchSkills(opts: SkillWatcherOptions): WatchHandle {
   const debounceMs = opts.debounceMs ?? 250;
   const validDirs = opts.dirs.filter(Boolean);
 
@@ -25,30 +25,10 @@ export function watchSkills(opts: SkillWatcherOptions): { close: () => Promise<v
   // Watch for SKILL.md files in skill subdirectories (depth 2)
   const patterns = validDirs.map((dir) => `${dir}/**/SKILL.md`);
 
-  const watcher = chokidar.watch(patterns, {
-    persistent: true,
-    ignoreInitial: true,
-    depth: 2,
+  return createWatcher({
+    paths: patterns,
+    debounceMs,
+    chokidarOpts: { depth: 2 },
+    onChange: opts.onChange,
   });
-
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-
-  const debouncedOnChange = () => {
-    if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(opts.onChange, debounceMs);
-  };
-
-  watcher.on('add', debouncedOnChange);
-  watcher.on('change', debouncedOnChange);
-  watcher.on('unlink', debouncedOnChange);
-
-  return {
-    async close() {
-      if (debounceTimer) {
-        clearTimeout(debounceTimer);
-        debounceTimer = null;
-      }
-      await watcher.close();
-    },
-  };
 }

--- a/src/watch/factory.ts
+++ b/src/watch/factory.ts
@@ -1,0 +1,59 @@
+import chokidar from 'chokidar';
+
+export interface WatcherOptions {
+  /** Glob patterns or file paths to watch */
+  paths: string[];
+  /** Debounce interval in ms */
+  debounceMs: number;
+  /** Additional chokidar options */
+  chokidarOpts?: chokidar.WatchOptions;
+  /** Callback invoked (debounced) when any watched path changes */
+  onChange: () => void;
+  /**
+   * Optional synchronous side-effect called immediately on 'add' events,
+   * before the debounced onChange fires (e.g. for file renames).
+   */
+  onAddSync?: (filePath: string) => void;
+}
+
+export interface WatchHandle {
+  close(): Promise<void> | void;
+}
+
+/**
+ * Shared chokidar watcher factory.
+ * Watches the given paths, debounces rapid changes, and calls onChange.
+ * Returns a WatchHandle with a close() method to stop watching.
+ */
+export function createWatcher(opts: WatcherOptions): WatchHandle {
+  const watcher = chokidar.watch(opts.paths, {
+    persistent: true,
+    ignoreInitial: true,
+    ...opts.chokidarOpts,
+  });
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const debounced = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(opts.onChange, opts.debounceMs);
+  };
+
+  watcher
+    .on('add', (filePath: string) => {
+      if (opts.onAddSync) opts.onAddSync(filePath);
+      debounced();
+    })
+    .on('change', debounced)
+    .on('unlink', debounced);
+
+  return {
+    async close() {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      await watcher.close();
+    },
+  };
+}

--- a/tests/integration/skills-hot-reload.test.ts
+++ b/tests/integration/skills-hot-reload.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Integration tests for skills hot-reload end-to-end:
+ * Watcher detects SKILL.md change -> workspace reloads -> CLAUDE.md rewritten
+ * -> registry refreshed -> idle session subprocesses stopped so the next message
+ * re-spawns with the updated system prompt.
+ *
+ * Mirrors the wiring in src/index.ts (watchSkills callback) while keeping the
+ * subprocess layer fully mocked through the existing child_process jest mock
+ * used by agent-runner.test.ts.
+ *
+ * HR1 — add shared skill triggers restart of idle session
+ * HR2 — modify shared skill triggers restart
+ * HR3 — delete shared skill triggers restart
+ * HR4 — busy session is NOT stopped; CLAUDE.md still refreshed
+ * HR5 — module-dir skill change behaves the same as shared-dir change
+ */
+
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── Mock child_process to prevent real subprocess spawns ──────────────────────
+
+interface MockStdin {
+  writable: boolean;
+  write: jest.Mock;
+}
+
+interface MockChildProcess extends EventEmitter {
+  stdin: MockStdin | null;
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+}
+
+const allProcesses: MockChildProcess[] = [];
+
+function makeMockProcess(): MockChildProcess {
+  const stdin: MockStdin = { writable: true, write: jest.fn() };
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdin = stdin;
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.killed = false;
+  proc.pid = Math.floor(Math.random() * 90000) + 10000;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = true;
+    process.nextTick(() => proc.emit('exit', 0, signal ?? 'SIGTERM'));
+    return true;
+  });
+
+  allProcesses.push(proc);
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn((..._args) => makeMockProcess()),
+}));
+
+// ── Imports (after jest.mock) ─────────────────────────────────────────────────
+
+import { AgentRunner } from '../../src/agent/runner';
+import { loadWorkspace } from '../../src/agent/workspace-loader';
+import { watchSkills } from '../../src/skills/watcher';
+import { AgentConfig, GatewayConfig } from '../../src/types';
+import { SessionProcess } from '../../src/session/process';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAgentConfig(workspace: string): AgentConfig {
+  return {
+    id: 'alfred',
+    description: 'hot-reload integration agent',
+    workspace,
+    env: '',
+    telegram: {
+      botToken: 'test-token',
+      allowedUsers: [],
+      dmPolicy: 'allowlist',
+    },
+    claude: {
+      model: 'claude-opus-4-6',
+      dangerouslySkipPermissions: false,
+      extraFlags: [],
+    },
+  };
+}
+
+function makeGatewayConfig(): GatewayConfig {
+  return {
+    gateway: { logDir: '/tmp/test-hr-logs', timezone: 'UTC' },
+    agents: [],
+  };
+}
+
+async function sendChannelPost(
+  port: number,
+  chatId: string,
+  content: string,
+): Promise<void> {
+  await fetch(`http://127.0.0.1:${port}/channel`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      content,
+      meta: {
+        chat_id: chatId,
+        message_id: '1',
+        user: 'tester',
+        ts: new Date().toISOString(),
+      },
+    }),
+  });
+}
+
+function getCallbackPort(runner: AgentRunner): number {
+  return (runner as unknown as { callbackPort: number }).callbackPort;
+}
+
+function getSessions(runner: AgentRunner): Map<string, SessionProcess> {
+  return (runner as unknown as { sessions: Map<string, SessionProcess> }).sessions;
+}
+
+function setLastActivity(proc: SessionProcess, msAgo: number): void {
+  (proc as unknown as { lastActivityAt: number }).lastActivityAt = Date.now() - msAgo;
+}
+
+function writeSkillFile(dir: string, name: string, body = ''): void {
+  const skillDir = path.join(dir, name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  const frontmatter = `---\nname: ${name}\ndescription: integration test skill ${name}\nuser-invocable: true\n---\n\n${body || `# ${name}`}\n`;
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), frontmatter);
+}
+
+function deleteSkillFile(dir: string, name: string): void {
+  fs.rmSync(path.join(dir, name), { recursive: true, force: true });
+}
+
+// Replicates the inline watcher callback in src/index.ts so the integration
+// test exercises the same sequence (reload -> setSkillRegistry ->
+// write CLAUDE.md -> restartIdleSessions).
+function wireSkillsWatcher(
+  runner: AgentRunner,
+  workspaceDir: string,
+  sharedSkillsDir: string,
+  mcpToolsDir: string,
+): { close: () => Promise<void> | void } {
+  const workspaceSkillsDir = path.join(workspaceDir, 'skills');
+  return watchSkills({
+    dirs: [workspaceSkillsDir, mcpToolsDir, sharedSkillsDir],
+    debounceMs: 50,
+    onChange: async () => {
+      const updated = await loadWorkspace(workspaceDir, {
+        mcpToolsDir,
+        sharedSkillsDir,
+      });
+      if (updated.skillRegistry) {
+        runner.setSkillRegistry(updated.skillRegistry);
+      }
+      await fs.promises.writeFile(
+        path.join(workspaceDir, 'CLAUDE.md'),
+        updated.systemPrompt,
+        'utf8',
+      );
+      await runner.restartIdleSessions();
+    },
+  });
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 3000,
+  intervalMs = 25,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (predicate()) return;
+    } catch {
+      // Predicate may throw while files are still being written; keep polling.
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+describe('Skills hot-reload end-to-end', () => {
+  let tmpRoot: string;
+  let workspaceDir: string;
+  let sharedSkillsDir: string;
+  let mcpToolsDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+  let watcher: { close: () => Promise<void> | void };
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hr-hotreload-'));
+    workspaceDir = path.join(tmpRoot, 'workspace');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(path.join(workspaceDir, 'AGENTS.md'), '# Integration Agent\n');
+    // Pre-create the workspace skills dir so chokidar has something to attach to
+    // when the watcher starts. (It only walks existing paths up to `depth`.)
+    fs.mkdirSync(path.join(workspaceDir, 'skills'), { recursive: true });
+
+    sharedSkillsDir = path.join(tmpRoot, 'shared-skills');
+    fs.mkdirSync(sharedSkillsDir, { recursive: true });
+
+    mcpToolsDir = path.join(tmpRoot, 'mcp-tools');
+    fs.mkdirSync(mcpToolsDir, { recursive: true });
+
+    agentConfig = makeAgentConfig(workspaceDir);
+    gatewayConfig = makeGatewayConfig();
+
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    await watcher?.close();
+    if (runner) {
+      await runner.stop();
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  async function bootRunnerWithIdleSession(chatId: string): Promise<SessionProcess> {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, chatId, 'hello');
+    await new Promise((r) => setTimeout(r, 100));
+    const sess = getSessions(runner).get(chatId)!;
+    expect(sess).toBeDefined();
+    setLastActivity(sess, 5_000);
+    return sess;
+  }
+
+  // --------------------------------------------------------------------------
+  // HR1 — add shared skill triggers restart of idle session
+  // --------------------------------------------------------------------------
+  it('HR1: adding a shared skill stops idle session and updates CLAUDE.md', async () => {
+    await bootRunnerWithIdleSession('chat:hr1');
+    watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
+
+    // Give the watcher a moment to attach before writing.
+    await new Promise((r) => setTimeout(r, 150));
+    writeSkillFile(sharedSkillsDir, 'hr1-skill');
+
+    await waitForCondition(() => !getSessions(runner).has('chat:hr1'));
+
+    const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain('/hr1-skill');
+    expect(claudeMd).toContain('**Shared Skills**');
+  }, 10000);
+
+  // --------------------------------------------------------------------------
+  // HR2 — modifying a shared skill triggers restart
+  // --------------------------------------------------------------------------
+  it('HR2: modifying a shared skill stops idle session', async () => {
+    // Seed the skill BEFORE the watcher so the "add" event doesn't fire.
+    writeSkillFile(sharedSkillsDir, 'hr2-skill');
+
+    await bootRunnerWithIdleSession('chat:hr2');
+    watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
+    await new Promise((r) => setTimeout(r, 150));
+
+    // Modify: rewrite with different description.
+    const skillFile = path.join(sharedSkillsDir, 'hr2-skill', 'SKILL.md');
+    fs.writeFileSync(
+      skillFile,
+      `---\nname: hr2-skill\ndescription: updated description\nuser-invocable: true\n---\n\n# hr2-skill v2\n`,
+    );
+
+    await waitForCondition(() => !getSessions(runner).has('chat:hr2'));
+
+    const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain('updated description');
+  }, 10000);
+
+  // --------------------------------------------------------------------------
+  // HR3 — deleting a shared skill triggers restart
+  // --------------------------------------------------------------------------
+  it('HR3: deleting a shared skill stops idle session and removes skill from CLAUDE.md', async () => {
+    writeSkillFile(sharedSkillsDir, 'hr3-skill');
+
+    await bootRunnerWithIdleSession('chat:hr3');
+    watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
+    await new Promise((r) => setTimeout(r, 150));
+
+    deleteSkillFile(sharedSkillsDir, 'hr3-skill');
+
+    await waitForCondition(() => !getSessions(runner).has('chat:hr3'));
+
+    const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).not.toContain('/hr3-skill');
+  }, 10000);
+
+  // --------------------------------------------------------------------------
+  // HR4 — busy session is NOT stopped; CLAUDE.md still refreshed
+  // --------------------------------------------------------------------------
+  it('HR4: busy session is left running; CLAUDE.md still updated', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:hr4', 'hi');
+    await new Promise((r) => setTimeout(r, 100));
+    const sess = getSessions(runner).get('chat:hr4')!;
+    // Mark as freshly active so it's well inside the 1s idle window.
+    setLastActivity(sess, 0);
+
+    watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
+    await new Promise((r) => setTimeout(r, 150));
+
+    writeSkillFile(sharedSkillsDir, 'hr4-skill');
+
+    await waitForCondition(() =>
+      fs
+        .readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8')
+        .includes('/hr4-skill'),
+    );
+
+    // Busy session survives the reload.
+    expect(getSessions(runner).has('chat:hr4')).toBe(true);
+    expect(sess.isRunning()).toBe(true);
+  }, 10000);
+
+  // --------------------------------------------------------------------------
+  // HR5 — workspace-dir skill change also triggers restart
+  // --------------------------------------------------------------------------
+  it('HR5: skill added under workspace skills dir also triggers restart', async () => {
+    await bootRunnerWithIdleSession('chat:hr5');
+    watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
+    await new Promise((r) => setTimeout(r, 150));
+
+    // Workspace skills: <workspace>/skills/<skill-name>/SKILL.md
+    const workspaceSkillsDir = path.join(workspaceDir, 'skills');
+    writeSkillFile(workspaceSkillsDir, 'hr5-skill');
+
+    await waitForCondition(() => !getSessions(runner).has('chat:hr5'));
+
+    const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain('/hr5-skill');
+    expect(claudeMd).toContain('**Workspace Skills**');
+  }, 10000);
+});

--- a/tests/integration/skills-hot-reload.test.ts
+++ b/tests/integration/skills-hot-reload.test.ts
@@ -144,7 +144,7 @@ function deleteSkillFile(dir: string, name: string): void {
 
 // Replicates the inline watcher callback in src/index.ts so the integration
 // test exercises the same sequence (reload -> setSkillRegistry ->
-// write CLAUDE.md -> restartIdleSessions).
+// write CLAUDE.md -> restartOrDefer).
 function wireSkillsWatcher(
   runner: AgentRunner,
   workspaceDir: string,
@@ -168,7 +168,7 @@ function wireSkillsWatcher(
         updated.systemPrompt,
         'utf8',
       );
-      await runner.restartIdleSessions();
+      await runner.restartOrDefer();
     },
   });
 }
@@ -241,7 +241,8 @@ describe('Skills hot-reload end-to-end', () => {
     await new Promise((r) => setTimeout(r, 100));
     const sess = getSessions(runner).get(chatId)!;
     expect(sess).toBeDefined();
-    setLastActivity(sess, 5_000);
+    // Simulate turn completed so restartOrDefer() stops the session immediately.
+    sess.setProcessing(false);
     return sess;
   }
 
@@ -315,8 +316,7 @@ describe('Skills hot-reload end-to-end', () => {
     await sendChannelPost(port, 'chat:hr4', 'hi');
     await new Promise((r) => setTimeout(r, 100));
     const sess = getSessions(runner).get('chat:hr4')!;
-    // Mark as freshly active so it's well inside the 1s idle window.
-    setLastActivity(sess, 0);
+    // Session is processing (isProcessing === true from sendChannelPost) — will be deferred, not stopped.
 
     watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
     await new Promise((r) => setTimeout(r, 150));

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -261,16 +261,16 @@ describe('AgentRunner (session pool)', () => {
   }, 15000);
 });
 
-// ── restartIdleSessions (skills hot-reload support) ───────────────────────────
+// ── restartOrDefer (skills hot-reload support) ────────────────────────────────
 
-describe('AgentRunner — restartIdleSessions', () => {
+describe('AgentRunner — restartOrDefer', () => {
   let tmpDir: string;
   let agentConfig: AgentConfig;
   let gatewayConfig: GatewayConfig;
   let runner: AgentRunner;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-restart-idle-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-restart-defer-'));
     agentConfig = makeAgentConfig(path.join(tmpDir, 'workspace'));
     fs.mkdirSync(agentConfig.workspace, { recursive: true });
     gatewayConfig = makeGatewayConfig();
@@ -286,15 +286,10 @@ describe('AgentRunner — restartIdleSessions', () => {
     jest.clearAllMocks();
   });
 
-  // Force a session's idle state by rewriting its lastActivityAt.
-  function setLastActivity(proc: SessionProcess, msAgo: number): void {
-    (proc as unknown as { lastActivityAt: number }).lastActivityAt = Date.now() - msAgo;
-  }
-
   // --------------------------------------------------------------------------
-  // RS1: stops an idle session subprocess
+  // RS1: stops a non-processing session immediately
   // --------------------------------------------------------------------------
-  it('RS1: stops an idle session subprocess', async () => {
+  it('RS1: stops a non-processing session subprocess immediately', async () => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
     await runner.start();
 
@@ -304,20 +299,19 @@ describe('AgentRunner — restartIdleSessions', () => {
 
     const sess = getSessions(runner).get('chat:idle')!;
     expect(sess).toBeDefined();
+    // Simulate turn completed: mark as not processing so it stops immediately.
+    sess.setProcessing(false);
 
-    // Mark as idle for well over the 1s threshold.
-    setLastActivity(sess, 5_000);
-
-    await runner.restartIdleSessions();
+    await runner.restartOrDefer();
 
     expect(getSessions(runner).has('chat:idle')).toBe(false);
     expect(getSessions(runner).size).toBe(0);
   }, 15000);
 
   // --------------------------------------------------------------------------
-  // RS2: leaves a busy session alone
+  // RS2: defers a processing session (does not stop immediately)
   // --------------------------------------------------------------------------
-  it('RS2: leaves a busy session alone', async () => {
+  it('RS2: defers restart for a processing session', async () => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
     await runner.start();
 
@@ -326,21 +320,22 @@ describe('AgentRunner — restartIdleSessions', () => {
     await new Promise(r => setTimeout(r, 100));
 
     const sess = getSessions(runner).get('chat:busy')!;
-    // Freshly active: lastActivityAt is "now" — well below the 1s idle threshold.
-    setLastActivity(sess, 0);
+    // Mark session as processing.
+    sess.setProcessing(true);
     const stopSpy = jest.spyOn(sess, 'stop');
 
-    await runner.restartIdleSessions();
+    await runner.restartOrDefer();
 
+    // Session still in pool; stop not called yet.
     expect(stopSpy).not.toHaveBeenCalled();
     expect(getSessions(runner).has('chat:busy')).toBe(true);
     expect(getSessions(runner).size).toBe(1);
   }, 15000);
 
   // --------------------------------------------------------------------------
-  // RS3: mixed idle/busy — only idle is stopped
+  // RS3: mixed — idle stopped immediately, processing deferred
   // --------------------------------------------------------------------------
-  it('RS3: stops only idle sessions in a mixed pool', async () => {
+  it('RS3: stops idle sessions immediately; defers processing sessions', async () => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
     await runner.start();
 
@@ -352,11 +347,13 @@ describe('AgentRunner — restartIdleSessions', () => {
 
     const sessA = getSessions(runner).get('chat:a')!;
     const sessB = getSessions(runner).get('chat:b')!;
-    setLastActivity(sessA, 10_000); // idle
-    setLastActivity(sessB, 0);       // busy
+    // sessA: reset processing (turn completed) → stops immediately
+    // sessB: remains processing (turn still running) → deferred
+    sessA.setProcessing(false);
+    // sessB.isProcessing is already true from sendChannelPost
     const stopSpyB = jest.spyOn(sessB, 'stop');
 
-    await runner.restartIdleSessions();
+    await runner.restartOrDefer();
 
     expect(getSessions(runner).has('chat:a')).toBe(false);
     expect(getSessions(runner).has('chat:b')).toBe(true);
@@ -372,7 +369,7 @@ describe('AgentRunner — restartIdleSessions', () => {
     await runner.start();
 
     expect(getSessions(runner).size).toBe(0);
-    await expect(runner.restartIdleSessions()).resolves.toBeUndefined();
+    await expect(runner.restartOrDefer()).resolves.toBeUndefined();
     expect(getSessions(runner).size).toBe(0);
   }, 15000);
 
@@ -388,12 +385,13 @@ describe('AgentRunner — restartIdleSessions', () => {
     await new Promise(r => setTimeout(r, 100));
 
     const sess = getSessions(runner).get('chat:keepalive')!;
-    setLastActivity(sess, 5_000);
+    // Simulate turn completed so session is stopped immediately.
+    sess.setProcessing(false);
 
     expect(runner.isRunning()).toBe(true);
     const portBefore = getCallbackPort(runner);
 
-    await runner.restartIdleSessions();
+    await runner.restartOrDefer();
 
     // Receiver still running; callback server still bound to the same port.
     expect(runner.isRunning()).toBe(true);
@@ -403,6 +401,32 @@ describe('AgentRunner — restartIdleSessions', () => {
     await sendChannelPost(port, 'chat:keepalive', 'again');
     await new Promise(r => setTimeout(r, 100));
     expect(getSessions(runner).has('chat:keepalive')).toBe(true);
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS6: deferred session stops when setProcessing(false) is called
+  // --------------------------------------------------------------------------
+  it('RS6: deferred session stops itself after turn completes', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:defer', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:defer')!;
+    // isProcessing is already true from sendChannelPost
+
+    await runner.restartOrDefer();
+    // Still in pool — processing
+    expect(getSessions(runner).has('chat:defer')).toBe(true);
+
+    // Simulate turn completing
+    sess.setProcessing(false);
+    await new Promise(r => setTimeout(r, 50));
+
+    // Session should now be stopped and removed via deferredRestartReady listener
+    expect(getSessions(runner).has('chat:defer')).toBe(false);
   }, 15000);
 });
 

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -261,6 +261,151 @@ describe('AgentRunner (session pool)', () => {
   }, 15000);
 });
 
+// ── restartIdleSessions (skills hot-reload support) ───────────────────────────
+
+describe('AgentRunner — restartIdleSessions', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-restart-idle-'));
+    agentConfig = makeAgentConfig(path.join(tmpDir, 'workspace'));
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) {
+      await runner.stop();
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // Force a session's idle state by rewriting its lastActivityAt.
+  function setLastActivity(proc: SessionProcess, msAgo: number): void {
+    (proc as unknown as { lastActivityAt: number }).lastActivityAt = Date.now() - msAgo;
+  }
+
+  // --------------------------------------------------------------------------
+  // RS1: stops an idle session subprocess
+  // --------------------------------------------------------------------------
+  it('RS1: stops an idle session subprocess', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:idle', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:idle')!;
+    expect(sess).toBeDefined();
+
+    // Mark as idle for well over the 1s threshold.
+    setLastActivity(sess, 5_000);
+
+    await runner.restartIdleSessions();
+
+    expect(getSessions(runner).has('chat:idle')).toBe(false);
+    expect(getSessions(runner).size).toBe(0);
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS2: leaves a busy session alone
+  // --------------------------------------------------------------------------
+  it('RS2: leaves a busy session alone', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:busy', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:busy')!;
+    // Freshly active: lastActivityAt is "now" — well below the 1s idle threshold.
+    setLastActivity(sess, 0);
+    const stopSpy = jest.spyOn(sess, 'stop');
+
+    await runner.restartIdleSessions();
+
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:busy')).toBe(true);
+    expect(getSessions(runner).size).toBe(1);
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS3: mixed idle/busy — only idle is stopped
+  // --------------------------------------------------------------------------
+  it('RS3: stops only idle sessions in a mixed pool', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:a', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+    await sendChannelPost(port, 'chat:b', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sessA = getSessions(runner).get('chat:a')!;
+    const sessB = getSessions(runner).get('chat:b')!;
+    setLastActivity(sessA, 10_000); // idle
+    setLastActivity(sessB, 0);       // busy
+    const stopSpyB = jest.spyOn(sessB, 'stop');
+
+    await runner.restartIdleSessions();
+
+    expect(getSessions(runner).has('chat:a')).toBe(false);
+    expect(getSessions(runner).has('chat:b')).toBe(true);
+    expect(stopSpyB).not.toHaveBeenCalled();
+    expect(getSessions(runner).size).toBe(1);
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS4: empty pool — no-op, does not throw
+  // --------------------------------------------------------------------------
+  it('RS4: empty session pool is a no-op', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    expect(getSessions(runner).size).toBe(0);
+    await expect(runner.restartIdleSessions()).resolves.toBeUndefined();
+    expect(getSessions(runner).size).toBe(0);
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS5: receiver and callback server remain up
+  // --------------------------------------------------------------------------
+  it('RS5: receiver and callback server keep running after restart', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:keepalive', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:keepalive')!;
+    setLastActivity(sess, 5_000);
+
+    expect(runner.isRunning()).toBe(true);
+    const portBefore = getCallbackPort(runner);
+
+    await runner.restartIdleSessions();
+
+    // Receiver still running; callback server still bound to the same port.
+    expect(runner.isRunning()).toBe(true);
+    expect(getCallbackPort(runner)).toBe(portBefore);
+
+    // And a new message re-spawns the stopped session lazily.
+    await sendChannelPost(port, 'chat:keepalive', 'again');
+    await new Promise(r => setTimeout(r, 100));
+    expect(getSessions(runner).has('chat:keepalive')).toBe(true);
+  }, 15000);
+});
+
 // ── Typing error notification tests ───────────────────────────────────────────
 
 describe('AgentRunner — typing error notification', () => {

--- a/tests/unit/config-watcher.test.ts
+++ b/tests/unit/config-watcher.test.ts
@@ -317,9 +317,7 @@ describe('config-watcher', () => {
   // ---------------------------------------------------------------------------
   // U-CW-06: config.json changes rapidly multiple times — debounce, emit once
   // ---------------------------------------------------------------------------
-  it('U-CW-06: debounces rapid changes and emits only once', () => {
-    jest.useFakeTimers();
-
+  it('U-CW-06: reload() emits changes when config differs', () => {
     const configPath = path.join(tmpDir, 'config.json');
     writeConfigFile(configPath, rawConfig());
 
@@ -329,29 +327,14 @@ describe('config-watcher', () => {
     const changeSpy = jest.fn();
     watcher.on('changes', changeSpy);
 
-    // Start watching (uses chokidar internally, but we simulate via onConfigChange)
-    // Access the private onConfigChange method to simulate rapid file change events
-    const onConfigChange = (watcher as unknown as { onConfigChange: () => void }).onConfigChange.bind(watcher);
-
-    // Write config with a different model for the final state
+    // Write config with a different model and reload
     writeConfigFile(configPath, rawConfig({ alfredModel: 'claude-sonnet-4-6' }));
-
-    // Simulate rapid file change events
-    onConfigChange();
-    onConfigChange();
-    onConfigChange();
-
-    // Nothing emitted yet — debounce timer not expired
-    expect(changeSpy).not.toHaveBeenCalled();
-
-    // Advance past the 500ms debounce
-    jest.advanceTimersByTime(600);
+    watcher.reload();
 
     // Should have emitted exactly once
     expect(changeSpy).toHaveBeenCalledTimes(1);
 
     watcher.stop();
-    jest.useRealTimers();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -285,6 +285,129 @@ describe('SessionProcess', () => {
   });
 
   // --------------------------------------------------------------------------
+  // U-SP-09a: >50 msgs with summary at [0] → summary + last 49 loaded (total 50)
+  // --------------------------------------------------------------------------
+  it('U-SP-09a: summary at history[0] is rescued when history exceeds 50 messages', async () => {
+    const summaryContent = '[Conversation Summary]\n**Summary:**\n\nPrior work on the project.';
+    // Insert summary as message[0]
+    await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
+      role: 'system',
+      content: summaryContent,
+      ts: 1000,
+    });
+    // Insert 60 normal messages (indices 1–60)
+    for (let i = 1; i <= 60; i++) {
+      await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
+        role: 'user',
+        content: `Message ${i}`,
+        ts: 1000 + i,
+      });
+    }
+
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
+    const parsed = JSON.parse(firstWrite);
+    const text: string = parsed.message.content[0].text;
+
+    // Summary and last message must be present
+    expect(text).toContain('[Conversation Summary]');
+    expect(text).toContain('Message 60');
+    // Message 12 is outside the 49-tail window (last 49 = messages 12–60)
+    expect(text).not.toContain('Message 11');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-09b: >50 msgs without summary → last 50 loaded normally
+  // --------------------------------------------------------------------------
+  it('U-SP-09b: last 50 messages loaded when no summary exists and history > 50', async () => {
+    for (let i = 0; i < 60; i++) {
+      await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
+        role: 'user',
+        content: `Msg ${i}`,
+        ts: Date.now() + i,
+      });
+    }
+
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
+    const parsed = JSON.parse(firstWrite);
+    const text: string = parsed.message.content[0].text;
+
+    expect(text).toContain('Msg 59');
+    expect(text).not.toContain('Msg 0');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-09c: <=50 msgs with summary → all messages loaded (summary included)
+  // --------------------------------------------------------------------------
+  it('U-SP-09c: all messages loaded when history <=50 even with a summary present', async () => {
+    const summaryContent = '[Conversation Summary]\n**Summary:**\n\nEarly work.';
+    await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
+      role: 'system',
+      content: summaryContent,
+      ts: 1000,
+    });
+    for (let i = 1; i <= 10; i++) {
+      await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
+        role: 'user',
+        content: `Short ${i}`,
+        ts: 1000 + i,
+      });
+    }
+
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
+    const parsed = JSON.parse(firstWrite);
+    const text: string = parsed.message.content[0].text;
+
+    expect(text).toContain('[Conversation Summary]');
+    expect(text).toContain('Short 1');
+    expect(text).toContain('Short 10');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-09d: summary at index 1 (not 0) → treated as normal, last 50 loaded
+  // --------------------------------------------------------------------------
+  it('U-SP-09d: summary not at history[0] is not rescued', async () => {
+    // First message is a normal user message
+    await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
+      role: 'user',
+      content: 'First normal message',
+      ts: 1000,
+    });
+    // Summary at index 1
+    await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
+      role: 'system',
+      content: '[Conversation Summary]\nShould not be rescued.',
+      ts: 1001,
+    });
+    for (let i = 2; i <= 60; i++) {
+      await sessionStore.appendTelegramMessage('alfred', 'chat:111', 'chat:111', {
+        role: 'user',
+        content: `Bulk ${i}`,
+        ts: 1000 + i,
+      });
+    }
+
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
+    const parsed = JSON.parse(firstWrite);
+    const text: string = parsed.message.content[0].text;
+
+    // Last 50 messages = indices 11–60, so 'First normal message' (idx 0) is out
+    expect(text).not.toContain('First normal message');
+    expect(text).toContain('Bulk 60');
+  });
+
+  // --------------------------------------------------------------------------
   // U-SP-10: --strict-mcp-config must NOT be in subprocess args
   // --------------------------------------------------------------------------
   it('U-SP-10: subprocess is spawned without --strict-mcp-config', async () => {
@@ -788,5 +911,102 @@ describe('SessionProcess', () => {
     const written = JSON.parse(fs.readFileSync(sp_path, 'utf-8'));
     expect(written.status).toBe('tool');
     expect(written.detail).toContain('List files');
+  });
+});
+
+// ── isProcessing + deferred restart ──────────────────────────────────────────
+
+describe('SessionProcess — isProcessing and deferred restart', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-proc-'));
+    agentConfig = makeAgentConfig({ workspace: path.join(tmpDir, 'workspace') });
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions'));
+    lastProcess = null;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // IP1: defaults to not processing
+  it('IP1: isProcessing defaults to false', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    expect(sp.isProcessing).toBe(false);
+    await sp.stop();
+  });
+
+  // IP2: setProcessing(true) flips the flag
+  it('IP2: setProcessing(true) → isProcessing true', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    expect(sp.isProcessing).toBe(true);
+    await sp.stop();
+  });
+
+  // IP3: setProcessing(false) resets the flag
+  it('IP3: setProcessing(false) → isProcessing false', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    sp.setProcessing(false);
+    expect(sp.isProcessing).toBe(false);
+    await sp.stop();
+  });
+
+  // IP4: emits processingChange event on transition
+  it('IP4: emits processingChange event when state changes', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    const changes: boolean[] = [];
+    sp.on('processingChange', (v: boolean) => changes.push(v));
+    sp.setProcessing(true);
+    sp.setProcessing(true);  // same value — no event
+    sp.setProcessing(false);
+    expect(changes).toEqual([true, false]);
+    await sp.stop();
+  });
+
+  // IP5: stop() works while processing
+  it('IP5: stop() succeeds while isProcessing is true', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    await expect(sp.stop()).resolves.toBeUndefined();
+  });
+
+  // IP6: markPendingRestart while not processing → emits deferredRestartReady immediately
+  it('IP6: markPendingRestart while idle emits deferredRestartReady immediately', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    let fired = false;
+    sp.once('deferredRestartReady', () => { fired = true; });
+    sp.markPendingRestart();
+    expect(fired).toBe(true);
+    await sp.stop();
+  });
+
+  // IP7: markPendingRestart while processing → deferred until setProcessing(false)
+  it('IP7: markPendingRestart while processing defers until turn ends', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    let fired = false;
+    sp.once('deferredRestartReady', () => { fired = true; });
+    sp.markPendingRestart();
+    expect(fired).toBe(false);  // not yet
+    sp.setProcessing(false);
+    expect(fired).toBe(true);  // fires when turn ends
+    await sp.stop();
   });
 });

--- a/tests/unit/skills-sync.test.ts
+++ b/tests/unit/skills-sync.test.ts
@@ -1,0 +1,129 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { syncSharedSkills } from '../../src/skills/sync';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'skills-sync-'));
+}
+
+function writeSharedSkill(sharedDir: string, name: string, content = `---\nname: ${name}\ndescription: "${name} skill"\n---\n# ${name}`): void {
+  const skillDir = path.join(sharedDir, name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+}
+
+function readPersonalSkill(personalDir: string, name: string): string {
+  return fs.readFileSync(path.join(personalDir, name, 'SKILL.md'), 'utf-8');
+}
+
+function hasMarker(personalDir: string, name: string): boolean {
+  return fs.existsSync(path.join(personalDir, name, '.shared'));
+}
+
+describe('syncSharedSkills', () => {
+  let sharedDir: string;
+  let personalDir: string;
+
+  beforeEach(() => {
+    sharedDir = makeTmpDir();
+    personalDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(sharedDir, { recursive: true, force: true });
+    fs.rmSync(personalDir, { recursive: true, force: true });
+  });
+
+  // SS1: copies a new shared skill to personal dir
+  it('SS1: copies new shared skill to personal dir', () => {
+    writeSharedSkill(sharedDir, 'my-skill');
+    syncSharedSkills(sharedDir, personalDir);
+
+    expect(fs.existsSync(path.join(personalDir, 'my-skill', 'SKILL.md'))).toBe(true);
+    expect(readPersonalSkill(personalDir, 'my-skill')).toContain('my-skill');
+  });
+
+  // SS2: writes .shared marker alongside synced SKILL.md
+  it('SS2: writes .shared marker for each synced skill', () => {
+    writeSharedSkill(sharedDir, 'foo');
+    syncSharedSkills(sharedDir, personalDir);
+
+    expect(hasMarker(personalDir, 'foo')).toBe(true);
+  });
+
+  // SS3: updates skill content when shared SKILL.md changes
+  it('SS3: updates skill when content changes', () => {
+    writeSharedSkill(sharedDir, 'bar', '---\nname: bar\ndescription: "v1"\n---\n# v1');
+    syncSharedSkills(sharedDir, personalDir);
+    expect(readPersonalSkill(personalDir, 'bar')).toContain('v1');
+
+    // Update shared skill
+    fs.writeFileSync(path.join(sharedDir, 'bar', 'SKILL.md'), '---\nname: bar\ndescription: "v2"\n---\n# v2', 'utf-8');
+    syncSharedSkills(sharedDir, personalDir);
+    expect(readPersonalSkill(personalDir, 'bar')).toContain('v2');
+  });
+
+  // SS4: removes stale skill from personal dir when deleted from shared
+  it('SS4: removes stale synced skill from personal dir', () => {
+    writeSharedSkill(sharedDir, 'to-delete');
+    writeSharedSkill(sharedDir, 'keep');
+    syncSharedSkills(sharedDir, personalDir);
+
+    expect(fs.existsSync(path.join(personalDir, 'to-delete'))).toBe(true);
+
+    // Remove from shared
+    fs.rmSync(path.join(sharedDir, 'to-delete'), { recursive: true, force: true });
+    syncSharedSkills(sharedDir, personalDir);
+
+    expect(fs.existsSync(path.join(personalDir, 'to-delete'))).toBe(false);
+    expect(fs.existsSync(path.join(personalDir, 'keep', 'SKILL.md'))).toBe(true);
+  });
+
+  // SS5: does NOT remove skills in personal dir without .shared marker (user-created)
+  it('SS5: does not remove user-created skills (no .shared marker)', () => {
+    // Create a user-owned skill in personal dir (no .shared marker)
+    const userSkillDir = path.join(personalDir, 'user-skill');
+    fs.mkdirSync(userSkillDir, { recursive: true });
+    fs.writeFileSync(path.join(userSkillDir, 'SKILL.md'), '# user owned', 'utf-8');
+
+    // sharedDir has no skills
+    syncSharedSkills(sharedDir, personalDir);
+
+    // User-owned skill must survive
+    expect(fs.existsSync(path.join(personalDir, 'user-skill', 'SKILL.md'))).toBe(true);
+  });
+
+  // SS6: does not rewrite file when content is unchanged (mtime stability)
+  it('SS6: does not overwrite file when content unchanged', () => {
+    writeSharedSkill(sharedDir, 'stable');
+    syncSharedSkills(sharedDir, personalDir);
+
+    const destFile = path.join(personalDir, 'stable', 'SKILL.md');
+    const mtimeBefore = fs.statSync(destFile).mtimeMs;
+
+    // Sync again with same content
+    syncSharedSkills(sharedDir, personalDir);
+    const mtimeAfter = fs.statSync(destFile).mtimeMs;
+
+    expect(mtimeAfter).toBe(mtimeBefore);
+  });
+
+  // SS7: handles non-existent sharedSkillsDir gracefully (no crash)
+  it('SS7: handles missing sharedSkillsDir gracefully', () => {
+    const missing = path.join(os.tmpdir(), 'does-not-exist-' + Date.now());
+    expect(() => syncSharedSkills(missing, personalDir)).not.toThrow();
+  });
+
+  // SS8: syncs multiple skills in one pass
+  it('SS8: syncs multiple skills', () => {
+    writeSharedSkill(sharedDir, 'alpha');
+    writeSharedSkill(sharedDir, 'beta');
+    writeSharedSkill(sharedDir, 'gamma');
+    syncSharedSkills(sharedDir, personalDir);
+
+    expect(fs.existsSync(path.join(personalDir, 'alpha', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(personalDir, 'beta', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(personalDir, 'gamma', 'SKILL.md'))).toBe(true);
+  });
+});

--- a/tests/unit/watch-factory.test.ts
+++ b/tests/unit/watch-factory.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for src/watch/factory.ts — shared chokidar watcher factory
+ * WF1: add event fires onChange
+ * WF2: change event fires onChange
+ * WF3: unlink event fires onChange
+ * WF4: rapid changes debounced to fewer calls
+ * WF5: close() stops the watcher
+ * WF6: onAddSync is called synchronously on add before debounce
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createWatcher } from '../../src/watch/factory';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wf-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('createWatcher', () => {
+  test('WF1: fires onChange when a file is added', async () => {
+    let count = 0;
+    const handle = createWatcher({
+      paths: [path.join(tmpDir, '*.md')],
+      debounceMs: 50,
+      onChange: () => { count++; },
+    });
+
+    await new Promise(r => setTimeout(r, 150));
+    fs.writeFileSync(path.join(tmpDir, 'new.md'), 'hello');
+    await new Promise(r => setTimeout(r, 300));
+
+    await handle.close();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('WF2: fires onChange when a file is modified', async () => {
+    const filePath = path.join(tmpDir, 'existing.md');
+    fs.writeFileSync(filePath, 'initial');
+
+    let count = 0;
+    const handle = createWatcher({
+      paths: [filePath],
+      debounceMs: 50,
+      onChange: () => { count++; },
+    });
+
+    await new Promise(r => setTimeout(r, 150));
+    fs.writeFileSync(filePath, 'updated');
+    await new Promise(r => setTimeout(r, 300));
+
+    await handle.close();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('WF3: fires onChange when a file is deleted', async () => {
+    const filePath = path.join(tmpDir, 'to-delete.md');
+    fs.writeFileSync(filePath, 'bye');
+
+    let count = 0;
+    const handle = createWatcher({
+      paths: [filePath],
+      debounceMs: 50,
+      onChange: () => { count++; },
+    });
+
+    await new Promise(r => setTimeout(r, 150));
+    fs.rmSync(filePath);
+    await new Promise(r => setTimeout(r, 300));
+
+    await handle.close();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('WF4: debounces rapid changes into fewer calls', async () => {
+    let count = 0;
+    const handle = createWatcher({
+      paths: [path.join(tmpDir, '*.md')],
+      debounceMs: 200,
+      onChange: () => { count++; },
+    });
+
+    await new Promise(r => setTimeout(r, 150));
+    for (let i = 0; i < 5; i++) {
+      fs.writeFileSync(path.join(tmpDir, `rapid-${i}.md`), 'x');
+    }
+    await new Promise(r => setTimeout(r, 800));
+
+    await handle.close();
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(count).toBeLessThanOrEqual(3);
+  });
+
+  test('WF5: close() prevents further onChange calls', async () => {
+    let count = 0;
+    const handle = createWatcher({
+      paths: [path.join(tmpDir, '*.md')],
+      debounceMs: 50,
+      onChange: () => { count++; },
+    });
+
+    await new Promise(r => setTimeout(r, 150));
+    await handle.close();
+
+    // Write after close — should NOT trigger onChange
+    fs.writeFileSync(path.join(tmpDir, 'after-close.md'), 'x');
+    await new Promise(r => setTimeout(r, 300));
+
+    expect(count).toBe(0);
+  });
+
+  test('WF6: onAddSync is called synchronously on add with file path', async () => {
+    const seen: string[] = [];
+    const handle = createWatcher({
+      paths: [path.join(tmpDir, '*.md')],
+      debounceMs: 50,
+      onAddSync: (fp) => { seen.push(path.basename(fp)); },
+      onChange: () => {},
+    });
+
+    await new Promise(r => setTimeout(r, 150));
+    fs.writeFileSync(path.join(tmpDir, 'hello.md'), 'x');
+    await new Promise(r => setTimeout(r, 300));
+
+    await handle.close();
+    expect(seen).toContain('hello.md');
+  });
+});


### PR DESCRIPTION
## Summary

- **Deferred restart** — `SessionProcess` gains `isProcessing` flag; `restartOrDefer()` waits until a busy session goes idle before restarting it, instead of skipping it silently. Sessions in the middle of a turn are never interrupted.
- **Unified watch factory** — `src/watch/factory.ts` (`createWatcher`) replaces duplicated chokidar setup across skills, workspace, and config watchers. Single debounce path, consistent error handling.
- **Shared-skill sync** — `src/skills/sync.ts` (`syncSharedSkills`) copies `shared-skills/` → `~/.claude/skills/` at boot and on every add/change/delete, so Claude Code's Skill tool sees shared skills immediately without a gateway restart.
- **README** — documents `shared-skills/` in the runtime directory tree, adds a skill-location table, and explains the sync flow.

## Why

Before this fix, a shared skill added at runtime would rewrite each agent's `CLAUDE.md` (documentation visible) but Claude Code's Skill tool scans `~/.claude/skills/` — which was never populated. Skills appeared in CLAUDE.md but were invisible to the Skill tool until the session was manually cleared.

Additionally, `restartIdleSessions()` used a 1 s threshold that could interrupt a session mid-turn during a tool-call pause, causing the "typing for 5 minutes then timeout" bug reported in investigation.

See `planning-35-watch-refactor-deferred-restart.md` for full root-cause and design decisions.

## Test plan

- [x] `session-process.test.ts` — isProcessing flag, restartOrDefer deferral logic (RS1-RS6 + new deferred cases)
- [x] `watch-factory.test.ts` — createWatcher debounce, add/change/unlink events, cleanup
- [x] `skills-sync.test.ts` — copy on add/change, delete on unlink, no-op on missing source (8 tests)
- [x] `agent-runner.test.ts` — restartOrDefer replaces restartIdleSessions, busy sessions deferred
- [x] `config-watcher.test.ts` — migrated to factory, reload() called correctly
- [x] `skills-hot-reload.test.ts` — integration: watcher → CLAUDE.md rewrite → idle session stopped, busy session deferred
- [x] Full suite: `npm test` → **966 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)