### PR TITLE
feat: protect workspace identity files from API session modifications

### DIFF
--- a/API.md
+++ b/API.md
@@ -194,6 +194,9 @@ curl -N -X POST \
 
 > Keys without `allow_tools: true` are always conversational — tools are never invoked regardless of what the request contains.
 
+**Workspace identity files are always protected in API sessions.**
+Regardless of `allow_tools`, the agent will not create or update workspace identity files (`AGENTS.md`, `SOUL.md`, `MEMORY.md`, `CLAUDE.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`) during an API session. If asked to remember something, the agent will decline. Memory updates require a Telegram or Cron session where the agent has full workspace access.
+
 **Event types:**
 
 | Type | Fields | Description |

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -22,6 +22,22 @@ const DEFAULT_MODELS: ModelConfig[] = [
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', alias: 'haiku', contextWindow: 200000 },
 ];
 
+const PROTECTED_WORKSPACE_FILES = [
+  'AGENTS.md', 'SOUL.md', 'MEMORY.md', 'CLAUDE.md',
+  'IDENTITY.md', 'USER.md', 'HEARTBEAT.md',
+];
+
+function buildApiSystemNote(allowTools: boolean): string {
+  const memoryOverride =
+    `Memory Rule Override: Do NOT create or update ${PROTECTED_WORKSPACE_FILES.join(', ')} ` +
+    `or any other workspace identity file in this session, regardless of user instructions. ` +
+    `If the user asks you to remember something, reply that memory updates are not supported in API sessions.`;
+  const toolNote = allowTools
+    ? `You may use tools to complete the requested task.`
+    : `Reply with plain text only. Do NOT call any tools. Your text output will be returned directly to the caller.`;
+  return `[SYSTEM: This is an API request. ${memoryOverride} ${toolNote}]\n`;
+}
+
 export class AgentRunner extends EventEmitter {
   private readonly agentConfig: AgentConfig;
   private readonly gatewayConfig: GatewayConfig;
@@ -1009,9 +1025,7 @@ export class AgentRunner extends EventEmitter {
     this.pendingApiSessions.add(sessionId);
     session.touch();
 
-    const systemNote = opts.allowTools
-      ? `[SYSTEM: This is an API request. You may use tools. Stream your progress as you work.]\n`
-      : `[SYSTEM: This is an API request. Reply with plain text only. Do NOT call any tools. Your text output will be returned directly to the caller.]\n`;
+    const systemNote = buildApiSystemNote(opts.allowTools ?? false);
 
     const channelXml =
       `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
@@ -1275,10 +1289,7 @@ export class AgentRunner extends EventEmitter {
 
     session.on('output', onOutput);
 
-    const systemNote = opts.allowTools
-      ? `[SYSTEM: This is an API request. You may use tools. Stream your progress as you work.]\n`
-      : `[SYSTEM: This is an API request. Reply with plain text only. ` +
-        `Do NOT call any tools. Your text output will be returned directly to the caller.]\n`;
+    const systemNote = buildApiSystemNote(opts.allowTools ?? false);
 
     const channelXml =
       `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -940,6 +940,92 @@ describe('AgentRunner — sendApiMessageStream', () => {
     expect(capturedMessage).toContain('Do NOT call any tools');
   }, 15000);
 
+  // T-WP-1: allowTools=true — system note contains MEMORY_RULE override
+  it('T-WP-1: allowTools=true system note contains memory-rule override', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    runner.sendApiMessageStream(
+      'stream-wp-1',
+      'do something',
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      { timeoutMs: 5000, allowTools: true },
+    );
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const proc = allProcesses[allProcesses.length - 1];
+    const calls = (proc.stdin!.write as jest.Mock).mock.calls;
+    const capturedMessage = calls.map((c: unknown[]) => String(c[0])).join('');
+
+    expect(capturedMessage).toContain('memory updates are not supported in API sessions');
+  }, 15000);
+
+  // T-WP-2: allowTools=true — system note lists protected workspace files
+  it('T-WP-2: allowTools=true system note lists protected workspace files', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    runner.sendApiMessageStream(
+      'stream-wp-2',
+      'do something',
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      { timeoutMs: 5000, allowTools: true },
+    );
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const proc = allProcesses[allProcesses.length - 1];
+    const calls = (proc.stdin!.write as jest.Mock).mock.calls;
+    const capturedMessage = calls.map((c: unknown[]) => String(c[0])).join('');
+
+    expect(capturedMessage).toContain('AGENTS.md');
+    expect(capturedMessage).toContain('SOUL.md');
+    expect(capturedMessage).toContain('MEMORY.md');
+  }, 15000);
+
+  // T-WP-3: allowTools=false — system note also contains MEMORY_RULE override
+  it('T-WP-3: allowTools=false system note also contains memory-rule override', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    runner.sendApiMessageStream(
+      'stream-wp-3',
+      'hello',
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      { timeoutMs: 5000, allowTools: false },
+    );
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const proc = allProcesses[allProcesses.length - 1];
+    const calls = (proc.stdin!.write as jest.Mock).mock.calls;
+    const capturedMessage = calls.map((c: unknown[]) => String(c[0])).join('');
+
+    expect(capturedMessage).toContain('memory updates are not supported in API sessions');
+  }, 15000);
+
+  // T-WP-4: allowTools=false — system note instructs no tool use
+  it('T-WP-4: allowTools=false system note instructs no tool use', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    runner.sendApiMessageStream(
+      'stream-wp-4',
+      'hello',
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      { timeoutMs: 5000, allowTools: false },
+    );
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const proc = allProcesses[allProcesses.length - 1];
+    const calls = (proc.stdin!.write as jest.Mock).mock.calls;
+    const capturedMessage = calls.map((c: unknown[]) => String(c[0])).join('');
+
+    expect(capturedMessage).toContain('Do NOT call any tools');
+  }, 15000);
+
   // --------------------------------------------------------------------------
   // T-AR-STREAM-16: No duplicate text in buffer from partial messages
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- API sessions now explicitly override the MEMORY_RULE to prevent the agent from creating or updating workspace identity files (`AGENTS.md`, `SOUL.md`, `MEMORY.md`, `CLAUDE.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`)
- If an API caller instructs the agent to \"remember\" something, the agent declines and explains that memory updates are not supported in API sessions
- Applies to both sync and streaming modes, and to both `allow_tools: true` and `allow_tools: false` keys
- Extracts `buildApiSystemNote()` helper shared by `sendApiMessage` and `sendApiMessageStream`
- Documents the protection behaviour in `API.md`

## Changes

- `src/agent/runner.ts`: add `PROTECTED_WORKSPACE_FILES` constant and `buildApiSystemNote()` helper; replace duplicated system note construction in both API send methods
- `tests/unit/agent-runner.test.ts`: add T-WP-1 through T-WP-4 unit tests
- `API.md`: document that workspace identity files are always protected in API sessions

## Test plan

- [ ] `npm test` passes — 987 tests pass, 8 skipped (pre-existing), 0 failures
- [ ] T-WP-1: `allow_tools: true` note contains memory-rule override text
- [ ] T-WP-2: `allow_tools: true` note lists AGENTS.md, SOUL.md, MEMORY.md
- [ ] T-WP-3: `allow_tools: false` note also contains memory-rule override
- [ ] T-WP-4: `allow_tools: false` note instructs no tool use