### PR TITLE
fix(api): enforce 2-dimension auth model across agent and skills APIs

### DIFF
--- a/src/agent/context-isolation.ts
+++ b/src/agent/context-isolation.ts
@@ -49,12 +49,14 @@ export class ContextIsolationGuard {
       }
       workspaces.set(ws, agent.id);
 
-      // Token check
+      // Token check — skip if token is empty (agent has no telegram channel configured)
       const token = agent.telegram?.botToken ?? '';
-      if (tokens.has(token)) {
-        throw new TokenConflictError([tokens.get(token)!, agent.id], token);
+      if (token) {
+        if (tokens.has(token)) {
+          throw new TokenConflictError([tokens.get(token)!, agent.id], token);
+        }
+        tokens.set(token, agent.id);
       }
-      tokens.set(token, agent.id);
 
       // Session dir: derived as <workspace>/../sessions (by convention),
       // but we also check the agent id-based session path if it were the same.

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1143,11 +1143,22 @@ export class AgentRunner extends EventEmitter {
 
     const systemNote = buildApiSystemNote(opts.allowTools ?? false);
 
+    // Detect skill commands (same as channel message path)
+    const skillInvocation = detectSkillCommand(message, this.skillRegistry);
+    if (skillInvocation) {
+      this.logger.info('Skill invoked via API', {
+        skill: skillInvocation.skillKey,
+        args: skillInvocation.args,
+        sessionId,
+      });
+    }
+
     const channelXml =
       `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
       `${message}\n\n` +
       `${systemNote}` +
-      `</channel>`;
+      `</channel>` +
+      (skillInvocation ? `\n${formatSkillContext(skillInvocation)}` : '');
 
     return new Promise<string>((resolve, reject) => {
       const buffer: string[] = [];
@@ -1407,11 +1418,22 @@ export class AgentRunner extends EventEmitter {
 
     const systemNote = buildApiSystemNote(opts.allowTools ?? false);
 
+    // Detect skill commands (same as channel message path)
+    const skillInvocationStream = detectSkillCommand(message, this.skillRegistry);
+    if (skillInvocationStream) {
+      this.logger.info('Skill invoked via API stream', {
+        skill: skillInvocationStream.skillKey,
+        args: skillInvocationStream.args,
+        sessionId,
+      });
+    }
+
     const channelXml =
       `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
       `${message}\n\n` +
       systemNote +
-      `</channel>`;
+      `</channel>` +
+      (skillInvocationStream ? `\n${formatSkillContext(skillInvocationStream)}` : '');
 
     session.setProcessing(true);
     session.sendMessage(channelXml);

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -57,3 +57,19 @@ export function canAccessAgent(apiKey: ApiKey, agentId: string): boolean {
   if (apiKey.agents === '*') return true;
   return (apiKey.agents as string[]).includes(agentId);
 }
+
+/**
+ * Returns true if the key has write access to the specified agent.
+ * Requires both agent-scope access AND write flag (or admin).
+ */
+export function canWriteAgent(apiKey: ApiKey, agentId: string): boolean {
+  if (apiKey.admin) return true;
+  return apiKey.write === true && canAccessAgent(apiKey, agentId);
+}
+
+/**
+ * Returns true if the key has admin privileges (cross-agent + destructive ops).
+ */
+export function isAdmin(apiKey: ApiKey): boolean {
+  return apiKey.admin === true;
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -50,8 +50,10 @@ export function createApiAuthMiddleware(apiKeys: ApiKey[]) {
 
 /**
  * Returns true if the given API key is allowed to access the specified agent.
+ * Keys with `admin: true` bypass all agent scope checks.
  */
 export function canAccessAgent(apiKey: ApiKey, agentId: string): boolean {
+  if (apiKey.admin) return true;
   if (apiKey.agents === '*') return true;
   return (apiKey.agents as string[]).includes(agentId);
 }

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -7,6 +7,8 @@ import { CronManager } from '../cron/manager';
 import { generateDashboardHtml } from '../ui/web-ui';
 import { createApiRouter } from './router';
 import { createCronRouter } from './cron-router';
+import { createWorkspaceRouter } from './workspace-router';
+import { createSkillsRouter } from './skills-router';
 
 export class GatewayRouter {
   private readonly agents: Map<string, AgentRunner>;
@@ -36,17 +38,22 @@ export class GatewayRouter {
   /** Optional persistent cron manager */
   private readonly cronManager?: CronManager;
 
+  /** Path to config.json for agent CRUD operations */
+  private readonly configPath?: string;
+
   constructor(
     agents: Map<string, AgentRunner>,
     configs: Map<string, AgentConfig>,
     schedulers?: Map<string, CronScheduler>,
     gatewayConfig?: GatewayConfig,
     cronManager?: CronManager,
+    configPath?: string,
   ) {
     this.agents = agents;
     this.configs = configs;
     this.gatewayConfig = gatewayConfig;
     this.cronManager = cronManager;
+    this.configPath = configPath;
     this.app = express();
 
     // Initialise counters for all known agents
@@ -82,8 +89,29 @@ export class GatewayRouter {
         this.agents,
         this.configs,
         this.gatewayConfig.gateway.api.keys,
+        this.configPath,
+        this.gatewayConfig.gateway.models,
       );
       this.app.use('/api', apiRouter);
+    }
+
+    // Mount workspace file routes
+    if (this.gatewayConfig?.gateway?.api?.keys?.length) {
+      const workspaceRouter = createWorkspaceRouter(
+        this.configs,
+        this.gatewayConfig.gateway.api.keys,
+      );
+      this.app.use('/api', workspaceRouter);
+    }
+
+    // Mount skills routes
+    if (this.gatewayConfig?.gateway?.api?.keys?.length) {
+      const skillsRouter = createSkillsRouter(
+        this.configs,
+        this.gatewayConfig.gateway.api.keys,
+        this.agents,
+      );
+      this.app.use('/api', skillsRouter);
     }
 
     // Mount cron manager routes with same API key auth as agent router
@@ -165,9 +193,16 @@ export class GatewayRouter {
   }
 
   async start(port: number): Promise<void> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.server = this.app.listen(port, () => {
         resolve();
+      });
+      this.server.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          reject(new Error(`Port ${port} is already in use. Stop the existing process or set a different PORT env var.`));
+        } else {
+          reject(err);
+        }
       });
     });
   }

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1,7 +1,10 @@
 import { Router, Request, Response } from 'express';
 import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { AgentRunner } from '../agent/runner';
-import { AgentConfig, ApiKey } from '../types';
+import { AgentConfig, ApiKey, ModelConfig } from '../types';
 import { createApiAuthMiddleware, canAccessAgent } from './auth';
 
 const MAX_MESSAGE_LENGTH = 10_000;
@@ -9,10 +12,32 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 
 type AuthedRequest = Request & { apiKey: ApiKey };
 
