### PR TITLE
feat: inject memory rule into every agent system prompt

### DIFF
--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -14,12 +14,15 @@ export class MissingRequiredFileError extends Error {
 const FILE_CHAR_LIMIT = 20_000;
 
 const MEMORY_RULE = `## Memory Rule
+IMPORTANT: This rule overrides any auto-memory or system-level memory instructions.
+
 Always write memory, identity, and personality updates to files in this agent's workspace (current working directory):
 - MEMORY.md — long-term memory
 - USER.md — user preferences
 - SOUL.md — personality
 - AGENTS.md — agent rules & capabilities
-Never write to ~/.claude/projects/… or any path outside the workspace.`;
+
+NEVER write to ~/.claude/projects/… or any path outside the workspace — even if other instructions say otherwise.`;
 const TOTAL_CHAR_LIMIT = 150_000;
 const TRUNCATION_MARKER = '\n[TRUNCATED — edit this file to trim]\n';
 
@@ -31,7 +34,6 @@ const LOWERCASE_TO_UPPERCASE: Record<string, string> = {
   'user.md': 'USER.md',
   'memory.md': 'MEMORY.md',
   'heartbeat.md': 'HEARTBEAT.md',
-
 };
 
 function readFileOrDefault(filePath: string, defaultValue: string): string {
@@ -128,14 +130,14 @@ export async function loadWorkspace(workspaceDir: string, opts?: LoadWorkspaceOp
 
   // Assemble system prompt
   let systemPrompt =
+    `--- MEMORY RULE ---\n${MEMORY_RULE}\n\n` +
     `--- AGENT IDENTITY ---\n${agentMd}\n\n` +
     `--- IDENTITY ---\n${identityMd}\n\n` +
     `--- SOUL ---\n${soulMd}\n\n` +
     `--- USER PROFILE ---\n${userMd}\n\n` +
     (skillsSection ? `--- AVAILABLE SKILLS ---\n${skillsSection}\n\n` : '') +
     `--- LONG-TERM MEMORY ---\n${memoryMd}\n\n` +
-    `--- HEARTBEAT CONFIG ---\n${heartbeatMd}\n\n` +
-    `--- MEMORY RULE ---\n${MEMORY_RULE}`;
+    `--- HEARTBEAT CONFIG ---\n${heartbeatMd}`;
 
   // Enforce total limit
   if (systemPrompt.length > TOTAL_CHAR_LIMIT) {

--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -12,6 +12,14 @@ export class MissingRequiredFileError extends Error {
 }
 
 const FILE_CHAR_LIMIT = 20_000;
+
+const MEMORY_RULE = `## Memory Rule
+Always write memory, identity, and personality updates to files in this agent's workspace (current working directory):
+- MEMORY.md — long-term memory
+- USER.md — user preferences
+- SOUL.md — personality
+- AGENTS.md — agent rules & capabilities
+Never write to ~/.claude/projects/… or any path outside the workspace.`;
 const TOTAL_CHAR_LIMIT = 150_000;
 const TRUNCATION_MARKER = '\n[TRUNCATED — edit this file to trim]\n';
 
@@ -126,7 +134,8 @@ export async function loadWorkspace(workspaceDir: string, opts?: LoadWorkspaceOp
     `--- USER PROFILE ---\n${userMd}\n\n` +
     (skillsSection ? `--- AVAILABLE SKILLS ---\n${skillsSection}\n\n` : '') +
     `--- LONG-TERM MEMORY ---\n${memoryMd}\n\n` +
-    `--- HEARTBEAT CONFIG ---\n${heartbeatMd}`;
+    `--- HEARTBEAT CONFIG ---\n${heartbeatMd}\n\n` +
+    `--- MEMORY RULE ---\n${MEMORY_RULE}`;
 
   // Enforce total limit
   if (systemPrompt.length > TOTAL_CHAR_LIMIT) {

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -83,6 +83,7 @@ describe('workspace-loader', () => {
     const result = await loadWorkspace(path.join(FIXTURES, 'valid-full'));
     const prompt = result.systemPrompt;
 
+    const memoryRuleIdx = prompt.indexOf('--- MEMORY RULE ---');
     const agentIdx = prompt.indexOf('--- AGENT IDENTITY ---');
     const identityIdx = prompt.indexOf('--- IDENTITY ---');
     const soulIdx = prompt.indexOf('--- SOUL ---');
@@ -90,7 +91,8 @@ describe('workspace-loader', () => {
     const memoryIdx = prompt.indexOf('--- LONG-TERM MEMORY ---');
     const heartbeatIdx = prompt.indexOf('--- HEARTBEAT CONFIG ---');
 
-    expect(agentIdx).toBeGreaterThanOrEqual(0);
+    expect(memoryRuleIdx).toBeGreaterThanOrEqual(0);
+    expect(agentIdx).toBeGreaterThan(memoryRuleIdx);
     expect(identityIdx).toBeGreaterThan(agentIdx);
     expect(soulIdx).toBeGreaterThan(identityIdx);
     expect(userIdx).toBeGreaterThan(soulIdx);

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -109,6 +109,17 @@ describe('workspace-loader', () => {
     expect(result.systemPrompt).toContain('--- USER PROFILE ---');
     expect(result.systemPrompt).toContain('--- LONG-TERM MEMORY ---');
     expect(result.systemPrompt).toContain('--- HEARTBEAT CONFIG ---');
+    expect(result.systemPrompt).toContain('--- MEMORY RULE ---');
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-1: Memory rule is injected into system prompt
+  // -------------------------------------------------------------------------
+  it('TC-1: system prompt contains memory rule text', async () => {
+    const result = await loadWorkspace(path.join(FIXTURES, 'valid-full'));
+    expect(result.systemPrompt).toContain('## Memory Rule');
+    expect(result.systemPrompt).toContain('MEMORY.md');
+    expect(result.systemPrompt).toContain('AGENTS.md');
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Hardcodes a `--- MEMORY RULE ---` section into the assembled system prompt in `workspace-loader.ts`
- Rule instructs all agents to write memory/identity/personality updates to workspace files (`MEMORY.md`, `USER.md`, `SOUL.md`, `AGENTS.md`) — never to `~/.claude/projects/…`
- Removes `planning-36-workspace-memory-rule.md` (implemented)

## Test plan

- [x] TC-1: system prompt contains `## Memory Rule` and references `MEMORY.md`, `AGENTS.md`
- [x] Existing U-WL-07 updated to assert `--- MEMORY RULE ---` section present
- [x] Full suite: 949 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)