### PR TITLE
docs: add Telegram Groups setup guide and fix skill state-dir resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,75 @@ make update-agent   # choose "Manage channels"
 
 ---
 
+## Telegram Groups
+
+The bot can respond in Telegram groups and supergroups. Groups must be registered before the bot will respond.
+
+**Step 1 — Add the bot to the group as Admin**
+
+Add your bot to the group and **promote it to Admin**. Without admin rights, Telegram does not deliver group messages to the bot — it will appear online but never respond.
+
+Minimum required admin permission: **"Read Messages"** (or any admin role — even the most restricted works).
+
+**Step 2 — Get the group ID**
+
+Forward any message from the group to [@userinfobot](https://t.me/userinfobot). It will reply with the chat ID — a negative number like `-1001234567890`.
+
+Alternatively, send a message in the group and visit:
+```
+https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates
+```
+Look for `"chat":{"id": ...}` in the result.
+
+**Step 3 — Register the group**
+
+Edit the agent's `access.json` directly:
+
+```
+~/.claude-gateway/agents/<your-agent-id>/workspace/.telegram-state/access.json
+```
+
+Add the group under `"groups"`:
+
+```json
+{
+  "dmPolicy": "allowlist",
+  "allowFrom": ["..."],
+  "groups": {
+    "-1001234567890": {
+      "requireMention": true,
+      "allowFrom": []
+    }
+  }
+}
+```
+
+Set `"requireMention": false` if you want the bot to respond to all messages without needing an @mention.
+To restrict to specific members only, add their Telegram user IDs to `"allowFrom"`.
+
+**Step 4 — Start chatting**
+
+@mention the bot in the group (or reply to one of its messages). Changes to `access.json` take effect immediately — no restart needed.
+
+**Managing groups**
+
+Edit `access.json` to add or remove entries from the `"groups"` object. The gateway re-reads the file on every inbound message.
+
+> **Note:** `/telegram:access` skill is available when running inside a gateway agent session (TELEGRAM_STATE_DIR is set automatically). For standalone terminal use, edit `access.json` directly as shown above.
+
+**Optional — Let the bot read all messages (disable Privacy Mode)**
+
+By default, Telegram bots in groups only receive messages that start with `/` or directly @mention the bot. If you want the bot to respond to every message without an @mention (and have set `"requireMention": false` in `access.json`), you also need to disable Privacy Mode at the bot level:
+
+1. Open [@BotFather](https://t.me/BotFather)
+2. Send `/setprivacy`
+3. Select your bot
+4. Choose **Disable**
+
+This is a bot-level setting — it applies to all groups the bot joins. If @mention-only is fine, skip this step and keep `"requireMention": true`.
+
+---
+
 ## Telegram Commands
 
 Once paired, the following bot commands are available in a private chat:

--- a/mcp/tools/telegram/skills/access/SKILL.md
+++ b/mcp/tools/telegram/skills/access/SKILL.md
@@ -31,13 +31,18 @@ Arguments passed: `$ARGUMENTS`
 Compute STATE_DIR at the very start before doing anything else:
 
 ```
-If $TELEGRAM_STATE_DIR env var is set:
-  STATE_DIR = $TELEGRAM_STATE_DIR
-Else:
-  STATE_DIR = ~/.claude/channels/telegram
+1. If $TELEGRAM_STATE_DIR env var is set:
+     STATE_DIR = $TELEGRAM_STATE_DIR
+
+2. Else if {CWD}/.telegram-state/ exists:
+     STATE_DIR = {CWD}/.telegram-state
+   (This handles gateway agent sessions where CWD = workspace dir)
+
+3. Else:
+     STATE_DIR = ~/.claude/channels/telegram  (legacy fallback)
 ```
 
-To target a specific gateway agent's state, set TELEGRAM_STATE_DIR before running Claude:
+To explicitly target a specific agent's state from an external terminal:
 
 ```bash
 TELEGRAM_STATE_DIR=~/.claude-gateway/agents/my-agent/workspace/.telegram-state claude

--- a/mcp/tools/telegram/skills/configure/SKILL.md
+++ b/mcp/tools/telegram/skills/configure/SKILL.md
@@ -11,10 +11,32 @@ allowed-tools:
 
 # /telegram:configure — Telegram Channel Setup
 
-Writes the bot token to `~/.claude/channels/telegram/.env` and orients the
-user on access policy. The server reads both files at boot.
+Writes the bot token to `{STATE_DIR}/.env` and orients the user on access policy.
+The server reads both files at boot.
 
 Arguments passed: `$ARGUMENTS`
+
+---
+
+## State directory resolution
+
+Compute STATE_DIR at the very start before doing anything else:
+
+```
+1. If $TELEGRAM_STATE_DIR env var is set:
+     STATE_DIR = $TELEGRAM_STATE_DIR
+
+2. Else if {CWD}/.telegram-state/ exists:
+     STATE_DIR = {CWD}/.telegram-state
+   (This handles gateway agent sessions where CWD = workspace dir)
+
+3. Else:
+     STATE_DIR = ~/.claude/channels/telegram  (legacy fallback)
+```
+
+Use STATE_DIR for all file paths:
+- Token file: `{STATE_DIR}/.env`
+- Access file: `{STATE_DIR}/access.json`
 
 ---
 
@@ -24,11 +46,11 @@ Arguments passed: `$ARGUMENTS`
 
 Read both state files and give the user a complete picture:
 
-1. **Token** — check `~/.claude/channels/telegram/.env` for
+1. **Token** — check `{STATE_DIR}/.env` for
    `TELEGRAM_BOT_TOKEN`. Show set/not-set; if set, show first 10 chars masked
    (`123456789:...`).
 
-2. **Access** — read `~/.claude/channels/telegram/access.json` (missing file
+2. **Access** — read `{STATE_DIR}/access.json` (missing file
    = defaults: `dmPolicy: "pairing"`, empty allowlist). Show:
    - DM policy and what it means in one line
    - Allowed senders: count, and list display names or IDs
@@ -74,10 +96,10 @@ offer.
 
 1. Treat `$ARGUMENTS` as the token (trim whitespace). BotFather tokens look
    like `123456789:AAH...` — numeric prefix, colon, long string.
-2. `mkdir -p ~/.claude/channels/telegram`
+2. `mkdir -p {STATE_DIR}`
 3. Read existing `.env` if present; update/add the `TELEGRAM_BOT_TOKEN=` line,
    preserve other keys. Write back, no quotes around the value.
-4. `chmod 600 ~/.claude/channels/telegram/.env` — the token is a credential.
+4. `chmod 600 {STATE_DIR}/.env` — the token is a credential.
 5. Confirm, then show the no-args status so the user sees where they stand.
 
 ### `clear` — remove the token


### PR DESCRIPTION
## Summary

- Add **Telegram Groups** section to README with 4-step setup guide (promote bot to Admin, get group ID, register in `access.json`, start chatting) plus an optional section on disabling Privacy Mode via BotFather
- Fix `/telegram:access` and `/telegram:configure` skills to resolve `STATE_DIR` by checking `{CWD}/.telegram-state/` first — enabling correct path resolution when running inside a gateway agent session without `TELEGRAM_STATE_DIR` explicitly set

## Test plan

- [ ] Follow README steps to add a new Telegram group — confirm bot responds after registration
- [ ] Run `/telegram:access` from inside a gateway agent session — confirm it reads/writes to `{workspace}/.telegram-state/access.json`
- [ ] Run `/telegram:configure` from inside a gateway agent session — confirm token writes to correct path
- [ ] Run both skills from standalone terminal (no `TELEGRAM_STATE_DIR`) — confirm fallback to `~/.claude/channels/telegram`

🤖 Generated with [Claude Code](https://claude.com/claude-code)