+const AGENT_ID_RE = /^[a-z][a-z0-9_-]{1,31}$/;
+
+/** Read config.json, mutate agents array, write back atomically. Throws if duplicate id detected. */
+function writeAgentsToConfig(
+  configPath: string,
+  mutate: (agents: unknown[]) => void,
+  newId?: string,
+): void {
+  const raw = fs.readFileSync(configPath, 'utf-8');
+  const config = JSON.parse(raw) as { agents: unknown[]; [k: string]: unknown };
+  if (newId) {
+    const exists = (config.agents as Record<string, unknown>[]).some((a) => a.id === newId);
+    if (exists) throw Object.assign(new Error(`Agent '${newId}' already exists in config`), { code: 'DUPLICATE' });
+  }
+  mutate(config.agents);
+  const tmp = configPath + '.tmp.' + randomUUID();
+  fs.writeFileSync(tmp, JSON.stringify(config, null, 2), 'utf-8');
+  fs.renameSync(tmp, configPath);
+}
+
 export function createApiRouter(
   agentRunners: Map<string, AgentRunner>,
   agentConfigs: Map<string, AgentConfig>,
   apiKeys: ApiKey[],
+  configPath?: string,
+  models?: ModelConfig[],
 ): Router {
   const router = Router();
   const auth = createApiAuthMiddleware(apiKeys);
@@ -105,11 +130,13 @@ export function createApiRouter(
         res.flushHeaders();
         res.socket?.setNoDelay(true);
 
+        const agentCfg = agentConfigs.get(agentId)!;
+        const allowTools = agentCfg.allow_tools ?? !!apiKey.allow_tools;
         cleanup = await runner.sendApiMessageStream(
           sessionId,
           message.trim(),
           sseCallbacks,
-          { timeoutMs, allowTools: !!apiKey.allow_tools },
+          { timeoutMs, allowTools },
         );
 
         // Client disconnect -> cleanup
@@ -132,9 +159,11 @@ export function createApiRouter(
     } else {
       // Synchronous mode (existing behavior)
       try {
+        const agentCfgSync = agentConfigs.get(agentId)!;
+        const allowToolsSync = agentCfgSync.allow_tools ?? !!apiKey.allow_tools;
         const response = await runner.sendApiMessage(sessionId, message.trim(), {
           timeoutMs,
-          allowTools: !!apiKey.allow_tools,
+          allowTools: allowToolsSync,
         });
         res.json({
           request_id: requestId,
@@ -157,16 +186,189 @@ export function createApiRouter(
   });
 
   /**
+   * GET /api/v1/models
+   *
+   * List all supported Claude models from gateway config (falls back to defaults).
+   */
+  router.get('/v1/models', auth, (_req: Request, res: Response) => {
+    res.json({ models: (models ?? []).map((m) => ({ id: m.id, name: m.label, alias: m.alias, contextWindow: m.contextWindow, multiplier: m.multiplier ?? 1 })) });
+  });
+
+  /**
    * GET /api/v1/agents
    *
-   * List agents accessible by the current API key.
+   * List all agents (no API-key scope filter — auth is handled by Go API).
    */
-  router.get('/v1/agents', auth, (req: Request, res: Response) => {
-    const apiKey = (req as AuthedRequest).apiKey;
-    const agents = [...agentConfigs.entries()]
-      .filter(([id]) => canAccessAgent(apiKey, id))
-      .map(([id, cfg]) => ({ id, description: cfg.description }));
+  router.get('/v1/agents', auth, (_req: Request, res: Response) => {
+    const agents = [...agentConfigs.entries()].map(([id, cfg]) => ({
+      id,
+      description: cfg.description,
+      model: cfg.claude?.model ?? null,
+      allow_tools: cfg.allow_tools ?? false,
+    }));
     res.json({ agents });
+  });
+
+  /**
+   * POST /api/v1/agents
+   *
+   * Create a new agent entry in config.json.
+   * Body: { id, description, model? }
+   */
+  router.post('/v1/agents', auth, (req: Request, res: Response) => {
+    if (!configPath) {
+      res.status(501).json({ error: 'Agent management not available (no configPath)' });
+      return;
+    }
+    const body = req.body as { id?: unknown; description?: unknown; model?: unknown };
+    const { id, description, model } = body;
+
+    if (!id || typeof id !== 'string' || !AGENT_ID_RE.test(id)) {
+      res.status(400).json({ error: 'id must match pattern [a-z][a-z0-9_-]{1,31}' });
+      return;
+    }
+    if (!description || typeof description !== 'string' || !description.trim()) {
+      res.status(400).json({ error: 'description is required' });
+      return;
+    }
+    if (agentConfigs.has(id)) {
+      res.status(409).json({ error: `Agent '${id}' already exists` });
+      return;
+    }
+
+    const workspace = path.join('~', '.claude-gateway', 'agents', id, 'workspace');
+    const workspaceAbs = path.join(os.homedir(), '.claude-gateway', 'agents', id, 'workspace');
+    const newAgent: Record<string, unknown> = {
+      id,
+      description: description.trim(),
+      workspace,
+      env: path.join('~', '.claude-gateway', 'agents', id, 'workspace', '.env'),
+      claude: {
+        model: typeof model === 'string' && model.trim() ? model.trim() : 'claude-sonnet-4-6',
+        dangerouslySkipPermissions: false,
+        extraFlags: [],
+      },
+    };
+
+    // Create workspace directory and stub files matching UI WORKSPACE_FILES
+    const stubFiles: Record<string, string> = {
+      'AGENTS.md': `# Agent: ${id}\n\n${description.trim()}\n`,
+      'SOUL.md': `# Soul\n\n`,
+      'USER.md': `# User Profile\n\n`,
+      'MEMORY.md': `# Memory\n\n`,
+    };
+    try {
+      fs.mkdirSync(workspaceAbs, { recursive: true });
+      for (const [filename, stub] of Object.entries(stubFiles)) {
+        const filePath = path.join(workspaceAbs, filename);
+        if (!fs.existsSync(filePath)) {
+          fs.writeFileSync(filePath, stub, 'utf8');
+        }
+      }
+    } catch (err) {
+      res.status(500).json({ error: `Failed to create workspace: ${(err as Error).message}` });
+      return;
+    }
+
+    try {
+      writeAgentsToConfig(configPath, (agents) => agents.push(newAgent), id);
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === 'DUPLICATE') {
+        res.status(409).json({ error: `Agent '${id}' already exists` });
+      } else {
+        res.status(500).json({ error: `Failed to write config: ${(err as Error).message}` });
+      }
+      return;
+    }
+
+    res.status(201).json({ agent: { id, description: newAgent.description, model: (newAgent.claude as Record<string, unknown>).model } });
+  });
+
+  /**
+   * PATCH /api/v1/agents/:agentId
+   *
+   * Update agent description and/or model.
+   * Body: { description?, model? }
+   */
+  router.patch('/v1/agents/:agentId', auth, (req: Request, res: Response) => {
+    if (!configPath) {
+      res.status(501).json({ error: 'Agent management not available (no configPath)' });
+      return;
+    }
+    const { agentId } = req.params as { agentId: string };
+    if (!agentConfigs.has(agentId)) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const body = req.body as { description?: unknown; model?: unknown; allow_tools?: unknown };
+    const { description, model, allow_tools } = body;
+    if (description !== undefined && (typeof description !== 'string' || !description.trim())) {
+      res.status(400).json({ error: 'description must be a non-empty string' });
+      return;
+    }
+    if (model !== undefined && (typeof model !== 'string' || !model.trim())) {
+      res.status(400).json({ error: 'model must be a non-empty string' });
+      return;
+    }
+    if (allow_tools !== undefined && typeof allow_tools !== 'boolean') {
+      res.status(400).json({ error: 'allow_tools must be a boolean' });
+      return;
+    }
+
+    try {
+      writeAgentsToConfig(configPath, (agents) => {
+        const agent = (agents as Record<string, unknown>[]).find((a) => a.id === agentId);
+        if (!agent) return;
+        if (description !== undefined) agent.description = (description as string).trim();
+        if (model !== undefined) {
+          const claude = agent.claude as Record<string, unknown> | undefined;
+          if (claude) claude.model = (model as string).trim();
+        }
+        if (allow_tools !== undefined) agent.allow_tools = allow_tools;
+      });
+    } catch (err) {
+      res.status(500).json({ error: `Failed to write config: ${(err as Error).message}` });
+      return;
+    }
+
+    // Sync in-memory map with what was written to disk
+    const cfg = agentConfigs.get(agentId)!;
+    if (description !== undefined) cfg.description = (description as string).trim();
+    if (model !== undefined && cfg.claude) cfg.claude.model = (model as string).trim();
+    if (allow_tools !== undefined) cfg.allow_tools = allow_tools;
+
+    res.json({ agent: { id: agentId, description: cfg.description, model: cfg.claude?.model, allow_tools: cfg.allow_tools ?? false } });
+  });
+
+  /**
+   * DELETE /api/v1/agents/:agentId
+   *
+   * Remove agent from config.json.
+   */
+  router.delete('/v1/agents/:agentId', auth, (req: Request, res: Response) => {
+    if (!configPath) {
+      res.status(501).json({ error: 'Agent management not available (no configPath)' });
+      return;
+    }
+    const { agentId } = req.params as { agentId: string };
+    if (!agentConfigs.has(agentId)) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    try {
+      writeAgentsToConfig(configPath, (agents) => {
+        const idx = (agents as Record<string, unknown>[]).findIndex((a) => a.id === agentId);
+        if (idx !== -1) agents.splice(idx, 1);
+      });
+    } catch (err) {
+      res.status(500).json({ error: `Failed to write config: ${(err as Error).message}` });
+      return;
+    }
+
+    res.json({ success: true, id: agentId });
   });
 
   return router;

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -208,7 +208,7 @@ export function createApiRouter(
   router.get('/v1/agents', auth, (req: Request, res: Response) => {
     const apiKey = (req as AuthedRequest).apiKey;
     const agents = [...agentConfigs.entries()]
-      .filter(([id]) => isAdmin(apiKey) || canAccessAgent(apiKey, id))
+      .filter(([id]) => canAccessAgent(apiKey, id))
       .map(([id, cfg]) => ({
         id,
         description: cfg.description,

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { AgentRunner } from '../agent/runner';
 import { AgentConfig, ApiKey, ModelConfig } from '../types';
-import { createApiAuthMiddleware, canAccessAgent } from './auth';
+import { createApiAuthMiddleware, canAccessAgent, canWriteAgent, isAdmin } from './auth';
 
 const MAX_MESSAGE_LENGTH = 10_000;
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -14,22 +14,28 @@ type AuthedRequest = Request & { apiKey: ApiKey };
 
 const AGENT_ID_RE = /^[a-z][a-z0-9_-]{1,31}$/;
 
-/** Read config.json, mutate agents array, write back atomically. Throws if duplicate id detected. */
+let _configWriteLock: Promise<void> = Promise.resolve();
+
+/** Read config.json, mutate agents array, write back atomically under an in-process lock. */
 function writeAgentsToConfig(
   configPath: string,
   mutate: (agents: unknown[]) => void,
   newId?: string,
-): void {
-  const raw = fs.readFileSync(configPath, 'utf-8');
-  const config = JSON.parse(raw) as { agents: unknown[]; [k: string]: unknown };
-  if (newId) {
-    const exists = (config.agents as Record<string, unknown>[]).some((a) => a.id === newId);
-    if (exists) throw Object.assign(new Error(`Agent '${newId}' already exists in config`), { code: 'DUPLICATE' });
-  }
-  mutate(config.agents);
-  const tmp = configPath + '.tmp.' + randomUUID();
-  fs.writeFileSync(tmp, JSON.stringify(config, null, 2), 'utf-8');
-  fs.renameSync(tmp, configPath);
+): Promise<void> {
+  const next = _configWriteLock.catch(() => {}).then(() => {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const config = JSON.parse(raw) as { agents: unknown[]; [k: string]: unknown };
+    if (newId) {
+      const exists = (config.agents as Record<string, unknown>[]).some((a) => a.id === newId);
+      if (exists) throw Object.assign(new Error(`Agent '${newId}' already exists in config`), { code: 'DUPLICATE' });
+    }
+    mutate(config.agents);
+    const tmp = configPath + '.tmp.' + randomUUID();
+    fs.writeFileSync(tmp, JSON.stringify(config, null, 2), 'utf-8');
+    fs.renameSync(tmp, configPath);
+  });
+  _configWriteLock = next.catch(() => {});
+  return next;
 }
 
 export function createApiRouter(
@@ -197,25 +203,33 @@ export function createApiRouter(
   /**
    * GET /api/v1/agents
    *
-   * List all agents (no API-key scope filter — auth is handled by Go API).
+   * List agents scoped to the API key. Admin keys see all agents.
    */
-  router.get('/v1/agents', auth, (_req: Request, res: Response) => {
-    const agents = [...agentConfigs.entries()].map(([id, cfg]) => ({
-      id,
-      description: cfg.description,
-      model: cfg.claude?.model ?? null,
-      allow_tools: cfg.allow_tools ?? false,
-    }));
+  router.get('/v1/agents', auth, (req: Request, res: Response) => {
+    const apiKey = (req as AuthedRequest).apiKey;
+    const agents = [...agentConfigs.entries()]
+      .filter(([id]) => isAdmin(apiKey) || canAccessAgent(apiKey, id))
+      .map(([id, cfg]) => ({
+        id,
+        description: cfg.description,
+        model: cfg.claude?.model ?? null,
+        allow_tools: cfg.allow_tools ?? false,
+      }));
     res.json({ agents });
   });
 
   /**
    * POST /api/v1/agents
    *
-   * Create a new agent entry in config.json.
+   * Create a new agent entry in config.json. Requires admin key.
    * Body: { id, description, model? }
    */
-  router.post('/v1/agents', auth, (req: Request, res: Response) => {
+  router.post('/v1/agents', auth, async (req: Request, res: Response) => {
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!isAdmin(apiKey)) {
+      res.status(403).json({ error: 'Admin key required to create agents' });
+      return;
+    }
     if (!configPath) {
       res.status(501).json({ error: 'Agent management not available (no configPath)' });
       return;
@@ -271,7 +285,7 @@ export function createApiRouter(
     }
 
     try {
-      writeAgentsToConfig(configPath, (agents) => agents.push(newAgent), id);
+      await writeAgentsToConfig(configPath, (agents) => agents.push(newAgent), id);
     } catch (err) {
       const code = (err as { code?: string }).code;
       if (code === 'DUPLICATE') {
@@ -288,15 +302,20 @@ export function createApiRouter(
   /**
    * PATCH /api/v1/agents/:agentId
    *
-   * Update agent description and/or model.
+   * Update agent description and/or model. Requires write access to the agent.
    * Body: { description?, model? }
    */
-  router.patch('/v1/agents/:agentId', auth, (req: Request, res: Response) => {
+  router.patch('/v1/agents/:agentId', auth, async (req: Request, res: Response) => {
+    const apiKey = (req as AuthedRequest).apiKey;
+    const { agentId } = req.params as { agentId: string };
+    if (!canWriteAgent(apiKey, agentId)) {
+      res.status(403).json({ error: 'Write permission required' });
+      return;
+    }
     if (!configPath) {
       res.status(501).json({ error: 'Agent management not available (no configPath)' });
       return;
     }
-    const { agentId } = req.params as { agentId: string };
     if (!agentConfigs.has(agentId)) {
       res.status(404).json({ error: `Agent '${agentId}' not found` });
       return;
@@ -318,7 +337,7 @@ export function createApiRouter(
     }
 
     try {
-      writeAgentsToConfig(configPath, (agents) => {
+      await writeAgentsToConfig(configPath, (agents) => {
         const agent = (agents as Record<string, unknown>[]).find((a) => a.id === agentId);
         if (!agent) return;
         if (description !== undefined) agent.description = (description as string).trim();
@@ -345,9 +364,14 @@ export function createApiRouter(
   /**
    * DELETE /api/v1/agents/:agentId
    *
-   * Remove agent from config.json.
+   * Remove agent from config.json. Requires admin key.
    */
-  router.delete('/v1/agents/:agentId', auth, (req: Request, res: Response) => {
+  router.delete('/v1/agents/:agentId', auth, async (req: Request, res: Response) => {
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!isAdmin(apiKey)) {
+      res.status(403).json({ error: 'Admin key required' });
+      return;
+    }
     if (!configPath) {
       res.status(501).json({ error: 'Agent management not available (no configPath)' });
       return;
@@ -359,7 +383,7 @@ export function createApiRouter(
     }
 
     try {
-      writeAgentsToConfig(configPath, (agents) => {
+      await writeAgentsToConfig(configPath, (agents) => {
         const idx = (agents as Record<string, unknown>[]).findIndex((a) => a.id === agentId);
         if (idx !== -1) agents.splice(idx, 1);
       });

--- a/src/api/skills-router.ts
+++ b/src/api/skills-router.ts
@@ -1,0 +1,417 @@
+import { Router, Request, Response } from 'express';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AgentConfig, ApiKey } from '../types';
+import { createApiAuthMiddleware, canAccessAgent } from './auth';
+import { loadSkills } from '../skills/loader';
+import { extractFrontmatter } from '../skills/parser';
+import type { AgentRunner } from '../agent/runner';
+
+type AuthedRequest = Request & { apiKey: ApiKey };
+
+const SHARED_SKILLS_DIR = path.join(os.homedir(), '.claude-gateway', 'shared-skills');
+const MCP_TOOLS_DIR = path.resolve(__dirname, '..', '..', 'mcp', 'tools');
+const MAX_SKILL_SIZE = 100 * 1024; // 100KB
+
+// Skill name validation: lowercase alphanumeric + hyphens, 1-64 chars
+const VALID_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const RESERVED_NAMES = new Set([
+  'help', 'sessions', 'session', 'new', 'clear', 'compact',
+  'rename', 'model', 'restart', 'access', 'configure',
+]);
+
+function validateSkillName(name: string): string | null {
+  if (!VALID_NAME_RE.test(name)) {
+    return `Invalid skill name "${name}". Must be lowercase alphanumeric with hyphens, 1-64 chars.`;
+  }
+  if (RESERVED_NAMES.has(name)) {
+    return `Skill name "${name}" is reserved.`;
+  }
+  return null;
+}
+
+function getSkillDir(scope: 'workspace' | 'shared', name: string, workspaceDir: string): string {
+  return scope === 'workspace'
+    ? path.join(workspaceDir, 'skills', name)
+    : path.join(SHARED_SKILLS_DIR, name);
+}
+
+function toRawGitHubUrl(url: string): string {
+  if (url.includes('raw.githubusercontent.com')) return url;
+  const match = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/(tree|blob)\/([^/]+)\/(.+)$/);
+  if (match) {
+    const [, owner, repo, , branch, filePath] = match;
+    const finalPath = filePath.endsWith('SKILL.md') ? filePath : `${filePath}/SKILL.md`;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${finalPath}`;
+  }
+  return url;
+}
+
+/**
+ * Extract source_url from a SKILL.md file's frontmatter (homepage field),
+ * or return null if not present.
+ */
+function extractSourceUrl(filePath: string): string | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const extracted = extractFrontmatter(raw);
+    if (!extracted) return null;
+    const homepage = extracted.frontmatter['homepage'];
+    return typeof homepage === 'string' ? homepage : null;
+  } catch {
+    return null;
+  }
+}
+
+function reloadRunnerRegistry(
+  agentId: string,
+  config: AgentConfig,
+  agents: Map<string, AgentRunner>,
+): void {
+  const runner = agents.get(agentId);
+  if (!runner) return;
+  const registry = loadSkills({
+    workspaceDir: config.workspace,
+    mcpToolsDir: MCP_TOOLS_DIR,
+    sharedSkillsDir: SHARED_SKILLS_DIR,
+  });
+  runner.setSkillRegistry(registry);
+}
+
+export function createSkillsRouter(
+  agentConfigs: Map<string, AgentConfig>,
+  apiKeys: ApiKey[],
+  agents?: Map<string, AgentRunner>,
+): Router {
+  const router = Router();
+  const auth = createApiAuthMiddleware(apiKeys);
+
+  /**
+   * GET /api/v1/agents/:agentId/skills
+   * List all skills (workspace + module + shared).
+   */
+  router.get('/v1/agents/:agentId/skills', auth, (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+
+    const config = agentConfigs.get(agentId);
+    if (!config) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const registry = loadSkills({
+      workspaceDir: config.workspace,
+      mcpToolsDir: MCP_TOOLS_DIR,
+      sharedSkillsDir: SHARED_SKILLS_DIR,
+    });
+
+    const skills = [...registry.skills.entries()].map(([key, skill]) => ({
+      key,
+      name: skill.name,
+      description: skill.description,
+      scope: skill.source,
+      emoji: skill.emoji ?? null,
+      userInvocable: skill.userInvocable,
+      modulePrefix: skill.modulePrefix ?? null,
+      source_url: extractSourceUrl(skill.filePath),
+    }));
+
+    res.json(skills);
+  });
+
+  /**
+   * GET /api/v1/agents/:agentId/skills/:name
+   * Get a single skill's content.
+   */
+  router.get('/v1/agents/:agentId/skills/:name', auth, (req: Request, res: Response) => {
+    const { agentId, name } = req.params as { agentId: string; name: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+
+    const config = agentConfigs.get(agentId);
+    if (!config) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const registry = loadSkills({
+      workspaceDir: config.workspace,
+      mcpToolsDir: MCP_TOOLS_DIR,
+      sharedSkillsDir: SHARED_SKILLS_DIR,
+    });
+
+    const scopeFilter = req.query['scope'] as string | undefined;
+
+    // Find skill by name, optionally filtered by scope.
+    // Module skills are keyed as "prefix:name" (e.g. "cron:cron") so a direct
+    // get(name) may miss them — fall back to a linear search by name+source.
+    let skill = registry.skills.get(name);
+    if (scopeFilter && skill && skill.source !== scopeFilter) {
+      // Direct key hit has the wrong scope — search by name within the requested scope.
+      const scopedMatch = [...registry.skills.values()].find(
+        (s) => s.name === name && s.source === scopeFilter,
+      );
+      skill = scopedMatch ?? undefined;
+    }
+    if (!skill && scopeFilter) {
+      // Direct key miss — search by name+scope (covers module skills keyed as prefix:name).
+      skill = [...registry.skills.values()].find(
+        (s) => s.name === name && s.source === scopeFilter,
+      );
+    }
+
+    if (!skill) {
+      res.status(404).json({ error: `Skill '${name}' not found${scopeFilter ? ` in scope '${scopeFilter}'` : ''}` });
+      return;
+    }
+
+    let rawContent = '';
+    try {
+      rawContent = fs.readFileSync(skill.filePath, 'utf-8');
+    } catch {
+      rawContent = skill.content;
+    }
+
+    res.json({
+      key: name,
+      name: skill.name,
+      description: skill.description,
+      scope: skill.source,
+      emoji: skill.emoji ?? null,
+      content: rawContent,
+      source_url: extractSourceUrl(skill.filePath),
+    });
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/skills
+   * Create a new skill.
+   * Body: { name, description, content, scope?: 'workspace' | 'shared' }
+   */
+  router.post('/v1/agents/:agentId/skills', auth, async (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+
+    const config = agentConfigs.get(agentId);
+    if (!config) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const body = req.body as { name?: unknown; description?: unknown; content?: unknown; scope?: unknown };
+
+    if (typeof body.name !== 'string' || !body.name.trim()) {
+      res.status(400).json({ error: 'name is required' });
+      return;
+    }
+    if (typeof body.description !== 'string' || !body.description.trim()) {
+      res.status(400).json({ error: 'description is required' });
+      return;
+    }
+    if (typeof body.content !== 'string' || !body.content.trim()) {
+      res.status(400).json({ error: 'content is required' });
+      return;
+    }
+
+    const name = body.name.trim();
+    const description = body.description.trim();
+    const content = body.content.trim();
+    const scope = body.scope === 'shared' ? 'shared' : 'workspace';
+
+    const nameErr = validateSkillName(name);
+    if (nameErr) {
+      res.status(400).json({ error: nameErr });
+      return;
+    }
+
+    const skillDir = getSkillDir(scope, name, config.workspace);
+    const skillFile = path.join(skillDir, 'SKILL.md');
+
+    if (fs.existsSync(skillFile)) {
+      res.status(409).json({ error: `Skill "${name}" already exists. Delete it first or choose a different name.` });
+      return;
+    }
+
+    const skillMd = `---\nname: ${name}\ndescription: "${description.replace(/"/g, '\\"')}"\n---\n\n${content}`;
+
+    try {
+      fs.mkdirSync(skillDir, { recursive: true });
+      const tmpFile = skillFile + '.tmp';
+      fs.writeFileSync(tmpFile, skillMd, 'utf-8');
+      fs.renameSync(tmpFile, skillFile);
+      if (agents) reloadRunnerRegistry(agentId, config, agents);
+      res.status(201).json({
+        key: name,
+        name,
+        description,
+        scope,
+        emoji: null,
+        userInvocable: true,
+        modulePrefix: null,
+        content: skillMd,
+        source_url: null,
+      });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/skills/install
+   * Install a skill from a GitHub or raw URL.
+   * Body: { url, scope?: 'workspace' | 'shared', name?, force? }
+   */
+  router.post('/v1/agents/:agentId/skills/install', auth, async (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+
+    const config = agentConfigs.get(agentId);
+    if (!config) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const body = req.body as { url?: unknown; scope?: unknown; name?: unknown; force?: unknown };
+
+    if (typeof body.url !== 'string' || !body.url.trim()) {
+      res.status(400).json({ error: 'url is required' });
+      return;
+    }
+
+    const url = body.url.trim();
+    if (!url.startsWith('https://')) {
+      res.status(400).json({ error: 'Only HTTPS URLs are supported' });
+      return;
+    }
+
+    const rawUrl = toRawGitHubUrl(url);
+    const scope = body.scope === 'shared' ? 'shared' : 'workspace';
+    const force = body.force === true;
+
+    try {
+      const response = await fetch(rawUrl);
+      if (!response.ok) {
+        res.status(400).json({ error: `Failed to fetch URL: ${response.status} ${response.statusText}` });
+        return;
+      }
+
+      const content = await response.text();
+
+      if (content.length > MAX_SKILL_SIZE) {
+        res.status(400).json({ error: `SKILL.md exceeds ${MAX_SKILL_SIZE / 1024}KB limit` });
+        return;
+      }
+
+      const extracted = extractFrontmatter(content);
+      if (!extracted) {
+        res.status(400).json({ error: 'Invalid SKILL.md: no valid YAML frontmatter found' });
+        return;
+      }
+
+      const fm = extracted.frontmatter;
+      const skillName = (typeof body.name === 'string' && body.name.trim())
+        ? body.name.trim()
+        : (typeof fm['name'] === 'string' ? fm['name'] : '');
+
+      if (!skillName) {
+        res.status(400).json({ error: 'Could not determine skill name from frontmatter. Use the name parameter.' });
+        return;
+      }
+
+      const nameErr = validateSkillName(skillName);
+      if (nameErr) {
+        res.status(400).json({ error: nameErr });
+        return;
+      }
+
+      const skillDir = getSkillDir(scope, skillName, config.workspace);
+      const skillFile = path.join(skillDir, 'SKILL.md');
+
+      if (fs.existsSync(skillFile) && !force) {
+        res.status(409).json({ error: `Skill "${skillName}" already exists. Use force: true to overwrite.` });
+        return;
+      }
+
+      fs.mkdirSync(skillDir, { recursive: true });
+      const tmpFile = skillFile + '.tmp';
+      fs.writeFileSync(tmpFile, content, 'utf-8');
+      fs.renameSync(tmpFile, skillFile);
+      if (agents) reloadRunnerRegistry(agentId, config, agents);
+      const description = typeof fm['description'] === 'string' ? fm['description'] : '(no description)';
+      res.status(201).json({
+        key: skillName,
+        name: skillName,
+        description,
+        scope,
+        emoji: typeof fm['emoji'] === 'string' ? fm['emoji'] : null,
+        userInvocable: true,
+        modulePrefix: null,
+        content,
+        source_url: url,
+      });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * DELETE /api/v1/agents/:agentId/skills/:name
+   * Delete a skill by name.
+   * Query: scope=workspace|shared (default: workspace)
+   */
+  router.delete('/v1/agents/:agentId/skills/:name', auth, (req: Request, res: Response) => {
+    const { agentId, name } = req.params as { agentId: string; name: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+
+    const config = agentConfigs.get(agentId);
+    if (!config) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const scope = req.query['scope'] === 'shared' ? 'shared' : 'workspace';
+    const skillDir = getSkillDir(scope, name, config.workspace);
+    const skillFile = path.join(skillDir, 'SKILL.md');
+
+    if (!fs.existsSync(skillFile)) {
+      res.status(404).json({ error: `Skill "${name}" not found in ${scope}` });
+      return;
+    }
+
+    try {
+      fs.rmSync(skillDir, { recursive: true, force: true });
+      if (agents) reloadRunnerRegistry(agentId, config, agents);
+      res.json({ message: `Skill "${name}" deleted from ${scope}` });
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  return router;
+}

--- a/src/api/skills-router.ts
+++ b/src/api/skills-router.ts
@@ -40,14 +40,19 @@ function getSkillDir(scope: 'workspace' | 'shared', name: string, workspaceDir: 
 function isPrivateHost(urlStr: string): boolean {
   try {
     const { hostname } = new URL(urlStr);
+    // Node.js keeps brackets for IPv6 literals — strip them for matching
+    const h = hostname.startsWith('[') ? hostname.slice(1, -1) : hostname;
     return (
-      hostname === 'localhost' ||
-      /^127\./.test(hostname) ||
-      /^10\./.test(hostname) ||
-      /^172\.(1[6-9]|2\d|3[01])\./.test(hostname) ||
-      /^192\.168\./.test(hostname) ||
-      /^169\.254\./.test(hostname) ||
-      hostname === '::1'
+      h === 'localhost' ||
+      /^127\./.test(h) ||
+      /^10\./.test(h) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
+      /^192\.168\./.test(h) ||
+      /^169\.254\./.test(h) ||
+      h === '::1' ||
+      /^fe80:/i.test(h) ||                   // IPv6 link-local fe80::/10
+      /^fc[0-9a-f]{2}:/i.test(h) ||          // IPv6 ULA fc00::/7
+      /^fd[0-9a-f]{2}:/i.test(h)             // IPv6 ULA fd00::/8
     );
   } catch {
     return true; // block if URL cannot be parsed
@@ -337,7 +342,7 @@ export function createSkillsRouter(
     const force = body.force === true;
 
     try {
-      const response = await fetch(rawUrl);
+      const response = await fetch(rawUrl, { signal: AbortSignal.timeout(10_000) });
       if (!response.ok) {
         res.status(400).json({ error: `Failed to fetch URL: ${response.status} ${response.statusText}` });
         return;

--- a/src/api/skills-router.ts
+++ b/src/api/skills-router.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { AgentConfig, ApiKey } from '../types';
-import { createApiAuthMiddleware, canAccessAgent } from './auth';
+import { createApiAuthMiddleware, canAccessAgent, canWriteAgent, isAdmin } from './auth';
 import { loadSkills } from '../skills/loader';
 import { extractFrontmatter } from '../skills/parser';
 import type { AgentRunner } from '../agent/runner';
@@ -35,6 +35,23 @@ function getSkillDir(scope: 'workspace' | 'shared', name: string, workspaceDir: 
   return scope === 'workspace'
     ? path.join(workspaceDir, 'skills', name)
     : path.join(SHARED_SKILLS_DIR, name);
+}
+
+function isPrivateHost(urlStr: string): boolean {
+  try {
+    const { hostname } = new URL(urlStr);
+    return (
+      hostname === 'localhost' ||
+      /^127\./.test(hostname) ||
+      /^10\./.test(hostname) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(hostname) ||
+      /^192\.168\./.test(hostname) ||
+      /^169\.254\./.test(hostname) ||
+      hostname === '::1'
+    );
+  } catch {
+    return true; // block if URL cannot be parsed
+  }
 }
 
 function toRawGitHubUrl(url: string): string {
@@ -203,8 +220,8 @@ export function createSkillsRouter(
     const { agentId } = req.params as { agentId: string };
     const apiKey = (req as AuthedRequest).apiKey;
 
-    if (!canAccessAgent(apiKey, agentId)) {
-      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+    if (!canWriteAgent(apiKey, agentId)) {
+      res.status(403).json({ error: 'Write permission required' });
       return;
     }
 
@@ -233,6 +250,11 @@ export function createSkillsRouter(
     const description = body.description.trim();
     const content = body.content.trim();
     const scope = body.scope === 'shared' ? 'shared' : 'workspace';
+
+    if (scope === 'shared' && !isAdmin(apiKey)) {
+      res.status(403).json({ error: 'Admin key required for shared scope' });
+      return;
+    }
 
     const nameErr = validateSkillName(name);
     if (nameErr) {
@@ -281,8 +303,8 @@ export function createSkillsRouter(
     const { agentId } = req.params as { agentId: string };
     const apiKey = (req as AuthedRequest).apiKey;
 
-    if (!canAccessAgent(apiKey, agentId)) {
-      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+    if (!isAdmin(apiKey)) {
+      res.status(403).json({ error: 'Admin key required to install skills from URL' });
       return;
     }
 
@@ -302,6 +324,11 @@ export function createSkillsRouter(
     const url = body.url.trim();
     if (!url.startsWith('https://')) {
       res.status(400).json({ error: 'Only HTTPS URLs are supported' });
+      return;
+    }
+
+    if (isPrivateHost(url)) {
+      res.status(400).json({ error: 'URL targets a private/internal address' });
       return;
     }
 
@@ -384,8 +411,8 @@ export function createSkillsRouter(
     const { agentId, name } = req.params as { agentId: string; name: string };
     const apiKey = (req as AuthedRequest).apiKey;
 
-    if (!canAccessAgent(apiKey, agentId)) {
-      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+    if (!canWriteAgent(apiKey, agentId)) {
+      res.status(403).json({ error: 'Write permission required' });
       return;
     }
 
@@ -396,6 +423,11 @@ export function createSkillsRouter(
     }
 
     const scope = req.query['scope'] === 'shared' ? 'shared' : 'workspace';
+
+    if (scope === 'shared' && !isAdmin(apiKey)) {
+      res.status(403).json({ error: 'Admin key required for shared scope' });
+      return;
+    }
     const skillDir = getSkillDir(scope, name, config.workspace);
     const skillFile = path.join(skillDir, 'SKILL.md');
 

--- a/src/api/workspace-router.ts
+++ b/src/api/workspace-router.ts
@@ -1,8 +1,11 @@
 import { Router, Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 import { AgentConfig, ApiKey } from '../types';
-import { createApiAuthMiddleware, canAccessAgent } from './auth';
+import { createApiAuthMiddleware, canAccessAgent, canWriteAgent } from './auth';
+
+const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB
 
 const ALLOWED_FILES = new Set([
   'SOUL.md',
@@ -76,15 +79,15 @@ export function createWorkspaceRouter(
   /**
    * PUT /api/v1/agents/:agentId/files/:filename
    *
-   * Write a workspace file for an agent.
+   * Write a workspace file for an agent. Requires write access.
    * Gateway's file watcher will auto-reload CLAUDE.md after write.
    */
   router.put('/v1/agents/:agentId/files/:filename', auth, (req: Request, res: Response) => {
     const { agentId, filename } = req.params as { agentId: string; filename: string };
     const apiKey = (req as AuthedRequest).apiKey;
 
-    if (!canAccessAgent(apiKey, agentId)) {
-      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+    if (!canWriteAgent(apiKey, agentId)) {
+      res.status(403).json({ error: 'Write permission required' });
       return;
     }
 
@@ -106,10 +109,18 @@ export function createWorkspaceRouter(
       return;
     }
 
+    if (body.content.length > MAX_FILE_SIZE) {
+      res.status(400).json({ error: 'Content exceeds 1MB limit' });
+      return;
+    }
+
     const filePath = path.join(config.workspace, filename);
+    const tmpPath = filePath + '.tmp.' + randomUUID();
     try {
-      fs.writeFileSync(filePath, body.content, 'utf-8');
+      fs.writeFileSync(tmpPath, body.content, 'utf-8');
+      fs.renameSync(tmpPath, filePath);
     } catch (writeErr) {
+      try { fs.unlinkSync(tmpPath); } catch { /* ignore cleanup error */ }
       res.status(500).json({ error: `Failed to write file: ${(writeErr as Error).message}` });
       return;
     }

--- a/src/api/workspace-router.ts
+++ b/src/api/workspace-router.ts
@@ -1,0 +1,121 @@
+import { Router, Request, Response } from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AgentConfig, ApiKey } from '../types';
+import { createApiAuthMiddleware, canAccessAgent } from './auth';
+
+const ALLOWED_FILES = new Set([
+  'SOUL.md',
+  'USER.md',
+  'MEMORY.md',
+  'AGENTS.md',
+  'HEARTBEAT.md',
+  'IDENTITY.md',
+]);
+
+const FILENAME_RE = /^[A-Z][A-Z0-9_-]*\.md$/i;
+
+type AuthedRequest = Request & { apiKey: ApiKey };
+
+function validateFilename(filename: string): string | null {
+  if (!FILENAME_RE.test(filename)) return 'Invalid filename format';
+  if (filename.includes('/') || filename.includes('\\') || filename.includes('..')) {
+    return 'Path traversal not allowed';
+  }
+  if (!ALLOWED_FILES.has(filename)) {
+    return `Filename not allowed. Allowed files: ${[...ALLOWED_FILES].join(', ')}`;
+  }
+  return null;
+}
+
+export function createWorkspaceRouter(
+  agentConfigs: Map<string, AgentConfig>,
+  apiKeys: ApiKey[],
+): Router {
+  const router = Router();
+  const auth = createApiAuthMiddleware(apiKeys);
+
+  /**
+   * GET /api/v1/agents/:agentId/files/:filename
+   *
+   * Read a workspace file for an agent.
+   * Returns 200 with empty content if the file does not exist yet.
+   */
+  router.get('/v1/agents/:agentId/files/:filename', auth, (req: Request, res: Response) => {
+    const { agentId, filename } = req.params as { agentId: string; filename: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+
+    const config = agentConfigs.get(agentId);
+    if (!config) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const err = validateFilename(filename);
+    if (err) {
+      res.status(400).json({ error: err });
+      return;
+    }
+
+    const filePath = path.join(config.workspace, filename);
+    let content = '';
+    try {
+      content = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      // File doesn't exist yet — return empty content (not an error)
+    }
+
+    res.json({ filename, content });
+  });
+
+  /**
+   * PUT /api/v1/agents/:agentId/files/:filename
+   *
+   * Write a workspace file for an agent.
+   * Gateway's file watcher will auto-reload CLAUDE.md after write.
+   */
+  router.put('/v1/agents/:agentId/files/:filename', auth, (req: Request, res: Response) => {
+    const { agentId, filename } = req.params as { agentId: string; filename: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+
+    const config = agentConfigs.get(agentId);
+    if (!config) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const err = validateFilename(filename);
+    if (err) {
+      res.status(400).json({ error: err });
+      return;
+    }
+
+    const body = req.body as { content?: unknown };
+    if (typeof body.content !== 'string') {
+      res.status(400).json({ error: 'content must be a string' });
+      return;
+    }
+
+    const filePath = path.join(config.workspace, filename);
+    try {
+      fs.writeFileSync(filePath, body.content, 'utf-8');
+    } catch (writeErr) {
+      res.status(500).json({ error: `Failed to write file: ${(writeErr as Error).message}` });
+      return;
+    }
+
+    res.json({ filename, message: 'File saved. CLAUDE.md will auto-reload.' });
+  });
+
+  return router;
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -65,9 +65,7 @@ function validateAgent(agent: Record<string, unknown>, index: number): string | 
   }
   const hasTelegram = agent.telegram && typeof agent.telegram === 'object';
   const hasDiscord = agent.discord && typeof agent.discord === 'object';
-  if (!hasTelegram && !hasDiscord) {
-    return `Agent "${agent.id}" must have at least one channel configured ("telegram" or "discord")`;
-  }
+  // Agents without channels are allowed (API-only agents accessed via HTTP API key)
   if (hasTelegram) {
     const telegram = agent.telegram as Record<string, unknown>;
     if (!telegram.botToken || typeof telegram.botToken !== 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,17 @@ async function startAgent(
   const logger = createLogger(agentConfig.id, logDir);
   logger.info('Initialising agent', { id: agentConfig.id });
 
+  // Ensure workspace directory exists (may be absent for newly created agents)
+  try {
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+  } catch (err) {
+    const reason = (err as Error).message;
+    logger.error('Failed to create workspace directory', { error: reason });
+    console.log(JSON.stringify({ id: agentConfig.id, status: 'failed', reason }));
+    startupResults.push({ id: agentConfig.id, status: 'failed', workspace: agentConfig.workspace, reason });
+    return;
+  }
+
   // ── Migrate legacy lowercase workspace files (agent.md → AGENTS.md, etc.) ──
   if (fs.existsSync(agentConfig.workspace)) {
     try {
@@ -419,7 +430,7 @@ async function main(): Promise<void> {
   printStartupTable(startupResults);
 
   // Start gateway router
-  const router = new GatewayRouter(agentRunners, agentConfigs, undefined, config, cronManager);
+  const router = new GatewayRouter(agentRunners, agentConfigs, undefined, config, cronManager, CONFIG_PATH);
   await router.start(PORT);
   console.log(`[gateway] Listening on port ${PORT}`);
 

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -201,7 +201,7 @@ export class SessionProcess extends EventEmitter {
   }
 
   private writeMcpConfig(): string | null {
-    if (this.source === 'api') return null; // API sessions don't need gateway MCP
+    if (this.source === 'api' && !this.agentConfig.allow_tools) return null;
 
     const stateDir = path.join(this.agentConfig.workspace, '.telegram-state');
     const sessionDir = path.join(this.agentConfig.workspace, '.sessions', this.sessionId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,8 @@ export interface ApiKey {
   description?: string;
   agents: string[] | '*'; // agent IDs this key can access, or '*' for all
   allow_tools?: boolean;  // permit tool-enabled (allow_tools) requests for this key
-  admin?: boolean;        // if true, bypasses all agent scope checks
+  write?: boolean;        // allow write ops for scoped agents (files, skills, PATCH agent)
+  admin?: boolean;        // bypass scope + destructive ops (agent CRUD, shared skills, install)
 }
 
 export interface ModelConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,8 @@ export interface AgentConfig {
   session?: SessionConfig;
   /** Agent's signature emoji (used in greetings/sign-offs) */
   signatureEmoji?: string;
+  /** Allow tool calls when agent is accessed via API channel. Falls back to ApiKey.allow_tools if not set. */
+  allow_tools?: boolean;
 }
 
 export interface AgentStats {
@@ -51,6 +53,7 @@ export interface ApiKey {
   description?: string;
   agents: string[] | '*'; // agent IDs this key can access, or '*' for all
   allow_tools?: boolean;  // permit tool-enabled (allow_tools) requests for this key
+  admin?: boolean;        // if true, bypasses all agent scope checks
 }
 
 export interface ModelConfig {
@@ -58,6 +61,7 @@ export interface ModelConfig {
   label: string;
   alias: string;
   contextWindow: number;
+  multiplier?: number;
 }
 
 export interface GatewayConfig {

--- a/tests/unit/api-auth.test.ts
+++ b/tests/unit/api-auth.test.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'http';
 import express from 'express';
-import { createApiAuthMiddleware, canAccessAgent } from '../../src/api/auth';
+import { createApiAuthMiddleware, canAccessAgent, canWriteAgent, isAdmin } from '../../src/api/auth';
 import { ApiKey } from '../../src/types';
 import * as supertest from 'supertest';
 
@@ -89,5 +89,45 @@ describe('canAccessAgent', () => {
   it('returns true for any agentId when agents is "*"', () => {
     expect(canAccessAgent(adminKey, 'alfred')).toBe(true);
     expect(canAccessAgent(adminKey, 'anything')).toBe(true);
+  });
+});
+
+describe('canWriteAgent', () => {
+  const readKey: ApiKey = { key: 'r', agents: ['alfred'] };
+  const writeKey: ApiKey = { key: 'w', agents: ['alfred'], write: true };
+  const adminKey: ApiKey = { key: 'a', agents: '*', admin: true };
+  const writeOtherKey: ApiKey = { key: 'wo', agents: ['baerbel'], write: true };
+
+  it('returns false for a read-only key even if in scope', () => {
+    expect(canWriteAgent(readKey, 'alfred')).toBe(false);
+  });
+
+  it('returns true for a write key scoped to the agent', () => {
+    expect(canWriteAgent(writeKey, 'alfred')).toBe(true);
+  });
+
+  it('returns false for a write key not scoped to the agent', () => {
+    expect(canWriteAgent(writeOtherKey, 'alfred')).toBe(false);
+  });
+
+  it('returns true for an admin key regardless of scope', () => {
+    expect(canWriteAgent(adminKey, 'anything')).toBe(true);
+  });
+});
+
+describe('isAdmin', () => {
+  it('returns true when admin flag is set', () => {
+    const key: ApiKey = { key: 'k', agents: '*', admin: true };
+    expect(isAdmin(key)).toBe(true);
+  });
+
+  it('returns false when admin flag is absent', () => {
+    const key: ApiKey = { key: 'k', agents: '*' };
+    expect(isAdmin(key)).toBe(false);
+  });
+
+  it('returns false when admin flag is false', () => {
+    const key: ApiKey = { key: 'k', agents: '*', admin: false };
+    expect(isAdmin(key)).toBe(false);
   });
 });

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -72,8 +72,9 @@ const agentConfig: AgentConfig = {
 
 const apiKeys: ApiKey[] = [
   { key: 'sk-test-app', agents: [AGENT_ID] },
-  { key: 'sk-test-admin', agents: '*' },
+  { key: 'sk-test-admin', agents: '*', admin: true },
   { key: 'sk-test-tools', agents: [AGENT_ID], allow_tools: true },
+  { key: 'sk-test-write', agents: [AGENT_ID], write: true },
 ];
 
 function buildApp(runnerImpl: (sessionId: string, msg: string) => Promise<string>) {
@@ -280,6 +281,93 @@ describe('GET /api/v1/agents', () => {
     const app = buildApp(async () => 'ok');
     const res = await supertest.default(app).get('/api/v1/agents');
     expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/v1/agents — access control', () => {
+  it('returns 403 for non-admin key', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post('/api/v1/agents')
+      .set(AUTH) // sk-test-app — no admin flag
+      .send({ id: 'new-agent', description: 'test' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/admin key required/i);
+  });
+
+  it('returns 403 for write key without admin flag', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post('/api/v1/agents')
+      .set({ Authorization: 'Bearer sk-test-write' })
+      .send({ id: 'new-agent', description: 'test' });
+    expect(res.status).toBe(403);
+  });
+
+  it('admin key passes auth check (returns 501 without configPath)', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .post('/api/v1/agents')
+      .set({ Authorization: 'Bearer sk-test-admin' })
+      .send({ id: 'new-agent', description: 'test' });
+    expect(res.status).toBe(501); // no configPath — auth check passed
+  });
+});
+
+describe('PATCH /api/v1/agents/:agentId — access control', () => {
+  it('returns 403 for key without write flag', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}`)
+      .set(AUTH) // sk-test-app — no write flag
+      .send({ description: 'new desc' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/write permission required/i);
+  });
+
+  it('write key with correct scope passes auth check (returns 501 without configPath)', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}`)
+      .set({ Authorization: 'Bearer sk-test-write' })
+      .send({ description: 'new desc' });
+    expect(res.status).toBe(501); // auth passed, no configPath
+  });
+
+  it('admin key passes auth check', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}`)
+      .set({ Authorization: 'Bearer sk-test-admin' })
+      .send({ description: 'new desc' });
+    expect(res.status).toBe(501); // auth passed, no configPath
+  });
+});
+
+describe('DELETE /api/v1/agents/:agentId — access control', () => {
+  it('returns 403 for non-admin key', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .delete(`/api/v1/agents/${AGENT_ID}`)
+      .set(AUTH);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/admin key required/i);
+  });
+
+  it('returns 403 for write key without admin flag', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .delete(`/api/v1/agents/${AGENT_ID}`)
+      .set({ Authorization: 'Bearer sk-test-write' });
+    expect(res.status).toBe(403);
+  });
+
+  it('admin key passes auth check (returns 501 without configPath)', async () => {
+    const app = buildApp(async () => 'ok');
+    const res = await supertest.default(app)
+      .delete(`/api/v1/agents/${AGENT_ID}`)
+      .set({ Authorization: 'Bearer sk-test-admin' });
+    expect(res.status).toBe(501); // auth passed, no configPath
   });
 });
 

--- a/tests/unit/skills-router.test.ts
+++ b/tests/unit/skills-router.test.ts
@@ -1,0 +1,195 @@
+import express from 'express';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as supertest from 'supertest';
+import { createSkillsRouter } from '../../src/api/skills-router';
+import { AgentConfig, ApiKey } from '../../src/types';
+
+const SHARED_SKILLS_DIR = path.join(os.homedir(), '.claude-gateway', 'shared-skills');
+
+const AGENT_ID = 'test-agent';
+
+function makeTmpWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'skills-router-test-'));
+}
+
+function buildApp(workspace: string, keys: ApiKey[]) {
+  const config: AgentConfig = {
+    id: AGENT_ID,
+    description: 'Test agent',
+    workspace,
+    env: '',
+    telegram: { botToken: 'tok' },
+    claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+  };
+  const configs = new Map([[AGENT_ID, config]]);
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createSkillsRouter(configs, keys));
+  return app;
+}
+
+const READ_KEY: ApiKey = { key: 'sk-read', agents: [AGENT_ID] };
+const WRITE_KEY: ApiKey = { key: 'sk-write', agents: [AGENT_ID], write: true };
+const ADMIN_KEY: ApiKey = { key: 'sk-admin', agents: '*', admin: true };
+const OTHER_WRITE_KEY: ApiKey = { key: 'sk-other-write', agents: ['other-agent'], write: true };
+
+const ALL_KEYS = [READ_KEY, WRITE_KEY, ADMIN_KEY, OTHER_WRITE_KEY];
+
+function authHeader(key: ApiKey) {
+  return { Authorization: `Bearer ${key.key}` };
+}
+
+describe('POST /api/v1/agents/:agentId/skills — access control', () => {
+  let workspace: string;
+  beforeEach(() => { workspace = makeTmpWorkspace(); });
+  afterEach(() => { fs.rmSync(workspace, { recursive: true, force: true }); });
+
+  const body = { name: 'my-skill', description: 'test', content: 'hello', scope: 'workspace' };
+  const url = `/api/v1/agents/${AGENT_ID}/skills`;
+
+  it('returns 403 for read-only key', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(READ_KEY)).send(body);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/write permission required/i);
+  });
+
+  it('returns 403 for write key scoped to different agent', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(OTHER_WRITE_KEY)).send(body);
+    expect(res.status).toBe(403);
+  });
+
+  it('allows write key with correct scope (workspace)', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(WRITE_KEY)).send(body);
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('my-skill');
+    expect(res.body.scope).toBe('workspace');
+  });
+
+  it('allows admin key (workspace scope)', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(ADMIN_KEY)).send(body);
+    expect(res.status).toBe(201);
+  });
+
+  it('returns 403 when write key tries shared scope', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(WRITE_KEY)).send({ ...body, scope: 'shared' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/admin key required for shared scope/i);
+  });
+
+  it('allows admin key to create shared scope skill', async () => {
+    const sharedSkillDir = path.join(SHARED_SKILLS_DIR, 'my-skill');
+    try { fs.rmSync(sharedSkillDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(ADMIN_KEY)).send({ ...body, scope: 'shared' });
+    expect(res.status).toBe(201);
+    expect(res.body.scope).toBe('shared');
+    try { fs.rmSync(sharedSkillDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+});
+
+describe('DELETE /api/v1/agents/:agentId/skills/:name — access control', () => {
+  let workspace: string;
+  beforeEach(() => {
+    workspace = makeTmpWorkspace();
+    const skillDir = path.join(workspace, 'skills', 'my-skill');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: my-skill\ndescription: test\n---\nhello');
+  });
+  afterEach(() => { fs.rmSync(workspace, { recursive: true, force: true }); });
+
+  const url = `/api/v1/agents/${AGENT_ID}/skills/my-skill`;
+
+  it('returns 403 for read-only key', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).delete(url).set(authHeader(READ_KEY));
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/write permission required/i);
+  });
+
+  it('returns 403 for write key scoped to different agent', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).delete(url).set(authHeader(OTHER_WRITE_KEY));
+    expect(res.status).toBe(403);
+  });
+
+  it('allows write key to delete workspace skill', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).delete(url).set(authHeader(WRITE_KEY));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 when write key tries to delete shared scope skill', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).delete(`${url}?scope=shared`).set(authHeader(WRITE_KEY));
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/admin key required for shared scope/i);
+  });
+});
+
+describe('POST /api/v1/agents/:agentId/skills/install — access control', () => {
+  let workspace: string;
+  beforeEach(() => { workspace = makeTmpWorkspace(); });
+  afterEach(() => { fs.rmSync(workspace, { recursive: true, force: true }); });
+
+  const url = `/api/v1/agents/${AGENT_ID}/skills/install`;
+
+  it('returns 403 for read-only key', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(READ_KEY))
+      .send({ url: 'https://github.com/example/repo/blob/main/SKILL.md' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/admin key required/i);
+  });
+
+  it('returns 403 for write key without admin flag', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(WRITE_KEY))
+      .send({ url: 'https://github.com/example/repo/blob/main/SKILL.md' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/admin key required/i);
+  });
+
+  it('admin key passes auth and hits URL validation (not 403)', async () => {
+    const app = buildApp(workspace, ALL_KEYS);
+    const res = await supertest.default(app).post(url).set(authHeader(ADMIN_KEY))
+      .send({ url: 'http://example.com/skill' }); // http:// fails URL check, not auth
+    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(400); // HTTPS required
+  });
+});
+
+describe('POST /api/v1/agents/:agentId/skills/install — SSRF protection', () => {
+  let workspace: string;
+  beforeEach(() => { workspace = makeTmpWorkspace(); });
+  afterEach(() => { fs.rmSync(workspace, { recursive: true, force: true }); });
+
+  const url = `/api/v1/agents/${AGENT_ID}/skills/install`;
+
+  const privateUrls = [
+    'https://localhost/SKILL.md',
+    'https://127.0.0.1/SKILL.md',
+    'https://10.0.0.1/SKILL.md',
+    'https://172.16.0.1/SKILL.md',
+    'https://192.168.1.1/SKILL.md',
+    'https://169.254.169.254/latest/meta-data/',
+    'https://[::1]/SKILL.md',
+    'https://[fe80::1]/SKILL.md',
+  ];
+
+  for (const privateUrl of privateUrls) {
+    it(`blocks private URL: ${privateUrl}`, async () => {
+      const app = buildApp(workspace, ALL_KEYS);
+      const res = await supertest.default(app).post(url).set(authHeader(ADMIN_KEY))
+        .send({ url: privateUrl });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/private\/internal/i);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Security fixes required before merging PR #58 (`feat(api): REST API extensions`). This branch contains the PR #58 commits plus one security-fix commit on top.

**Changes in the security-fix commit:**

- **`src/types.ts`** — add `write?: boolean` to `ApiKey` for scoped write operations
- **`src/api/auth.ts`** — add `canWriteAgent()` and `isAdmin()` helpers
- **`src/api/router.ts`** — restore scope filter on `GET /agents`, require admin for `POST`/`DELETE` agents, require `canWriteAgent` for `PATCH` agents, add promise-chain mutex to prevent concurrent `config.json` write races
- **`src/api/workspace-router.ts`** — require `canWriteAgent` for `PUT /files`, add 1MB size limit, atomic write via temp-file rename
- **`src/api/skills-router.ts`** — require `canWriteAgent` for `POST`/`DELETE` skills, require admin for shared scope and skill install from URL, add `isPrivateHost` SSRF deny-list on install endpoint
- **`tests/`** — unit tests for `canWriteAgent`/`isAdmin`, `POST`/`PATCH`/`DELETE` agent access control

## Permission Matrix

| Operation | (no flags) | `write` | `admin` |
|-----------|-----------|---------|---------|
| GET /agents — scoped | ✅ | ✅ | ✅ |
| GET /agents — all | ❌ | ❌ | ✅ |
| POST /agents | ❌ | ❌ | ✅ |
| PATCH /agents/:id | ❌ | ✅+scope | ✅ |
| DELETE /agents/:id | ❌ | ❌ | ✅ |
| PUT /files/:filename | ❌ | ✅+scope | ✅ |
| POST /skills (workspace) | ❌ | ✅+scope | ✅ |
| DELETE /skills (workspace) | ❌ | ✅+scope | ✅ |
| POST/DELETE /skills (shared) | ❌ | ❌ | ✅ |
| POST /skills/install | ❌ | ❌ | ✅ |

## Test plan

- [ ] `npm test` passes (74 suites, 1216 tests)
- [ ] `canWriteAgent` and `isAdmin` helpers covered in `api-auth.test.ts`
- [ ] `POST`/`PATCH`/`DELETE` agent access control covered in `api-router.test.ts`