### PR TITLE
feat(api): allow_tools — key-level tool access for Agent API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ research*.md
 restart.sh
 stop.sh
 .skills
+.claude-gateway

--- a/API.md
+++ b/API.md
@@ -101,8 +101,9 @@ Send a message to an agent. Returns a JSON response or SSE stream.
 | `message` | Yes | Message text (max 10,000 chars) |
 | `session_id` | No | Resume an existing session; omit to start a new one |
 | `stream` | No | `true` to enable SSE streaming (default `false`) |
-| `allow_tools` | No | `true` to allow the agent to call tools (Read, Bash, etc.). **Requires `stream: true` and the API key must have `allow_tools: true` in config.** Default `false` — agent is conversational only |
-| `timeout_ms` | No | Override the default response timeout in milliseconds (default 60000). Useful for long-running tool executions |
+| `timeout_ms` | No | Override the default response timeout in milliseconds (default 60000). Useful when the key has `allow_tools: true` and runs long-running tools |
+
+> Tool access is configured per API key in `config.json` — see `allow_tools` below.
 
 **New session:**
 
@@ -138,9 +139,9 @@ curl -X POST \
 
 | Status | When |
 |--------|------|
-| 400 | Empty message, exceeds 10,000 characters, or `allow_tools: true` without `stream: true` |
+| 400 | Empty message or exceeds 10,000 characters |
 | 401 | Missing API key |
-| 403 | Invalid key, key has no access to that agent, or key lacks `allow_tools` permission |
+| 403 | Invalid key or key has no access to that agent |
 | 404 | Agent ID not found |
 | 409 | Session is busy processing another request |
 | 504 | Agent did not respond within timeout (default 60s) |
@@ -175,26 +176,23 @@ data: {"type":"result","text":"Here's the full explanation...","request_id":"550
 data: [DONE]
 ```
 
-### Streaming with tool use (`allow_tools`)
+### Streaming with tool use
 
-By default the agent is conversational only (no tool calls). Set `allow_tools: true` together with `stream: true` to let the agent execute tools (Read, Bash, Grep, etc.) and stream the results back.
+When the API key has `allow_tools: true` in `config.json`, the agent can call tools (Read, Bash, Grep, etc.) and stream results back. No extra field is needed in the request body — tool access is governed entirely by the key config.
 
 ```bash
 curl -N -X POST \
-  -H "X-Api-Key: my-secret-key" \
+  -H "X-Api-Key: automation-key-789" \
   -H "Content-Type: application/json" \
   -d '{
     "message": "Run the setup script in /workspace and report the output",
     "stream": true,
-    "allow_tools": true,
     "timeout_ms": 120000
   }' \
   http://localhost:3000/api/v1/agents/alfred/messages
 ```
 
-> **Two requirements for `allow_tools`:**
-> 1. `stream: true` must also be set (sync mode + tools would block indefinitely → `400`)
-> 2. The API key must have `allow_tools: true` in `config.json` (otherwise → `403`)
+> Keys without `allow_tools: true` are always conversational — tools are never invoked regardless of what the request contains.
 
 **Event types:**
 

--- a/API.md
+++ b/API.md
@@ -50,6 +50,12 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
           "key": "admin-key-456",
           "description": "Admin — full access",
           "agents": "*"
+        },
+        {
+          "key": "automation-key-789",
+          "description": "Automation — may use tools",
+          "agents": ["alfred"],
+          "allow_tools": true
         }
       ]
     }
@@ -58,6 +64,8 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 ```
 
 `agents` can be an array of agent IDs or `"*"` for full access. Keys support `${ENV_VAR}` interpolation.
+
+`allow_tools` grants the key permission to send requests with `allow_tools: true` in the body. Without this, any request that sets `allow_tools: true` is rejected with `403`.
 
 **2. Restart the gateway**
 
@@ -93,7 +101,7 @@ Send a message to an agent. Returns a JSON response or SSE stream.
 | `message` | Yes | Message text (max 10,000 chars) |
 | `session_id` | No | Resume an existing session; omit to start a new one |
 | `stream` | No | `true` to enable SSE streaming (default `false`) |
-| `allow_tools` | No | `true` to allow the agent to call tools (Read, Bash, etc.). **Requires `stream: true`.** Default `false` — agent is conversational only |
+| `allow_tools` | No | `true` to allow the agent to call tools (Read, Bash, etc.). **Requires `stream: true` and the API key must have `allow_tools: true` in config.** Default `false` — agent is conversational only |
 | `timeout_ms` | No | Override the default response timeout in milliseconds (default 60000). Useful for long-running tool executions |
 
 **New session:**
