### PR TITLE
feat: add Discord delivery for cron jobs + agent MCP validation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ restart.sh
 stop.sh
 .skills
 .claude-gateway
+tasks/
+.ralph-tui/

--- a/API.md
+++ b/API.md
@@ -231,7 +231,8 @@ Jobs are persisted to `~/.claude-gateway/crons.json` and survive gateway restart
 | `type` | No | `"command"` (default) or `"agent"` |
 | `command` | If `type=command` | Shell command to run |
 | `prompt` | If `type=agent` | Prompt sent to the agent as a new turn |
-| `telegram` | If `type=agent` | Telegram chat_id to deliver the agent response (required for `type=agent`) |
+| `telegram` | If `type=agent` | Telegram chat_id to deliver the agent response |
+| `discord` | If `type=agent` | Discord channel_id to deliver the agent response |
 | `timeoutMs` | No | Execution timeout in ms (default 120000) — applies to both `command` and `agent` |
 | `deleteAfterRun` | No | `true` to auto-delete after first run (one-shot jobs) |
 | `enabled` | No | `true` (default) / `false` to create disabled |
@@ -241,9 +242,11 @@ Jobs are persisted to `~/.claude-gateway/crons.json` and survive gateway restart
 | | `command` | `agent` |
 |---|---|---|
 | Runs | Shell command | Agent turn (new Claude session) |
-| Key field | `command` | `prompt` + `telegram` |
+| Key field | `command` | `prompt` + `telegram` and/or `discord` |
 | Output | stdout/stderr | Agent response text |
-| Delivery | Logged only | Sent to Telegram chat |
+| Delivery | Logged only | Sent to Telegram and/or Discord |
+
+> **Note:** For `type=agent`, at least one of `telegram` or `discord` is required. Both can be set to deliver to multiple channels simultaneously.
 
 ---
 
@@ -267,7 +270,7 @@ curl -H "X-Api-Key: my-secret-key-123" \
       "schedule": "0 9 * * *",
       "type": "agent",
       "prompt": "Give me a morning summary.",
-      "telegram": "997170033",
+      "telegram": "99000000",
       "enabled": true,
       "createdAt": 1775737709284,
       "state": {
@@ -320,7 +323,44 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
     "schedule": "0 9 * * *",
     "type": "agent",
     "prompt": "Give me a morning summary.",
-    "telegram": "997170033"
+    "telegram": "99000000"
+  }' | jq
+```
+
+#### Example: Daily agent prompt — deliver to Discord
+
+Run every day at 09:00 — agent sends a morning summary to a Discord channel.
+
+```bash
+curl -s -X POST http://localhost:3000/api/v1/crons \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "claude-founder",
+    "name": "morning-brief-discord",
+    "scheduleKind": "cron",
+    "schedule": "0 9 * * *",
+    "type": "agent",
+    "prompt": "Give me a morning summary.",
+    "discord": "1234567890123456789"
+  }' | jq
+```
+
+#### Example: Deliver to both Telegram and Discord
+
+```bash
+curl -s -X POST http://localhost:3000/api/v1/crons \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "claude-founder",
+    "name": "morning-brief-all",
+    "scheduleKind": "cron",
+    "schedule": "0 9 * * *",
+    "type": "agent",
+    "prompt": "Give me a morning summary.",
+    "telegram": "99000000",
+    "discord": "1234567890123456789"
   }' | jq
 ```
 
@@ -339,7 +379,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
     "scheduleAt": "2026-04-09T23:00:00.000Z",
     "type": "agent",
     "prompt": "good night",
-    "telegram": "997170033",
+    "telegram": "99000000",
     "deleteAfterRun": true
   }' | jq
 ```
@@ -392,7 +432,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
     "schedule": "0 18 * * 5",
     "type": "agent",
     "prompt": "Generate a weekly progress report.",
-    "telegram": "997170033",
+    "telegram": "99000000",
     "enabled": false
   }' | jq
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 - **Typing indicators** — continuous typing animation while the agent is working (Telegram and Discord)
 - **Streaming API** — SSE (Server-Sent Events) endpoint for real-time response streaming
 - **Auto-forward** — agent text output automatically forwarded to Telegram even without explicit reply tool calls
