### PR TITLE
feat: persistent chat history — SQLite storage, History API, media store

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,25 +8,130 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 
 ## Endpoints Overview
 
+### System
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/health` | None | Health check — status + agent list |
+| `GET` | `/status` | None | Per-agent stats + heartbeat history |
+| `GET` | `/ui` | None | Web UI dashboard |
+
 ### Agent API
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/agents` | List agents accessible by the provided key |
-| `POST` | `/api/v1/agents/:agentId/messages` | Send a message — sync JSON or SSE stream |
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/v1/agents` | Key | List agents accessible by the provided key |
+| `POST` | `/api/v1/agents` | Admin | Create a new agent |
+| `PATCH` | `/api/v1/agents/:agentId` | Write | Update agent description, model, or allow_tools |
+| `DELETE` | `/api/v1/agents/:agentId` | Admin | Delete an agent |
+| `POST` | `/api/v1/agents/:agentId/messages` | Key | Send a message — sync JSON or SSE stream |
+| `GET` | `/api/v1/models` | Key | List supported Claude models |
+
+### Workspace File API
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/v1/agents/:agentId/files/:filename` | Key | Read a workspace file |
+| `PUT` | `/api/v1/agents/:agentId/files/:filename` | Write | Write a workspace file |
+
+### Skill API
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/v1/agents/:agentId/skills` | Key | List all skills (workspace + module + shared) |
+| `GET` | `/api/v1/agents/:agentId/skills/:name` | Key | Get a single skill's content |
+| `POST` | `/api/v1/agents/:agentId/skills` | Write | Create a new skill |
+| `POST` | `/api/v1/agents/:agentId/skills/install` | Admin | Install a skill from a GitHub/raw URL |
+| `DELETE` | `/api/v1/agents/:agentId/skills/:name` | Write | Delete a skill |
 
 ### Cron API
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/crons` | List jobs (filtered to key's accessible agents) |
-| `GET` | `/api/v1/crons/status` | Scheduler status (total, enabled, running) |
-| `POST` | `/api/v1/crons` | Create a new job |
-| `GET` | `/api/v1/crons/:id` | Get a single job |
-| `PUT` | `/api/v1/crons/:id` | Update a job |
-| `DELETE` | `/api/v1/crons/:id` | Delete a job |
-| `POST` | `/api/v1/crons/:id/run` | Trigger a job manually |
-| `GET` | `/api/v1/crons/:id/runs` | Get run history (last 20 by default) |
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/v1/crons` | Key | List jobs (filtered to key's accessible agents) |
+| `GET` | `/api/v1/crons/status` | Key | Scheduler status (total, enabled, running) |
+| `POST` | `/api/v1/crons` | Key | Create a new job |
+| `GET` | `/api/v1/crons/:id` | Key | Get a single job |
+| `PUT` | `/api/v1/crons/:id` | Key | Update a job |
+| `DELETE` | `/api/v1/crons/:id` | Key | Delete a job |
+| `POST` | `/api/v1/crons/:id/run` | Key | Trigger a job manually |
+| `GET` | `/api/v1/crons/:id/runs` | Key | Get run history (last 20 by default) |
+
+### Chat History API
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/v1/agents/:agentId/chats` | Key | List all chats for an agent |
+| `GET` | `/api/v1/agents/:agentId/chats/:chatId/sessions` | Key | List sessions for a specific chat |
+| `GET` | `/api/v1/agents/:agentId/chats/:chatId/messages` | Key | Paginated message history (cursor-based) |
+| `GET` | `/api/v1/agents/:agentId/chats/:chatId/messages/search` | Key | Full-text search across messages (SQLite FTS5) |
+| `POST` | `/api/v1/agents/:agentId/chats/:chatId/sessions/:sessionId/messages` | Key | Inject a message into an existing channel session (SSE stream) |
+
+### Media API
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/api/v1/agents/:agentId/media` | Key | Upload a media file (image/* or PDF) — returns `mediaPath` |
+| `GET` | `/api/v1/agents/:agentId/media/*` | Key | Serve a media file by path |
+
+**Auth levels:** `Key` = any valid API key, `Write` = key with write access to the agent, `Admin` = key with `agents: "*"`.
+
+---
+
+## System Endpoints
+
+### GET /health
+
+Health check. No auth required.
+
+```bash
+curl http://localhost:3000/health
+```
+
+```json
+{ "status": "ok", "agents": ["alfred", "claude-founder"] }
+```
+
+---
+
+### GET /status
+
+Per-agent stats and heartbeat history. No auth required.
+
+```bash
+curl http://localhost:3000/status | jq
+```
+
+```json
+{
+  "agents": [
+    {
+      "id": "alfred",
+      "isRunning": true,
+      "messagesReceived": 12,
+      "messagesSent": 48,
+      "lastActivityAt": "2026-05-10T02:00:00.000Z",
+      "heartbeat": {
+        "tasks": ["morning-check"],
+        "lastResults": [
+          { "taskName": "morning-check", "suppressed": false, "rateLimited": false, "durationMs": 1200, "ts": 1746835200000 }
+        ]
+      },
+      "sessions": [
+        { "chatId": "<CHAT_ID>", "messageCount": 5, "lastActivity": "2026-05-10T01:50:00.000Z" }
+      ]
+    }
+  ],
+  "uptime": 3600,
+  "startedAt": "2026-05-10T01:00:00.000Z"
+}
+```
+
+---
+
+### GET /ui
+
+Serves the web UI dashboard. No auth required.
 
 ---
 
@@ -73,6 +178,8 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 npm start
 ```
 
+---
+
 ### GET /api/v1/agents
 
 List agents accessible by the provided API key.
@@ -85,10 +192,89 @@ curl -H "X-Api-Key: my-secret-key-123" \
 ```json
 {
   "agents": [
-    { "id": "alfred", "description": "Personal assistant" }
+    { "id": "alfred", "description": "Personal assistant", "model": "claude-sonnet-4-6", "allow_tools": false }
   ]
 }
 ```
+
+---
+
+### POST /api/v1/agents
+
+Create a new agent entry in `config.json`. Requires admin key. Also creates the workspace directory with stub files (`AGENTS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`).
+
+**Request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Agent ID — pattern `[a-z][a-z0-9_-]{1,31}` |
+| `description` | Yes | Human-readable description |
+| `model` | No | Claude model ID (default: `claude-sonnet-4-6`) |
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: admin-key-456" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "my-bot", "description": "My new bot", "model": "claude-sonnet-4-6"}' \
+  http://localhost:3000/api/v1/agents | jq
+```
+
+```json
+{ "agent": { "id": "my-bot", "description": "My new bot", "model": "claude-sonnet-4-6" } }
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Invalid `id` format or missing `description` |
+| 403 | Not an admin key |
+| 409 | Agent ID already exists |
+| 501 | Gateway started without a config path |
+
+---
+
+### PATCH /api/v1/agents/:agentId
+
+Update an agent's description, model, or allow_tools flag. Requires write access to the agent. Only fields provided are updated.
+
+**Request body (all optional):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | string | New description |
+| `model` | string | New Claude model ID |
+| `allow_tools` | boolean | Override tool access for this agent |
+
+```bash
+curl -X PATCH \
+  -H "X-Api-Key: admin-key-456" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "claude-opus-4-7"}' \
+  http://localhost:3000/api/v1/agents/alfred | jq
+```
+
+```json
+{ "agent": { "id": "alfred", "description": "Personal assistant", "model": "claude-opus-4-7", "allow_tools": false } }
+```
+
+---
+
+### DELETE /api/v1/agents/:agentId
+
+Remove an agent from `config.json` and stop the running process. Requires admin key. Does **not** delete the workspace directory.
+
+```bash
+curl -X DELETE \
+  -H "X-Api-Key: admin-key-456" \
+  http://localhost:3000/api/v1/agents/my-bot | jq
+```
+
+```json
+{ "success": true, "id": "my-bot" }
+```
+
+---
 
 ### POST /api/v1/agents/:agentId/messages
 
@@ -211,6 +397,251 @@ The stream ends with `data: [DONE]`.
 
 ---
 
+## Models API
+
+### GET /api/v1/models
+
+List all supported Claude models from gateway config.
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  http://localhost:3000/api/v1/models | jq
+```
+
+```json
+{
+  "models": [
+    { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "alias": "sonnet", "contextWindow": 200000, "multiplier": 1 },
+    { "id": "claude-opus-4-7", "name": "Claude Opus 4.7", "alias": "opus", "contextWindow": 200000, "multiplier": 3 }
+  ]
+}
+```
+
+---
+
+## Workspace File API
+
+Read and write an agent's workspace identity files via the API. The gateway's file watcher auto-reloads `CLAUDE.md` after a write.
+
+**Allowed filenames:** `SOUL.md`, `USER.md`, `MEMORY.md`, `AGENTS.md`, `HEARTBEAT.md`, `IDENTITY.md`
+
+### GET /api/v1/agents/:agentId/files/:filename
+
+Read a workspace file. Returns empty `content` if the file does not exist yet (not a 404).
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  http://localhost:3000/api/v1/agents/alfred/files/SOUL.md | jq
+```
+
+```json
+{ "filename": "SOUL.md", "content": "# Soul\n\nAlfred is warm, helpful, and precise." }
+```
+
+---
+
+### PUT /api/v1/agents/:agentId/files/:filename
+
+Write a workspace file. Requires write access to the agent. Max 1MB.
+
+**Request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `content` | Yes | Full file content as a string |
+
+```bash
+curl -X PUT \
+  -H "X-Api-Key: admin-key-456" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "# Soul\n\nAlfred is warm, helpful, and precise."}' \
+  http://localhost:3000/api/v1/agents/alfred/files/SOUL.md | jq
+```
+
+```json
+{ "filename": "SOUL.md", "message": "File saved. CLAUDE.md will auto-reload." }
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Filename not in allowed list, invalid format, or content not a string |
+| 400 | Content exceeds 1MB |
+| 403 | Key has no write access to agent |
+| 404 | Agent not found |
+
+---
+
+## Skill API
+
+Manage per-agent and shared skills. Skills are `SKILL.md` files stored in the agent workspace or shared directory.
+
+### GET /api/v1/agents/:agentId/skills
+
+List all skills for an agent (workspace + module + shared).
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  http://localhost:3000/api/v1/agents/alfred/skills | jq
+```
+
+```json
+[
+  {
+    "key": "my-helper",
+    "name": "my-helper",
+    "description": "Does something useful",
+    "scope": "workspace",
+    "emoji": null,
+    "userInvocable": true,
+    "modulePrefix": null,
+    "source_url": null
+  }
+]
+```
+
+**Scope values:** `workspace`, `shared`, `module`
+
+---
+
+### GET /api/v1/agents/:agentId/skills/:name
+
+Get a single skill's content. Optional query param `?scope=workspace|shared` to disambiguate when the same name exists in multiple scopes.
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/skills/my-helper" | jq
+```
+
+```json
+{
+  "key": "my-helper",
+  "name": "my-helper",
+  "description": "Does something useful",
+  "scope": "workspace",
+  "emoji": null,
+  "content": "---\nname: my-helper\ndescription: \"Does something useful\"\n---\n\nInstructions here.",
+  "source_url": null
+}
+```
+
+---
+
+### POST /api/v1/agents/:agentId/skills
+
+Create a new skill. Requires write access. Use `scope: "shared"` with an admin key to create a shared skill.
+
+**Request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill slug — lowercase alphanumeric + hyphens, 1-64 chars |
+| `description` | Yes | One-line description |
+| `content` | Yes | Skill instructions (Markdown body, excluding frontmatter) |
+| `scope` | No | `"workspace"` (default) or `"shared"` (admin only) |
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-helper",
+    "description": "Does something useful",
+    "content": "When invoked, do the following:\n1. Step one\n2. Step two"
+  }' \
+  http://localhost:3000/api/v1/agents/alfred/skills | jq
+```
+
+```json
+{
+  "key": "my-helper",
+  "name": "my-helper",
+  "description": "Does something useful",
+  "scope": "workspace",
+  "emoji": null,
+  "userInvocable": true,
+  "modulePrefix": null,
+  "content": "---\nname: my-helper\ndescription: \"Does something useful\"\n---\n\nWhen invoked...",
+  "source_url": null
+}
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Invalid skill name, reserved name, or missing fields |
+| 403 | No write access, or `shared` scope without admin key |
+| 409 | Skill with that name already exists |
+
+---
+
+### POST /api/v1/agents/:agentId/skills/install
+
+Install a skill from a GitHub URL or raw URL pointing to a `SKILL.md` file. Requires admin key.
+
+**Request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | HTTPS URL to `SKILL.md` (GitHub URLs auto-converted to raw) |
+| `scope` | No | `"workspace"` (default) or `"shared"` |
+| `name` | No | Override skill name (default: parsed from frontmatter) |
+| `force` | No | `true` to overwrite an existing skill |
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: admin-key-456" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+    "scope": "shared"
+  }' \
+  http://localhost:3000/api/v1/agents/alfred/skills/install | jq
+```
+
+```json
+{
+  "key": "my-skill",
+  "name": "my-skill",
+  "description": "Skill from GitHub",
+  "scope": "shared",
+  "emoji": null,
+  "userInvocable": true,
+  "modulePrefix": null,
+  "content": "---\nname: my-skill\n...",
+  "source_url": "https://github.com/owner/repo/blob/main/skills/my-skill/SKILL.md"
+}
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Missing/non-HTTPS URL, private host, fetch failure, invalid SKILL.md |
+| 400 | SKILL.md exceeds 100KB |
+| 403 | Not an admin key |
+| 409 | Skill already exists and `force` not set |
+
+---
+
+### DELETE /api/v1/agents/:agentId/skills/:name
+
+Delete a skill by name. Requires write access. Use `?scope=shared` (admin only) to delete a shared skill.
+
+```bash
+curl -X DELETE \
+  -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/skills/my-helper" | jq
+```
+
+```json
+{ "message": "Skill \"my-helper\" deleted from workspace" }
+```
+
+---
+
 ## Cron API
 
 Manage persistent scheduled jobs. All routes require the same API key auth as the Agent API. Write operations (`POST`, `PUT`, `DELETE`) additionally verify the key has access to the job's `agentId`.
@@ -270,7 +701,7 @@ curl -H "X-Api-Key: my-secret-key-123" \
       "schedule": "0 9 * * *",
       "type": "agent",
       "prompt": "Give me a morning summary.",
-      "telegram": "99000000",
+      "telegram": "<CHAT_ID>",
       "enabled": true,
       "createdAt": 1775737709284,
       "state": {
@@ -323,7 +754,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
     "schedule": "0 9 * * *",
     "type": "agent",
     "prompt": "Give me a morning summary.",
-    "telegram": "99000000"
+    "telegram": "<CHAT_ID>"
   }' | jq
 ```
 
@@ -342,7 +773,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
     "schedule": "0 9 * * *",
     "type": "agent",
     "prompt": "Give me a morning summary.",
-    "discord": "1234567890123456789"
+    "discord": "<CHANNEL_ID>"
   }' | jq
 ```
 
@@ -359,8 +790,8 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
     "schedule": "0 9 * * *",
     "type": "agent",
     "prompt": "Give me a morning summary.",
-    "telegram": "99000000",
-    "discord": "1234567890123456789"
+    "telegram": "<CHAT_ID>",
+    "discord": "<CHANNEL_ID>"
   }' | jq
 ```
 
@@ -379,7 +810,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
     "scheduleAt": "2026-04-09T23:00:00.000Z",
     "type": "agent",
     "prompt": "good night",
-    "telegram": "99000000",
+    "telegram": "<CHAT_ID>",
     "deleteAfterRun": true
   }' | jq
 ```
@@ -432,7 +863,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
     "schedule": "0 18 * * 5",
     "type": "agent",
     "prompt": "Generate a weekly progress report.",
-    "telegram": "99000000",
+    "telegram": "<CHAT_ID>",
     "enabled": false
   }' | jq
 ```
@@ -578,3 +1009,214 @@ curl -H "X-Api-Key: my-secret-key-123" \
 | `0 18 * * 5` | Every Friday at 18:00 |
 | `*/15 * * * *` | Every 15 minutes |
 | `0 0 1 * *` | First day of month at midnight |
+
+---
+
+## Chat History API
+
+Access per-agent conversation history stored in the history DB (SQLite). `chatId` uses the format `telegram-{rawId}` or `discord-{rawId}`.
+
+### GET /api/v1/agents/:agentId/chats
+
+List all chats (across all channels) for an agent.
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  http://localhost:3000/api/v1/agents/alfred/chats | jq
+```
+
+```json
+{
+  "chats": [
+    { "chatId": "telegram-<CHAT_ID>", "messageCount": 42, "lastActivity": "2026-05-10T03:00:00.000Z" }
+  ]
+}
+```
+
+---
+
+### GET /api/v1/agents/:agentId/chats/:chatId/sessions
+
+List sessions for a specific chat. Only supports `telegram` and `discord` chats.
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/sessions" | jq
+```
+
+```json
+{
+  "sessions": [
+    { "sessionId": "abc-123", "messageCount": 10, "createdAt": "2026-05-10T02:00:00.000Z", "lastActivity": "2026-05-10T03:00:00.000Z" }
+  ]
+}
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | `chatId` is not a telegram/discord chat |
+| 403 | Key has no access to agent |
+| 404 | Agent not found |
+
+---
+
+### GET /api/v1/agents/:agentId/chats/:chatId/messages
+
+Paginated message history (cursor-based). Returns messages in reverse chronological order.
+
+**Query parameters:**
+
+| Param | Description |
+|-------|-------------|
+| `limit` | Max messages to return (default 50, max 200) |
+| `before` | Return messages before this timestamp (ms) |
+| `after` | Return messages after this timestamp (ms) |
+| `session_id` | Filter to a specific session |
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages?limit=20" | jq
+```
+
+```json
+{
+  "messages": [
+    { "role": "user", "content": "Hello!", "ts": 1775737709000, "sessionId": "abc-123" },
+    { "role": "assistant", "content": "Hi there!", "ts": 1775737712000, "sessionId": "abc-123" }
+  ],
+  "hasMore": false
+}
+```
+
+---
+
+### GET /api/v1/agents/:agentId/chats/:chatId/messages/search
+
+Full-text search across messages using SQLite FTS5.
+
+**Query parameters:**
+
+| Param | Required | Description |
+|-------|----------|-------------|
+| `q` | Yes | Search query string |
+| `limit` | No | Max results (default 20, max 100) |
+| `offset` | No | Pagination offset (default 0) |
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages/search?q=meeting" | jq
+```
+
+```json
+{
+  "messages": [
+    { "role": "user", "content": "Schedule a meeting tomorrow", "ts": 1775737709000, "sessionId": "abc-123" }
+  ],
+  "total": 1
+}
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | `q` is missing or empty |
+
+---
+
+### POST /api/v1/agents/:agentId/chats/:chatId/sessions/:sessionId/messages
+
+Inject a message into an existing Telegram or Discord session and stream the assistant's response via SSE. Useful for cross-channel continuation.
+
+**Request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `content` | Yes | Message text (max 10,000 chars) |
+| `senderName` | No | Optional display name for the injected message |
+
+```bash
+curl -N -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Continue from where we left off", "senderName": "API"}' \
+  "http://localhost:3000/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/sessions/abc-123/messages"
+```
+
+**Response** (SSE stream):
+
+```
+data: {"type":"text_delta","text":"Sure, let me continue..."}
+data: {"type":"result","text":"Sure, let me continue...","session_id":"abc-123"}
+data: [DONE]
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | `chatId` is not telegram/discord, or `content` is missing/too long |
+| 403 | Key has no access to agent |
+| 404 | Agent not found |
+
+---
+
+## Media API
+
+Upload and serve media files (images and PDFs) associated with an agent. Uploaded files are stored in the agent's media directory and can be referenced in messages via `mediaFiles[]`.
+
+### POST /api/v1/agents/:agentId/media
+
+Upload a media file as a raw binary body. Supported MIME types: `image/*`, `application/pdf`.
+
+**Request headers:**
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Content-Type` | Yes | MIME type of the file (e.g. `image/jpeg`, `application/pdf`) |
+| `X-Filename` | No | Original filename — used to preserve extension |
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: image/jpeg" \
+  -H "X-Filename: photo.jpg" \
+  --data-binary @/path/to/photo.jpg \
+  http://localhost:3000/api/v1/agents/alfred/media | jq
+```
+
+```json
+{ "mediaPath": "ui-upload/2026-05-10/gw-1746837600000.jpg" }
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | No file body received |
+| 403 | Key has no access to agent |
+| 404 | Agent not found |
+| 413 | File exceeds max upload size |
+| 415 | Unsupported MIME type |
+
+---
+
+### GET /api/v1/agents/:agentId/media/*
+
+Serve a media file by path. The path must stay within the agent's media directory.
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/media/ui-upload/2026-05-10/gw-1746837600000.jpg" \
+  --output photo.jpg
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Path traversal attempt or invalid path |
+| 403 | Key has no access to agent |
+| 404 | Agent or file not found |

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/express": "^4.17.0",
         "@types/jest": "^29.0.0",
         "@types/js-yaml": "^4.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.19.18",
         "@types/node-cron": "^3.0.0",
         "@types/supertest": "^7.2.0",
         "@types/tmp": "^0.2.0",
@@ -1259,9 +1259,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/express": "^4.17.0",
     "@types/jest": "^29.0.0",
     "@types/js-yaml": "^4.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.19.18",
     "@types/node-cron": "^3.0.0",
     "@types/supertest": "^7.2.0",
     "@types/tmp": "^0.2.0",

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -13,6 +13,9 @@ import { TelegramReceiver } from '../telegram/receiver';
 import { DiscordReceiver } from '../discord/receiver';
 import { hasMarkdown, toTelegramHtml } from '../telegram/markdown';
 import { detectSkillCommand, formatSkillContext, type SkillRegistry } from '../skills';
+import { HistoryDB } from '../history/db';
+import { MediaStore } from '../history/media-store';
+import type { HistorySource } from '../history/types';
 
 const DEFAULT_IDLE_TIMEOUT_MINUTES = 30;
 const DEFAULT_MAX_CONCURRENT = 20;
@@ -82,6 +85,12 @@ export class AgentRunner extends EventEmitter {
   // Path to gateway config.json for persisting model changes
   private readonly configPath: string;
 
+  // Persistent chat history database (Layer 2 — separate from session context)
+  private readonly historyDb: HistoryDB;
+
+  // Resolved agentsBaseDir for media and history paths
+  private readonly agentsBaseDir: string;
+
   constructor(agentConfig: AgentConfig, gatewayConfig: GatewayConfig, logger?: Logger) {
     super();
     this.agentConfig = agentConfig;
@@ -90,9 +99,11 @@ export class AgentRunner extends EventEmitter {
 
     // Resolve agentsBaseDir: workspace is at <agentsBaseDir>/<agentId>/workspace
     const agentsBaseDir = path.resolve(agentConfig.workspace, '..', '..');
+    this.agentsBaseDir = agentsBaseDir;
     this.sessionStore = new SessionStore(agentsBaseDir);
     // config.json lives 3 levels above workspace: <base>/<agentId>/workspace -> <base>/config.json
     this.configPath = path.resolve(agentConfig.workspace, '..', '..', '..', 'config.json');
+    this.historyDb = HistoryDB.forAgent(agentsBaseDir, agentConfig.id);
 
     this.idleTimeoutMs =
       (agentConfig.session?.idleTimeoutMinutes ?? DEFAULT_IDLE_TIMEOUT_MINUTES) * 60 * 1000;
@@ -174,11 +185,36 @@ export class AgentRunner extends EventEmitter {
           this.sessionStore.getActiveSessionId(this.agentConfig.id, chatId, channelSource)
             .then(async (sessionId) => {
               // Append user message to the active session
+              const userContent = content || (meta['attachment_file_id'] ? '(photo)' : '');
+              const userTs = Date.now();
               await this.sessionStore.appendTelegramMessage(this.agentConfig.id, chatId, sessionId, {
                 role: 'user',
-                content: content || (meta['attachment_file_id'] ? '(photo)' : ''),
-                ts: Date.now(),
+                content: userContent,
+                ts: userTs,
               }, channelSource);
+
+              // Persist to permanent history DB (separate from session context)
+              const mediaFiles: string[] = [];
+              if (meta['image_path']) {
+                try {
+                  const rel = MediaStore.copyToMedia(this.agentsBaseDir, this.agentConfig.id, `${channelSource}-${chatId}`, meta['image_path']);
+                  mediaFiles.push(rel);
+                } catch {
+                  // Non-fatal — continue without media
+                }
+              }
+              this.historyDb.insertMessage({
+                chatId: `${channelSource}-${chatId}`,
+                sessionId,
+                source: channelSource as HistorySource,
+                role: 'user',
+                content: userContent,
+                senderName: meta['user'] ?? undefined,
+                senderId: meta['user_id'] ?? meta['chat_id'] ?? undefined,
+                platformMessageId: meta['message_id'] ?? undefined,
+                mediaFiles: mediaFiles.length > 0 ? mediaFiles : undefined,
+                ts: userTs,
+              });
               // Restart session before this turn if accumulated image size exceeded threshold
               if (this.pendingRestarts.has(chatId)) {
                 const existingSession = this.sessions.get(chatId);
@@ -478,6 +514,10 @@ export class AgentRunner extends EventEmitter {
     }
   }
 
+  private static escapeXmlAttr(value: string): string {
+    return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
   private static buildChannelXml(params: {
     content?: string;
     meta?: Record<string, string>;
@@ -622,8 +662,18 @@ export class AgentRunner extends EventEmitter {
             const resultText = typeof obj['result'] === 'string' ? obj['result'] : '';
             if (resultText.trim() && !proc.queryMode) {
               const text = resultText.trim();
-              const channelSrc = this.channelSourceMap.get(mapKey) ?? 'telegram';
-              if (channelSrc !== 'discord' && hasMarkdown(text)) {
+              const channelSrcForResult = this.channelSourceMap.get(mapKey) ?? 'telegram';
+              // Persist assistant reply to permanent history DB
+              this.historyDb.insertMessage({
+                chatId: `${channelSrcForResult}-${mapKey}`,
+                sessionId: actualSessionId,
+                source: channelSrcForResult as HistorySource,
+                role: 'assistant',
+                content: text,
+                ts: Date.now(),
+              });
+              // Forward to channel
+              if (channelSrcForResult !== 'discord' && hasMarkdown(text)) {
                 this.writeAutoForward(mapKey, toTelegramHtml(text), 'html');
               } else {
                 this.writeAutoForward(mapKey, text);
@@ -834,6 +884,7 @@ export class AgentRunner extends EventEmitter {
 
   /**
    * /clear — clear history of the current session and restart the process.
+   * Also clears the permanent history DB and media files for this chat.
    */
   private async handleCommandClear(agentId: string, chatId: string): Promise<void> {
     const ch = this.channelFor(chatId);
@@ -848,6 +899,13 @@ export class AgentRunner extends EventEmitter {
       loadedAtSpawn: undefined,
       messageCountAtSpawn: undefined,
     }, ch);
+
+    // Clear permanent history DB for this chat
+    const historyChatId = `${ch}-${chatId}`;
+    this.historyDb.clearChat(historyChatId);
+
+    // Delete persisted media files for this chat
+    MediaStore.clearChatMedia(this.agentsBaseDir, agentId, historyChatId);
 
     // Kill old process so next message spawns fresh
     this.restartProcess(chatId).catch(() => {});
@@ -1134,13 +1192,22 @@ export class AgentRunner extends EventEmitter {
     const session = await this.getOrSpawnSession(sessionId, 'api');
 
     // Persist user message
+    const apiUserTs = Date.now();
     await this.sessionStore
       .appendMessage(this.agentConfig.id, sessionId, {
         role: 'user',
         content: message,
-        ts: Date.now(),
+        ts: apiUserTs,
       })
       .catch(() => {});
+    this.historyDb.insertMessage({
+      chatId: `api-${sessionId}`,
+      sessionId,
+      source: 'api',
+      role: 'user',
+      content: message,
+      ts: apiUserTs,
+    });
 
     this.pendingApiSessions.add(sessionId);
     session.touch();
@@ -1174,13 +1241,22 @@ export class AgentRunner extends EventEmitter {
         cleanup();
         // Persist assistant reply
         if (result.trim()) {
+          const apiAssistantTs = Date.now();
           this.sessionStore
             .appendMessage(this.agentConfig.id, sessionId, {
               role: 'assistant',
               content: result.trim(),
-              ts: Date.now(),
+              ts: apiAssistantTs,
             })
             .catch(() => {});
+          this.historyDb.insertMessage({
+            chatId: `api-${sessionId}`,
+            sessionId,
+            source: 'api',
+            role: 'assistant',
+            content: result.trim(),
+            ts: apiAssistantTs,
+          });
         }
         resolve(result.trim());
       };
@@ -1283,13 +1359,22 @@ export class AgentRunner extends EventEmitter {
     const session = await this.getOrSpawnSession(sessionId, 'api');
 
     // Persist user message
+    const streamUserTs = Date.now();
     await this.sessionStore
       .appendMessage(this.agentConfig.id, sessionId, {
         role: 'user',
         content: message,
-        ts: Date.now(),
+        ts: streamUserTs,
       })
       .catch(() => {});
+    this.historyDb.insertMessage({
+      chatId: `api-${sessionId}`,
+      sessionId,
+      source: 'api',
+      role: 'user',
+      content: message,
+      ts: streamUserTs,
+    });
 
     this.pendingApiSessions.add(sessionId);
     session.touch();
@@ -1305,13 +1390,22 @@ export class AgentRunner extends EventEmitter {
       cleanup();
       // Persist assistant reply
       if (result.trim()) {
+        const streamAssistantTs = Date.now();
         this.sessionStore
           .appendMessage(this.agentConfig.id, sessionId, {
             role: 'assistant',
             content: result.trim(),
-            ts: Date.now(),
+            ts: streamAssistantTs,
           })
           .catch(() => {});
+        this.historyDb.insertMessage({
+          chatId: `api-${sessionId}`,
+          sessionId,
+          source: 'api',
+          role: 'assistant',
+          content: result.trim(),
+          ts: streamAssistantTs,
+        });
       }
       callbacks.onDone(result.trim());
     };
@@ -1456,6 +1550,149 @@ export class AgentRunner extends EventEmitter {
    */
   hasActiveApiSession(sessionId: string): boolean {
     return this.pendingApiSessions.has(sessionId);
+  }
+
+  getAgentsBaseDir(): string {
+    return this.agentsBaseDir;
+  }
+
+  getHistoryDb(): HistoryDB {
+    return this.historyDb;
+  }
+
+  async listSessionsForChat(chatId: string, channel: 'telegram' | 'discord'): Promise<import('../types').SessionIndex> {
+    return this.sessionStore.listSessions(this.agentConfig.id, chatId, channel);
+  }
+
+  /**
+   * Send a message into an existing channel session (cross-channel continuation from UI).
+   * The session process receives full history context from the session JSON (Layer 1).
+   * The reply is streamed back via SSE callbacks and persisted to history DB.
+   */
+  async sendMessageToSession(
+    rawChatId: string,
+    channel: 'telegram' | 'discord',
+    sessionId: string,
+    message: string,
+    senderName: string | undefined,
+    callbacks: {
+      onChunk: (event: StreamEvent) => void;
+      onDone: (fullText: string) => void;
+      onError: (err: Error) => void;
+    },
+    opts: { timeoutMs: number },
+  ): Promise<() => void> {
+    // Ensure the session process uses the correct channel source
+    this.channelSourceMap.set(rawChatId, channel);
+
+    const session = await this.getOrSpawnSession(rawChatId, channel, sessionId);
+
+    // Persist user message (Layer 1 session JSON + Layer 2 history DB)
+    const uiUserTs = Date.now();
+    await this.sessionStore.appendTelegramMessage(this.agentConfig.id, rawChatId, sessionId, {
+      role: 'user',
+      content: message,
+      ts: uiUserTs,
+    }, channel).catch(() => {});
+
+    this.historyDb.insertMessage({
+      chatId: `${channel}-${rawChatId}`,
+      sessionId,
+      source: 'ui',
+      role: 'user',
+      content: message,
+      senderName,
+      ts: uiUserTs,
+    });
+
+    const buffer: string[] = [];
+    let settled = false;
+    let lastPartialText = '';
+
+    const done = (result: string) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (result.trim()) {
+        const uiAssistantTs = Date.now();
+        this.sessionStore.appendTelegramMessage(this.agentConfig.id, rawChatId, sessionId, {
+          role: 'assistant',
+          content: result.trim(),
+          ts: uiAssistantTs,
+        }, channel).catch(() => {});
+        this.historyDb.insertMessage({
+          chatId: `${channel}-${rawChatId}`,
+          sessionId,
+          source: channel as HistorySource,
+          role: 'assistant',
+          content: result.trim(),
+          ts: uiAssistantTs,
+        });
+      }
+      callbacks.onDone(result.trim());
+    };
+
+    const fail = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callbacks.onError(err);
+    };
+
+    let globalTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (globalTimer) clearTimeout(globalTimer);
+      session.off('output', onOutput);
+    };
+
+    const onOutput = (line: string) => {
+      try {
+        const obj = JSON.parse(line) as Record<string, unknown>;
+        if (obj['type'] === 'assistant') {
+          const msg = obj['message'] as { content?: Array<{ type: string; text?: string }> } | undefined;
+          if (Array.isArray(msg?.content)) {
+            let fullText = '';
+            for (const block of msg!.content) {
+              if (block.type === 'text' && block.text) fullText += block.text;
+            }
+            if (fullText.length > lastPartialText.length) {
+              const delta = fullText.slice(lastPartialText.length);
+              buffer.push(delta);
+              callbacks.onChunk({ type: 'text_delta', text: delta });
+            }
+            lastPartialText = fullText;
+          }
+        }
+        if (obj['type'] === 'text') {
+          const text = (obj['text'] as string) ?? '';
+          if (text) { buffer.push(text); callbacks.onChunk({ type: 'text_delta', text }); }
+        }
+        if (obj['type'] === 'result') {
+          session.setProcessing(false);
+          const resultText = (obj['result'] as string | undefined) ?? buffer.join('');
+          done(resultText);
+        }
+      } catch { /* non-JSON */ }
+    };
+
+    globalTimer = setTimeout(() => {
+      session.setProcessing(false);
+      fail(Object.assign(new Error('Agent response timeout'), { code: 'TIMEOUT' }));
+    }, opts.timeoutMs);
+
+    session.on('output', onOutput);
+
+    const channelXml =
+      `<channel source="ui" chat_id="${AgentRunner.escapeXmlAttr(rawChatId)}" session_id="${AgentRunner.escapeXmlAttr(sessionId)}" ` +
+      `user="${AgentRunner.escapeXmlAttr(senderName ?? 'ui')}" ts="${new Date().toISOString()}">\n${message}\n</channel>`;
+
+    session.setProcessing(true);
+    session.sendMessage(channelXml);
+
+    return () => {
+      if (!settled) { settled = true; cleanup(); }
+    };
   }
 
   /**

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -553,7 +553,7 @@ export class AgentRunner extends EventEmitter {
     const source = meta['source'] ?? 'telegram';
     return (
       `<channel source="${source}" chat_id="${meta['chat_id'] ?? ''}" ` +
-      `message_id="${meta['message_id'] ?? ''}" user="${meta['user'] ?? ''}" ` +
+      `message_id="${meta['message_id'] ?? ''}" user="${AgentRunner.escapeXmlAttr(meta['user'] ?? '')}" ` +
       `ts="${meta['ts'] ?? new Date().toISOString()}"${optionalAttrs}>${repliedBlock}${params.content ?? ''}</channel>`
     );
   }

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -8,6 +8,7 @@ import { AgentRunner } from '../agent/runner';
 import { AgentConfig, ApiKey, ModelConfig } from '../types';
 import { createApiAuthMiddleware, canAccessAgent, canWriteAgent, isAdmin } from './auth';
 import { MediaStore } from '../history/media-store';
+import { HistoryDB } from '../history/db';
 
 const MAX_MESSAGE_LENGTH = 10_000;
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -407,6 +408,7 @@ export function createApiRouter(
     if (runner) {
       try { await runner.stop(); } catch { /* ignore stop errors */ }
       agentRunners.delete(agentId);
+      HistoryDB.evict(runner.getAgentsBaseDir(), agentId);
     }
     agentConfigs.delete(agentId);
 
@@ -632,8 +634,8 @@ export function createApiRouter(
       req.on('data', (chunk: Buffer) => {
         size += chunk.length;
         if (size > MediaStore.maxUploadBytes) {
+          if (!res.headersSent) res.status(413).json({ error: `File too large (max ${MediaStore.maxUploadBytes / 1024 / 1024}MB)` });
           req.destroy();
-          res.status(413).json({ error: `File too large (max ${MediaStore.maxUploadBytes / 1024 / 1024}MB)` });
           return;
         }
         chunks.push(chunk);

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { AgentRunner } from '../agent/runner';
 import { AgentConfig, ApiKey, ModelConfig } from '../types';
 import { createApiAuthMiddleware, canAccessAgent, canWriteAgent, isAdmin } from './auth';
+import { MediaStore } from '../history/media-store';
 
 const MAX_MESSAGE_LENGTH = 10_000;
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -412,5 +413,313 @@ export function createApiRouter(
     res.json({ success: true, id: agentId });
   });
 
+  // ─── Chat History API ─────────────────────────────────────────────────────────
+
+  /**
+   * GET /api/v1/agents/:agentId/chats
+   * List all chats (across all channels) for an agent from the history DB.
+   */
+  router.get('/v1/agents/:agentId/chats', auth, (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+    const chats = runner.getHistoryDb().listChats();
+    res.json({ chats });
+  });
+
+  /**
+   * GET /api/v1/agents/:agentId/chats/:chatId/sessions
+   * List sessions for a specific chat (delegated to SessionStore).
+   * chatId format: "telegram-{rawId}" | "discord-{rawId}"
+   */
+  router.get('/v1/agents/:agentId/chats/:chatId/sessions', auth, async (req: Request, res: Response) => {
+    const { agentId, chatId } = req.params as { agentId: string; chatId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+    const { source, rawChatId } = parseHistoryChatId(chatId);
+    if (source !== 'telegram' && source !== 'discord') {
+      res.status(400).json({ error: 'Sessions endpoint only supports telegram/discord chats' });
+      return;
+    }
+    try {
+      const index = await runner.listSessionsForChat(rawChatId, source as 'telegram' | 'discord');
+      res.json(index);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * GET /api/v1/agents/:agentId/chats/:chatId/messages
+   * Paginated message history (cursor-based).
+   * Query: limit, before (ts ms), after (ts ms), session_id
+   */
+  router.get('/v1/agents/:agentId/chats/:chatId/messages', auth, (req: Request, res: Response) => {
+    const { agentId, chatId } = req.params as { agentId: string; chatId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+    const query = req.query as Record<string, string>;
+    const limit = query['limit'] ? Math.min(parseInt(query['limit'], 10) || 50, 200) : 50;
+    const before = query['before'] ? parseInt(query['before'], 10) : undefined;
+    const after = query['after'] ? parseInt(query['after'], 10) : undefined;
+    const sessionId = query['session_id'] ?? undefined;
+
+    const page = runner.getHistoryDb().getMessages(chatId, { limit, before, after, sessionId });
+    res.json(page);
+  });
+
+  /**
+   * GET /api/v1/agents/:agentId/chats/:chatId/messages/search
+   * Full-text search using SQLite FTS5.
+   * Query: q, limit, offset
+   */
+  router.get('/v1/agents/:agentId/chats/:chatId/messages/search', auth, (req: Request, res: Response) => {
+    const { agentId, chatId } = req.params as { agentId: string; chatId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+    const query = req.query as Record<string, string>;
+    const q = (query['q'] ?? '').trim();
+    if (!q) {
+      res.status(400).json({ error: 'q is required' });
+      return;
+    }
+    const limit = query['limit'] ? Math.min(parseInt(query['limit'], 10) || 20, 100) : 20;
+    const offset = query['offset'] ? parseInt(query['offset'], 10) : 0;
+
+    const page = runner.getHistoryDb().searchMessages(chatId, q, { limit, offset });
+    res.json(page);
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/chats/:chatId/sessions/:sessionId/messages
+   * Inject a message into an existing channel session (cross-channel continuation).
+   * Streams the assistant response as SSE.
+   * Body: { content: string, senderName?: string }
+   */
+  router.post('/v1/agents/:agentId/chats/:chatId/sessions/:sessionId/messages', auth, async (req: Request, res: Response) => {
+    const { agentId, chatId, sessionId } = req.params as { agentId: string; chatId: string; sessionId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+    const { source, rawChatId } = parseHistoryChatId(chatId);
+    if (source !== 'telegram' && source !== 'discord') {
+      res.status(400).json({ error: 'Cross-channel messaging only supported for telegram/discord chats' });
+      return;
+    }
+
+    const body = req.body as { content?: unknown; senderName?: unknown };
+    const content = body.content;
+    if (!content || typeof content !== 'string' || !content.trim()) {
+      res.status(400).json({ error: 'content is required and must be a non-empty string' });
+      return;
+    }
+    if (content.length > MAX_MESSAGE_LENGTH) {
+      res.status(400).json({ error: `content too long (max ${MAX_MESSAGE_LENGTH} characters)` });
+      return;
+    }
+    const senderName = typeof body.senderName === 'string' ? body.senderName : undefined;
+
+    let cleanup: (() => void) | undefined;
+    try {
+      const sseCallbacks = {
+        onChunk: (event: import('../types').StreamEvent) => {
+          try { res.write(`data: ${JSON.stringify(event)}\n\n`); } catch { /* client gone */ }
+        },
+        onDone: (fullText: string) => {
+          try {
+            res.write(`data: ${JSON.stringify({ type: 'result', text: fullText, session_id: sessionId })}\n\n`);
+            res.write('data: [DONE]\n\n');
+            res.end();
+          } catch { /* client gone */ }
+        },
+        onError: (err: Error) => {
+          try {
+            res.write(`data: ${JSON.stringify({ type: 'error', message: err.message })}\n\n`);
+            res.end();
+          } catch { /* client gone */ }
+        },
+      };
+
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      });
+      res.flushHeaders();
+      res.socket?.setNoDelay(true);
+
+      cleanup = await runner.sendMessageToSession(
+        rawChatId,
+        source as 'telegram' | 'discord',
+        sessionId,
+        content.trim(),
+        senderName,
+        sseCallbacks,
+        { timeoutMs: DEFAULT_TIMEOUT_MS },
+      );
+      res.on('close', cleanup);
+    } catch (err: unknown) {
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Internal error' });
+      } else {
+        try {
+          res.write(`data: ${JSON.stringify({ type: 'error', message: 'Internal error' })}\n\n`);
+          res.end();
+        } catch { /* client gone */ }
+      }
+    }
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/media
+   * Upload a media file as raw binary body (image/* or application/pdf).
+   * Headers: Content-Type (mime type), X-Filename (optional original filename)
+   * Body: raw file bytes
+   * Returns: { mediaPath: string }  — relative path usable in message mediaFiles[]
+   */
+  router.post(
+    '/v1/agents/:agentId/media',
+    auth,
+    (req: Request, res: Response, next) => {
+      // Buffer raw body up to maxUploadBytes; express.json/urlencoded don't handle binary
+      const mimeType = (req.headers['content-type'] ?? '').split(';')[0]!.trim();
+      if (!MediaStore.isAllowedMime(mimeType)) {
+        res.status(415).json({ error: 'Unsupported file type. Allowed: image/*, application/pdf' });
+        return;
+      }
+      const chunks: Buffer[] = [];
+      let size = 0;
+      req.on('data', (chunk: Buffer) => {
+        size += chunk.length;
+        if (size > MediaStore.maxUploadBytes) {
+          req.destroy();
+          res.status(413).json({ error: `File too large (max ${MediaStore.maxUploadBytes / 1024 / 1024}MB)` });
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on('end', () => {
+        (req as Request & { rawFileBuffer?: Buffer; rawFileMime?: string }).rawFileBuffer = Buffer.concat(chunks);
+        (req as Request & { rawFileMime?: string }).rawFileMime = mimeType;
+        next();
+      });
+      req.on('error', () => {
+        if (!res.headersSent) res.status(500).json({ error: 'Upload stream error' });
+      });
+    },
+    async (req: Request, res: Response) => {
+      const { agentId } = req.params as { agentId: string };
+      const apiKey = (req as AuthedRequest).apiKey;
+      if (!canAccessAgent(apiKey, agentId)) {
+        res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+        return;
+      }
+      const runner = agentRunners.get(agentId);
+      if (!runner) {
+        res.status(404).json({ error: `Agent '${agentId}' not found` });
+        return;
+      }
+      const buf = (req as Request & { rawFileBuffer?: Buffer }).rawFileBuffer;
+      const mimeType = (req as Request & { rawFileMime?: string }).rawFileMime ?? '';
+      if (!buf || buf.length === 0) {
+        res.status(400).json({ error: 'No file body received' });
+        return;
+      }
+      const originalName = (req.headers['x-filename'] as string | undefined) ?? `upload`;
+      const safeExt = path.extname(originalName).replace(/[^a-zA-Z0-9.]/g, '').slice(0, 10);
+      const ext = safeExt || (mimeType.includes('pdf') ? '.pdf' : '.bin');
+      const tmpFile = path.join(os.tmpdir(), `gw-${Date.now()}${ext}`);
+      try {
+        await fsp.writeFile(tmpFile, buf);
+        const agentsBaseDir = runner.getAgentsBaseDir();
+        const mediaPath = MediaStore.copyToMedia(agentsBaseDir, agentId, 'ui-upload', tmpFile);
+        res.json({ mediaPath });
+      } catch (err) {
+        res.status(500).json({ error: `Upload failed: ${(err as Error).message}` });
+      } finally {
+        fsp.unlink(tmpFile).catch(() => {});
+      }
+    },
+  );
+
+  /**
+   * GET /api/v1/agents/:agentId/media/*filepath
+   * Serve a media file. Validates path stays within agent's media directory.
+   */
+  router.get('/v1/agents/:agentId/media/*', auth, (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+
+    const wildcardParam = (req.params as Record<string, string>)['0'] ?? '';
+    const agentsBaseDir = runner.getAgentsBaseDir();
+    let absPath: string;
+    try {
+      absPath = MediaStore.resolvePath(agentsBaseDir, agentId, wildcardParam);
+    } catch {
+      res.status(400).json({ error: 'Invalid path' });
+      return;
+    }
+    if (!fs.existsSync(absPath)) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    res.sendFile(absPath);
+  });
+
   return router;
+}
+
+function parseHistoryChatId(fullChatId: string): { source: string; rawChatId: string } {
+  if (fullChatId.startsWith('telegram-')) return { source: 'telegram', rawChatId: fullChatId.slice(9) };
+  if (fullChatId.startsWith('discord-')) return { source: 'discord', rawChatId: fullChatId.slice(8) };
+  return { source: 'api', rawChatId: fullChatId };
 }

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -1,0 +1,274 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { DatabaseSync, StatementSync } from 'node:sqlite';
+import {
+  ChatSummary,
+  HistoryMessage,
+  HistorySource,
+  MessagePage,
+  MessageRole,
+  PaginationOpts,
+  SearchOpts,
+  SearchPage,
+  SearchResult,
+} from './types';
+
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 50;
+const PREVIEW_LENGTH = 120;
+
+// Singleton cache: one DB per (agentsBaseDir + agentId)
+const cache = new Map<string, HistoryDB>();
+
+export class HistoryDB {
+  private readonly db: DatabaseSync;
+  private readonly insertStmt: StatementSync;
+  private readonly agentId: string;
+
+  private constructor(dbPath: string, agentId: string) {
+    this.agentId = agentId;
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec('PRAGMA journal_mode=WAL');
+    this.db.exec('PRAGMA synchronous=NORMAL');
+    this.db.exec('PRAGMA foreign_keys=ON');
+    this._initSchema();
+    this.insertStmt = this.db.prepare(
+      `INSERT INTO messages (chat_id, session_id, source, role, content, sender_name, sender_id, platform_message_id, media_files, ts)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+  }
+
+  static forAgent(agentsBaseDir: string, agentId: string): HistoryDB {
+    const key = `${agentsBaseDir}::${agentId}`;
+    if (!cache.has(key)) {
+      const dbPath = path.join(agentsBaseDir, agentId, 'history.db');
+      cache.set(key, new HistoryDB(dbPath, agentId));
+    }
+    return cache.get(key)!;
+  }
+
+  private _initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS messages (
+        id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+        chat_id             TEXT    NOT NULL,
+        session_id          TEXT    NOT NULL,
+        source              TEXT    NOT NULL,
+        role                TEXT    NOT NULL,
+        content             TEXT    NOT NULL,
+        sender_name         TEXT,
+        sender_id           TEXT,
+        platform_message_id TEXT,
+        media_files         TEXT,
+        ts                  INTEGER NOT NULL,
+        created_at          INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_messages_chat_ts    ON messages(chat_id, ts DESC);
+      CREATE INDEX IF NOT EXISTS idx_messages_session    ON messages(session_id, ts ASC);
+      CREATE INDEX IF NOT EXISTS idx_messages_source     ON messages(source, ts DESC);
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+        content,
+        sender_name,
+        content='messages',
+        content_rowid='id'
+      );
+
+      CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+        INSERT INTO messages_fts(rowid, content, sender_name)
+        VALUES (new.id, new.content, new.sender_name);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+        INSERT INTO messages_fts(messages_fts, rowid, content, sender_name)
+        VALUES ('delete', old.id, old.content, old.sender_name);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+        INSERT INTO messages_fts(messages_fts, rowid, content, sender_name)
+        VALUES ('delete', old.id, old.content, old.sender_name);
+        INSERT INTO messages_fts(rowid, content, sender_name)
+        VALUES (new.id, new.content, new.sender_name);
+      END;
+    `);
+  }
+
+  insertMessage(msg: HistoryMessage): void {
+    try {
+      this.insertStmt.run(
+        msg.chatId,
+        msg.sessionId,
+        msg.source,
+        msg.role,
+        msg.content,
+        msg.senderName ?? null,
+        msg.senderId ?? null,
+        msg.platformMessageId ?? null,
+        msg.mediaFiles ? JSON.stringify(msg.mediaFiles) : null,
+        msg.ts,
+      );
+    } catch (err) {
+      // Non-fatal — history is best-effort
+      console.error(`[HistoryDB:${this.agentId}] insertMessage failed:`, err);
+    }
+  }
+
+  listChats(): ChatSummary[] {
+    const stmt = this.db.prepare(`
+      SELECT
+        chat_id,
+        source,
+        MAX(CASE WHEN role = 'user' THEN sender_name END) AS display_name,
+        COUNT(*) AS message_count,
+        MAX(ts) AS last_active
+      FROM messages
+      GROUP BY chat_id
+      ORDER BY last_active DESC
+    `);
+    const rows = stmt.all() as Array<{
+      chat_id: string;
+      source: string;
+      display_name: string | null;
+      message_count: number;
+      last_active: number;
+    }>;
+
+    return rows.map((row) => {
+      const previewStmt = this.db.prepare(
+        'SELECT content FROM messages WHERE chat_id = ? ORDER BY ts DESC LIMIT 1',
+      );
+      const previewRow = previewStmt.get(row.chat_id) as { content: string } | undefined;
+      const preview = previewRow
+        ? previewRow.content.slice(0, PREVIEW_LENGTH)
+        : null;
+
+      return {
+        chatId: row.chat_id,
+        source: row.source as HistorySource,
+        displayName: row.display_name,
+        messageCount: row.message_count,
+        lastActive: row.last_active,
+        lastMessagePreview: preview,
+      };
+    });
+  }
+
+  getMessages(chatId: string, opts: PaginationOpts = {}): MessagePage {
+    const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+    const conditions: string[] = ['chat_id = ?'];
+    const params: (string | number)[] = [chatId];
+
+    if (opts.sessionId) {
+      conditions.push('session_id = ?');
+      params.push(opts.sessionId);
+    }
+    if (opts.before !== undefined) {
+      conditions.push('ts < ?');
+      params.push(opts.before);
+    }
+    if (opts.after !== undefined) {
+      conditions.push('ts > ?');
+      params.push(opts.after);
+    }
+
+    // Fetch limit+1 to determine hasMore
+    params.push(limit + 1);
+    const sql = `
+      SELECT id, chat_id, session_id, source, role, content, sender_name, sender_id,
+             platform_message_id, media_files, ts
+      FROM messages
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY ts DESC
+      LIMIT ?
+    `;
+
+    const rows = this.db.prepare(sql).all(...params) as Array<Record<string, unknown>>;
+    const hasMore = rows.length > limit;
+    const slice = hasMore ? rows.slice(0, limit) : rows;
+
+    const messages = slice.map((r) => this._rowToMessage(r));
+    const nextCursor = hasMore && slice.length > 0
+      ? (slice[slice.length - 1]!['ts'] as number)
+      : null;
+
+    return { messages, hasMore, nextCursor };
+  }
+
+  searchMessages(chatId: string, query: string, opts: SearchOpts = {}): SearchPage {
+    const limit = Math.min(opts.limit ?? 20, 100);
+    const offset = opts.offset ?? 0;
+
+    if (!query.trim()) {
+      return { results: [], total: 0, hasMore: false };
+    }
+
+    const sanitizedQuery = query.replace(/['"*\-]/g, ' ').trim();
+    if (!sanitizedQuery) {
+      return { results: [], total: 0, hasMore: false };
+    }
+
+    try {
+      const countStmt = this.db.prepare(`
+        SELECT COUNT(*) as cnt
+        FROM messages_fts
+        JOIN messages ON messages.id = messages_fts.rowid
+        WHERE messages.chat_id = ? AND messages_fts MATCH ?
+      `);
+      const countRow = countStmt.get(chatId, sanitizedQuery) as { cnt: number };
+      const total = countRow?.cnt ?? 0;
+
+      const stmt = this.db.prepare(`
+        SELECT
+          messages.id, messages.chat_id, messages.session_id, messages.source,
+          messages.role, messages.content, messages.sender_name, messages.sender_id,
+          messages.platform_message_id, messages.media_files, messages.ts,
+          snippet(messages_fts, 0, '<b>', '</b>', '...', 32) AS snippet
+        FROM messages_fts
+        JOIN messages ON messages.id = messages_fts.rowid
+        WHERE messages.chat_id = ? AND messages_fts MATCH ?
+        ORDER BY messages.ts DESC
+        LIMIT ? OFFSET ?
+      `);
+
+      const rows = stmt.all(chatId, sanitizedQuery, limit, offset) as Array<Record<string, unknown>>;
+      const results: SearchResult[] = rows.map((r) => ({
+        ...this._rowToMessage(r),
+        snippet: (r['snippet'] as string | null) ?? '',
+      }));
+
+      return { results, total, hasMore: offset + results.length < total };
+    } catch {
+      return { results: [], total: 0, hasMore: false };
+    }
+  }
+
+  clearChat(chatId: string): void {
+    this.db.prepare('DELETE FROM messages WHERE chat_id = ?').run(chatId);
+  }
+
+  private _rowToMessage(r: Record<string, unknown>): HistoryMessage {
+    let mediaFiles: string[] | undefined;
+    if (r['media_files'] && typeof r['media_files'] === 'string') {
+      try {
+        mediaFiles = JSON.parse(r['media_files'] as string) as string[];
+      } catch {
+        mediaFiles = undefined;
+      }
+    }
+    return {
+      id: r['id'] as number,
+      chatId: r['chat_id'] as string,
+      sessionId: r['session_id'] as string,
+      source: r['source'] as HistorySource,
+      role: r['role'] as MessageRole,
+      content: r['content'] as string,
+      senderName: (r['sender_name'] as string | null) ?? undefined,
+      senderId: (r['sender_id'] as string | null) ?? undefined,
+      platformMessageId: (r['platform_message_id'] as string | null) ?? undefined,
+      mediaFiles,
+      ts: r['ts'] as number,
+    };
+  }
+}

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -48,6 +48,10 @@ export class HistoryDB {
     return cache.get(key)!;
   }
 
+  static evict(agentsBaseDir: string, agentId: string): void {
+    cache.delete(`${agentsBaseDir}::${agentId}`);
+  }
+
   private _initSchema(): void {
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS messages (
@@ -86,12 +90,6 @@ export class HistoryDB {
         VALUES ('delete', old.id, old.content, old.sender_name);
       END;
 
-      CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-        INSERT INTO messages_fts(messages_fts, rowid, content, sender_name)
-        VALUES ('delete', old.id, old.content, old.sender_name);
-        INSERT INTO messages_fts(rowid, content, sender_name)
-        VALUES (new.id, new.content, new.sender_name);
-      END;
     `);
   }
 