@@ -132,7 +140,7 @@ curl -X POST \
 |--------|------|
 | 400 | Empty message, exceeds 10,000 characters, or `allow_tools: true` without `stream: true` |
 | 401 | Missing API key |
-| 403 | Invalid key or key has no access to that agent |
+| 403 | Invalid key, key has no access to that agent, or key lacks `allow_tools` permission |
 | 404 | Agent ID not found |
 | 409 | Session is busy processing another request |
 | 504 | Agent did not respond within timeout (default 60s) |
@@ -184,7 +192,9 @@ curl -N -X POST \
   http://localhost:3000/api/v1/agents/alfred/messages
 ```
 
-> `allow_tools` requires `stream: true` — sync mode + tool calls would block indefinitely, so the API rejects the combination with `400 Bad Request`.
+> **Two requirements for `allow_tools`:**
+> 1. `stream: true` must also be set (sync mode + tools would block indefinitely → `400`)
+> 2. The API key must have `allow_tools: true` in `config.json` (otherwise → `403`)
 
 **Event types:**
 

--- a/API.md
+++ b/API.md
@@ -93,6 +93,8 @@ Send a message to an agent. Returns a JSON response or SSE stream.
 | `message` | Yes | Message text (max 10,000 chars) |
 | `session_id` | No | Resume an existing session; omit to start a new one |
 | `stream` | No | `true` to enable SSE streaming (default `false`) |
+| `allow_tools` | No | `true` to allow the agent to call tools (Read, Bash, etc.). **Requires `stream: true`.** Default `false` — agent is conversational only |
+| `timeout_ms` | No | Override the default response timeout in milliseconds (default 60000). Useful for long-running tool executions |
 
 **New session:**
 
@@ -128,12 +130,12 @@ curl -X POST \
 
 | Status | When |
 |--------|------|
-| 400 | Empty message or exceeds 10,000 characters |
+| 400 | Empty message, exceeds 10,000 characters, or `allow_tools: true` without `stream: true` |
 | 401 | Missing API key |
 | 403 | Invalid key or key has no access to that agent |
 | 404 | Agent ID not found |
 | 409 | Session is busy processing another request |
-| 504 | Agent did not respond within 60s |
+| 504 | Agent did not respond within timeout (default 60s) |
 | 500 | Internal error |
 
 > - `session_id` is optional — omit for a stateless one-shot call
@@ -164,6 +166,25 @@ data: {"type":"text_delta","text":"Here's the explanation..."}
 data: {"type":"result","text":"Here's the full explanation...","request_id":"550e8400-...","session_id":"abc-123","duration_ms":4200}
 data: [DONE]
 ```
+
+### Streaming with tool use (`allow_tools`)
+
+By default the agent is conversational only (no tool calls). Set `allow_tools: true` together with `stream: true` to let the agent execute tools (Read, Bash, Grep, etc.) and stream the results back.
+
+```bash
+curl -N -X POST \
+  -H "X-Api-Key: my-secret-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Run the setup script in /workspace and report the output",
+    "stream": true,
+    "allow_tools": true,
+    "timeout_ms": 120000
+  }' \
+  http://localhost:3000/api/v1/agents/alfred/messages
+```
+
+> `allow_tools` requires `stream: true` — sync mode + tool calls would block indefinitely, so the API rejects the combination with `400 Bad Request`.
 
 **Event types:**
 

--- a/API.md
+++ b/API.md
@@ -65,7 +65,7 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 
 `agents` can be an array of agent IDs or `"*"` for full access. Keys support `${ENV_VAR}` interpolation.
 
-`allow_tools` grants the key permission to send requests with `allow_tools: true` in the body. Without this, any request that sets `allow_tools: true` is rejected with `403`.
+`allow_tools` grants the key permission to invoke tools (Read, Bash, Grep, etc.). Tool access is governed entirely by this config — no extra field is needed in the request body. Keys without `allow_tools: true` are always conversational regardless of what the request contains.
 
 **2. Restart the gateway**
 
