### PR TITLE
feat: add gateway_restart MCP tool with dynamic channel notification

### DIFF
--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -17,6 +17,7 @@ import { DiscordModule } from './tools/discord/module';
 import { CronModule } from './tools/cron/module';
 import { SkillsModule } from './tools/skills/module';
 import { AgentModule } from './tools/agent/module';
+import { GatewayModule } from './tools/gateway/module';
 import type { ChannelModule, ToolModule, McpToolDefinition } from './types';
 
 const ORIGIN_CHANNEL = process.env.GATEWAY_ORIGIN_CHANNEL ?? '';
@@ -33,6 +34,7 @@ const modules: AnyModule[] = [
   new CronModule(),
   new SkillsModule(),
   new AgentModule(),
+  new GatewayModule(),
 ];
 
 // Build tool-to-module mapping for enabled modules

--- a/mcp/tools/gateway/module.ts
+++ b/mcp/tools/gateway/module.ts
@@ -1,0 +1,90 @@
+/**
+ * Gateway tool module — exposes gateway management tools via MCP.
+ * Tool visibility: "all-configured" (callable from any channel).
+ */
+
+import { spawn } from 'child_process';
+import * as path from 'path';
+import type {
+  ToolModule,
+  McpToolDefinition,
+  McpToolResult,
+  ToolVisibility,
+} from '../../types';
+
+export class GatewayModule implements ToolModule {
+  id = 'gateway';
+  toolVisibility: ToolVisibility = 'all-configured';
+
+  isEnabled(): boolean {
+    return true;
+  }
+
+  getTools(): McpToolDefinition[] {
+    return [
+      {
+        name: 'gateway_restart',
+        description:
+          'Restart the claude-gateway process. Kills all gateway processes, rebuilds, and starts a new instance. Sends a notification to the originating channel when complete.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            notify_target_id: {
+              type: 'string',
+              description:
+                'Chat ID (Telegram) or Channel ID (Discord) to send the completion notification to.',
+            },
+            reason: {
+              type: 'string',
+              description: 'Optional reason for the restart (informational only).',
+            },
+          },
+          required: ['notify_target_id'],
+          additionalProperties: false,
+        },
+      },
+    ];
+  }
+
+  async handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+    if (name === 'gateway_restart') return this.handleRestart(args);
+    return {
+      content: [{ type: 'text', text: `unknown tool: ${name}` }],
+      isError: true,
+    };
+  }
+
+  private handleRestart(args: Record<string, unknown>): McpToolResult {
+    const notifyTargetId = String(args.notify_target_id ?? '');
+    const originChannel = process.env.GATEWAY_ORIGIN_CHANNEL ?? '';
+    const botToken =
+      originChannel === 'telegram'
+        ? (process.env.TELEGRAM_BOT_TOKEN ?? '')
+        : (process.env.DISCORD_BOT_TOKEN ?? '');
+
+    const workerPath = path.resolve(__dirname, 'restart-worker.ts');
+    const gatewayRoot = path.resolve(__dirname, '..', '..', '..');
+
+    const child = spawn('bun', [workerPath], {
+      detached: true,
+      stdio: 'ignore',
+      env: {
+        ...process.env,
+        RESTART_ORIGIN_CHANNEL: originChannel,
+        RESTART_NOTIFY_TARGET_ID: notifyTargetId,
+        RESTART_NOTIFY_BOT_TOKEN: botToken,
+        GATEWAY_ROOT: gatewayRoot,
+      },
+    });
+    child.unref();
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: '🔄 Gateway restart initiated. A notification will be sent to your channel when complete (usually ~15 seconds).',
+        },
+      ],
+    };
+  }
+}

