### PR TITLE
feat(browser): add GETPOD_BROWSER_API_KEY auth header support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,14 @@
 
 # Override the Telegram API base URL (useful for local testing / mocks)
 # TELEGRAM_API_BASE=https://api.telegram.org
+
+# ── Browser Module ────────────────────────────────────────────────────────────
+
+# URL of the getpod-browser service (default: http://127.0.0.1:10880)
+# GETPOD_BROWSER_URL=http://127.0.0.1:10880
+
+# Set to 1 to disable the browser module entirely
+# GETPOD_BROWSER_DISABLED=true
+
+# Per-VM key for getpod-browser authentication (injected at provision; leave empty for local dev)
+# GETPOD_BROWSER_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@
 # URL of the getpod-browser service (default: http://127.0.0.1:10880)
 # GETPOD_BROWSER_URL=http://127.0.0.1:10880
 
-# Set to 1 to disable the browser module entirely
+# Set to true to disable the browser module entirely
 # GETPOD_BROWSER_DISABLED=true
 
 # Per-VM key for getpod-browser authentication (injected at provision; leave empty for local dev)

--- a/mcp/tools/browser/module.ts
+++ b/mcp/tools/browser/module.ts
@@ -9,7 +9,7 @@ export class BrowserModule implements ToolModule {
   toolVisibility: ToolVisibility = 'all-configured';
 
   isEnabled(): boolean {
-    return process.env.GETPOD_BROWSER_DISABLED !== '1';
+    return process.env.GETPOD_BROWSER_DISABLED !== 'true';
   }
 
   getTools(): McpToolDefinition[] {
@@ -80,11 +80,16 @@ async function callGetpodBrowser(
   });
 
   const baseUrl = process.env.GETPOD_BROWSER_URL ?? 'http://127.0.0.1:10880';
+  const apiKey = process.env.GETPOD_BROWSER_API_KEY ?? '';
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`;
+  }
   let res: Response;
   try {
     res = await fetch(`${baseUrl}/mcp`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body,
     });
   } catch (err) {

--- a/tests/unit/browser-module.test.ts
+++ b/tests/unit/browser-module.test.ts
@@ -23,14 +23,14 @@ describe('BrowserModule', () => {
       expect(mod.isEnabled()).toBe(true);
     });
 
-    it('returns false when GETPOD_BROWSER_DISABLED=1', () => {
-      process.env.GETPOD_BROWSER_DISABLED = '1';
+    it('returns false when GETPOD_BROWSER_DISABLED=true', () => {
+      process.env.GETPOD_BROWSER_DISABLED = 'true';
       const mod = new BrowserModule();
       expect(mod.isEnabled()).toBe(false);
     });
 
-    it('returns true when GETPOD_BROWSER_DISABLED is set to a value other than "1"', () => {
-      process.env.GETPOD_BROWSER_DISABLED = '0';
+    it('returns true when GETPOD_BROWSER_DISABLED is set to a value other than "true"', () => {
+      process.env.GETPOD_BROWSER_DISABLED = '1';
       const mod = new BrowserModule();
       expect(mod.isEnabled()).toBe(true);
     });
@@ -225,6 +225,56 @@ describe('BrowserModule', () => {
 
       const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
       expect(url).toBe('http://custom-host:9999/mcp');
+    });
+
+    it('sends Authorization: Bearer header when GETPOD_BROWSER_API_KEY is set', async () => {
+      process.env.GETPOD_BROWSER_API_KEY = 'test-api-key-abc123';
+      const rpc = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: { content: [{ type: 'text', text: 'ok' }] },
+      };
+      fetchMock.mockResolvedValue(new Response(`data: ${JSON.stringify(rpc)}\n\n`, { status: 200 }));
+      const mod = new BrowserModule();
+      await mod.handleTool('browser_snapshot', { session_id: 'test-session' });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer test-api-key-abc123');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('omits Authorization header when GETPOD_BROWSER_API_KEY is not set', async () => {
+      delete process.env.GETPOD_BROWSER_API_KEY;
+      const rpc = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: { content: [{ type: 'text', text: 'ok' }] },
+      };
+      fetchMock.mockResolvedValue(new Response(`data: ${JSON.stringify(rpc)}\n\n`, { status: 200 }));
+      const mod = new BrowserModule();
+      await mod.handleTool('browser_snapshot', { session_id: 'test-session' });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBeUndefined();
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('omits Authorization header when GETPOD_BROWSER_API_KEY is empty string', async () => {
+      process.env.GETPOD_BROWSER_API_KEY = '';
+      const rpc = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: { content: [{ type: 'text', text: 'ok' }] },
+      };
+      fetchMock.mockResolvedValue(new Response(`data: ${JSON.stringify(rpc)}\n\n`, { status: 200 }));
+      const mod = new BrowserModule();
+      await mod.handleTool('browser_navigate', { session_id: 'test-session', url: 'https://example.com' });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Inject `Authorization: Bearer <key>` header in every `getpod-browser` MCP request when `GETPOD_BROWSER_API_KEY` is set
- Header is omitted when the env var is absent or empty — backward-compatible for local dev
- Normalize `GETPOD_BROWSER_DISABLED` to use `'true'` instead of `'1'` for readability
- Add `GETPOD_BROWSER_API_KEY=` to `.env.example` with explanation comment

## Test plan

- [x] `sends Authorization: Bearer header when GETPOD_BROWSER_API_KEY is set`
- [x] `omits Authorization header when GETPOD_BROWSER_API_KEY is not set`
- [x] `omits Authorization header when GETPOD_BROWSER_API_KEY is empty string`
- [x] Full test suite: 23/23 browser-module tests pass, 1296/1296 total pass