@@ -176,9 +176,9 @@ data: {"type":"result","text":"Here's the full explanation...","request_id":"550
 data: [DONE]
 ```
 
-### Streaming with tool use
+### Requests with tool use
 
-When the API key has `allow_tools: true` in `config.json`, the agent can call tools (Read, Bash, Grep, etc.) and stream results back. No extra field is needed in the request body — tool access is governed entirely by the key config.
+When the API key has `allow_tools: true` in `config.json`, the agent can call tools (Read, Bash, Grep, etc.). No extra field is needed in the request body — tool access is governed entirely by the key config. This applies to both sync and streaming modes.
 
 ```bash
 curl -N -X POST \

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -985,7 +985,7 @@ export class AgentRunner extends EventEmitter {
   async sendApiMessage(
     sessionId: string,
     message: string,
-    opts: { timeoutMs: number },
+    opts: { timeoutMs: number; allowTools?: boolean },
   ): Promise<string> {
     if (this.pendingApiSessions.has(sessionId)) {
       const err = Object.assign(
@@ -1009,11 +1009,14 @@ export class AgentRunner extends EventEmitter {
     this.pendingApiSessions.add(sessionId);
     session.touch();
 
+    const systemNote = opts.allowTools
+      ? `[SYSTEM: This is an API request. You may use tools. Stream your progress as you work.]\n`
+      : `[SYSTEM: This is an API request. Reply with plain text only. Do NOT call any tools. Your text output will be returned directly to the caller.]\n`;
+
     const channelXml =
       `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
       `${message}\n\n` +
-      `[SYSTEM: This is an API request. Reply with plain text only. ` +
-      `Do NOT call any tools. Your text output will be returned directly to the caller.]\n` +
+      `${systemNote}` +
       `</channel>`;
 
     return new Promise<string>((resolve, reject) => {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1122,7 +1122,7 @@ export class AgentRunner extends EventEmitter {
       onDone: (fullText: string) => void;
       onError: (err: Error) => void;
     },
-    opts: { timeoutMs: number },
+    opts: { timeoutMs: number; allowTools?: boolean },
   ): Promise<() => void> {
     if (this.pendingApiSessions.has(sessionId)) {
       const err = Object.assign(
@@ -1272,11 +1272,15 @@ export class AgentRunner extends EventEmitter {
 
     session.on('output', onOutput);
 
+    const systemNote = opts.allowTools
+      ? `[SYSTEM: This is an API request. You may use tools. Stream your progress as you work.]\n`
+      : `[SYSTEM: This is an API request. Reply with plain text only. ` +
+        `Do NOT call any tools. Your text output will be returned directly to the caller.]\n`;
+
     const channelXml =
       `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
       `${message}\n\n` +
-      `[SYSTEM: This is an API request. Reply with plain text only. ` +
-      `Do NOT call any tools. Your text output will be returned directly to the caller.]\n` +
+      systemNote +
       `</channel>`;
 
     session.setProcessing(true);

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -42,10 +42,9 @@ export function createApiRouter(
       message?: unknown;
       session_id?: unknown;
       stream?: unknown;
-      allow_tools?: unknown;
       timeout_ms?: unknown;
     };
-    const { message, session_id, stream, allow_tools, timeout_ms } = body;
+    const { message, session_id, stream, timeout_ms } = body;
 
     if (!message || typeof message !== 'string' || !message.trim()) {
       res.status(400).json({ error: 'message is required and must be a non-empty string' });
@@ -57,14 +56,6 @@ export function createApiRouter(
     }
     if (session_id !== undefined && typeof session_id !== 'string') {
       res.status(400).json({ error: 'session_id must be a string if provided' });
-      return;
-    }
-    if (allow_tools && !stream) {
-      res.status(400).json({ error: 'allow_tools requires stream: true' });
-      return;
-    }
-    if (allow_tools && !apiKey.allow_tools) {
-      res.status(403).json({ error: 'API key does not have allow_tools permission' });
       return;
     }
 
@@ -118,7 +109,7 @@ export function createApiRouter(
           sessionId,
           message.trim(),
           sseCallbacks,
-          { timeoutMs, allowTools: !!allow_tools },
+          { timeoutMs, allowTools: !!apiKey.allow_tools },
         );
 
         // Client disconnect -> cleanup

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -38,8 +38,14 @@ export function createApiRouter(
       return;
     }
 
-    const body = req.body as { message?: unknown; session_id?: unknown; stream?: unknown };
-    const { message, session_id, stream } = body;
+    const body = req.body as {
+      message?: unknown;
+      session_id?: unknown;
+      stream?: unknown;
+      allow_tools?: unknown;
+      timeout_ms?: unknown;
+    };
+    const { message, session_id, stream, allow_tools, timeout_ms } = body;
 
     if (!message || typeof message !== 'string' || !message.trim()) {
       res.status(400).json({ error: 'message is required and must be a non-empty string' });
@@ -53,10 +59,22 @@ export function createApiRouter(
       res.status(400).json({ error: 'session_id must be a string if provided' });
       return;
     }
+    if (allow_tools && !stream) {
+      res.status(400).json({ error: 'allow_tools requires stream: true' });
+      return;
+    }
+    if (allow_tools && !apiKey.allow_tools) {
+      res.status(403).json({ error: 'API key does not have allow_tools permission' });
+      return;
+    }
 
     const requestId = randomUUID();
     const sessionId = (session_id as string | undefined) ?? randomUUID();
     const startTime = Date.now();
+    const timeoutMs =
+      typeof timeout_ms === 'number' && timeout_ms > 0 && timeout_ms <= 600_000
+        ? timeout_ms
+        : DEFAULT_TIMEOUT_MS;
 
     if (stream) {
       // SSE streaming mode
@@ -100,7 +118,7 @@ export function createApiRouter(
           sessionId,
           message.trim(),
           sseCallbacks,
-          { timeoutMs: DEFAULT_TIMEOUT_MS },
+          { timeoutMs, allowTools: !!allow_tools },
         );
 
         // Client disconnect -> cleanup
@@ -124,7 +142,7 @@ export function createApiRouter(
       // Synchronous mode (existing behavior)
       try {
         const response = await runner.sendApiMessage(sessionId, message.trim(), {
-          timeoutMs: DEFAULT_TIMEOUT_MS,
+          timeoutMs,
         });
         res.json({
           request_id: requestId,

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -134,6 +134,7 @@ export function createApiRouter(
       try {
         const response = await runner.sendApiMessage(sessionId, message.trim(), {
           timeoutMs,
+          allowTools: !!apiKey.allow_tools,
         });
         res.json({
           request_id: requestId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface ApiKey {
   key: string;
   description?: string;
   agents: string[] | '*'; // agent IDs this key can access, or '*' for all
+  allow_tools?: boolean;  // permit tool-enabled (allow_tools) requests for this key
 }
 
 export interface ModelConfig {

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -874,6 +874,72 @@ describe('AgentRunner — sendApiMessageStream', () => {
     expect((textDeltas[1] as { text: string }).text).toBe(' world');
   }, 15000);
 
+  // T-AR-STREAM-ALLOW-TOOLS-1: allowTools=false injects "Do NOT call any tools"
+  it('T-AR-STREAM-ALLOW-TOOLS-1: allowTools=false includes tool-restriction instruction', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    let capturedMessage = '';
+    runner.sendApiMessageStream(
+      'stream-at-1',
+      'hello',
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      { timeoutMs: 5000, allowTools: false },
+    );
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const proc = allProcesses[allProcesses.length - 1];
+    const calls = (proc.stdin!.write as jest.Mock).mock.calls;
+    capturedMessage = calls.map((c: unknown[]) => String(c[0])).join('');
+
+    expect(capturedMessage).toContain('Do NOT call any tools');
+    expect(capturedMessage).not.toContain('You may use tools');
+  }, 15000);
+
+  // T-AR-STREAM-ALLOW-TOOLS-2: allowTools=true removes restriction, adds permission
+  it('T-AR-STREAM-ALLOW-TOOLS-2: allowTools=true omits tool-restriction instruction', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    runner.sendApiMessageStream(
+      'stream-at-2',
+      'run job',
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      { timeoutMs: 5000, allowTools: true },
+    );
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const proc = allProcesses[allProcesses.length - 1];
+    const calls = (proc.stdin!.write as jest.Mock).mock.calls;
+    const capturedMessage = calls.map((c: unknown[]) => String(c[0])).join('');
+
+    expect(capturedMessage).not.toContain('Do NOT call any tools');
+    expect(capturedMessage).toContain('You may use tools');
+  }, 15000);
+
+  // T-AR-STREAM-ALLOW-TOOLS-3: default (no allowTools) behaves like allowTools=false
+  it('T-AR-STREAM-ALLOW-TOOLS-3: omitting allowTools defaults to tool-restricted mode', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    runner.sendApiMessageStream(
+      'stream-at-3',
+      'hello',
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      { timeoutMs: 5000 },
+    );
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const proc = allProcesses[allProcesses.length - 1];
+    const calls = (proc.stdin!.write as jest.Mock).mock.calls;
+    const capturedMessage = calls.map((c: unknown[]) => String(c[0])).join('');
+
+    expect(capturedMessage).toContain('Do NOT call any tools');
+  }, 15000);
+
   // --------------------------------------------------------------------------
   // T-AR-STREAM-16: No duplicate text in buffer from partial messages
   // --------------------------------------------------------------------------

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -14,7 +14,7 @@ interface StreamCallbacks {
 }
 
 class MockAgentRunner extends EventEmitter {
-  sendApiMessageImpl: (sessionId: string, message: string) => Promise<string>;
+  sendApiMessageImpl: (sessionId: string, message: string, opts?: { allowTools?: boolean }) => Promise<string>;
   sendApiMessageStreamImpl?: (
     sessionId: string,
     message: string,
@@ -23,7 +23,7 @@ class MockAgentRunner extends EventEmitter {
   ) => Promise<() => void>;
   private _activeApiSessions = new Set<string>();
 
-  constructor(impl: (sessionId: string, message: string) => Promise<string>) {
+  constructor(impl: (sessionId: string, message: string, opts?: { allowTools?: boolean }) => Promise<string>) {
     super();
     this.sendApiMessageImpl = impl;
   }
@@ -31,9 +31,9 @@ class MockAgentRunner extends EventEmitter {
   async sendApiMessage(
     sessionId: string,
     message: string,
-    _opts: { timeoutMs: number },
+    opts: { timeoutMs: number; allowTools?: boolean },
   ): Promise<string> {
-    return this.sendApiMessageImpl(sessionId, message);
+    return this.sendApiMessageImpl(sessionId, message, { allowTools: opts.allowTools });
   }
 
   async sendApiMessageStream(
@@ -556,6 +556,50 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     await collectSSE(app, { message: 'hi', stream: true, timeout_ms: 999999 });
 
     expect(capturedOpts!.timeoutMs).toBe(60000); // DEFAULT_TIMEOUT_MS
+  });
+
+  // I-API-14: key with allow_tools=true passes allowTools=true to sync runner
+  it('I-API-14: key with allow_tools=true passes allowTools=true to sync sendApiMessage', async () => {
+    let capturedAllowTools: boolean | undefined;
+    const runner = new MockAgentRunner(async (_sid, _msg, opts) => {
+      capturedAllowTools = opts?.allowTools;
+      return 'ok';
+    });
+    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+    const configs = new Map([[AGENT_ID, agentConfig]]);
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys));
+
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/messages`)
+      .set('Authorization', 'Bearer sk-test-tools')
+      .send({ message: 'run job' });
+
+    expect(res.status).toBe(200);
+    expect(capturedAllowTools).toBe(true);
+  });
+
+  // I-API-15: key without allow_tools passes allowTools=false to sync runner
+  it('I-API-15: key without allow_tools passes allowTools=false to sync sendApiMessage', async () => {
+    let capturedAllowTools: boolean | undefined;
+    const runner = new MockAgentRunner(async (_sid, _msg, opts) => {
+      capturedAllowTools = opts?.allowTools;
+      return 'ok';
+    });
+    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+    const configs = new Map([[AGENT_ID, agentConfig]]);
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys));
+
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/messages`)
+      .set('Authorization', 'Bearer sk-test-app')
+      .send({ message: 'hello' });
+
+    expect(res.status).toBe(200);
+    expect(capturedAllowTools).toBe(false);
   });
 
   // T-API-STREAM-TCP: TCP_NODELAY is set on SSE connections (regression test)

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -473,35 +473,14 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     expect(cleanupCalled).toBe(true);
   }, 10000);
 
-  // T-ALLOW-TOOLS-1: allow_tools without stream returns 400
-  it('T-ALLOW-TOOLS-1: allow_tools without stream returns 400', async () => {
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
-      cb.onDone('ok');
-      return () => {};
-    });
-    const res = await supertest.default(app)
-      .post(POST_URL)
-      .set(AUTH)
-      .send({ message: 'run job', allow_tools: true });
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/allow_tools requires stream/i);
-  });
-
-  // T-ALLOW-TOOLS-2: allow_tools=true with stream=true passes allowTools=true to runner
-  it('T-ALLOW-TOOLS-2: allow_tools=true with stream=true passes allowTools to runner', async () => {
+  // T-ALLOW-TOOLS-1: key with allow_tools=true passes allowTools=true to runner
+  it('T-ALLOW-TOOLS-1: key with allow_tools=true passes allowTools=true to runner', async () => {
     let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
     const runner = new MockAgentRunner(async () => 'ok');
-    runner.sendApiMessageStreamImpl = async (_sid, _msg, cb, opts) => {
-      capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
-      cb.onDone('done');
-      return () => {};
-    };
-
-    // Patch the mock to capture opts
-    const origStream = runner.sendApiMessageStream.bind(runner);
     runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
       capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
-      return origStream(sid, msg, cbs, opts);
+      cbs.onDone('done');
+      return () => {};
     };
 
     const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
@@ -510,23 +489,41 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     app.use(express.json());
     app.use('/api', createApiRouter(runners, configs, apiKeys));
 
-    await collectSSE(app, { message: 'run job', stream: true, allow_tools: true }, 'Bearer sk-test-tools');
+    await collectSSE(app, { message: 'run job', stream: true }, 'Bearer sk-test-tools');
 
     expect(capturedOpts).toBeDefined();
     expect(capturedOpts!.allowTools).toBe(true);
+  });
+
+  // T-ALLOW-TOOLS-2: key without allow_tools passes allowTools=false to runner
+  it('T-ALLOW-TOOLS-2: key without allow_tools passes allowTools=false to runner', async () => {
+    let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
+    const runner = new MockAgentRunner(async () => 'ok');
+    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+      capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
+      cbs.onDone('done');
+      return () => {};
+    };
+
+    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+    const configs = new Map([[AGENT_ID, agentConfig]]);
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys));
+
+    await collectSSE(app, { message: 'hi', stream: true });
+
+    expect(capturedOpts!.allowTools).toBe(false);
   });
 
   // T-ALLOW-TOOLS-3: timeout_ms forwarded to runner
   it('T-ALLOW-TOOLS-3: custom timeout_ms is forwarded to runner', async () => {
     let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
     const runner = new MockAgentRunner(async () => 'ok');
-    runner.sendApiMessageStreamImpl = async (_sid, _msg, cb) => {
-      cb.onDone('done');
-      return () => {};
-    };
     runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
       capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
-      return runner.sendApiMessageStreamImpl!(sid, msg, cbs);
+      cbs.onDone('done');
+      return () => {};
     };
 
     const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
@@ -544,13 +541,10 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   it('T-ALLOW-TOOLS-4: timeout_ms over max is clamped to default', async () => {
     let capturedOpts: { timeoutMs: number } | undefined;
     const runner = new MockAgentRunner(async () => 'ok');
-    runner.sendApiMessageStreamImpl = async (_sid, _msg, cb) => {
-      cb.onDone('done');
-      return () => {};
-    };
     runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
       capturedOpts = opts as { timeoutMs: number };
-      return runner.sendApiMessageStreamImpl!(sid, msg, cbs);
+      cbs.onDone('done');
+      return () => {};
     };
 
     const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
@@ -562,44 +556,6 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     await collectSSE(app, { message: 'hi', stream: true, timeout_ms: 999999 });
 
     expect(capturedOpts!.timeoutMs).toBe(60000); // DEFAULT_TIMEOUT_MS
-  });
-
-  // T-ALLOW-TOOLS-5: no allow_tools flag defaults to allowTools=false
-  it('T-ALLOW-TOOLS-5: omitting allow_tools defaults to allowTools=false', async () => {
-    let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
-    const runner = new MockAgentRunner(async () => 'ok');
-    runner.sendApiMessageStreamImpl = async (_sid, _msg, cb) => {
-      cb.onDone('done');
-      return () => {};
-    };
-    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
-      capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
-      return runner.sendApiMessageStreamImpl!(sid, msg, cbs);
-    };
-
-    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
-    const configs = new Map([[AGENT_ID, agentConfig]]);
-    const app = express();
-    app.use(express.json());
-    app.use('/api', createApiRouter(runners, configs, apiKeys));
-
-    await collectSSE(app, { message: 'hi', stream: true });
-
-    expect(capturedOpts!.allowTools).toBe(false);
-  });
-
-  // T-ALLOW-TOOLS-6: key without allow_tools permission returns 403 when request uses allow_tools
-  it('T-ALLOW-TOOLS-6: key without allow_tools permission returns 403', async () => {
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
-      cb.onDone('ok');
-      return () => {};
-    });
-    const res = await supertest.default(app)
-      .post(POST_URL)
-      .set({ Authorization: 'Bearer sk-test-app' }) // no allow_tools on this key
-      .send({ message: 'run job', stream: true, allow_tools: true });
-    expect(res.status).toBe(403);
-    expect(res.body.error).toMatch(/allow_tools permission/i);
   });
 
   // T-API-STREAM-TCP: TCP_NODELAY is set on SSE connections (regression test)

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -19,6 +19,7 @@ class MockAgentRunner extends EventEmitter {
     sessionId: string,
     message: string,
     callbacks: StreamCallbacks,
+    opts?: { timeoutMs: number; allowTools?: boolean },
   ) => Promise<() => void>;
   private _activeApiSessions = new Set<string>();
 
@@ -39,10 +40,10 @@ class MockAgentRunner extends EventEmitter {
     sessionId: string,
     message: string,
     callbacks: StreamCallbacks,
-    _opts: { timeoutMs: number },
+    _opts: { timeoutMs: number; allowTools?: boolean },
   ): Promise<() => void> {
     if (this.sendApiMessageStreamImpl) {
-      return this.sendApiMessageStreamImpl(sessionId, message, callbacks);
+      return this.sendApiMessageStreamImpl(sessionId, message, callbacks, _opts);
     }
     throw new Error('sendApiMessageStream not implemented in mock');
   }
@@ -72,6 +73,7 @@ const agentConfig: AgentConfig = {
 const apiKeys: ApiKey[] = [
   { key: 'sk-test-app', agents: [AGENT_ID] },
   { key: 'sk-test-admin', agents: '*' },
+  { key: 'sk-test-tools', agents: [AGENT_ID], allow_tools: true },
 ];
 
 function buildApp(runnerImpl: (sessionId: string, msg: string) => Promise<string>) {
@@ -89,6 +91,7 @@ function buildStreamApp(
     sessionId: string,
     message: string,
     callbacks: StreamCallbacks,
+    opts?: { timeoutMs: number; allowTools?: boolean },
   ) => Promise<() => void>,
 ): { app: express.Express; runner: MockAgentRunner } {
   const runner = new MockAgentRunner(async () => 'ok');
@@ -289,6 +292,7 @@ describe('GET /api/v1/agents', () => {
 function collectSSE(
   app: express.Express,
   body: Record<string, unknown>,
+  auth = 'Bearer sk-test-app',
 ): Promise<{ status: number; headers: http.IncomingHttpHeaders; data: string }> {
   return new Promise((resolve, reject) => {
     const server = app.listen(0, () => {
@@ -302,7 +306,7 @@ function collectSSE(
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': 'Bearer sk-test-app',
+            'Authorization': auth,
             'Content-Length': Buffer.byteLength(reqBody),
           },
         },
@@ -468,6 +472,135 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
 
     expect(cleanupCalled).toBe(true);
   }, 10000);
+
+  // T-ALLOW-TOOLS-1: allow_tools without stream returns 400
+  it('T-ALLOW-TOOLS-1: allow_tools without stream returns 400', async () => {
+    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+      cb.onDone('ok');
+      return () => {};
+    });
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: 'run job', allow_tools: true });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/allow_tools requires stream/i);
+  });
+
+  // T-ALLOW-TOOLS-2: allow_tools=true with stream=true passes allowTools=true to runner
+  it('T-ALLOW-TOOLS-2: allow_tools=true with stream=true passes allowTools to runner', async () => {
+    let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
+    const runner = new MockAgentRunner(async () => 'ok');
+    runner.sendApiMessageStreamImpl = async (_sid, _msg, cb, opts) => {
+      capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
+      cb.onDone('done');
+      return () => {};
+    };
+
+    // Patch the mock to capture opts
+    const origStream = runner.sendApiMessageStream.bind(runner);
+    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+      capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
+      return origStream(sid, msg, cbs, opts);
+    };
+
+    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+    const configs = new Map([[AGENT_ID, agentConfig]]);
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys));
+
+    await collectSSE(app, { message: 'run job', stream: true, allow_tools: true }, 'Bearer sk-test-tools');
+
+    expect(capturedOpts).toBeDefined();
+    expect(capturedOpts!.allowTools).toBe(true);
+  });
+
+  // T-ALLOW-TOOLS-3: timeout_ms forwarded to runner
+  it('T-ALLOW-TOOLS-3: custom timeout_ms is forwarded to runner', async () => {
+    let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
+    const runner = new MockAgentRunner(async () => 'ok');
+    runner.sendApiMessageStreamImpl = async (_sid, _msg, cb) => {
+      cb.onDone('done');
+      return () => {};
+    };
+    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+      capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
+      return runner.sendApiMessageStreamImpl!(sid, msg, cbs);
+    };
+
+    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+    const configs = new Map([[AGENT_ID, agentConfig]]);
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys));
+
+    await collectSSE(app, { message: 'hi', stream: true, timeout_ms: 120000 });
+
+    expect(capturedOpts!.timeoutMs).toBe(120000);
+  });
+
+  // T-ALLOW-TOOLS-4: timeout_ms over max is clamped to default (60000)
+  it('T-ALLOW-TOOLS-4: timeout_ms over max is clamped to default', async () => {
+    let capturedOpts: { timeoutMs: number } | undefined;
+    const runner = new MockAgentRunner(async () => 'ok');
+    runner.sendApiMessageStreamImpl = async (_sid, _msg, cb) => {
+      cb.onDone('done');
+      return () => {};
+    };
+    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+      capturedOpts = opts as { timeoutMs: number };
+      return runner.sendApiMessageStreamImpl!(sid, msg, cbs);
+    };
+
+    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+    const configs = new Map([[AGENT_ID, agentConfig]]);
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys));
+
+    await collectSSE(app, { message: 'hi', stream: true, timeout_ms: 999999 });
+
+    expect(capturedOpts!.timeoutMs).toBe(60000); // DEFAULT_TIMEOUT_MS
+  });
+
+  // T-ALLOW-TOOLS-5: no allow_tools flag defaults to allowTools=false
+  it('T-ALLOW-TOOLS-5: omitting allow_tools defaults to allowTools=false', async () => {
+    let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
+    const runner = new MockAgentRunner(async () => 'ok');
+    runner.sendApiMessageStreamImpl = async (_sid, _msg, cb) => {
+      cb.onDone('done');
+      return () => {};
+    };
+    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+      capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
+      return runner.sendApiMessageStreamImpl!(sid, msg, cbs);
+    };
+
+    const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+    const configs = new Map([[AGENT_ID, agentConfig]]);
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys));
+
+    await collectSSE(app, { message: 'hi', stream: true });
+
+    expect(capturedOpts!.allowTools).toBe(false);
+  });
+
+  // T-ALLOW-TOOLS-6: key without allow_tools permission returns 403 when request uses allow_tools
+  it('T-ALLOW-TOOLS-6: key without allow_tools permission returns 403', async () => {
+    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+      cb.onDone('ok');
+      return () => {};
+    });
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set({ Authorization: 'Bearer sk-test-app' }) // no allow_tools on this key
+      .send({ message: 'run job', stream: true, allow_tools: true });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/allow_tools permission/i);
+  });
 
   // T-API-STREAM-TCP: TCP_NODELAY is set on SSE connections (regression test)
   it('T-API-STREAM-TCP: SSE streaming works correctly with TCP_NODELAY set', async () => {


### PR DESCRIPTION
## Summary

- Add `allow_tools?: boolean` to the `ApiKey` interface in `config.json`
- Keys with `allow_tools: true` let the agent call tools (Read, Bash, Grep, etc.) when responding via the streaming API
- Tool access is governed entirely by key config — no request body field needed
- Add `timeout_ms` request field to override the default 60s timeout (useful for long-running tool jobs)

## Motivation

Enables use cases like [hell-factory](https://github.com/0xMaxMa/hell-factory-company) where a scheduled job calls the Agent API and expects the agent to execute scripts and report output — not just chat.

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `allow_tools?: boolean` to `ApiKey` |
| `src/api/router.ts` | Derive `allowTools` from key config; add `timeout_ms` parsing |
| `src/agent/runner.ts` | Pass `allowTools` and `timeoutMs` opts to `sendApiMessageStream`; conditionally build tool-restricted channel XML |
| `tests/unit/api-router.test.ts` | 4 new tests (T-ALLOW-TOOLS-1 to 4); add `sk-test-tools` key fixture |
| `tests/unit/agent-runner.test.ts` | 3 new tests for `allowTools` channel XML branching |
| `API.md` | Document `allow_tools` key config, `timeout_ms` request field, streaming-with-tools example |

## Config example

```json
{
  "key": "automation-key-789",
  "description": "Automation — may use tools",
  "agents": ["alfred"],
  "allow_tools": true
}
```

## Test plan

- [x] `npm test` — 974 passed, 8 skipped (pre-existing)
- [x] Keys with `allow_tools: true` pass `allowTools=true` to runner
- [x] Keys without `allow_tools` pass `allowTools=false` to runner
- [x] `timeout_ms` forwarded correctly; values over 600s clamped to default