--- a/mcp/tools/gateway/restart-worker.ts
+++ b/mcp/tools/gateway/restart-worker.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+/**
+ * Gateway restart worker — runs as a detached process.
+ * Kills all gateway processes, rebuilds, starts a new instance,
+ * and notifies the originating channel (Telegram or Discord).
+ *
+ * Required env vars:
+ *   GATEWAY_ROOT              — absolute path to project root
+ *   RESTART_ORIGIN_CHANNEL    — "telegram" | "discord"
+ *   RESTART_NOTIFY_TARGET_ID  — chat_id (Telegram) or channel_id (Discord)
+ *   RESTART_NOTIFY_BOT_TOKEN  — bot token for the originating channel
+ */
+
+import { execSync, spawn } from 'child_process';
+import * as path from 'path';
+
+const GATEWAY_ROOT = process.env.GATEWAY_ROOT ?? path.resolve(__dirname, '..', '..', '..');
+const ORIGIN_CHANNEL = process.env.RESTART_ORIGIN_CHANNEL ?? '';
+const NOTIFY_TARGET = process.env.RESTART_NOTIFY_TARGET_ID ?? '';
+const NOTIFY_TOKEN = process.env.RESTART_NOTIFY_BOT_TOKEN ?? '';
+
+async function notify(text: string): Promise<void> {
+  if (!NOTIFY_TARGET || !NOTIFY_TOKEN) return;
+
+  try {
+    if (ORIGIN_CHANNEL === 'telegram') {
+      await fetch(`https://api.telegram.org/bot${NOTIFY_TOKEN}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: NOTIFY_TARGET, text }),
+      });
+    } else if (ORIGIN_CHANNEL === 'discord') {
+      await fetch(`https://discord.com/api/v10/channels/${NOTIFY_TARGET}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bot ${NOTIFY_TOKEN}`,
+        },
+        body: JSON.stringify({ content: text }),
+      });
+    }
+  } catch {
+    // Best-effort — do not crash worker on notification failure
+  }
+}
+
+function killProcesses(): void {
+  const patterns = [
+    'node.*dist/index.js',
+    'bun.*claude-gateway',
+    'bun.*telegram/server',
+    'bun.*plugins',
+  ];
+  for (const pat of patterns) {
+    try {
+      execSync(`pkill -9 -f "${pat}" 2>/dev/null || true`, { stdio: 'ignore' });
+    } catch {
+      // Ignore — process may not exist
+    }
+  }
+}
+
+async function waitDead(timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      execSync(
+        'pgrep -f "node.*dist/index.js" 2>/dev/null; pgrep -f "bun.*claude-gateway" 2>/dev/null; true',
+        { stdio: 'pipe' },
+      );
+    } catch {
+      // pgrep exits 1 when nothing found — we're done
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+
+function build(): void {
+  execSync('npm run build', { cwd: GATEWAY_ROOT, stdio: 'inherit' });
+}
+
+function startGateway(): number {
+  const child = spawn('node', ['--env-file-if-exists=.env', 'dist/index.js'], {
+    cwd: GATEWAY_ROOT,
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+  return child.pid!;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  await notify('🔄 Gateway restarting...');
+
+  killProcesses();
+  await waitDead();
+
+  try {
+    build();
+  } catch (err) {
+    await notify(`❌ Restart failed at build step: ${err}`);
+    process.exit(1);
+  }
+
+  const pid = startGateway();
+
+  // Brief health window — if the process is still alive after 5s, assume success
+  await sleep(5_000);
+
+  try {
+    execSync(`kill -0 ${pid}`, { stdio: 'ignore' });
+    await notify(`✅ Gateway restarted (PID ${pid})`);
+  } catch {
+    await notify('❌ Gateway failed to start after restart');
+    process.exit(1);
+  }
+}
+
+main();

--- a/tests/unit/gateway-module.test.ts
+++ b/tests/unit/gateway-module.test.ts
@@ -1,0 +1,147 @@
+import { GatewayModule } from '../../mcp/tools/gateway/module';
+import { spawn } from 'child_process';
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn().mockReturnValue({ unref: jest.fn(), pid: 12345 }),
+}));
+
+const mockSpawn = spawn as jest.Mock;
+
+describe('GatewayModule', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    mockSpawn.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('isEnabled', () => {
+    it('always returns true', () => {
+      const mod = new GatewayModule();
+      expect(mod.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('properties', () => {
+    it('has correct id and visibility', () => {
+      const mod = new GatewayModule();
+      expect(mod.id).toBe('gateway');
+      expect(mod.toolVisibility).toBe('all-configured');
+    });
+  });
+
+  describe('getTools', () => {
+    it('returns exactly one tool named gateway_restart', () => {
+      const mod = new GatewayModule();
+      const tools = mod.getTools();
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('gateway_restart');
+    });
+
+    it('requires notify_target_id in schema', () => {
+      const mod = new GatewayModule();
+      const schema = mod.getTools()[0].inputSchema as any;
+      expect(schema.required).toContain('notify_target_id');
+    });
+
+    it('has notify_target_id and reason as optional additional property', () => {
+      const mod = new GatewayModule();
+      const schema = mod.getTools()[0].inputSchema as any;
+      expect(schema.properties).toHaveProperty('notify_target_id');
+      expect(schema.properties).toHaveProperty('reason');
+    });
+  });
+
+  describe('handleTool', () => {
+    it('returns error for unknown tool name', async () => {
+      const mod = new GatewayModule();
+      const result = await mod.handleTool('unknown_tool', {});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('unknown tool');
+    });
+
+    it('gateway_restart resolves immediately with restart message', async () => {
+      const mod = new GatewayModule();
+      const result = await mod.handleTool('gateway_restart', {
+        notify_target_id: 'PLACEHOLDER_CHAT_ID',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text.toLowerCase()).toMatch(/restart/);
+    });
+
+    it('spawns worker with detached:true', async () => {
+      const mod = new GatewayModule();
+      await mod.handleTool('gateway_restart', { notify_target_id: 'PLACEHOLDER_CHAT_ID' });
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+      const spawnOptions = mockSpawn.mock.calls[0][2];
+      expect(spawnOptions.detached).toBe(true);
+    });
+
+    it('calls unref() on spawned child', async () => {
+      const mockChild = { unref: jest.fn(), pid: 42 };
+      mockSpawn.mockReturnValueOnce(mockChild);
+
+      const mod = new GatewayModule();
+      await mod.handleTool('gateway_restart', { notify_target_id: 'PLACEHOLDER_CHAT_ID' });
+      expect(mockChild.unref).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes RESTART_ORIGIN_CHANNEL from GATEWAY_ORIGIN_CHANNEL env', async () => {
+      process.env.GATEWAY_ORIGIN_CHANNEL = 'telegram';
+      const mod = new GatewayModule();
+      await mod.handleTool('gateway_restart', { notify_target_id: 'PLACEHOLDER_CHAT_ID' });
+
+      const spawnEnv = mockSpawn.mock.calls[0][2].env;
+      expect(spawnEnv.RESTART_ORIGIN_CHANNEL).toBe('telegram');
+    });
+
+    it('passes TELEGRAM_BOT_TOKEN when channel is telegram', async () => {
+      process.env.GATEWAY_ORIGIN_CHANNEL = 'telegram';
+      process.env.TELEGRAM_BOT_TOKEN = 'tg-token-placeholder';
+      const mod = new GatewayModule();
+      await mod.handleTool('gateway_restart', { notify_target_id: 'PLACEHOLDER_CHAT_ID' });
+
+      const spawnEnv = mockSpawn.mock.calls[0][2].env;
+      expect(spawnEnv.RESTART_NOTIFY_BOT_TOKEN).toBe('tg-token-placeholder');
+    });
+
+    it('passes DISCORD_BOT_TOKEN when channel is discord', async () => {
+      process.env.GATEWAY_ORIGIN_CHANNEL = 'discord';
+      process.env.DISCORD_BOT_TOKEN = 'discord-token-placeholder';
+      const mod = new GatewayModule();
+      await mod.handleTool('gateway_restart', { notify_target_id: 'PLACEHOLDER_CHANNEL_ID' });
+
+      const spawnEnv = mockSpawn.mock.calls[0][2].env;
+      expect(spawnEnv.RESTART_NOTIFY_BOT_TOKEN).toBe('discord-token-placeholder');
+    });
+
+    it('passes RESTART_NOTIFY_TARGET_ID from notify_target_id arg', async () => {
+      const mod = new GatewayModule();
+      await mod.handleTool('gateway_restart', { notify_target_id: 'TARGET_ID_PLACEHOLDER' });
+
+      const spawnEnv = mockSpawn.mock.calls[0][2].env;
+      expect(spawnEnv.RESTART_NOTIFY_TARGET_ID).toBe('TARGET_ID_PLACEHOLDER');
+    });
+
+    it('passes GATEWAY_ROOT as absolute path', async () => {
+      const mod = new GatewayModule();
+      await mod.handleTool('gateway_restart', { notify_target_id: 'PLACEHOLDER_CHAT_ID' });
+
+      const spawnEnv = mockSpawn.mock.calls[0][2].env;
+      expect(path.isAbsolute(spawnEnv.GATEWAY_ROOT)).toBe(true);
+    });
+
+    it('resolves in under 200ms', async () => {
+      const mod = new GatewayModule();
+      const start = Date.now();
+      await mod.handleTool('gateway_restart', { notify_target_id: 'PLACEHOLDER_CHAT_ID' });
+      expect(Date.now() - start).toBeLessThan(200);
+    });
+  });
+});
+
+import * as path from 'path';


### PR DESCRIPTION
## Summary

- Adds `GatewayModule` at `mcp/tools/gateway/module.ts` exposing a `gateway_restart` MCP tool
- Implements `restart-worker.ts` — a detached Bun script that kills all gateway processes, rebuilds, starts a new instance, and sends a completion notification
- Notification is sent back to the **originating channel** (Telegram or Discord) automatically — no hardcoded chat IDs
- Worker is spawned detached + unref'd so MCP reply reaches the user before the gateway shuts down

## Flow

```
User → "restart gateway" (Telegram or Discord)
  → gateway_restart(notify_target_id="<id>")
  → spawn restart-worker.ts (detached, non-blocking)
  → MCP returns "🔄 Restarting..." immediately
  → Claude replies to channel
  → [worker: kill → build → start → notify ✅]
```

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1156 tests pass, 15 new unit tests for GatewayModule
- [x] Unit tests cover: isEnabled, getTools schema, handleTool dispatch, spawn options (detached, unref, env vars), Telegram vs Discord token selection, response time < 200ms