@@ -116,43 +114,40 @@ export class HistoryDB {
   }
 
   listChats(): ChatSummary[] {
-    const stmt = this.db.prepare(`
+    const rows = this.db.prepare(`
       SELECT
-        chat_id,
-        source,
-        MAX(CASE WHEN role = 'user' THEN sender_name END) AS display_name,
+        m.chat_id,
+        m.source,
+        MAX(CASE WHEN m.role = 'user' THEN m.sender_name END) AS display_name,
         COUNT(*) AS message_count,
-        MAX(ts) AS last_active
-      FROM messages
-      GROUP BY chat_id
+        MAX(m.ts) AS last_active,
+        (
+          SELECT SUBSTR(m2.content, 1, ${PREVIEW_LENGTH})
+          FROM messages m2
+          WHERE m2.chat_id = m.chat_id
+          ORDER BY m2.ts DESC
+          LIMIT 1
+        ) AS last_preview
+      FROM messages m
+      GROUP BY m.chat_id
       ORDER BY last_active DESC
-    `);
-    const rows = stmt.all() as Array<{
+    `).all() as Array<{
       chat_id: string;
       source: string;
       display_name: string | null;
       message_count: number;
       last_active: number;
+      last_preview: string | null;
     }>;
 
-    return rows.map((row) => {
-      const previewStmt = this.db.prepare(
-        'SELECT content FROM messages WHERE chat_id = ? ORDER BY ts DESC LIMIT 1',
-      );
-      const previewRow = previewStmt.get(row.chat_id) as { content: string } | undefined;
-      const preview = previewRow
-        ? previewRow.content.slice(0, PREVIEW_LENGTH)
-        : null;
-
-      return {
-        chatId: row.chat_id,
-        source: row.source as HistorySource,
-        displayName: row.display_name,
-        messageCount: row.message_count,
-        lastActive: row.last_active,
-        lastMessagePreview: preview,
-      };
-    });
+    return rows.map((row) => ({
+      chatId: row.chat_id,
+      source: row.source as HistorySource,
+      displayName: row.display_name,
+      messageCount: row.message_count,
+      lastActive: row.last_active,
+      lastMessagePreview: row.last_preview,
+    }));
   }
 
   getMessages(chatId: string, opts: PaginationOpts = {}): MessagePage {

--- a/src/history/media-store.ts
+++ b/src/history/media-store.ts
@@ -1,0 +1,70 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MAX_UPLOAD_BYTES = 20 * 1024 * 1024; // 20 MB
+const ALLOWED_MIME_PREFIXES = ['image/', 'application/pdf'];
+
+export class MediaStore {
+  static mediaDir(agentsBaseDir: string, agentId: string, chatId: string): string {
+    return path.join(agentsBaseDir, agentId, 'media', chatId);
+  }
+
+  static agentMediaRoot(agentsBaseDir: string, agentId: string): string {
+    return path.join(agentsBaseDir, agentId, 'media');
+  }
+
+  /**
+   * Copy a file from srcPath into the permanent media directory for chatId.
+   * Returns the relative path stored in HistoryMessage.mediaFiles[].
+   */
+  static copyToMedia(
+    agentsBaseDir: string,
+    agentId: string,
+    chatId: string,
+    srcPath: string,
+  ): string {
+    const dir = MediaStore.mediaDir(agentsBaseDir, agentId, chatId);
+    fs.mkdirSync(dir, { recursive: true });
+    const ext = path.extname(srcPath) || '';
+    const basename = `${Date.now()}-${path.basename(srcPath)}`;
+    const destName = basename.length > 128 ? basename.slice(-128) : basename;
+    const destPath = path.join(dir, destName);
+    fs.copyFileSync(srcPath, destPath);
+    return path.join('media', chatId, destName);
+  }
+
+  /**
+   * Resolve a relative media path to an absolute filesystem path.
+   * Throws if the resolved path escapes the agent's media root (path traversal guard).
+   */
+  static resolvePath(agentsBaseDir: string, agentId: string, relativePath: string): string {
+    const root = MediaStore.agentMediaRoot(agentsBaseDir, agentId);
+    // Strip leading "media/" prefix if present (callers may or may not include it)
+    const withoutPrefix = relativePath.startsWith('media/')
+      ? relativePath.slice(6)
+      : relativePath;
+    const resolved = path.resolve(root, withoutPrefix);
+    if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+      throw new Error('Path traversal detected');
+    }
+    return resolved;
+  }
+
+  /**
+   * Delete all media files for a chatId (called by /clear).
+   */
+  static clearChatMedia(agentsBaseDir: string, agentId: string, chatId: string): void {
+    const dir = MediaStore.mediaDir(agentsBaseDir, agentId, chatId);
+    if (fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  static isAllowedMime(mime: string): boolean {
+    return ALLOWED_MIME_PREFIXES.some((p) => mime.startsWith(p));
+  }
+
+  static get maxUploadBytes(): number {
+    return MAX_UPLOAD_BYTES;
+  }
+}

--- a/src/history/media-store.ts
+++ b/src/history/media-store.ts
@@ -25,9 +25,8 @@ export class MediaStore {
   ): string {
     const dir = MediaStore.mediaDir(agentsBaseDir, agentId, chatId);
     fs.mkdirSync(dir, { recursive: true });
-    const ext = path.extname(srcPath) || '';
     const basename = `${Date.now()}-${path.basename(srcPath)}`;
-    const destName = basename.length > 128 ? basename.slice(-128) : basename;
+    const destName = basename.length > 128 ? basename.slice(0, 128) : basename;
     const destPath = path.join(dir, destName);
     fs.copyFileSync(srcPath, destPath);
     return path.join('media', chatId, destName);

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -1,0 +1,53 @@
+export type HistorySource = 'telegram' | 'discord' | 'api' | 'ui';
+export type MessageRole = 'user' | 'assistant' | 'system';
+
+export interface HistoryMessage {
+  id?: number;
+  chatId: string;
+  sessionId: string;
+  source: HistorySource;
+  role: MessageRole;
+  content: string;
+  senderName?: string;
+  senderId?: string;
+  platformMessageId?: string;
+  mediaFiles?: string[];
+  ts: number;
+}
+
+export interface MessagePage {
+  messages: HistoryMessage[];
+  hasMore: boolean;
+  nextCursor: number | null;
+}
+
+export interface SearchResult extends HistoryMessage {
+  snippet: string;
+}
+
+export interface SearchPage {
+  results: SearchResult[];
+  total: number;
+  hasMore: boolean;
+}
+
+export interface ChatSummary {
+  chatId: string;
+  source: HistorySource;
+  displayName: string | null;
+  messageCount: number;
+  lastActive: number;
+  lastMessagePreview: string | null;
+}
+
+export interface PaginationOpts {
+  limit?: number;
+  before?: number;
+  after?: number;
+  sessionId?: string;
+}
+
+export interface SearchOpts {
+  limit?: number;
+  offset?: number;
+}

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Integration tests: Chat History API (planning-50)
+ *
+ * Spins up a real AgentRunner + GatewayRouter with a mock claude subprocess
+ * and exercises all 7 Chat History / Media API endpoints via supertest.
+ *
+ * Test IDs: I-HIST-01 through I-HIST-12
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import supertest from 'supertest';
+import { AgentRunner } from '../../src/agent/runner';
+import { GatewayRouter } from '../../src/api/gateway-router';
+import { AgentConfig, GatewayConfig } from '../../src/types';
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+const MOCK_CLAUDE_API_BIN = path.resolve(__dirname, '../helpers/mock-claude-api.js');
+const API_KEY_ADMIN = 'sk-test-admin-hist';
+const API_KEY_OTHER = 'sk-test-other-hist';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function createStructuredWorkspace(agentsBaseDir: string, agentId: string): string {
+  const ws = path.join(agentsBaseDir, agentId, 'workspace');
+  fs.mkdirSync(ws, { recursive: true });
+  const stubs: Record<string, string> = {
+    'AGENTS.md': '# Agent\nYou are a test assistant.',
+    'SOUL.md': '# Soul\nBe helpful.',
+    'USER.md': '# User\nTester.',
+    'HEARTBEAT.md': '# Heartbeat\n',
+    'MEMORY.md': '# Memory\n',
+  };
+  for (const [name, content] of Object.entries(stubs)) {
+    fs.writeFileSync(path.join(ws, name), content, 'utf-8');
+  }
+  return ws;
+}
+
+function makeAgentConfig(id: string, workspace: string): AgentConfig {
+  return {
+    id,
+    description: `Test agent ${id}`,
+    workspace,
+    env: '',
+    telegram: { botToken: `token-${id}` },
+    claude: { model: 'claude-test', dangerouslySkipPermissions: false, extraFlags: [] },
+  };
+}
+
+function makeGatewayConfig(logDir: string): GatewayConfig {
+  return {
+    gateway: {
+      logDir,
+      timezone: 'UTC',
+      api: {
+        keys: [
+          { key: API_KEY_ADMIN, description: 'Admin all', agents: '*' },
+          { key: API_KEY_OTHER, description: 'Other agent', agents: ['other-agent'] },
+        ],
+      },
+    },
+    agents: [],
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 5000,
+  intervalMs = 50,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error('waitFor timeout exceeded');
+}
+
+/** Send a message and wait for response, return session_id */
+async function sendMessage(
+  app: ReturnType<GatewayRouter['getApp']>,
+  agentId: string,
+  message: string,
+  sessionId?: string,
+): Promise<{ sessionId: string; response: string }> {
+  const res = await supertest(app)
+    .post(`/api/v1/agents/${agentId}/messages`)
+    .set('X-Api-Key', API_KEY_ADMIN)
+    .send({ message, ...(sessionId ? { session_id: sessionId } : {}) });
+  if (res.status !== 200) throw new Error(`sendMessage failed: ${res.status} ${JSON.stringify(res.body)}`);
+  return { sessionId: res.body.session_id as string, response: res.body.response as string };
+}
+
+// ─── suite ───────────────────────────────────────────────────────────────────
+
+describe('Chat History API integration (planning-50)', () => {
+  beforeAll(() => {
+    process.env.CLAUDE_BIN = `node ${MOCK_CLAUDE_API_BIN}`;
+  });
+
+  afterAll(() => {
+    delete process.env.CLAUDE_BIN;
+  });
+
+  // ─── I-HIST-01: GET /chats returns empty array before any messages ─────────
+  it('I-HIST-01: GET /chats returns empty array for fresh agent', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-01-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-01-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.chats)).toBe(true);
+    expect(res.body.chats).toHaveLength(0);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-02: GET /chats shows chat after message is sent ───────────────
+  it('I-HIST-02: GET /chats returns chat entry after API message', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-02-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-02-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const { sessionId } = await sendMessage(router.getApp(), 'alfred', 'Hello history!');
+
+    // Allow history write to settle
+    await new Promise((r) => setTimeout(r, 200));
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(res.body.chats.length).toBeGreaterThanOrEqual(1);
+
+    const chat = res.body.chats.find((c: { chatId: string }) => c.chatId === `api-${sessionId}`);
+    expect(chat).toBeDefined();
+    expect(chat.messageCount).toBeGreaterThanOrEqual(1);
+    expect(typeof chat.lastActive).toBe('number');
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-03: GET /chats/:chatId/messages returns messages ──────────────
+  it('I-HIST-03: GET /chats/:chatId/messages returns stored messages', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-03-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-03-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+    const app = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await app.start(0);
+
+    const { sessionId } = await sendMessage(app.getApp(), 'alfred', 'Tell me a story');
+    await new Promise((r) => setTimeout(r, 200));
+
+    const chatId = `api-${sessionId}`;
+    const res = await supertest(app.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.messages)).toBe(true);
+    expect(res.body.messages.length).toBeGreaterThanOrEqual(1);
+    expect(typeof res.body.hasMore).toBe('boolean');
+
+    const userMsg = res.body.messages.find((m: { role: string }) => m.role === 'user');
+    expect(userMsg).toBeDefined();
+    expect(userMsg.content).toBe('Tell me a story');
+    expect(userMsg.chatId).toBe(chatId);
+    expect(typeof userMsg.ts).toBe('number');
+
+    await app.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-04: Pagination — limit and nextCursor ─────────────────────────
+  it('I-HIST-04: GET /chats/:chatId/messages paginates with limit and cursor', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-04-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-04-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const sid = 'hist-04-session';
+    // Send 3 messages in the same session — produces 6 rows (3 user + 3 assistant)
+    for (let i = 0; i < 3; i++) {
+      await sendMessage(router.getApp(), 'alfred', `message-${i}`, sid);
+    }
+    await new Promise((r) => setTimeout(r, 300));
+
+    const chatId = `api-${sid}`;
+
+    // Request only 2 at a time
+    const page1 = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=2`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(page1.status).toBe(200);
+    expect(page1.body.messages).toHaveLength(2);
+    expect(page1.body.hasMore).toBe(true);
+    expect(page1.body.nextCursor).not.toBeNull();
+
+    // Fetch next page using cursor
+    const cursor = page1.body.nextCursor as number;
+    const page2 = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=2&before=${cursor}`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(page2.status).toBe(200);
+    expect(page2.body.messages.length).toBeGreaterThanOrEqual(1);
+    // No message should appear in both pages
+    const ids1 = new Set(page1.body.messages.map((m: { ts: number }) => m.ts));
+    for (const m of page2.body.messages) {
+      expect(ids1.has(m.ts)).toBe(false);
+    }
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-05: FTS search finds matching messages ─────────────────────────
+  it('I-HIST-05: GET /chats/:chatId/messages/search finds matching content', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-05-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-05-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const sid = 'hist-05-session';
+    await sendMessage(router.getApp(), 'alfred', 'quantum computing is fascinating', sid);
+    await sendMessage(router.getApp(), 'alfred', 'what is the weather today', sid);
+    await new Promise((r) => setTimeout(r, 300));
+
+    const chatId = `api-${sid}`;
+    const res = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages/search?q=quantum`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results.length).toBeGreaterThanOrEqual(1);
+    expect(typeof res.body.total).toBe('number');
+    expect(res.body.results[0].content).toMatch(/quantum/i);
+
+    // "weather" should not appear in results
+    const noMatch = res.body.results.every((r: { content: string }) => !r.content.includes('weather'));
+    expect(noMatch).toBe(true);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-06: FTS search with empty q returns 400 ──────────────────────
+  it('I-HIST-06: GET /messages/search with empty q returns 400', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-06-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-06-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats/api-any/messages/search?q=')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-07: GET /chats/:chatId/sessions returns 400 for api chat ──────
+  it('I-HIST-07: GET /chats/:chatId/sessions returns 400 for api:// chatId', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-07-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-07-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats/api-some-session/sessions')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/telegram|discord/i);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-08: Media upload returns mediaPath ────────────────────────────
+  it('I-HIST-08: POST /media uploads file and returns mediaPath', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-08-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-08-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // Minimal JPEG header bytes (enough to pass MIME check via Content-Type)
+    const fakeImage = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/media')
+      .set('X-Api-Key', API_KEY_ADMIN)
+      .set('Content-Type', 'image/jpeg')
+      .set('X-Filename', 'test-photo.jpg')
+      .send(fakeImage);
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.mediaPath).toBe('string');
+    expect(res.body.mediaPath).toMatch(/ui-upload/);
+    expect(res.body.mediaPath).toMatch(/\.jpg$/);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-09: Media upload and serve round-trip ─────────────────────────
+  it('I-HIST-09: Uploaded media file can be served back via GET /media/*', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-09-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-09-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const uniquePayload = Buffer.from(`unique-test-content-${Date.now()}`);
+
+    // Upload
+    const uploadRes = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/media')
+      .set('X-Api-Key', API_KEY_ADMIN)
+      .set('Content-Type', 'image/png')
+      .set('X-Filename', 'round-trip.png')
+      .send(uniquePayload);
+
+    expect(uploadRes.status).toBe(200);
+    const mediaPath = uploadRes.body.mediaPath as string;
+
+    // Serve — strip leading "media/" as the endpoint adds its own path prefix
+    const servePath = mediaPath.startsWith('media/') ? mediaPath.slice(6) : mediaPath;
+    const serveRes = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/media/${servePath}`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(serveRes.status).toBe(200);
+    expect(serveRes.body).toBeDefined();
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-10: Upload unsupported MIME type → 415 ────────────────────────
+  it('I-HIST-10: POST /media with unsupported MIME type returns 415', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-10-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-10-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .post('/api/v1/agents/alfred/media')
+      .set('X-Api-Key', API_KEY_ADMIN)
+      .set('Content-Type', 'application/javascript')
+      .send(Buffer.from('alert(1)'));
+
+    expect(res.status).toBe(415);
+    expect(res.body.error).toMatch(/unsupported/i);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-11: Auth — history endpoint returns 403 for wrong agent ────────
+  it('I-HIST-11: GET /chats returns 403 when key has no access to agent', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-11-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-11-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // API_KEY_OTHER only has access to 'other-agent', not 'alfred'
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats')
+      .set('X-Api-Key', API_KEY_OTHER);
+
+    expect(res.status).toBe(403);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-12: Media serve — path traversal blocked ─────────────────────
+  it('I-HIST-12: GET /media with path traversal returns 400', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-12-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-12-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // Use percent-encoded traversal to bypass HTTP client URL normalization
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/media/%2e%2e%2f%2e%2e%2fetc%2fpasswd')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(400);
+
+    await router.stop();
+    await runner.stop();
+  });
+});

--- a/tests/unit/history-db.test.ts
+++ b/tests/unit/history-db.test.ts
@@ -1,0 +1,192 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { HistoryDB } from '../../src/history/db';
+import { HistoryMessage } from '../../src/history/types';
+
+let tmpDir: string;
+let agentsBaseDir: string;
+const AGENT_ID = 'test-agent';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'history-db-test-'));
+  agentsBaseDir = tmpDir;
+  // Clear singleton cache between tests by using unique dirs
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeDb(): HistoryDB {
+  // Each test gets its own unique agentsBaseDir so singleton cache doesn't interfere
+  return HistoryDB.forAgent(agentsBaseDir, AGENT_ID);
+}
+
+function makeMsg(overrides: Partial<HistoryMessage> = {}): HistoryMessage {
+  return {
+    chatId: 'telegram-12345',
+    sessionId: 'session-uuid-1',
+    source: 'telegram',
+    role: 'user',
+    content: 'Hello world',
+    senderName: 'testuser',
+    ts: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('HistoryDB.insertMessage', () => {
+  it('inserts a message without error', () => {
+    const db = makeDb();
+    expect(() => db.insertMessage(makeMsg())).not.toThrow();
+  });
+
+  it('inserts message with media files', () => {
+    const db = makeDb();
+    const msg = makeMsg({ mediaFiles: ['media/telegram-12345/photo.jpg'] });
+    db.insertMessage(msg);
+    const page = db.getMessages('telegram-12345');
+    expect(page.messages).toHaveLength(1);
+    expect(page.messages[0]!.mediaFiles).toEqual(['media/telegram-12345/photo.jpg']);
+  });
+
+  it('inserts multiple messages', () => {
+    const db = makeDb();
+    for (let i = 0; i < 5; i++) {
+      db.insertMessage(makeMsg({ content: `Message ${i}`, ts: 1000 + i }));
+    }
+    const page = db.getMessages('telegram-12345');
+    expect(page.messages).toHaveLength(5);
+  });
+});
+
+describe('HistoryDB.getMessages', () => {
+  it('returns empty page for unknown chat', () => {
+    const db = makeDb();
+    const page = db.getMessages('telegram-unknown');
+    expect(page.messages).toHaveLength(0);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('paginates with cursor (before)', () => {
+    const db = makeDb();
+    const base = 1000000;
+    for (let i = 0; i < 10; i++) {
+      db.insertMessage(makeMsg({ content: `msg-${i}`, ts: base + i }));
+    }
+    // Get first page (5 most recent)
+    const page1 = db.getMessages('telegram-12345', { limit: 5 });
+    expect(page1.messages).toHaveLength(5);
+    expect(page1.hasMore).toBe(true);
+    expect(page1.nextCursor).not.toBeNull();
+
+    // Get next page using cursor
+    const page2 = db.getMessages('telegram-12345', { limit: 5, before: page1.nextCursor! });
+    expect(page2.messages).toHaveLength(5);
+    expect(page2.hasMore).toBe(false);
+  });
+
+  it('filters by sessionId', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ sessionId: 'session-a', content: 'a' }));
+    db.insertMessage(makeMsg({ sessionId: 'session-b', content: 'b' }));
+    const page = db.getMessages('telegram-12345', { sessionId: 'session-a' });
+    expect(page.messages).toHaveLength(1);
+    expect(page.messages[0]!.content).toBe('a');
+  });
+
+  it('returns messages for specific chatId only', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ chatId: 'telegram-12345' }));
+    db.insertMessage(makeMsg({ chatId: 'discord-99999' }));
+    const page = db.getMessages('telegram-12345');
+    expect(page.messages).toHaveLength(1);
+    expect(page.messages[0]!.chatId).toBe('telegram-12345');
+  });
+});
+
+describe('HistoryDB.listChats', () => {
+  it('returns empty array when no messages', () => {
+    const db = makeDb();
+    expect(db.listChats()).toHaveLength(0);
+  });
+
+  it('returns one entry per distinct chatId', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ chatId: 'telegram-111' }));
+    db.insertMessage(makeMsg({ chatId: 'discord-222' }));
+    db.insertMessage(makeMsg({ chatId: 'telegram-111', content: 'second' }));
+    const chats = db.listChats();
+    expect(chats).toHaveLength(2);
+    const chatIds = chats.map((c) => c.chatId).sort();
+    expect(chatIds).toEqual(['discord-222', 'telegram-111']);
+  });
+
+  it('returns messageCount and lastMessagePreview', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ chatId: 'telegram-111', content: 'first', ts: 1000 }));
+    db.insertMessage(makeMsg({ chatId: 'telegram-111', role: 'assistant', content: 'reply', ts: 2000 }));
+    const chats = db.listChats();
+    const chat = chats.find((c) => c.chatId === 'telegram-111');
+    expect(chat).toBeDefined();
+    expect(chat!.messageCount).toBe(2);
+    expect(chat!.lastMessagePreview).toBe('reply');
+  });
+});
+
+describe('HistoryDB.clearChat', () => {
+  it('removes all messages for a chatId', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ chatId: 'telegram-12345', content: 'a' }));
+    db.insertMessage(makeMsg({ chatId: 'telegram-12345', content: 'b' }));
+    db.insertMessage(makeMsg({ chatId: 'discord-999', content: 'c' }));
+
+    db.clearChat('telegram-12345');
+
+    const page = db.getMessages('telegram-12345');
+    expect(page.messages).toHaveLength(0);
+    // Other chat unaffected
+    const discordPage = db.getMessages('discord-999');
+    expect(discordPage.messages).toHaveLength(1);
+  });
+});
+
+describe('HistoryDB.searchMessages', () => {
+  it('returns empty result for empty query', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ content: 'hello world' }));
+    const result = db.searchMessages('telegram-12345', '');
+    expect(result.results).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('finds messages matching query', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ content: 'hello world testing', ts: 1000 }));
+    db.insertMessage(makeMsg({ content: 'unrelated content here', ts: 2000 }));
+    const result = db.searchMessages('telegram-12345', 'hello');
+    expect(result.results.length).toBeGreaterThanOrEqual(1);
+    expect(result.results[0]!.content).toContain('hello');
+  });
+
+  it('returns no results for nonexistent term', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ content: 'hello world' }));
+    const result = db.searchMessages('telegram-12345', 'xyznonexistent');
+    expect(result.results).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('limits results', () => {
+    const db = makeDb();
+    for (let i = 0; i < 10; i++) {
+      db.insertMessage(makeMsg({ content: `searchterm message ${i}`, ts: 1000 + i }));
+    }
+    const result = db.searchMessages('telegram-12345', 'searchterm', { limit: 3 });
+    expect(result.results).toHaveLength(3);
+    expect(result.total).toBe(10);
+    expect(result.hasMore).toBe(true);
+  });
+});

