### PR TITLE
feat: add firstMessage field to SessionSummary

### DIFF
--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -266,7 +266,10 @@ export class HistoryDB {
         MAX(ts)   AS last_activity,
         (SELECT content FROM messages m2
          WHERE m2.session_id = m.session_id
-         ORDER BY ts DESC LIMIT 1) AS last_message
+         ORDER BY ts DESC LIMIT 1) AS last_message,
+        (SELECT content FROM messages m3
+         WHERE m3.session_id = m.session_id AND m3.role = 'user'
+         ORDER BY ts ASC LIMIT 1) AS first_message
       FROM messages m
       GROUP BY session_id
       ORDER BY last_activity DESC
@@ -278,6 +281,7 @@ export class HistoryDB {
       created_at: number;
       last_activity: number;
       last_message: string | null;
+      first_message: string | null;
     }>;
 
     return rows.map((row) => ({
@@ -288,6 +292,7 @@ export class HistoryDB {
       createdAt: row.created_at,
       lastActivity: row.last_activity,
       lastMessage: row.last_message ?? null,
+      firstMessage: row.first_message ?? null,
     }));
   }
 

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -60,6 +60,7 @@ export interface SessionSummary {
   createdAt: number;
   lastActivity: number;
   lastMessage: string | null;
+  firstMessage: string | null;
 }
 
 export interface AgentSessionSummary {


### PR DESCRIPTION
## Summary
- Add `firstMessage` field to `SessionSummary` type in `src/history/types.ts`
- Populate it via an `ASC` subquery on `role = 'user'` in `listSessions()` in `src/history/db.ts`
- Additive change — does not modify `lastMessage`, existing fields, or any other API behavior

## Motivation
Expose the first user message in session list responses so clients can use it as a conversation label without fetching full chat history.

## Test plan
- [ ] `GET /v1/sessions` — verify `firstMessage` is populated for sessions that have at least one user message
- [ ] Sessions with no user messages return `firstMessage: ""`
- [ ] `lastMessage` and all other fields are unaffected
- [ ] No regression in existing session listing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)