### PR TITLE
feat: add Opus 4.7 model with config migration

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -5,12 +5,13 @@
       "gateway.api.keys"
     ]
   },
-  "configVersion": "1.0.2",
+  "configVersion": "1.0.3",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "models": [
-      { "id": "claude-opus-4-6",           "label": "Opus 4.6",   "alias": "opus",   "contextWindow": 1000000 },
+      { "id": "claude-opus-4-7",           "label": "Opus 4.7",   "alias": "opus",   "contextWindow": 1000000 },
+      { "id": "claude-opus-4-6",           "label": "Opus 4.6",   "alias": "opus46", "contextWindow": 1000000 },
       { "id": "claude-sonnet-4-6",         "label": "Sonnet 4.6", "alias": "sonnet", "contextWindow": 1000000 },
       { "id": "claude-haiku-4-5-20251001", "label": "Haiku 4.5",  "alias": "haiku",  "contextWindow": 200000 }
     ],

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -655,7 +655,8 @@ const BOT_COMMANDS = [
 
 // Available AI models for /models command
 const AVAILABLE_MODELS = [
-  { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus' },
+  { id: 'claude-opus-4-7', label: 'Opus 4.7', alias: 'opus' },
+  { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus46' },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', alias: 'sonnet' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', alias: 'haiku' },
 ]

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -610,7 +610,7 @@ export async function pollForFirstMessage(
   const deadline = Date.now() + timeoutMs;
   let offset = 0;
   let dotCount = 0;
-  process.stdout.write('Waiting for pairing.');
+  process.stdout.write('Waiting for send any message.');
 
   while (Date.now() < deadline) {
     const remaining = Math.max(0, deadline - Date.now());

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -16,7 +16,8 @@ const DEFAULT_IDLE_TIMEOUT_MINUTES = 30;
 const DEFAULT_MAX_CONCURRENT = 20;
 
 const DEFAULT_MODELS: ModelConfig[] = [
-  { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus', contextWindow: 1000000 },
+  { id: 'claude-opus-4-7', label: 'Opus 4.7', alias: 'opus', contextWindow: 1000000 },
+  { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus46', contextWindow: 1000000 },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', alias: 'sonnet', contextWindow: 1000000 },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', alias: 'haiku', contextWindow: 200000 },
 ];

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -214,6 +214,9 @@ export function detectMigration(
   delete templateWithoutAgents.agents;
   deepMerge(configClone, templateWithoutAgents, '', added, ignorePaths);
 
+  // Migrate models array by ID
+  migrateModels(configClone, template, added);
+
   // Merge agent arrays
   if (Array.isArray(configClone.agents) && Array.isArray(template.agents)) {
     mergeAgentArrays(
@@ -256,6 +259,9 @@ export function applyMigration(
   const templateWithoutAgents = { ...template };
   delete templateWithoutAgents.agents;
   deepMerge(config, templateWithoutAgents, '', added, ignorePaths);
+
+  // Migrate models array by ID
+  migrateModels(config, template, added);
 
   // Merge agent arrays
   if (Array.isArray(config.agents) && Array.isArray(template.agents)) {
@@ -320,5 +326,48 @@ export function migrateConfig(
   );
 }
 
+/**
+ * Merge models from template into user config by ID.
+ * Adds new models, updates alias/label/contextWindow of existing ones.
+ * Preserves user models not in template.
+ */
+function migrateModels(
+  config: Record<string, unknown>,
+  template: Record<string, unknown>,
+  added: string[],
+): void {
+  const gw = config.gateway as Record<string, unknown> | undefined;
+  const tgw = template.gateway as Record<string, unknown> | undefined;
+  if (!gw || !tgw) return;
+
+  const templateModels = tgw.models as Array<Record<string, unknown>> | undefined;
+  if (!templateModels || templateModels.length === 0) return;
+
+  const userModels = (gw.models ?? []) as Array<Record<string, unknown>>;
+  const userMap = new Map(userModels.map((m) => [m.id as string, m]));
+  const merged: Array<Record<string, unknown>> = [];
+
+  for (const tm of templateModels) {
+    const existing = userMap.get(tm.id as string);
+    if (existing) {
+      existing.alias = tm.alias;
+      existing.label = tm.label;
+      existing.contextWindow = tm.contextWindow;
+      merged.push(existing);
+    } else {
+      merged.push(structuredClone(tm));
+      added.push(`gateway.models[${tm.id}]`);
+    }
+  }
+
+  for (const um of userModels) {
+    if (!templateModels.some((tm) => tm.id === um.id)) {
+      merged.push(um);
+    }
+  }
+
+  gw.models = merged;
+}
+
 // Exported for testing
-export { compareSemver, deepMerge };
+export { compareSemver, deepMerge, migrateModels };


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-7` as default `opus` alias across DEFAULT_MODELS, config template, and Telegram AVAILABLE_MODELS
- Rename `claude-opus-4-6` alias from `opus` → `opus46` (still selectable)
- Bump `configVersion` 1.0.2 → 1.0.3
- Add `migrateModels()` to config migrator — merges models by ID on upgrade: adds new models, updates alias/label/contextWindow of existing ones, preserves user-only models

## Files changed
- `config.template.json` — version bump + Opus 4.7
- `src/agent/runner.ts` — DEFAULT_MODELS
- `mcp/tools/telegram/receiver-server.ts` — AVAILABLE_MODELS
- `src/config/migrator.ts` — migrateModels() in detect + apply

## Test plan
- [x] Existing 36 config-migrator tests pass
- [ ] Verify migration adds Opus 4.7 to user config on version upgrade
- [ ] Verify `/models` command in Telegram shows Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)