-- **Heartbeat / scheduled tasks** — cron-based proactive messages and recurring tasks via HEARTBEAT.md + REST API
+- **Heartbeat / scheduled tasks** — cron-based proactive messages and recurring tasks via HEARTBEAT.md + REST API; agent jobs deliver output to Telegram, Discord, or both
 - **Long-term memory** — persistent memory system across sessions
 - **Config auto-migration** — automatic schema migration when config format changes
 - **Access control** — allowlist, open, or pairing-based Telegram access policies

--- a/mcp/tools/agent/module.ts
+++ b/mcp/tools/agent/module.ts
@@ -42,7 +42,7 @@ export class AgentModule implements ToolModule {
             telegram_user_id: {
               type: 'string',
               description:
-                'Telegram numeric chat_id (6–15 digits, e.g. "997170033"). ONLY pass here when channel=telegram. IMPORTANT: If you are responding to a Telegram message, use the sender chat_id from the inbound message context directly — do NOT ask the user for it. NEVER put a Discord Snowflake (17–19 digits) here.',
+                'Telegram numeric chat_id (6–15 digits, e.g. "99000000"). ONLY pass here when channel=telegram. IMPORTANT: If you are responding to a Telegram message, use the sender chat_id from the inbound message context directly — do NOT ask the user for it. NEVER put a Discord Snowflake (17–19 digits) here.',
             },
             discord_user_id: {
               type: 'string',

--- a/mcp/tools/cron/module.ts
+++ b/mcp/tools/cron/module.ts
@@ -57,6 +57,7 @@ export class CronModule implements ToolModule {
             command: { type: 'string', description: 'Shell command (type=command)' },
             prompt: { type: 'string', description: 'Agent prompt (type=agent)' },
             telegram: { type: 'string', description: 'Telegram chat_id for response' },
+            discord: { type: 'string', description: 'Discord channel_id for agent response delivery' },
             timeout_ms: { type: 'number', description: 'Timeout in milliseconds' },
             scheduleKind: {
               type: 'string',

--- a/src/api/cron-router.ts
+++ b/src/api/cron-router.ts
@@ -91,6 +91,10 @@ export function createCronRouter(manager: CronManager, apiKeys?: ApiKey[], known
       res.status(400).json({ error: 'scheduleAt is required for scheduleKind=at' });
       return;
     }
+    if (scheduleKind === 'at' && body.scheduleAt && isNaN(Date.parse(body.scheduleAt))) {
+      res.status(400).json({ error: `Invalid ISO-8601 timestamp: "${body.scheduleAt}"` });
+      return;
+    }
     // Payload validation
     if (type === 'command' && !body.command) {
       res.status(400).json({ error: 'command is required for type=command' });
@@ -100,8 +104,8 @@ export function createCronRouter(manager: CronManager, apiKeys?: ApiKey[], known
       res.status(400).json({ error: 'prompt is required for type=agent' });
       return;
     }
-    if (type === 'agent' && !body.telegram) {
-      res.status(400).json({ error: 'telegram is required for type=agent' });
+    if (type === 'agent' && !body.telegram && !body.discord) {
+      res.status(400).json({ error: 'telegram or discord is required for type=agent' });
       return;
     }
 

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -31,10 +31,28 @@ const DEFAULT_RUNS_DIR = path.join(
 const MAX_RUN_LOGS_PER_JOB = 100;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const TELEGRAM_API_BASE = 'https://api.telegram.org';
+const DISCORD_API_BASE = 'https://discord.com/api/v10';
+const DISCORD_MAX_MESSAGE_LENGTH = 2000;
 
 interface StoreFormat {
   version: 1;
   jobs: CronJob[];
+}
+
+function chunkDiscordText(text: string, limit: number): string[] {
+  if (text.length <= limit) return text.length === 0 ? [] : [text];
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > limit) {
+    const para = rest.lastIndexOf('\n\n', limit);
+    const nl = rest.lastIndexOf('\n', limit);
+    const sp = rest.lastIndexOf(' ', limit);
+    const cut = para > limit / 2 ? para : nl > limit / 2 ? nl : sp > 0 ? sp : limit;
+    chunks.push(rest.slice(0, cut));
+    rest = rest.slice(cut).replace(/^\n+/, '');
+  }
+  if (rest) chunks.push(rest);
+  return chunks;
 }
 
 export class CronManager extends EventEmitter {
@@ -127,6 +145,7 @@ export class CronManager extends EventEmitter {
       command: input.command,
       prompt: input.prompt,
       telegram: input.telegram,
+      discord: input.discord,
       timeoutMs: input.timeoutMs,
       deleteAfterRun: input.deleteAfterRun,
       enabled: input.enabled ?? true,
@@ -181,6 +200,7 @@ export class CronManager extends EventEmitter {
     if (input.command !== undefined) job.command = input.command;
     if (input.prompt !== undefined) job.prompt = input.prompt;
     if (input.telegram !== undefined) job.telegram = input.telegram;
+    if (input.discord !== undefined) job.discord = input.discord;
     if (input.timeoutMs !== undefined) job.timeoutMs = input.timeoutMs;
     if (input.deleteAfterRun !== undefined) job.deleteAfterRun = input.deleteAfterRun;
     if (input.name !== undefined) job.name = input.name;
@@ -280,13 +300,15 @@ export class CronManager extends EventEmitter {
     }
   }
 
-  private validatePayload(input: { type?: string; command?: string; prompt?: string; telegram?: string }): void {
+  private validatePayload(input: { type?: string; command?: string; prompt?: string; telegram?: string; discord?: string }): void {
     const kind = input.type ?? 'command';
     if (kind === 'command') {
       if (!input.command) throw new Error('command is required for type=command');
     } else if (kind === 'agent') {
       if (!input.prompt) throw new Error('prompt is required for type=agent');
-      if (!input.telegram) throw new Error('telegram is required for type=agent');
+      if (!input.telegram && !input.discord) {
+        throw new Error('telegram or discord is required for type=agent');
+      }
     }
   }
 
@@ -302,6 +324,10 @@ export class CronManager extends EventEmitter {
 
     } else if (kind === 'at') {
       const targetMs = Date.parse(job.scheduleAt!);
+      if (isNaN(targetMs)) {
+        this.logger.error(`at-job "${job.name}" has invalid scheduleAt "${job.scheduleAt}", skipping`, { id: job.id });
+        return;
+      }
       const delayMs = targetMs - Date.now();
 
       // Fix 1: If the job already ran before a crash, skip re-fire and complete cleanup.
@@ -417,9 +443,18 @@ export class CronManager extends EventEmitter {
       this.appendRunLog(job.id, runLog),
     ]);
 
-    // Deliver agent response to Telegram
-    if (status === 'ok' && job.type === 'agent' && job.telegram) {
-      await this.sendTelegram(job.agentId, job.telegram, runLog.output);
+    // Deliver agent response to configured channels (independently; one failure must not block the other)
+    if (status === 'ok' && job.type === 'agent') {
+      const deliveries: Promise<void>[] = [];
+      if (job.telegram) {
+        deliveries.push(this.sendTelegram(job.agentId, job.telegram, runLog.output));
+      }
+      if (job.discord) {
+        deliveries.push(this.sendDiscord(job.agentId, job.discord, runLog.output));
+      }
+      if (deliveries.length > 0) {
+        await Promise.allSettled(deliveries);
+      }
     }
 
     this.emit('job:executed', job, runLog);
@@ -478,6 +513,41 @@ export class CronManager extends EventEmitter {
       }
     } catch (err) {
       this.logger.warn(`Telegram notify error: ${(err as Error).message}`, { chatId });
+    }
+  }
+
+  private async sendDiscord(agentId: string, channelId: string, text: string): Promise<void> {
+    const agentConfig = this.agentConfigs.get(agentId);
+    const botToken = agentConfig?.discord?.botToken;
+
+    if (!botToken) {
+      this.logger.warn(`Cannot send Discord notify: no botToken for agent "${agentId}"`);
+      return;
+    }
+
+    const url = `${DISCORD_API_BASE}/channels/${channelId}/messages`;
+    const chunks = chunkDiscordText(text, DISCORD_MAX_MESSAGE_LENGTH);
+
+    for (const content of chunks) {
+      try {
+        const resp = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bot ${botToken}`,
+          },
+          body: JSON.stringify({ content }),
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!resp.ok) {
+          const body = await resp.text();
+          this.logger.warn(`Discord notify failed: ${resp.status} ${body}`, { channelId });
+          return;
+        }
+      } catch (err) {
+        this.logger.warn(`Discord notify error: ${(err as Error).message}`, { channelId });
+        return;
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,7 @@ export interface CronJob {
   command?: string;                 // shell command (type=command)
   prompt?: string;                  // agent prompt (type=agent)
   telegram?: string;                // chat_id to deliver agent response (type=agent, required)
+  discord?: string;                 // discord channel/user id to deliver agent response (type=agent)
   timeoutMs?: number;               // execution timeout ms (default 120000)
   // Lifecycle
   deleteAfterRun?: boolean;         // auto-delete after first successful run
@@ -190,6 +191,7 @@ export interface CronJobCreate {
   command?: string;
   prompt?: string;
   telegram?: string;
+  discord?: string;
   timeoutMs?: number;
   // Lifecycle
   deleteAfterRun?: boolean;
@@ -205,6 +207,7 @@ export interface CronJobUpdate {
   command?: string;
   prompt?: string;
   telegram?: string;
+  discord?: string;
   timeoutMs?: number;
   deleteAfterRun?: boolean;
   enabled?: boolean;

--- a/tests/unit/agent-mcp-handlers.test.ts
+++ b/tests/unit/agent-mcp-handlers.test.ts
@@ -226,14 +226,14 @@ describe('createAgent — Telegram happy path', () => {
       description: 'A test agent',
       channel: 'telegram',
       bot_token: VALID_TG_TOKEN,
-      telegram_user_id: '997170033',
+      telegram_user_id: '99000000',
     });
 
     const wsDir = path.join(tmpDir, 'agents', 'myagent2', 'workspace');
     const stateDir = path.join(wsDir, '.telegram-state');
-    expect(mockWriteTelegramAccess).toHaveBeenCalledWith(stateDir, '997170033');
+    expect(mockWriteTelegramAccess).toHaveBeenCalledWith(stateDir, '99000000');
     const access = JSON.parse(fs.readFileSync(path.join(stateDir, 'access.json'), 'utf8'));
-    expect(access.allowFrom).toEqual(['997170033']);
+    expect(access.allowFrom).toEqual(['99000000']);
   });
 
   it('AMH-01c: does NOT use telegram_user_id for discord channel (isolation test)', async () => {
@@ -244,7 +244,7 @@ describe('createAgent — Telegram happy path', () => {
       description: 'Isolation test',
       channel: 'discord',
       bot_token: VALID_DC_TOKEN,
-      telegram_user_id: '997170033',
+      telegram_user_id: '99000000',
     });
 
     const wsDir = path.join(tmpDir, 'agents', 'dcagent-iso', 'workspace');

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -33,7 +33,11 @@ function makeRunner(response = 'agent ok') {
   };
 }
 
-function makeAgentConfig(agentId: string, botToken = 'bot-token-123'): AgentConfig {
+function makeAgentConfig(
+  agentId: string,
+  botToken = 'bot-token-123',
+  discordBotToken?: string,
+): AgentConfig {
   return {
     id: agentId,
     description: 'test agent',
@@ -42,6 +46,7 @@ function makeAgentConfig(agentId: string, botToken = 'bot-token-123'): AgentConf
     telegram: {
       botToken,
     },
+    ...(discordBotToken ? { discord: { botToken: discordBotToken } } : {}),
     claude: {
       model: 'claude-opus-4-6',
       dangerouslySkipPermissions: false,
@@ -54,6 +59,7 @@ function makeManager(opts: {
   agentId?: string;
   runner?: ReturnType<typeof makeRunner>;
   botToken?: string;
+  discordBotToken?: string;
   tmpDir?: string;
 } = {}) {
   const agentId = opts.agentId ?? 'test-agent';
@@ -64,7 +70,10 @@ function makeManager(opts: {
   if (opts.runner) {
     agentRunners.set(agentId, opts.runner);
   }
-  agentConfigs.set(agentId, makeAgentConfig(agentId, opts.botToken ?? 'bot-token-123'));
+  agentConfigs.set(
+    agentId,
+    makeAgentConfig(agentId, opts.botToken ?? 'bot-token-123', opts.discordBotToken),
+  );
 
   const manager = new CronManager(
     { storePath: path.join(tmpDir, 'crons.json'), runsDir: path.join(tmpDir, 'runs') },
@@ -378,6 +387,235 @@ describe('T11-T13: Telegram delivery', () => {
       expect.stringContaining('Telegram notify error'),
       expect.anything(),
     );
+
+    manager.stop();
+  });
+});
+
+// ─── T14-T19: Discord delivery ────────────────────────────────────────────────
+
+describe('T14-T19: Discord delivery', () => {
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    } as Response);
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  it('T14: fetch → 200, discord CHANNEL_123 → posts to channels API with Bot auth and output content', async () => {
+    const runner = makeRunner('hello world');
+    const { manager, agentId } = makeManager({ runner, discordBotToken: 'DISC123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'discord-ok',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hi',
+      discord: 'CHANNEL_123',
+    });
+
+    await manager.run(job.id);
+
+    const discordCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    expect(discordCall).toBeDefined();
+    expect(discordCall![0]).toContain('/channels/CHANNEL_123/messages');
+    const init = discordCall![1];
+    const authHeader = (init.headers as Record<string, string>).Authorization;
+    expect(authHeader.startsWith('Bot ')).toBe(true);
+    expect(JSON.parse(init.body).content).toContain('hello world');
+
+    manager.stop();
+  });
+
+  it('T15: runner throws → Discord fetch not called', async () => {
+    const runner = {
+      sendApiMessage: jest.fn().mockRejectedValue(new Error('agent failed')),
+    };
+    const { manager, agentId } = makeManager({ runner, discordBotToken: 'DISC123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'discord-runner-fail',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hi',
+      discord: 'CHANNEL_123',
+    });
+
+    await manager.run(job.id);
+
+    const discordCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    expect(discordCall).toBeUndefined();
+
+    manager.stop();
+  });
+
+  it('T16: fetch → 500, runner succeeds → runLog.status=ok, warn logged with Discord failure info', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'internal server error',
+    } as Response);
+
+    const runner = makeRunner('ok');
+    const logger = makeLogger();
+    const agentId = 'test-agent';
+    const tmpDir = makeTmpDir();
+    const agentRunners = new Map<string, any>([[agentId, runner]]);
+    const agentConfigs = new Map<string, AgentConfig>([
+      [agentId, makeAgentConfig(agentId, 'bot-token-123', 'DISC')],
+    ]);
+
+    const manager = new CronManager(
+      { storePath: path.join(tmpDir, 'crons.json'), runsDir: path.join(tmpDir, 'runs') },
+      agentRunners,
+      agentConfigs,
+      logger,
+    );
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'discord-500',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hi',
+      discord: 'CHANNEL_123',
+    });
+
+    const log = await manager.run(job.id);
+    expect(log.status).toBe('ok');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Discord notify failed'),
+      expect.objectContaining({ channelId: 'CHANNEL_123' }),
+    );
+
+    manager.stop();
+  });
+
+  it('T17: output longer than 2000 chars → chunked into multiple Discord messages', async () => {
+    const longText = 'a'.repeat(4500);
+    const runner = makeRunner(longText);
+    const { manager, agentId } = makeManager({ runner, discordBotToken: 'DISC' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'discord-chunked',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hi',
+      discord: 'CHANNEL_123',
+    });
+
+    await manager.run(job.id);
+
+    const discordCalls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    // output truncated to 5000 chars in runLog, then split into <=2000-char chunks
+    expect(discordCalls.length).toBeGreaterThanOrEqual(2);
+    for (const call of discordCalls) {
+      const body = JSON.parse(call[1].body);
+      expect(body.content.length).toBeLessThanOrEqual(2000);
+    }
+
+    manager.stop();
+  });
+
+  it('T18: missing Discord botToken → warn logged, no fetch call, status still ok', async () => {
+    const runner = makeRunner('ok');
+    const logger = makeLogger();
+    const agentId = 'test-agent';
+    const tmpDir = makeTmpDir();
+    const agentRunners = new Map<string, any>([[agentId, runner]]);
+    // agent config omits discord block → no botToken
+    const agentConfigs = new Map<string, AgentConfig>([[agentId, makeAgentConfig(agentId)]]);
+
+    const manager = new CronManager(
+      { storePath: path.join(tmpDir, 'crons.json'), runsDir: path.join(tmpDir, 'runs') },
+      agentRunners,
+      agentConfigs,
+      logger,
+    );
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'no-token',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hi',
+      discord: 'CHANNEL_123',
+    });
+
+    const log = await manager.run(job.id);
+    expect(log.status).toBe('ok');
+
+    const discordCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    expect(discordCall).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('no botToken'),
+    );
+
+    manager.stop();
+  });
+
+  it('T19: both telegram and discord → delivered independently; Discord failure does not block Telegram', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('discord.com/api')) {
+        return Promise.reject(new Error('discord down'));
+      }
+      return Promise.resolve({ ok: true, status: 200, text: async () => '' } as Response);
+    });
+
+    const runner = makeRunner('both');
+    const { manager, agentId } = makeManager({ runner, discordBotToken: 'DISC' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'both-channels',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hi',
+      telegram: '12345',
+      discord: 'CHANNEL_123',
+    });
+
+    const log = await manager.run(job.id);
+    expect(log.status).toBe('ok');
+
+    const telegramCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('/sendMessage'),
+    );
+    const discordCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    expect(telegramCall).toBeDefined();
+    expect(discordCall).toBeDefined();
 
     manager.stop();
   });

--- a/tests/unit/cron-router.test.ts
+++ b/tests/unit/cron-router.test.ts
@@ -83,6 +83,23 @@ describe('T21-T23: Router validation for new fields', () => {
     expect(res.body.error).toContain('scheduleAt');
   });
 
+  it('T22b: POST with scheduleKind=at + malformed scheduleAt (Discord emoji corruption) → 400', async () => {
+    const { app } = makeApp();
+
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .send({
+        agentId: 'agent-1',
+        name: 'bad-at-emoji',
+        scheduleKind: 'at',
+        scheduleAt: '2026-04-22T03<:37:1387546541849575464>06.000Z',
+        command: 'echo hi',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid ISO-8601 timestamp');
+  });
+
   it('T23: POST with type=agent + missing prompt → 400', async () => {
     const { app } = makeApp();
 
@@ -102,7 +119,7 @@ describe('T21-T23: Router validation for new fields', () => {
     expect(res.body.error).toContain('prompt');
   });
 
-  it('T23b: POST with type=agent + missing telegram → 400', async () => {
+  it('T23b: POST with type=agent + missing telegram and discord → 400', async () => {
     const { app } = makeApp();
 
     const res = await request(app)
@@ -114,11 +131,69 @@ describe('T21-T23: Router validation for new fields', () => {
         schedule: '* * * * *',
         type: 'agent',
         prompt: 'hello',
-        // no telegram
+        // no telegram, no discord
       });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain('telegram');
+    expect(res.body.error).toBe('telegram or discord is required for type=agent');
+  });
+
+  it('T23c: POST with type=agent + telegram only → 201', async () => {
+    const { app } = makeApp();
+
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .send({
+        agentId: 'agent-1',
+        name: 'agent-job-tg',
+        scheduleKind: 'cron',
+        schedule: '* * * * *',
+        type: 'agent',
+        prompt: 'hello',
+        telegram: '12345',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.job).toBeDefined();
+  });
+
+  it('T23d: POST with type=agent + discord only → 201', async () => {
+    const { app } = makeApp();
+
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .send({
+        agentId: 'agent-1',
+        name: 'agent-job-dc',
+        scheduleKind: 'cron',
+        schedule: '* * * * *',
+        type: 'agent',
+        prompt: 'hello',
+        discord: '987654321',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.job).toBeDefined();
+  });
+
+  it('T23e: POST with type=agent + both telegram and discord → 201', async () => {
+    const { app } = makeApp();
+
+    const res = await request(app)
+      .post('/api/v1/crons')
+      .send({
+        agentId: 'agent-1',
+        name: 'agent-job-both',
+        scheduleKind: 'cron',
+        schedule: '* * * * *',
+        type: 'agent',
+        prompt: 'hello',
+        telegram: '12345',
+        discord: '987654321',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.job).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add Discord channel_id support for agent-type cron jobs (CronManager, CronModule MCP, CronRouter, types)
- Fix agent MCP schema: replace real Telegram user ID example with generic placeholder to avoid leaking real IDs
- Add Discord message chunking (2000 char limit) in CronManager

## Changes
- `src/cron/manager.ts` — Discord delivery support with chunked message sending
- `mcp/tools/cron/module.ts` — expose `discord` field in create/update MCP tools
- `src/api/cron-router.ts` — pass `discord` field through REST API
- `src/types.ts` — add `discord?: string` to `CronJobInput`
- `mcp/tools/agent/module.ts` — sanitize example user ID in description

## Test plan
- [ ] Cron manager tests pass (including new Discord delivery tests)
- [ ] Cron router tests pass
- [ ] Agent MCP handler tests pass
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)