--- a/tests/unit/media-store.test.ts
+++ b/tests/unit/media-store.test.ts
@@ -1,0 +1,108 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MediaStore } from '../../src/history/media-store';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'media-store-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('MediaStore.copyToMedia', () => {
+  it('copies file and returns relative path', () => {
+    const srcFile = path.join(tmpDir, 'photo.jpg');
+    fs.writeFileSync(srcFile, 'fake-image-bytes');
+
+    const rel = MediaStore.copyToMedia(tmpDir, 'agent1', 'telegram-123', srcFile);
+
+    expect(rel).toMatch(/^media\/telegram-123\//);
+    const absPath = path.join(tmpDir, 'agent1', rel);
+    expect(fs.existsSync(absPath)).toBe(true);
+    expect(fs.readFileSync(absPath, 'utf-8')).toBe('fake-image-bytes');
+  });
+
+  it('creates directories as needed', () => {
+    const srcFile = path.join(tmpDir, 'doc.pdf');
+    fs.writeFileSync(srcFile, 'pdf-content');
+
+    const rel = MediaStore.copyToMedia(tmpDir, 'agent-new', 'telegram-456', srcFile);
+    expect(rel).toMatch(/^media\/telegram-456\//);
+  });
+});
+
+describe('MediaStore.resolvePath', () => {
+  it('resolves a valid relative path', () => {
+    const rel = 'telegram-123/photo.jpg';
+    const resolved = MediaStore.resolvePath(tmpDir, 'agent1', rel);
+    expect(resolved).toBe(path.join(tmpDir, 'agent1', 'media', 'telegram-123', 'photo.jpg'));
+  });
+
+  it('strips media/ prefix if present', () => {
+    const rel = 'media/telegram-123/photo.jpg';
+    const resolved = MediaStore.resolvePath(tmpDir, 'agent1', rel);
+    expect(resolved).toBe(path.join(tmpDir, 'agent1', 'media', 'telegram-123', 'photo.jpg'));
+  });
+
+  it('throws on path traversal', () => {
+    expect(() =>
+      MediaStore.resolvePath(tmpDir, 'agent1', '../../../etc/passwd'),
+    ).toThrow('Path traversal detected');
+  });
+
+  it('throws on absolute path injection', () => {
+    expect(() =>
+      MediaStore.resolvePath(tmpDir, 'agent1', '/etc/passwd'),
+    ).toThrow('Path traversal detected');
+  });
+});
+
+describe('MediaStore.clearChatMedia', () => {
+  it('removes directory for chatId', () => {
+    const dir = path.join(tmpDir, 'agent1', 'media', 'telegram-123');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'photo.jpg'), 'data');
+
+    MediaStore.clearChatMedia(tmpDir, 'agent1', 'telegram-123');
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('does not error if directory does not exist', () => {
+    expect(() => MediaStore.clearChatMedia(tmpDir, 'agent1', 'nonexistent-chat')).not.toThrow();
+  });
+
+  it('does not remove other chats', () => {
+    const dir1 = path.join(tmpDir, 'agent1', 'media', 'telegram-111');
+    const dir2 = path.join(tmpDir, 'agent1', 'media', 'telegram-222');
+    fs.mkdirSync(dir1, { recursive: true });
+    fs.mkdirSync(dir2, { recursive: true });
+
+    MediaStore.clearChatMedia(tmpDir, 'agent1', 'telegram-111');
+    expect(fs.existsSync(dir1)).toBe(false);
+    expect(fs.existsSync(dir2)).toBe(true);
+  });
+});
+
+describe('MediaStore.isAllowedMime', () => {
+  it('allows image types', () => {
+    expect(MediaStore.isAllowedMime('image/jpeg')).toBe(true);
+    expect(MediaStore.isAllowedMime('image/png')).toBe(true);
+    expect(MediaStore.isAllowedMime('image/gif')).toBe(true);
+    expect(MediaStore.isAllowedMime('image/webp')).toBe(true);
+  });
+
+  it('allows PDF', () => {
+    expect(MediaStore.isAllowedMime('application/pdf')).toBe(true);
+  });
+
+  it('rejects other types', () => {
+    expect(MediaStore.isAllowedMime('application/javascript')).toBe(false);
+    expect(MediaStore.isAllowedMime('text/plain')).toBe(false);
+    expect(MediaStore.isAllowedMime('application/octet-stream')).toBe(false);
+    expect(MediaStore.isAllowedMime('video/mp4')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **HistoryDB** (`src/history/db.ts`): SQLite WAL + FTS5, singleton per agent, cursor-based pagination, full-text search — stored as Layer 2 separate from session context JSON so history survives `/compact`
- **MediaStore** (`src/history/media-store.ts`): permanent media file copy on message receive, path traversal guard, MIME allowlist for uploads
- **History API** (7 new endpoints): list chats, list sessions, paginated messages, FTS search, cross-channel SSE message injection, media upload, media serve
- **`/clear` integration**: clears history DB rows and media files for the cleared chat only
- **Security fixes**: XML attribute escaping for `senderName`/`rawChatId`/`sessionId` in `sendMessageToSession`; API.md examples replace hardcoded numeric IDs with `<CHAT_ID>`/`<CHANNEL_ID>` placeholders

## New API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/agents/:agentId/chats` | List all chats with message counts and previews |
| `GET` | `/api/v1/agents/:agentId/chats/:chatId/sessions` | List sessions for a chat |
| `GET` | `/api/v1/agents/:agentId/chats/:chatId/messages` | Paginated messages (cursor via `before` timestamp) |
| `GET` | `/api/v1/agents/:agentId/chats/:chatId/messages/search` | FTS5 full-text search |
| `POST` | `/api/v1/agents/:agentId/chats/:chatId/sessions/:sessionId/messages` | Inject message into existing session (SSE stream) |
| `POST` | `/api/v1/agents/:agentId/media` | Upload media file (raw binary body) |
| `GET` | `/api/v1/agents/:agentId/media/*` | Serve media file |

## Test plan

- [ ] 1016/1016 unit tests pass (`npm test`)
- [ ] `HistoryDB`: insert, paginate (cursor), FTS5 search, clearChat
- [ ] `MediaStore`: copy, resolve (path traversal rejected), clearChatMedia, MIME allowlist
- [ ] Send Telegram message → appears in `GET /chats/:chatId/messages`
- [ ] `/clear` → messages and media removed from DB; other chats unaffected
- [ ] Upload image via `POST /media` → serve back via `GET /media/*`
- [ ] Cross-channel SSE: send message to Telegram session from API, receive streamed reply