### PR TITLE
feat(telegram): add /stop command to interrupt running sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Once paired, the following bot commands are available in a private chat:
 | `/rename <name>` | Rename the current session |
 | `/clear` | Clear current session history (with confirmation) |
 | `/compact` | Summarise old history and keep only recent messages |
+| `/stop` | Interrupt the in-flight turn (gateway sends SIGINT to the subprocess) |
 | `/restart` | Graceful session restart — shows a confirmation button; confirms and notifies when the session is back online |
 
 **Agent**

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -645,6 +645,7 @@ const BOT_COMMANDS = [
   { command: 'rename', description: 'Rename current session' },
   { command: 'clear', description: 'Clear current session history' },
   { command: 'compact', description: 'Summarize and compress session history' },
+  { command: 'stop', description: 'Interrupt the agent and stop current work' },
   { command: 'restart', description: 'Graceful restart session' },
   { command: 'model', description: 'Show current AI model' },
   { command: 'models', description: 'Switch AI model' },
@@ -875,6 +876,7 @@ bot.command('help', async ctx => {
     `/rename <name> — rename current session\n` +
     `/clear — clear current session history\n` +
     `/compact — summarise and compress session history\n` +
+    `/stop — interrupt the running turn\n` +
     `/restart — graceful restart session\n\n` +
     `*Agent*\n` +
     `/model — show current AI model\n` +

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -614,7 +614,7 @@ export class AgentRunner extends EventEmitter {
    * Returns true if the message content is a session management command.
    */
   private isSessionCommand(content: string): boolean {
-    return /^\/sessions?\b|^\/new(\s|$)|^\/clear\b|^\/compact\b|^\/rename(\s|$)/.test(content);
+    return /^\/sessions?\b|^\/new(\s|$)|^\/clear\b|^\/compact\b|^\/rename(\s|$)|^\/stop(\s|$)/.test(content);
   }
 
   /**
@@ -637,6 +637,8 @@ export class AgentRunner extends EventEmitter {
     } else if (content.startsWith('/rename')) {
       const name = content.replace('/rename', '').trim();
       await this.handleCommandRename(agentId, chatId, name);
+    } else if (content.startsWith('/stop')) {
+      await this.handleCommandStop(chatId);
     }
   }
 
@@ -728,6 +730,16 @@ export class AgentRunner extends EventEmitter {
     const sessionId = await this.sessionStore.getActiveSessionId(agentId, chatId);
     await this.sessionStore.updateSessionMeta(agentId, chatId, sessionId, { name });
     this.writeAutoForward(chatId, `✅ Session renamed to "${name}"`);
+  }
+
+  /**
+   * /stop — interrupt the in-flight turn for this chat by sending SIGINT to the subprocess.
+   * Leaves session history and metadata intact. Queued messages still process afterwards.
+   */
+  private async handleCommandStop(chatId: string): Promise<void> {
+    const session = this.sessions.get(chatId);
+    const stopped = session ? session.interrupt() : false;
+    this.writeAutoForward(chatId, stopped ? 'Stopped.' : 'No turn in progress.');
   }
 
   /**

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -619,6 +619,13 @@ export class SessionProcess extends EventEmitter {
     }
   }
 
+  interrupt(): boolean {
+    if (!this.process || this.process.killed) return false;
+    if (!this._processing) return false;
+    this.process.kill('SIGINT');
+    return true;
+  }
+
   markPendingRestart(): void {
     if (!this._processing) {
       this.emit('deferredRestartReady');

--- a/tests/unit/session-commands.test.ts
+++ b/tests/unit/session-commands.test.ts
@@ -271,3 +271,151 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
     expect(text).toContain('Context: 25%');     // 50000/200000 = 25%
   }, 15000);
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// /stop command — interrupts the in-flight turn via SIGINT
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('AgentRunner — /stop command', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+
+  const chatId = 'chat:stop-test';
+
+  function getForwardFile(): string {
+    return path.join(agentConfig.workspace, '.telegram-state', 'typing', `${chatId}.forward`);
+  }
+
+  function getForwardText(): string {
+    const forwardFile = getForwardFile();
+    expect(fs.existsSync(forwardFile)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    return content.text as string;
+  }
+
+  type SessionLike = {
+    interrupt: () => boolean;
+    setProcessing: (v: boolean) => void;
+    process: MockChildProcess | null;
+  };
+
+  function getActiveSession(): SessionLike | undefined {
+    const sessions = (runner as unknown as { sessions: Map<string, SessionLike> }).sessions;
+    return sessions.get(chatId);
+  }
+
+  function getSessionSubprocess(): MockChildProcess {
+    const session = getActiveSession();
+    expect(session).toBeDefined();
+    expect(session!.process).not.toBeNull();
+    return session!.process!;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-stop-'));
+    const workspace = path.join(tmpDir, 'agents', 'test-agent', 'workspace');
+    agentConfig = makeAgentConfig(workspace);
+    fs.mkdirSync(workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig(200000);
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // T1 acceptance: /stop with no spawned session → "No turn in progress."
+  it('replies "No turn in progress." when there is no active session', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, '/stop');
+    await new Promise(r => setTimeout(r, 300));
+
+    expect(getForwardText()).toBe('No turn in progress.');
+  }, 15000);
+
+  // T1 acceptance: /stop while session exists but no turn in flight
+  it('replies "No turn in progress." when session exists but is idle', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    // Spawn a session with a regular message — handler sets processing=true,
+    // but we manually clear it to simulate an idle session.
+    await postChannelMessage(port, chatId, 'hello');
+    await new Promise(r => setTimeout(r, 300));
+    const subprocess = getSessionSubprocess();
+    getActiveSession()!.setProcessing(false);
+
+    try { fs.rmSync(getForwardFile(), { force: true }); } catch {}
+
+    await postChannelMessage(port, chatId, '/stop');
+    await new Promise(r => setTimeout(r, 300));
+
+    expect(getForwardText()).toBe('No turn in progress.');
+    expect(subprocess.kill).not.toHaveBeenCalledWith('SIGINT');
+  }, 15000);
+
+  // T1 acceptance: /stop while turn in flight → SIGINT sent + "Stopped."
+  it('sends SIGINT and replies "Stopped." when a turn is in flight', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, 'long task');
+    await new Promise(r => setTimeout(r, 300));
+    const subprocess = getSessionSubprocess();
+    // Simulate an in-flight turn
+    getActiveSession()!.setProcessing(true);
+
+    try { fs.rmSync(getForwardFile(), { force: true }); } catch {}
+
+    await postChannelMessage(port, chatId, '/stop');
+    await new Promise(r => setTimeout(r, 300));
+
+    expect(getForwardText()).toBe('Stopped.');
+    expect(subprocess.kill).toHaveBeenCalledWith('SIGINT');
+  }, 15000);
+
+  // T1 acceptance: /stop is never forwarded as user text to the subprocess
+  it('does not write /stop to the subprocess stdin', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, 'hello');
+    await new Promise(r => setTimeout(r, 300));
+    const subprocess = getSessionSubprocess();
+    getActiveSession()!.setProcessing(true);
+
+    const writesBefore = (subprocess.stdin!.write as jest.Mock).mock.calls.length;
+
+    await postChannelMessage(port, chatId, '/stop');
+    await new Promise(r => setTimeout(r, 300));
+
+    const writesAfter = (subprocess.stdin!.write as jest.Mock).mock.calls.length;
+    expect(writesAfter).toBe(writesBefore);
+  }, 15000);
+
+  // Detector behaviour — guard against word-boundary false positives
+  it('does not match "/stopwatch" — forwards as a normal prompt', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await postChannelMessage(port, chatId, '/stopwatch');
+    await new Promise(r => setTimeout(r, 300));
+
+    const subprocess = getSessionSubprocess();
+    const stdinWrites = (subprocess.stdin!.write as jest.Mock).mock.calls;
+    const allWritten = stdinWrites.map(([s]) => s as string).join(' ');
+    expect(allWritten).toContain('/stopwatch');
+  }, 15000);
+});

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1009,4 +1009,50 @@ describe('SessionProcess — isProcessing and deferred restart', () => {
     expect(fired).toBe(true);  // fires when turn ends
     await sp.stop();
   });
+
+  // ── interrupt() ────────────────────────────────────────────────────────────
+
+  it('U-SP-INT-01: interrupt() sends SIGINT when a turn is in flight', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+
+    const result = sp.interrupt();
+
+    expect(result).toBe(true);
+    expect(lastProcess!.kill).toHaveBeenCalledWith('SIGINT');
+  });
+
+  it('U-SP-INT-02: interrupt() returns false when no turn is in flight', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    // Do NOT setProcessing(true) — idle state
+
+    const result = sp.interrupt();
+
+    expect(result).toBe(false);
+    expect(lastProcess!.kill).not.toHaveBeenCalled();
+    await sp.stop();
+  });
+
+  it('U-SP-INT-03: interrupt() returns false when subprocess is already killed', async () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.killed = true;
+
+    const result = sp.interrupt();
+
+    expect(result).toBe(false);
+    expect(lastProcess!.kill).not.toHaveBeenCalled();
+  });
+
+  it('U-SP-INT-04: interrupt() returns false when subprocess never started', () => {
+    const sp = new SessionProcess('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    // No start() — process is null
+
+    const result = sp.interrupt();
+
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `/stop` Telegram command that sends `SIGINT` to the active Claude Code subprocess, letting users abort an in-flight task (e.g. after a typo or wrong prompt).
- Wire `/stop` through the existing command interceptor in `runner.ts`, update `/help` output, and register `/stop` in `BOT_COMMANDS` so it appears in Telegram's autocomplete.
- Add unit tests for `SessionProcess.interrupt()` and the `/stop` dispatch path; update README's Telegram commands table.

## Changes
- `src/session/process.ts` — new `interrupt()` method (SIGINT to child)
- `src/agent/runner.ts` — `/stop` dispatcher + `handleCommandStop` (uses `startsWith` like other commands)
- `mcp/tools/telegram/receiver-server.ts` — `/help` text + `BOT_COMMANDS` entry
- `README.md` — document `/stop` in the Telegram commands section
- `tests/unit/session-process.test.ts` + `tests/unit/session-commands.test.ts` — coverage

## Test plan
- [x] `bun test` — 967 passed, 8 skipped (no regressions)
- [x] Manual: send `/stop` while a session is processing → SIGINT delivered, session reports interruption
- [ ] After restart, verify `/stop` appears in Telegram's autocomplete (requires `setMyCommands` refresh)

Planned in `planning-33-stop-commands.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)