### PR TITLE
feat: Web API commands, session management, and chat_id support

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,6 +15,7 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 | `GET` | `/health` | None | Health check — status + agent list |
 | `GET` | `/status` | None | Per-agent stats + heartbeat history |
 | `GET` | `/ui` | None | Web UI dashboard |
+| `GET` | `/api/v1/commands` | None | List slash commands available in the chat UI |
 
 ### Agent API
 
@@ -24,8 +25,26 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 | `POST` | `/api/v1/agents` | Admin | Create a new agent |
 | `PATCH` | `/api/v1/agents/:agentId` | Write | Update agent description, model, or allow_tools |
 | `DELETE` | `/api/v1/agents/:agentId` | Admin | Delete an agent |
-| `POST` | `/api/v1/agents/:agentId/messages` | Key | Send a message — sync JSON or SSE stream |
-| `GET` | `/api/v1/models` | Key | List supported Claude models |
+| `POST` | `/api/v1/agents/:agentId/messages` | Key | Send a message — sync JSON or SSE stream; supports slash commands |
+| `GET` | `/api/v1/models` | Key | List all supported Claude models |
+| `PUT` | `/api/v1/agents/:agentId/model` | Admin | Set the active model for an agent |
+
+### Session Management API
+
+All session endpoints require `chat_id` (query param for GET/DELETE, body for POST/PATCH).
+Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{id}` and `discord-{id}`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/v1/agents/:agentId/sessions` | Key | List API sessions for a `chat_id` |
+| `POST` | `/api/v1/agents/:agentId/sessions` | Key | Create a new API session (auto-names from prompt) |
+| `GET` | `/api/v1/agents/:agentId/sessions/:sessionId/info` | Key | Get session info (name, message count, context %) |
+| `PATCH` | `/api/v1/agents/:agentId/sessions/:sessionId` | Key | Rename a session |
+| `DELETE` | `/api/v1/agents/:agentId/sessions/:sessionId` | Key | Delete a session |
+| `POST` | `/api/v1/agents/:agentId/sessions/:sessionId/clear` | Key | Clear session history |
+| `POST` | `/api/v1/agents/:agentId/sessions/:sessionId/compact` | Key | Summarise old history, keep only recent messages |
+| `POST` | `/api/v1/agents/:agentId/sessions/:sessionId/stop` | Key | Interrupt the in-flight turn |
+| `POST` | `/api/v1/agents/:agentId/sessions/:sessionId/restart` | Key | Graceful session restart |
 
 ### Workspace File API
 
@@ -133,6 +152,29 @@ curl http://localhost:3000/status | jq
 ### GET /ui
 
 Serves the web UI dashboard. No auth required.
+
+---
+
+### GET /api/v1/commands
+
+List the slash commands available in the chat UI. No auth required.
+
+```bash
+curl http://localhost:3000/api/v1/commands | jq
+```
+
+```json
+{
+  "commands": [
+    { "name": "/session",  "description": "Show current session info (name, message count, context %)" },
+    { "name": "/clear",    "description": "Clear current session history" },
+    { "name": "/compact",  "description": "Summarise old history and keep only recent messages" },
+    { "name": "/stop",     "description": "Interrupt the in-flight turn" },
+    { "name": "/restart",  "description": "Graceful session restart" },
+    { "name": "/model",    "description": "Show the current AI model" }
+  ]
+}
+```
 
 ---
 
@@ -281,16 +323,45 @@ curl -X DELETE \
 
 Send a message to an agent. Returns a JSON response or SSE stream.
 
+> **Breaking change (PR #69):** `chat_id` is now required. Messages are stored under `sessions/api-{chat_id}/` on disk.
+
 **Request body:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `message` | Yes | Message text (max 10,000 chars) |
+| `message` | Yes | Message text (max 10,000 chars), or a slash command (e.g. `/session`, `/clear`) |
+| `chat_id` | Yes | Caller identity — used to namespace sessions (e.g. `"myapp"`, `"user-123"`) |
 | `session_id` | No | Resume an existing session; omit to start a new one |
 | `stream` | No | `true` to enable SSE streaming (default `false`) |
-| `timeout_ms` | No | Override the default response timeout in milliseconds (default 60000). Useful when the key has `allow_tools: true` and runs long-running tools |
+| `timeout_ms` | No | Override the default response timeout in milliseconds (default 60000) |
+| `media_files` | No | Array of `mediaPath` strings returned by the Media Upload endpoint |
 
-> Tool access is configured per API key in `config.json` — see `allow_tools` below.
+#### Slash command dispatch
+
+If `message` starts with `/`, the endpoint executes the command instead of forwarding to Claude:
+
+| Command | Description |
+|---------|-------------|
+| `/session` | Return current session info (name, message count, context %) |
+| `/clear` | Clear the session history |
+| `/compact` | Summarise old history and keep only recent messages |
+| `/stop` | Interrupt the in-flight turn |
+| `/restart` | Gracefully restart the session |
+| `/model` | Return the current model for this agent |
+
+**Command response:**
+
+```json
+{
+  "command": "/session",
+  "session_id": "da19d84a-6a36-4f57-b419-d322d82c4db8",
+  "result": {
+    "name": "My Project Discussion",
+    "messageCount": 42,
+    "contextPercent": 18
+  }
+}
+```
 
 **New session:**
 
@@ -298,7 +369,7 @@ Send a message to an agent. Returns a JSON response or SSE stream.
 curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Hello! What can you help me with?"}' \
+  -d '{"message": "Hello! What can you help me with?", "chat_id": "myapp"}' \
   http://localhost:3000/api/v1/agents/alfred/messages | jq
 ```
 
@@ -318,7 +389,7 @@ curl -X POST \
 curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
-  -d '{"message": "What did I just ask you?", "session_id": "da19d84a-6a36-4f57-b419-d322d82c4db8"}' \
+  -d '{"message": "What did I just ask you?", "chat_id": "myapp", "session_id": "da19d84a-6a36-4f57-b419-d322d82c4db8"}' \
   http://localhost:3000/api/v1/agents/alfred/messages | jq
 ```
 
@@ -326,7 +397,7 @@ curl -X POST \
 
 | Status | When |
 |--------|------|
-| 400 | Empty message or exceeds 10,000 characters |
+| 400 | Empty or too-long message, or missing `chat_id` |
 | 401 | Missing API key |
 | 403 | Invalid key or key has no access to that agent |
 | 404 | Agent ID not found |
@@ -348,7 +419,7 @@ Set `"stream": true` in the request body to receive a Server-Sent Events stream.
 curl -N -X POST \
   -H "X-Api-Key: my-secret-key" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Explain this code", "stream": true}' \
+  -d '{"message": "Explain this code", "chat_id": "myapp", "stream": true}' \
   http://localhost:3000/api/v1/agents/alfred/messages
 ```
 
@@ -373,6 +444,7 @@ curl -N -X POST \
   -H "Content-Type: application/json" \
   -d '{
     "message": "Run the setup script in /workspace and report the output",
+    "chat_id": "myapp",
     "stream": true,
     "timeout_ms": 120000
   }' \
@@ -416,6 +488,250 @@ curl -H "X-Api-Key: my-secret-key-123" \
     { "id": "claude-opus-4-7", "name": "Claude Opus 4.7", "alias": "opus", "contextWindow": 200000, "multiplier": 3 }
   ]
 }
+```
+
+---
+
+### PUT /api/v1/agents/:agentId/model
+
+Set the active model for a specific agent. Persists to `config.json`. Requires admin key.
+
+**Request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `model` | Yes | Claude model ID (e.g. `"claude-opus-4-7"`) |
+
+```bash
+curl -X PUT \
+  -H "X-Api-Key: admin-key-456" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "claude-opus-4-7"}' \
+  http://localhost:3000/api/v1/agents/alfred/model | jq
+```
+
+```json
+{ "model": "claude-opus-4-7" }
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Missing or unknown model ID |
+| 403 | Not an admin key |
+| 404 | Agent not found |
+
+---
+
+## Session Management API
+
+Manage API sessions for a specific agent and `chat_id`. Sessions are stored at `sessions/api-{chat_id}/` — symmetric with Telegram (`telegram-{id}`) and Discord (`discord-{id}`).
+
+**`chat_id`** identifies the caller. Use any stable string (e.g. `"myapp"`, `"user-123"`, `"getpod"`). It is **required** on all session endpoints — pass it as:
+- Query string for `GET` and `DELETE` requests: `?chat_id=myapp`
+- Request body for `POST` and `PATCH` requests: `{"chat_id": "myapp", ...}`
+
+---
+
+### GET /api/v1/agents/:agentId/sessions
+
+List all API sessions for a given `chat_id`.
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/sessions?chat_id=myapp" | jq
+```
+
+```json
+{
+  "sessions": [
+    {
+      "id": "da19d84a-6a36-4f57-b419-d322d82c4db8",
+      "name": "Project Planning",
+      "createdAt": 1775737709000,
+      "lastActivity": 1775823600000
+    }
+  ]
+}
+```
+
+---
+
+### POST /api/v1/agents/:agentId/sessions
+
+Create a new API session. Optionally auto-generates a session name by summarising a prompt.
+
+**Request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `chat_id` | Yes | Caller identity |
+| `prompt` | No | Initial user intent — used to auto-generate a session name |
+| `name` | No | Explicit session name (overrides auto-generated name) |
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "myapp", "prompt": "I want to discuss the deployment plan for Q3"}' \
+  http://localhost:3000/api/v1/agents/alfred/sessions | jq
+```
+
+```json
+{
+  "sessionId": "da19d84a-6a36-4f57-b419-d322d82c4db8",
+  "sessionName": "Q3 Deployment Plan",
+  "createdAt": 1775737709000
+}
+```
+
+---
+
+### GET /api/v1/agents/:agentId/sessions/:sessionId/info
+
+Get info for a specific session — name, message count, and context usage.
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/info?chat_id=myapp" | jq
+```
+
+```json
+{
+  "sessionId": "da19d84a-6a36-4f57-b419-d322d82c4db8",
+  "sessionName": "Q3 Deployment Plan",
+  "messageCount": 42,
+  "contextPercent": 18,
+  "createdAt": 1775737709000,
+  "lastActivity": 1775823600000
+}
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 404 | Session not found |
+
+---
+
+### PATCH /api/v1/agents/:agentId/sessions/:sessionId
+
+Rename a session.
+
+**Request body:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `chat_id` | Yes | Caller identity |
+| `sessionName` | Yes | New session name |
+
+```bash
+curl -X PATCH \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "myapp", "sessionName": "Q3 Infra Discussion"}' \
+  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a | jq
+```
+
+```json
+{
+  "sessionId": "da19d84a-6a36-4f57-b419-d322d82c4db8",
+  "sessionName": "Q3 Infra Discussion"
+}
+```
+
+---
+
+### DELETE /api/v1/agents/:agentId/sessions/:sessionId
+
+Delete a session. Returns 204 No Content on success.
+
+```bash
+curl -X DELETE \
+  -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a?chat_id=myapp"
+```
+
+---
+
+### POST /api/v1/agents/:agentId/sessions/:sessionId/clear
+
+Clear all history for a session.
+
+**Request body:** `{ "chat_id": "myapp" }`
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "myapp"}' \
+  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/clear | jq
+```
+
+```json
+{ "cleared": true, "sessionId": "da19d84a-6a36-4f57-b419-d322d82c4db8" }
+```
+
+---
+
+### POST /api/v1/agents/:agentId/sessions/:sessionId/compact
+
+Summarise old history and keep only recent messages, reducing context usage.
+
+**Request body:** `{ "chat_id": "myapp" }`
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "myapp"}' \
+  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/compact | jq
+```
+
+```json
+{ "compacted": true, "keptMessages": 10, "sessionId": "da19d84a-6a36-4f57-b419-d322d82c4db8" }
+```
+
+---
+
+### POST /api/v1/agents/:agentId/sessions/:sessionId/stop
+
+Interrupt the currently in-flight turn for this session (sends SIGINT to the subprocess).
+
+**Request body:** `{ "chat_id": "myapp" }`
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "myapp"}' \
+  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/stop | jq
+```
+
+```json
+{ "stopped": true }
+```
+
+---
+
+### POST /api/v1/agents/:agentId/sessions/:sessionId/restart
+
+Gracefully restart the session (kills the subprocess and notifies when back online).
+
+**Request body:** `{ "chat_id": "myapp" }`
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "myapp"}' \
+  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/restart | jq
+```
+
+```json
+{ "restarting": true }
 ```
 
 ---
@@ -1015,7 +1331,7 @@ curl -H "X-Api-Key: my-secret-key-123" \
 
 ## Chat History API
 
-Access per-agent conversation history stored in the history DB (SQLite). `chatId` uses the format `telegram-{rawId}` or `discord-{rawId}`.
+Access per-agent conversation history stored in the history DB (SQLite). `chatId` uses the format `telegram-{rawId}`, `discord-{rawId}`, or `api-{rawId}`.
 
 ### GET /api/v1/agents/sessions
 
@@ -1040,7 +1356,8 @@ curl -H "X-Api-Key: admin-key-456" \
           "messageCount": 42,
           "createdAt": 1775737709000,
           "lastActivity": 1775823600000,
-          "lastMessage": "Sure, I can help with that!"
+          "lastMessage": "Sure, I can help with that!",
+          "sessionName": "Project Planning"
         }
       ]
     }
@@ -1052,13 +1369,14 @@ curl -H "X-Api-Key: admin-key-456" \
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `chatId` | string | Channel chat ID (`telegram-{id}` / `discord-{id}`) — null for API sessions |
+| `chatId` | string | Channel chat ID (`telegram-{id}` / `discord-{id}` / `api-{id}`) |
 | `sessionId` | string | Unique session identifier |
 | `source` | string | `telegram`, `discord`, or `api` |
 | `messageCount` | number | Total messages in this session |
 | `createdAt` | number | Session start timestamp (ms) |
 | `lastActivity` | number | Last message timestamp (ms) |
 | `lastMessage` | string\|null | Preview of the last message content |
+| `sessionName` | string\|null | Human-readable session name (set via `/rename` or `POST /sessions`) |
 
 **Error responses:**
 
@@ -1089,7 +1407,7 @@ curl -H "X-Api-Key: my-secret-key-123" \
 
 ### GET /api/v1/agents/:agentId/chats/:chatId/sessions
 
-List sessions for a specific chat. Only supports `telegram` and `discord` chats.
+List sessions for a specific chat. Supports `telegram`, `discord`, and `api` chats.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
@@ -1108,7 +1426,6 @@ curl -H "X-Api-Key: my-secret-key-123" \
 
 | Status | When |
 |--------|------|
-| 400 | `chatId` is not a telegram/discord chat |
 | 403 | Key has no access to agent |
 | 404 | Agent not found |
 
@@ -1180,7 +1497,7 @@ curl -H "X-Api-Key: my-secret-key-123" \
 
 ### POST /api/v1/agents/:agentId/chats/:chatId/sessions/:sessionId/messages
 
-Inject a message into an existing Telegram or Discord session and stream the assistant's response via SSE. Useful for cross-channel continuation.
+Inject a message into an existing Telegram, Discord, or API session and stream the assistant's response via SSE. Useful for cross-channel continuation.
 
 **Request body:**
 
@@ -1209,7 +1526,7 @@ data: [DONE]
 
 | Status | When |
 |--------|------|
-| 400 | `chatId` is not telegram/discord, or `content` is missing/too long |
+| 400 | `content` is missing or too long |
 | 403 | Key has no access to agent |
 | 404 | Agent not found |
 
@@ -1217,7 +1534,7 @@ data: [DONE]
 
 ## Media API
 
-Upload and serve media files (images and PDFs) associated with an agent. Uploaded files are stored in the agent's media directory and can be referenced in messages via `mediaFiles[]`.
+Upload and serve media files (images and PDFs) associated with an agent. Uploaded files are stored in the agent's media directory and can be referenced in messages via `media_files[]`.
 
 ### POST /api/v1/agents/:agentId/media
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1290,7 +1290,9 @@ export class AgentRunner extends EventEmitter {
 
     // Register session in api-{chatId} index.json on first use
     const internalChatIdForSession = `api-${chatId}`;
-    await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatIdForSession, sessionId).catch(() => {});
+    await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatIdForSession, sessionId).catch((err: unknown) => {
+      this.logger.warn('Failed to register API session in index', { agentId: this.agentConfig.id, chatId, sessionId, error: (err as Error).message });
+    });
 
     // Promote UI-uploaded files from staging to permanent per-session storage
     const finalMediaFiles = opts.mediaFiles?.length
@@ -1473,7 +1475,9 @@ export class AgentRunner extends EventEmitter {
 
     // Register session in api-{chatId} index.json on first use
     const internalChatIdStream = `api-${chatId}`;
-    await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatIdStream, sessionId).catch(() => {});
+    await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatIdStream, sessionId).catch((err: unknown) => {
+      this.logger.warn('Failed to register API session in index', { agentId: this.agentConfig.id, chatId, sessionId, error: (err as Error).message });
+    });
 
     // Promote UI-uploaded files from staging to permanent per-session storage
     const finalMediaFilesStream = opts.mediaFiles?.length
@@ -1747,8 +1751,8 @@ export class AgentRunner extends EventEmitter {
         loadedAtSpawn: undefined,
         messageCountAtSpawn: undefined,
       }, ch);
-      this.historyDb.clearChat(internalChatId);
-      MediaStore.clearChatMedia(this.agentsBaseDir, agentId, internalChatId);
+      const mediaPaths = this.historyDb.clearSession(internalChatId, sessionId);
+      MediaStore.deleteMediaFiles(this.agentsBaseDir, agentId, mediaPaths);
       this.restartProcess(sessionId).catch(() => {});
       return { success: true };
     }
@@ -1769,7 +1773,7 @@ export class AgentRunner extends EventEmitter {
       return { success: true, keptMessages: result.afterMessages, archivedMessages: result.beforeMessages - result.afterMessages };
     }
 
-    return { error: `Unknown command: ${command}` };
+    throw new Error(`Unknown command: ${command}`);
   }
 
   async setModel(newModel: string): Promise<void> {
@@ -1791,13 +1795,16 @@ export class AgentRunner extends EventEmitter {
     let sessionName = name;
     if (!sessionName && prompt) {
       try {
-        const { execSync } = await import('child_process');
+        const { execFile } = await import('child_process');
+        const { promisify } = await import('util');
+        const execFileAsync = promisify(execFile);
         const titlePrompt = `Summarise in 3-5 words as a session title (no punctuation, no quotes): ${prompt}`;
-        const out = execSync(
-          `claude -p ${JSON.stringify(titlePrompt)} --output-format text --model claude-haiku-4-5-20251001`,
+        const { stdout } = await execFileAsync(
+          'claude',
+          ['-p', titlePrompt, '--output-format', 'text', '--model', 'claude-haiku-4-5-20251001'],
           { timeout: 15000, encoding: 'utf-8' },
         );
-        sessionName = out.trim().slice(0, 60) || undefined;
+        sessionName = stdout.trim().slice(0, 60) || undefined;
       } catch {
         sessionName = undefined;
       }

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1274,6 +1274,7 @@ export class AgentRunner extends EventEmitter {
    */
   async sendApiMessage(
     sessionId: string,
+    chatId: string,
     message: string,
     opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[] },
   ): Promise<string> {
@@ -1286,6 +1287,10 @@ export class AgentRunner extends EventEmitter {
     }
 
     const session = await this.getOrSpawnSession(sessionId, 'api');
+
+    // Register session in api-{chatId} index.json on first use
+    const internalChatIdForSession = `api-${chatId}`;
+    await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatIdForSession, sessionId).catch(() => {});
 
     // Promote UI-uploaded files from staging to permanent per-session storage
     const finalMediaFiles = opts.mediaFiles?.length
@@ -1307,7 +1312,7 @@ export class AgentRunner extends EventEmitter {
       })
       .catch(() => {});
     this.historyDb.insertMessage({
-      chatId: `api-${sessionId}`,
+      chatId: `api-${chatId}`,
       sessionId,
       source: 'api',
       role: 'user',
@@ -1332,7 +1337,7 @@ export class AgentRunner extends EventEmitter {
     }
 
     const channelXml =
-      `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
+      `<channel source="api" chat_id="${chatId}" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
       `${message}\n\n` +
       `${systemNote}` +
       `</channel>` +
@@ -1357,7 +1362,7 @@ export class AgentRunner extends EventEmitter {
             })
             .catch(() => {});
           this.historyDb.insertMessage({
-            chatId: `api-${sessionId}`,
+            chatId: `api-${chatId}`,
             sessionId,
             source: 'api',
             role: 'assistant',
@@ -1447,6 +1452,7 @@ export class AgentRunner extends EventEmitter {
    */
   async sendApiMessageStream(
     sessionId: string,
+    chatId: string,
     message: string,
     callbacks: {
       onChunk: (event: StreamEvent) => void;
@@ -1464,6 +1470,10 @@ export class AgentRunner extends EventEmitter {
     }
 
     const session = await this.getOrSpawnSession(sessionId, 'api');
+
+    // Register session in api-{chatId} index.json on first use
+    const internalChatIdStream = `api-${chatId}`;
+    await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatIdStream, sessionId).catch(() => {});
 
     // Promote UI-uploaded files from staging to permanent per-session storage
     const finalMediaFilesStream = opts.mediaFiles?.length
@@ -1485,7 +1495,7 @@ export class AgentRunner extends EventEmitter {
       })
       .catch(() => {});
     this.historyDb.insertMessage({
-      chatId: `api-${sessionId}`,
+      chatId: `api-${chatId}`,
       sessionId,
       source: 'api',
       role: 'user',
@@ -1517,7 +1527,7 @@ export class AgentRunner extends EventEmitter {
           })
           .catch(() => {});
         this.historyDb.insertMessage({
-          chatId: `api-${sessionId}`,
+          chatId: `api-${chatId}`,
           sessionId,
           source: 'api',
           role: 'assistant',
@@ -1645,7 +1655,7 @@ export class AgentRunner extends EventEmitter {
     }
 
     const channelXml =
-      `<channel source="api" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
+      `<channel source="api" chat_id="${chatId}" session_id="${sessionId}" ts="${new Date().toISOString()}">\n` +
       `${message}\n\n` +
       systemNote +
       `</channel>` +
@@ -1688,6 +1698,137 @@ export class AgentRunner extends EventEmitter {
 
   async listSessionsForChat(chatId: string, channel: 'telegram' | 'discord'): Promise<import('../types').SessionIndex> {
     return this.sessionStore.listSessions(this.agentConfig.id, chatId, channel);
+  }
+
+  async executeApiCommand(sessionId: string, chatId: string, command: string): Promise<Record<string, unknown>> {
+    const agentId = this.agentConfig.id;
+    const internalChatId = `api-${chatId}`;
+
+    if (command === '/model') {
+      return { model: this.agentConfig.claude.model };
+    }
+
+    if (command === '/stop') {
+      const session = this.sessions.get(sessionId);
+      const stopped = session ? session.interrupt() : false;
+      return { stopped };
+    }
+
+    if (command === '/restart') {
+      this.restartProcess(sessionId).catch(() => {});
+      return { restarting: true };
+    }
+
+    if (command === '/session') {
+      const index = await this.sessionStore.listSessions(agentId, internalChatId, 'api').catch(() => null);
+      const meta = index?.sessions.find((s) => s.id === sessionId);
+      if (!meta) return { sessionId, sessionName: null, messageCount: 0, archivedCount: 0, contextUsedPct: 0, model: this.agentConfig.claude.model };
+      const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+      const modelConfig = availableModels.find((m) => m.id === this.agentConfig.claude.model);
+      const contextWindow = modelConfig?.contextWindow ?? 200000;
+      const contextUsedPct = Math.round(((meta.lastInputTokens ?? 0) / contextWindow) * 100);
+      return {
+        sessionId,
+        sessionName: meta.name,
+        messageCount: meta.messageCount,
+        archivedCount: meta.archivedCount ?? 0,
+        contextUsedPct,
+        model: this.agentConfig.claude.model,
+      };
+    }
+
+    if (command === '/clear') {
+      const ch = 'api' as const;
+      await this.sessionStore.clearTelegramSessionHistory(agentId, internalChatId, sessionId, ch);
+      await this.sessionStore.updateSessionMeta(agentId, internalChatId, sessionId, {
+        totalTokensUsed: 0,
+        lastInputTokens: 0,
+        archivedCount: 0,
+        loadedAtSpawn: undefined,
+        messageCountAtSpawn: undefined,
+      }, ch);
+      this.historyDb.clearChat(internalChatId);
+      MediaStore.clearChatMedia(this.agentsBaseDir, agentId, internalChatId);
+      this.restartProcess(sessionId).catch(() => {});
+      return { success: true };
+    }
+
+    if (command === '/compact') {
+      const ch = 'api' as const;
+      const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+      const modelConfig = availableModels.find((m) => m.id === this.agentConfig.claude.model);
+      const contextWindow = modelConfig?.contextWindow ?? 200000;
+      const compactor = new SessionCompactor(this.sessionStore);
+      const result = await compactor.compact(agentId, internalChatId, sessionId, this.agentConfig.claude.model, contextWindow, ch);
+      await this.sessionStore.updateSessionMeta(agentId, internalChatId, sessionId, {
+        loadedAtSpawn: undefined,
+        archivedCount: undefined,
+        messageCountAtSpawn: undefined,
+      }, ch);
+      await this.restartProcess(sessionId);
+      return { success: true, keptMessages: result.afterMessages, archivedMessages: result.beforeMessages - result.afterMessages };
+    }
+
+    return { error: `Unknown command: ${command}` };
+  }
+
+  async setModel(newModel: string): Promise<void> {
+    const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+    if (!availableModels.find((m) => m.id === newModel)) {
+      throw Object.assign(new Error(`Unknown model: ${newModel}`), { code: 'UNKNOWN_MODEL' });
+    }
+    this.agentConfig.claude.model = newModel;
+    try { this.persistModelToConfig(newModel); } catch (err) {
+      this.logger.error('Failed to persist model to config', { error: (err as Error).message });
+    }
+  }
+
+  async listApiSessions(chatId: string): Promise<import('../types').SessionIndex> {
+    return this.sessionStore.listSessions(this.agentConfig.id, `api-${chatId}`, 'api');
+  }
+
+  async createApiSession(chatId: string, prompt?: string, name?: string): Promise<import('../types').SessionMeta> {
+    let sessionName = name;
+    if (!sessionName && prompt) {
+      try {
+        const { execSync } = await import('child_process');
+        const titlePrompt = `Summarise in 3-5 words as a session title (no punctuation, no quotes): ${prompt}`;
+        const out = execSync(
+          `claude -p ${JSON.stringify(titlePrompt)} --output-format text --model claude-haiku-4-5-20251001`,
+          { timeout: 15000, encoding: 'utf-8' },
+        );
+        sessionName = out.trim().slice(0, 60) || undefined;
+      } catch {
+        sessionName = undefined;
+      }
+    }
+    return this.sessionStore.createTelegramSession(this.agentConfig.id, `api-${chatId}`, sessionName, 'api');
+  }
+
+  async getApiSessionInfo(chatId: string, sessionId: string): Promise<Record<string, unknown> | null> {
+    const index = await this.sessionStore.listSessions(this.agentConfig.id, `api-${chatId}`, 'api').catch(() => null);
+    const meta = index?.sessions.find((s) => s.id === sessionId);
+    if (!meta) return null;
+    const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+    const modelConfig = availableModels.find((m) => m.id === this.agentConfig.claude.model);
+    const contextWindow = modelConfig?.contextWindow ?? 200000;
+    const contextUsedPct = Math.round(((meta.lastInputTokens ?? 0) / contextWindow) * 100);
+    return {
+      sessionId: meta.id,
+      sessionName: meta.name,
+      messageCount: meta.messageCount,
+      archivedCount: meta.archivedCount ?? 0,
+      contextUsedPct,
+      model: this.agentConfig.claude.model,
+    };
+  }
+
+  async renameApiSession(chatId: string, sessionId: string, sessionName: string): Promise<void> {
+    await this.sessionStore.updateSessionMeta(this.agentConfig.id, `api-${chatId}`, sessionId, { name: sessionName }, 'api');
+  }
+
+  async deleteApiSession(chatId: string, sessionId: string): Promise<void> {
+    await this.sessionStore.deleteTelegramSession(this.agentConfig.id, `api-${chatId}`, sessionId, 'api');
   }
 
   /**

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -153,6 +153,10 @@ export function createApiRouter(
       res.status(400).json({ error: 'chat_id is required and must be a non-empty string' });
       return;
     }
+    if (!/^[a-zA-Z0-9_-]{1,64}$/.test((chat_id as string).trim())) {
+      res.status(400).json({ error: 'chat_id must be 1-64 alphanumeric characters, hyphens, or underscores' });
+      return;
+    }
     if (session_id !== undefined && typeof session_id !== 'string') {
       res.status(400).json({ error: 'session_id must be a string if provided' });
       return;
@@ -928,6 +932,10 @@ export function createApiRouter(
       res.status(400).json({ error: 'chat_id is required' });
       return null;
     }
+    if (!/^[a-zA-Z0-9_-]{1,64}$/.test(chatId.trim())) {
+      res.status(400).json({ error: 'chat_id must be 1-64 alphanumeric characters, hyphens, or underscores' });
+      return null;
+    }
     return { runner, agentId, chatId: chatId.trim() };
   }
 
@@ -990,7 +998,7 @@ export function createApiRouter(
   router.patch('/v1/agents/:agentId/sessions/:sessionId', auth, async (req: Request, res: Response) => {
     const ctx = resolveApiSession(req, res);
     if (!ctx) return;
-    const { runner, agentId, chatId } = ctx;
+    const { runner, chatId } = ctx;
     const { sessionId } = req.params as { sessionId: string };
     const body = req.body as { sessionName?: unknown };
     const sessionName = typeof body.sessionName === 'string' ? body.sessionName.trim() : undefined;
@@ -1009,7 +1017,7 @@ export function createApiRouter(
   router.delete('/v1/agents/:agentId/sessions/:sessionId', auth, async (req: Request, res: Response) => {
     const ctx = resolveApiSession(req, res);
     if (!ctx) return;
-    const { runner, agentId, chatId } = ctx;
+    const { runner, chatId } = ctx;
     const { sessionId } = req.params as { sessionId: string };
     try {
       await runner.deleteApiSession(chatId, sessionId);

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -93,10 +93,28 @@ export function createApiRouter(
   }
 
   /**
+   * GET /api/v1/commands
+   *
+   * Return the list of slash commands available in the chat UI. No auth required.
+   */
+  router.get('/v1/commands', (_req: Request, res: Response) => {
+    res.json({
+      commands: [
+        { name: '/session',  description: 'Show current session info (name, message count, context %)' },
+        { name: '/clear',    description: 'Clear current session history' },
+        { name: '/compact',  description: 'Summarise old history and keep only recent messages' },
+        { name: '/stop',     description: 'Interrupt the in-flight turn' },
+        { name: '/restart',  description: 'Graceful session restart' },
+        { name: '/model',    description: 'Show the current AI model' },
+      ],
+    });
+  });
+
+  /**
    * POST /api/v1/agents/:agentId/messages
    *
    * Send a message to an agent and receive its response synchronously.
-   * Body: { message: string, session_id?: string }
+   * Body: { message: string, chat_id: string, session_id?: string }
    */
   router.post('/v1/agents/:agentId/messages', auth, async (req: Request, res: Response) => {
     const { agentId } = req.params as { agentId: string };
@@ -115,12 +133,13 @@ export function createApiRouter(
 
     const body = req.body as {
       message?: unknown;
+      chat_id?: unknown;
       session_id?: unknown;
       stream?: unknown;
       timeout_ms?: unknown;
       media_files?: unknown;
     };
-    const { message, session_id, stream, timeout_ms, media_files } = body;
+    const { message, chat_id, session_id, stream, timeout_ms, media_files } = body;
 
     if (!message || typeof message !== 'string' || !message.trim()) {
       res.status(400).json({ error: 'message is required and must be a non-empty string' });
@@ -128,6 +147,10 @@ export function createApiRouter(
     }
     if (message.length > MAX_MESSAGE_LENGTH) {
       res.status(400).json({ error: `message too long (max ${MAX_MESSAGE_LENGTH} characters)` });
+      return;
+    }
+    if (!chat_id || typeof chat_id !== 'string' || !chat_id.trim()) {
+      res.status(400).json({ error: 'chat_id is required and must be a non-empty string' });
       return;
     }
     if (session_id !== undefined && typeof session_id !== 'string') {
@@ -161,11 +184,23 @@ export function createApiRouter(
 
     const requestId = randomUUID();
     const sessionId = (session_id as string | undefined) ?? randomUUID();
+    const chatIdStr = (chat_id as string).trim();
     const startTime = Date.now();
     const timeoutMs =
       typeof timeout_ms === 'number' && timeout_ms > 0 && timeout_ms <= 600_000
         ? timeout_ms
         : DEFAULT_TIMEOUT_MS;
+
+    // Slash command dispatch — runs instead of sending to Claude
+    if (message.trim().startsWith('/')) {
+      try {
+        const result = await runner.executeApiCommand(sessionId, chatIdStr, message.trim());
+        res.json({ command: message.trim(), session_id: sessionId, result });
+      } catch (err: unknown) {
+        res.status(500).json({ error: (err as Error).message ?? 'Command failed' });
+      }
+      return;
+    }
 
     if (stream) {
       // SSE streaming mode
@@ -209,6 +244,7 @@ export function createApiRouter(
         const allowTools = agentCfg.allow_tools ?? !!apiKey.allow_tools;
         cleanup = await runner.sendApiMessageStream(
           sessionId,
+          chatIdStr,
           message.trim(),
           sseCallbacks,
           { timeoutMs, allowTools, mediaFiles: validatedMediaFiles },
@@ -236,7 +272,7 @@ export function createApiRouter(
       try {
         const agentCfgSync = agentConfigs.get(agentId)!;
         const allowToolsSync = agentCfgSync.allow_tools ?? !!apiKey.allow_tools;
-        const response = await runner.sendApiMessage(sessionId, message.trim(), {
+        const response = await runner.sendApiMessage(sessionId, chatIdStr, message.trim(), {
           timeoutMs,
           allowTools: allowToolsSync,
           mediaFiles: validatedMediaFiles,
@@ -836,6 +872,216 @@ export function createApiRouter(
       try { MediaStore.cleanupStaging(firstRunner.getAgentsBaseDir()); } catch { /* non-critical */ }
     }
   }, 60 * 60 * 1000).unref(); // unref so cleanup timer doesn't keep process alive
+
+  // ──────────────────────────────────────────────────────────────
+  // Model management
+  // ──────────────────────────────────────────────────────────────
+
+  /**
+   * PUT /api/v1/agents/:agentId/model
+   *
+   * Set the active model for an agent. Persists to config.json.
+   */
+  router.put('/v1/agents/:agentId/model', auth, async (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!isAdmin(apiKey)) {
+      res.status(403).json({ error: 'Admin key required' });
+      return;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return; }
+    const body = req.body as { model?: unknown };
+    const { model: newModel } = body;
+    if (!newModel || typeof newModel !== 'string') {
+      res.status(400).json({ error: 'model is required' });
+      return;
+    }
+    try {
+      await runner.setModel(newModel);
+      res.json({ model: newModel });
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (code === 'UNKNOWN_MODEL') {
+        res.status(400).json({ error: `Unknown model: ${newModel}` });
+      } else {
+        res.status(500).json({ error: 'Failed to set model' });
+      }
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────
+  // API Session management  (/v1/agents/:agentId/sessions/...)
+  // ──────────────────────────────────────────────────────────────
+
+  function resolveApiSession(req: Request, res: Response): { runner: AgentRunner; agentId: string; chatId: string } | null {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return null;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return null; }
+    const chatId = (req.query['chat_id'] ?? (req.body as Record<string, unknown>)?.['chat_id']) as string | undefined;
+    if (!chatId || typeof chatId !== 'string' || !chatId.trim()) {
+      res.status(400).json({ error: 'chat_id is required' });
+      return null;
+    }
+    return { runner, agentId, chatId: chatId.trim() };
+  }
+
+  /**
+   * GET /api/v1/agents/:agentId/sessions
+   * List API sessions for a chat_id.
+   */
+  router.get('/v1/agents/:agentId/sessions', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, agentId, chatId } = ctx;
+    try {
+      const index = await runner.listApiSessions(chatId);
+      res.json(index);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/sessions
+   * Create a new API session. Optionally auto-names from a prompt.
+   */
+  router.post('/v1/agents/:agentId/sessions', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, agentId, chatId } = ctx;
+    const body = req.body as { prompt?: unknown; name?: unknown };
+    const promptText = typeof body.prompt === 'string' ? body.prompt.trim() : undefined;
+    const explicitName = typeof body.name === 'string' ? body.name.trim() : undefined;
+    try {
+      const meta = await runner.createApiSession(chatId, promptText, explicitName);
+      res.status(201).json({ sessionId: meta.id, sessionName: meta.name, createdAt: meta.createdAt });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * GET /api/v1/agents/:agentId/sessions/:sessionId/info
+   */
+  router.get('/v1/agents/:agentId/sessions/:sessionId/info', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, chatId } = ctx;
+    const { sessionId } = req.params as { sessionId: string };
+    try {
+      const info = await runner.getApiSessionInfo(chatId, sessionId);
+      if (!info) { res.status(404).json({ error: 'Session not found' }); return; }
+      res.json(info);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * PATCH /api/v1/agents/:agentId/sessions/:sessionId
+   * Rename a session.
+   */
+  router.patch('/v1/agents/:agentId/sessions/:sessionId', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, agentId, chatId } = ctx;
+    const { sessionId } = req.params as { sessionId: string };
+    const body = req.body as { sessionName?: unknown };
+    const sessionName = typeof body.sessionName === 'string' ? body.sessionName.trim() : undefined;
+    if (!sessionName) { res.status(400).json({ error: 'sessionName is required' }); return; }
+    try {
+      await runner.renameApiSession(chatId, sessionId, sessionName);
+      res.json({ sessionId, sessionName });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * DELETE /api/v1/agents/:agentId/sessions/:sessionId
+   */
+  router.delete('/v1/agents/:agentId/sessions/:sessionId', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, agentId, chatId } = ctx;
+    const { sessionId } = req.params as { sessionId: string };
+    try {
+      await runner.deleteApiSession(chatId, sessionId);
+      res.status(204).send();
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/sessions/:sessionId/clear
+   */
+  router.post('/v1/agents/:agentId/sessions/:sessionId/clear', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, chatId } = ctx;
+    const { sessionId } = req.params as { sessionId: string };
+    try {
+      const result = await runner.executeApiCommand(sessionId, chatId, '/clear');
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/sessions/:sessionId/compact
+   */
+  router.post('/v1/agents/:agentId/sessions/:sessionId/compact', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, chatId } = ctx;
+    const { sessionId } = req.params as { sessionId: string };
+    try {
+      const result = await runner.executeApiCommand(sessionId, chatId, '/compact');
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/sessions/:sessionId/stop
+   */
+  router.post('/v1/agents/:agentId/sessions/:sessionId/stop', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, chatId } = ctx;
+    const { sessionId } = req.params as { sessionId: string };
+    try {
+      const result = await runner.executeApiCommand(sessionId, chatId, '/stop');
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/v1/agents/:agentId/sessions/:sessionId/restart
+   */
+  router.post('/v1/agents/:agentId/sessions/:sessionId/restart', auth, async (req: Request, res: Response) => {
+    const ctx = resolveApiSession(req, res);
+    if (!ctx) return;
+    const { runner, chatId } = ctx;
+    const { sessionId } = req.params as { sessionId: string };
+    try {
+      const result = await runner.executeApiCommand(sessionId, chatId, '/restart');
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
 
   return router;
 }

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -487,7 +487,7 @@ export class CronManager extends EventEmitter {
     const sessionId = `cron-${job.id}`;
     const timeoutMs = job.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-    return runner.sendApiMessage(sessionId, job.prompt!, { timeoutMs });
+    return runner.sendApiMessage(sessionId, 'cron', job.prompt!, { timeoutMs });
   }
 
   private async sendTelegram(agentId: string, chatId: string, text: string): Promise<void> {

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -487,7 +487,7 @@ export class CronManager extends EventEmitter {
     const sessionId = `cron-${job.id}`;
     const timeoutMs = job.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-    return runner.sendApiMessage(sessionId, 'cron', job.prompt!, { timeoutMs });
+    return runner.sendApiMessage(sessionId, `cron-${job.id}`, job.prompt!, { timeoutMs });
   }
 
   private async sendTelegram(agentId: string, chatId: string, text: string): Promise<void> {

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -296,6 +296,18 @@ export class HistoryDB {
     this.db.prepare('DELETE FROM messages WHERE chat_id = ?').run(chatId);
   }
 
+  clearSession(chatId: string, sessionId: string): string[] {
+    const rows = this.db.prepare(
+      `SELECT media_files FROM messages WHERE chat_id = ? AND session_id = ? AND media_files IS NOT NULL`,
+    ).all(chatId, sessionId) as Array<{ media_files: string }>;
+    const mediaPaths: string[] = [];
+    for (const row of rows) {
+      try { mediaPaths.push(...(JSON.parse(row.media_files) as string[])); } catch { /* skip */ }
+    }
+    this.db.prepare('DELETE FROM messages WHERE chat_id = ? AND session_id = ?').run(chatId, sessionId);
+    return mediaPaths;
+  }
+
   /**
    * Delete all messages older than cutoffMs (Unix ms timestamp).
    * Returns relative media_files paths from deleted rows for disk cleanup.

--- a/src/history/media-store.ts
+++ b/src/history/media-store.ts
@@ -104,6 +104,15 @@ export class MediaStore {
     }
   }
 
+  static deleteMediaFiles(agentsBaseDir: string, agentId: string, relativePaths: string[]): void {
+    for (const rel of relativePaths) {
+      try {
+        const abs = MediaStore.resolvePath(agentsBaseDir, agentId, rel);
+        if (fs.existsSync(abs)) fs.unlinkSync(abs);
+      } catch { /* skip — path traversal or missing file */ }
+    }
+  }
+
   static isAllowedMime(mime: string): boolean {
     return ALLOWED_MIME_PREFIXES.some((p) => mime.startsWith(p));
   }

--- a/src/session/compactor.ts
+++ b/src/session/compactor.ts
@@ -49,7 +49,7 @@ export class SessionCompactor {
     sessionId: string,
     model: string,
     contextWindow: number,
-    channel: 'telegram' | 'discord' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' = 'telegram',
   ): Promise<CompactionResult> {
     // Load current history
     const messages = await this.sessionStore.loadTelegramSession(agentId, chatId, sessionId, channel);

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -156,28 +156,28 @@ export class SessionStore {
   /**
    * Resolve the directory for a chat's multi-session data.
    */
-  private resolveTelegramDir(agentId: string, chatId: string, channel: 'telegram' | 'discord' = 'telegram'): string {
+  private resolveTelegramDir(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): string {
     return path.join(this.agentsBaseDir, agentId, 'sessions', `${channel}-${chatId}`);
   }
 
   /**
    * Resolve the path to the session index file for a chat.
    */
-  private resolveTelegramIndexPath(agentId: string, chatId: string, channel: 'telegram' | 'discord' = 'telegram'): string {
+  private resolveTelegramIndexPath(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): string {
     return path.join(this.resolveTelegramDir(agentId, chatId, channel), 'index.json');
   }
 
   /**
    * Resolve the path to a specific session's message file.
    */
-  private resolveTelegramSessionPath(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' = 'telegram'): string {
+  private resolveTelegramSessionPath(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): string {
     return path.join(this.resolveTelegramDir(agentId, chatId, channel), `${sessionId}.json`);
   }
 
   /**
    * Read index.json for a chat. Returns null if file doesn't exist.
    */
-  async loadIndex(agentId: string, chatId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<SessionIndex | null> {
+  async loadIndex(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionIndex | null> {
     const indexPath = this.resolveTelegramIndexPath(agentId, chatId, channel);
     if (!fs.existsSync(indexPath)) {
       return null;
@@ -193,7 +193,7 @@ export class SessionStore {
   /**
    * Write index.json atomically (tmp + rename).
    */
-  async saveIndex(agentId: string, chatId: string, index: SessionIndex, channel: 'telegram' | 'discord' = 'telegram'): Promise<void> {
+  async saveIndex(agentId: string, chatId: string, index: SessionIndex, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
     const indexPath = this.resolveTelegramIndexPath(agentId, chatId, channel);
     const dir = path.dirname(indexPath);
     fs.mkdirSync(dir, { recursive: true });
@@ -216,7 +216,7 @@ export class SessionStore {
    * Internal (unlocked) version — call this only from WITHIN a getTelegramQueue task
    * to avoid deadlock. The public getOrCreateIndex wraps this in the queue.
    */
-  private async loadOrCreateIndexUnlocked(agentId: string, chatId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<SessionIndex> {
+  private async loadOrCreateIndexUnlocked(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionIndex> {
     // 1. Check for existing index
     const existingIndex = await this.loadIndex(agentId, chatId, channel);
     if (existingIndex !== null) {
@@ -285,7 +285,7 @@ export class SessionStore {
     return index;
   }
 
-  async getOrCreateIndex(agentId: string, chatId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<SessionIndex> {
+  async getOrCreateIndex(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionIndex> {
     const queue = this.getTelegramQueue(agentId, chatId);
     return queue.add(() => this.loadOrCreateIndexUnlocked(agentId, chatId, channel)) as Promise<SessionIndex>;
   }
@@ -294,7 +294,7 @@ export class SessionStore {
    * Create a new session for a chat, add it to the index, and return the SessionMeta.
    * If name is not provided, auto-generates "Session N" based on current session count.
    */
-  async createTelegramSession(agentId: string, chatId: string, name?: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<SessionMeta> {
+  async createTelegramSession(agentId: string, chatId: string, name?: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionMeta> {
     const queue = this.getTelegramQueue(agentId, chatId);
     return queue.add(async () => {
       const index = await this.loadOrCreateIndexUnlocked(agentId, chatId, channel);
@@ -325,16 +325,16 @@ export class SessionStore {
     }) as Promise<SessionMeta>;
   }
 
-  async listSessions(agentId: string, chatId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<SessionIndex> {
+  async listSessions(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionIndex> {
     return this.getOrCreateIndex(agentId, chatId, channel);
   }
 
-  async getActiveSessionId(agentId: string, chatId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<string> {
+  async getActiveSessionId(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<string> {
     const index = await this.getOrCreateIndex(agentId, chatId, channel);
     return index.activeSessionId;
   }
 
-  async setActiveSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<void> {
+  async setActiveSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
       const index = await this.loadIndex(agentId, chatId, channel);
@@ -350,7 +350,7 @@ export class SessionStore {
     });
   }
 
-  async deleteTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<void> {
+  async deleteTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
       const index = await this.loadIndex(agentId, chatId, channel);
@@ -386,7 +386,7 @@ export class SessionStore {
     });
   }
 
-  async clearTelegramSessionHistory(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<void> {
+  async clearTelegramSessionHistory(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
       const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId, channel);
@@ -411,7 +411,7 @@ export class SessionStore {
     chatId: string,
     sessionId: string,
     meta: Partial<Pick<SessionMeta, 'name' | 'totalTokensUsed' | 'messageCount' | 'lastInputTokens' | 'loadedAtSpawn' | 'archivedCount' | 'messageCountAtSpawn'>>,
-    channel: 'telegram' | 'discord' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' = 'telegram',
   ): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
@@ -429,7 +429,7 @@ export class SessionStore {
     });
   }
 
-  async loadTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' = 'telegram'): Promise<Message[]> {
+  async loadTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<Message[]> {
     const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId, channel);
     if (!fs.existsSync(sessionPath)) {
       return [];
@@ -448,7 +448,7 @@ export class SessionStore {
     chatId: string,
     sessionId: string,
     messages: Message[],
-    channel: 'telegram' | 'discord' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' = 'telegram',
   ): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
@@ -469,7 +469,7 @@ export class SessionStore {
     chatId: string,
     sessionId: string,
     message: Message,
-    channel: 'telegram' | 'discord' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' = 'telegram',
   ): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
@@ -505,7 +505,7 @@ export class SessionStore {
     chatId: string,
     sessionId: string,
     count: number,
-    channel: 'telegram' | 'discord' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' = 'telegram',
   ): Promise<void> {
     const index = await this.loadIndex(agentId, chatId, channel);
     if (index) {
@@ -516,6 +516,25 @@ export class SessionStore {
         await this.saveIndex(agentId, chatId, index, channel);
       }
     }
+  }
+
+  async ensureApiSession(agentId: string, internalChatId: string, sessionId: string): Promise<void> {
+    const queue = this.getTelegramQueue(agentId, internalChatId);
+    await queue.add(async () => {
+      const index = await this.loadOrCreateIndexUnlocked(agentId, internalChatId, 'api');
+      if (index.sessions.some((s) => s.id === sessionId)) return;
+      const now = Date.now();
+      index.sessions.push({
+        id: sessionId,
+        name: `Session ${index.sessions.length + 1}`,
+        createdAt: now,
+        lastActive: now,
+        messageCount: 0,
+        totalTokensUsed: 0,
+      });
+      if (!index.activeSessionId) index.activeSessionId = sessionId;
+      await this.saveIndex(agentId, internalChatId, index, 'api');
+    });
   }
 
   async getAllSessionNames(agentId: string): Promise<Map<string, string>> {

--- a/tests/integration/api-e2e.test.ts
+++ b/tests/integration/api-e2e.test.ts
@@ -179,7 +179,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/alfred/messages')
       .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
-      .send({ message: 'Hello!' });
+      .send({ message: 'Hello!', chat_id: 'test-chat' });
 
     expect(res.status).toBe(200);
     expect(res.body.agent_id).toBe('alfred');
@@ -211,7 +211,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
 
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/alfred/messages')
-      .send({ message: 'Hello' });
+      .send({ message: 'Hello', chat_id: 'test-chat' });
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBeDefined();
@@ -238,7 +238,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/alfred/messages')
       .set('Authorization', `Bearer ${API_KEY_WRONG}`)
-      .send({ message: 'Hello' });
+      .send({ message: 'Hello', chat_id: 'test-chat' });
 
     expect(res.status).toBe(403);
 
@@ -269,7 +269,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/warrior/messages')
       .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
-      .send({ message: 'Hello warrior' });
+      .send({ message: 'Hello warrior', chat_id: 'test-chat' });
 
     expect(res.status).toBe(403);
 
@@ -296,7 +296,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/nonexistent/messages')
       .set('Authorization', `Bearer ${API_KEY_ADMIN}`)
-      .send({ message: 'Hello' });
+      .send({ message: 'Hello', chat_id: 'test-chat' });
 
     expect(res.status).toBe(404);
 
@@ -350,7 +350,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/alfred/messages')
       .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
-      .send({ message: 'Hi', session_id: sessionId });
+      .send({ message: 'Hi', chat_id: 'test-chat', session_id: sessionId });
 
     expect(res.status).toBe(200);
     expect(res.body.session_id).toBe(sessionId);
@@ -378,7 +378,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/alfred/messages')
       .set('Authorization', `Bearer ${API_KEY_ALFRED}`)
-      .send({ message: 'Stateless call' });
+      .send({ message: 'Stateless call', chat_id: 'test-chat' });
 
     expect(res.status).toBe(200);
     // UUID v4 format
@@ -409,7 +409,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/alfred/messages')
       .set('X-Api-Key', API_KEY_ALFRED)
-      .send({ message: 'Auth via X-Api-Key' });
+      .send({ message: 'Auth via X-Api-Key', chat_id: 'test-chat' });
 
     expect(res.status).toBe(200);
     expect(res.body.response).toContain('X-Api-Key');
@@ -457,7 +457,7 @@ describe('Agent HTTP API integration (planning-05)', () => {
     const res = await supertest(router.getApp())
       .post('/api/v1/agents/alfred/messages')
       .set('Authorization', `Bearer ${API_KEY_ADMIN}`)
-      .send({ message: 'Remember this message', session_id: sessionId });
+      .send({ message: 'Remember this message', chat_id: 'test-chat', session_id: sessionId });
 
     expect(res.status).toBe(200);
 

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -10,6 +10,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { randomUUID } from 'crypto';
 import supertest from 'supertest';
 import { AgentRunner } from '../../src/agent/runner';
 import { GatewayRouter } from '../../src/api/gateway-router';
@@ -86,10 +87,13 @@ async function sendMessage(
   message: string,
   sessionId?: string,
 ): Promise<{ sessionId: string; response: string }> {
+  // Pre-generate a stable ID used as both chat_id and session_id so that
+  // chatId in the DB (api-{chat_id}) always equals api-{returned session_id}.
+  const sid = sessionId ?? randomUUID();
   const res = await supertest(app)
     .post(`/api/v1/agents/${agentId}/messages`)
     .set('X-Api-Key', API_KEY_ADMIN)
-    .send({ message, ...(sessionId ? { session_id: sessionId } : {}) });
+    .send({ message, chat_id: sid, session_id: sid });
   if (res.status !== 200) throw new Error(`sendMessage failed: ${res.status} ${JSON.stringify(res.body)}`);
   return { sessionId: res.body.session_id as string, response: res.body.response as string };
 }

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -620,6 +620,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     const donePromise = new Promise<string>((resolve) => {
       runner.sendApiMessageStream(
         'stream-t9',
+        'test-chat',
         'hello',
         {
           onChunk: (event) => chunks.push(event),
@@ -667,6 +668,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     const donePromise = new Promise<string>((resolve) => {
       runner.sendApiMessageStream(
         'stream-t10',
+        'test-chat',
         'test',
         {
           onChunk: () => {},
@@ -694,6 +696,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     const donePromise = new Promise<void>((resolve) => {
       runner.sendApiMessageStream(
         'stream-t11',
+        'test-chat',
         'persist test',
         {
           onChunk: () => {},
@@ -734,6 +737,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     // Start first stream (never resolves)
     runner.sendApiMessageStream(
       'stream-t12',
+        'test-chat',
       'first',
       { onChunk: () => {}, onDone: () => {}, onError: () => {} },
       { timeoutMs: 10000 },
@@ -745,6 +749,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     await expect(
       runner.sendApiMessageStream(
         'stream-t12',
+        'test-chat',
         'second',
         { onChunk: () => {}, onDone: () => {}, onError: () => {} },
         { timeoutMs: 5000 },
@@ -760,6 +765,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     const errorPromise = new Promise<Error>((resolve) => {
       runner.sendApiMessageStream(
         'stream-t13',
+        'test-chat',
         'timeout test',
         {
           onChunk: () => {},
@@ -784,6 +790,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     const cleanupReady = new Promise<void>((resolve) => {
       runner.sendApiMessageStream(
         'stream-t14',
+        'test-chat',
         'cleanup test',
         {
           onChunk: () => {},
@@ -812,6 +819,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     await expect(
       runner.sendApiMessageStream(
         'stream-t14',
+        'test-chat',
         'after cleanup',
         { onChunk: () => {}, onDone: () => {}, onError: () => {} },
         { timeoutMs: 5000 },
@@ -830,6 +838,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     const donePromise = new Promise<string>((resolve) => {
       runner.sendApiMessageStream(
         'stream-partial-15',
+        'test-chat',
         'hello',
         {
           onChunk: (event) => chunks.push(event),
@@ -880,6 +889,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     let capturedMessage = '';
     runner.sendApiMessageStream(
       'stream-at-1',
+        'test-chat',
       'hello',
       { onChunk: () => {}, onDone: () => {}, onError: () => {} },
       { timeoutMs: 5000, allowTools: false },
@@ -902,6 +912,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
 
     runner.sendApiMessageStream(
       'stream-at-2',
+        'test-chat',
       'run job',
       { onChunk: () => {}, onDone: () => {}, onError: () => {} },
       { timeoutMs: 5000, allowTools: true },
@@ -924,6 +935,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
 
     runner.sendApiMessageStream(
       'stream-at-3',
+        'test-chat',
       'hello',
       { onChunk: () => {}, onDone: () => {}, onError: () => {} },
       { timeoutMs: 5000 },
@@ -945,6 +957,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
 
     runner.sendApiMessageStream(
       'stream-wp-1',
+        'test-chat',
       'do something',
       { onChunk: () => {}, onDone: () => {}, onError: () => {} },
       { timeoutMs: 5000, allowTools: true },
@@ -966,6 +979,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
 
     runner.sendApiMessageStream(
       'stream-wp-2',
+        'test-chat',
       'do something',
       { onChunk: () => {}, onDone: () => {}, onError: () => {} },
       { timeoutMs: 5000, allowTools: true },
@@ -989,6 +1003,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
 
     runner.sendApiMessageStream(
       'stream-wp-3',
+        'test-chat',
       'hello',
       { onChunk: () => {}, onDone: () => {}, onError: () => {} },
       { timeoutMs: 5000, allowTools: false },
@@ -1010,6 +1025,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
 
     runner.sendApiMessageStream(
       'stream-wp-4',
+        'test-chat',
       'hello',
       { onChunk: () => {}, onDone: () => {}, onError: () => {} },
       { timeoutMs: 5000, allowTools: false },
@@ -1035,6 +1051,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
     const donePromise = new Promise<string>((resolve) => {
       runner.sendApiMessageStream(
         'stream-partial-16',
+        'test-chat',
         'hello',
         {
           onChunk: (event) => chunks.push(event),

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -14,36 +14,39 @@ interface StreamCallbacks {
 }
 
 class MockAgentRunner extends EventEmitter {
-  sendApiMessageImpl: (sessionId: string, message: string, opts?: { allowTools?: boolean }) => Promise<string>;
+  sendApiMessageImpl: (sessionId: string, chatId: string, message: string, opts?: { allowTools?: boolean }) => Promise<string>;
   sendApiMessageStreamImpl?: (
     sessionId: string,
+    chatId: string,
     message: string,
     callbacks: StreamCallbacks,
     opts?: { timeoutMs: number; allowTools?: boolean },
   ) => Promise<() => void>;
   private _activeApiSessions = new Set<string>();
 
-  constructor(impl: (sessionId: string, message: string, opts?: { allowTools?: boolean }) => Promise<string>) {
+  constructor(impl: (sessionId: string, chatId: string, message: string, opts?: { allowTools?: boolean }) => Promise<string>) {
     super();
     this.sendApiMessageImpl = impl;
   }
 
   async sendApiMessage(
     sessionId: string,
+    chatId: string,
     message: string,
     opts: { timeoutMs: number; allowTools?: boolean },
   ): Promise<string> {
-    return this.sendApiMessageImpl(sessionId, message, { allowTools: opts.allowTools });
+    return this.sendApiMessageImpl(sessionId, chatId, message, { allowTools: opts.allowTools });
   }
 
   async sendApiMessageStream(
     sessionId: string,
+    chatId: string,
     message: string,
     callbacks: StreamCallbacks,
     _opts: { timeoutMs: number; allowTools?: boolean },
   ): Promise<() => void> {
     if (this.sendApiMessageStreamImpl) {
-      return this.sendApiMessageStreamImpl(sessionId, message, callbacks, _opts);
+      return this.sendApiMessageStreamImpl(sessionId, chatId, message, callbacks, _opts);
     }
     throw new Error('sendApiMessageStream not implemented in mock');
   }
@@ -77,7 +80,7 @@ const apiKeys: ApiKey[] = [
   { key: 'sk-test-write', agents: [AGENT_ID], write: true },
 ];
 
-function buildApp(runnerImpl: (sessionId: string, msg: string) => Promise<string>) {
+function buildApp(runnerImpl: (sessionId: string, chatId: string, msg: string) => Promise<string>) {
   const runner = new MockAgentRunner(runnerImpl);
   const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
   const configs = new Map([[AGENT_ID, agentConfig]]);
@@ -90,6 +93,7 @@ function buildApp(runnerImpl: (sessionId: string, msg: string) => Promise<string
 function buildStreamApp(
   streamImpl: (
     sessionId: string,
+    chatId: string,
     message: string,
     callbacks: StreamCallbacks,
     opts?: { timeoutMs: number; allowTools?: boolean },
@@ -116,7 +120,7 @@ describe('POST /api/v1/agents/:agentId/messages', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'Hi' });
+      .send({ message: 'Hi', chat_id: 'test-chat' });
     expect(res.status).toBe(200);
     expect(res.body.response).toBe('Hello!');
     expect(res.body.agent_id).toBe(AGENT_ID);
@@ -130,7 +134,7 @@ describe('POST /api/v1/agents/:agentId/messages', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'ping', session_id: 'my-session-001' });
+      .send({ message: 'ping', chat_id: 'test-chat', session_id: 'my-session-001' });
     expect(res.status).toBe(200);
     expect(res.body.session_id).toBe('my-session-001');
   });
@@ -140,7 +144,7 @@ describe('POST /api/v1/agents/:agentId/messages', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'ping' });
+      .send({ message: 'ping', chat_id: 'test-chat' });
     expect(res.status).toBe(200);
     // UUID v4 pattern
     expect(res.body.session_id).toMatch(
@@ -182,7 +186,7 @@ describe('POST /api/v1/agents/:agentId/messages', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'hi', session_id: 123 });
+      .send({ message: 'hi', chat_id: 'test-chat', session_id: 123 });
     expect(res.status).toBe(400);
   });
 
@@ -229,7 +233,7 @@ describe('POST /api/v1/agents/:agentId/messages', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'hi' });
+      .send({ message: 'hi', chat_id: 'test-chat' });
     expect(res.status).toBe(504);
   });
 
@@ -241,7 +245,7 @@ describe('POST /api/v1/agents/:agentId/messages', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'hi' });
+      .send({ message: 'hi', chat_id: 'test-chat' });
     expect(res.status).toBe(409);
   });
 
@@ -252,7 +256,7 @@ describe('POST /api/v1/agents/:agentId/messages', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'hi' });
+      .send({ message: 'hi', chat_id: 'test-chat' });
     expect(res.status).toBe(500);
   });
 });
@@ -417,11 +421,11 @@ function collectSSE(
 describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   // T1: SSE headers
   it('T1: returns SSE headers when stream=true', async () => {
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       cb.onDone('Hello');
       return () => {};
     });
-    const { status, headers } = await collectSSE(app, { message: 'hi', stream: true });
+    const { status, headers } = await collectSSE(app, { message: 'hi', chat_id: 'test-chat', stream: true });
     expect(status).toBe(200);
     expect(headers['content-type']).toBe('text/event-stream');
     expect(headers['cache-control']).toBe('no-cache');
@@ -429,13 +433,13 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
 
   // T2: text_delta events
   it('T2: stream receives text_delta events', async () => {
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       cb.onChunk({ type: 'text_delta', text: 'Hello' });
       cb.onChunk({ type: 'text_delta', text: ' world' });
       cb.onDone('Hello world');
       return () => {};
     });
-    const { data } = await collectSSE(app, { message: 'hi', stream: true });
+    const { data } = await collectSSE(app, { message: 'hi', chat_id: 'test-chat', stream: true });
     const lines = data.split('\n').filter(l => l.startsWith('data: '));
     const events = lines
       .map(l => l.slice(6))
@@ -449,17 +453,17 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
 
   // T3: ends with [DONE]
   it('T3: stream ends with [DONE]', async () => {
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       cb.onDone('done');
       return () => {};
     });
-    const { data } = await collectSSE(app, { message: 'hi', stream: true });
+    const { data } = await collectSSE(app, { message: 'hi', chat_id: 'test-chat', stream: true });
     expect(data.trimEnd()).toMatch(/data: \[DONE\]$/);
   });
 
   // T4: no message returns 400 JSON
   it('T4: stream with no message returns 400 JSON', async () => {
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       cb.onDone('ok');
       return () => {};
     });
@@ -473,7 +477,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
 
   // T5: conflict returns 409 JSON
   it('T5: stream conflict returns 409 JSON', async () => {
-    const { app, runner } = buildStreamApp(async (_sid, _msg, cb) => {
+    const { app, runner } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       cb.onDone('ok');
       return () => {};
     });
@@ -481,18 +485,18 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'hi', session_id: 'conflict-session', stream: true });
+      .send({ message: 'hi', chat_id: 'test-chat', session_id: 'conflict-session', stream: true });
     expect(res.status).toBe(409);
     expect(res.body.error).toMatch(/pending request/i);
   });
 
   // T6: timeout sends error event in SSE
   it('T6: stream timeout sends error event in SSE', async () => {
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       cb.onError(new Error('Agent response timeout'));
       return () => {};
     });
-    const { data } = await collectSSE(app, { message: 'hi', stream: true });
+    const { data } = await collectSSE(app, { message: 'hi', chat_id: 'test-chat', stream: true });
     const lines = data.split('\n').filter(l => l.startsWith('data: '));
     const events = lines.map(l => l.slice(6)).filter(s => s !== '[DONE]');
     const errorEvent = JSON.parse(events[events.length - 1]);
@@ -506,7 +510,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: 'Hi', stream: false });
+      .send({ message: 'Hi', chat_id: 'test-chat', stream: false });
     expect(res.status).toBe(200);
     expect(res.body.response).toBe('Hello!');
   });
@@ -516,7 +520,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     let cleanupCalled = false;
     let sendChunk: ((event: StreamEvent) => void) | undefined;
 
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       sendChunk = cb.onChunk;
       // Send initial chunk so client gets data
       cb.onChunk({ type: 'text_delta', text: 'hi' });
@@ -526,7 +530,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     await new Promise<void>((resolve, reject) => {
       const server = app.listen(0, () => {
         const addr = server.address() as { port: number };
-        const reqBody = JSON.stringify({ message: 'hi', stream: true });
+        const reqBody = JSON.stringify({ message: 'hi', chat_id: 'test-chat', stream: true });
         const req = http.request(
           {
             hostname: '127.0.0.1',
@@ -541,7 +545,6 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
           },
           (res) => {
             res.once('data', () => {
-              // Destroy the socket to simulate client disconnect
               res.destroy();
             });
           },
@@ -565,7 +568,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   it('T-ALLOW-TOOLS-1: key with allow_tools=true passes allowTools=true to runner', async () => {
     let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
     const runner = new MockAgentRunner(async () => 'ok');
-    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+    runner.sendApiMessageStream = async (sid, chatId, msg, cbs, opts) => {
       capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
       cbs.onDone('done');
       return () => {};
@@ -577,7 +580,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     app.use(express.json());
     app.use('/api', createApiRouter(runners, configs, apiKeys));
 
-    await collectSSE(app, { message: 'run job', stream: true }, 'Bearer sk-test-tools');
+    await collectSSE(app, { message: 'run job', chat_id: 'test-chat', stream: true }, 'Bearer sk-test-tools');
 
     expect(capturedOpts).toBeDefined();
     expect(capturedOpts!.allowTools).toBe(true);
@@ -587,7 +590,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   it('T-ALLOW-TOOLS-2: key without allow_tools passes allowTools=false to runner', async () => {
     let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
     const runner = new MockAgentRunner(async () => 'ok');
-    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+    runner.sendApiMessageStream = async (sid, chatId, msg, cbs, opts) => {
       capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
       cbs.onDone('done');
       return () => {};
@@ -599,7 +602,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     app.use(express.json());
     app.use('/api', createApiRouter(runners, configs, apiKeys));
 
-    await collectSSE(app, { message: 'hi', stream: true });
+    await collectSSE(app, { message: 'hi', chat_id: 'test-chat', stream: true });
 
     expect(capturedOpts!.allowTools).toBe(false);
   });
@@ -608,7 +611,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   it('T-ALLOW-TOOLS-3: custom timeout_ms is forwarded to runner', async () => {
     let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;
     const runner = new MockAgentRunner(async () => 'ok');
-    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+    runner.sendApiMessageStream = async (sid, chatId, msg, cbs, opts) => {
       capturedOpts = opts as { timeoutMs: number; allowTools?: boolean };
       cbs.onDone('done');
       return () => {};
@@ -620,7 +623,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     app.use(express.json());
     app.use('/api', createApiRouter(runners, configs, apiKeys));
 
-    await collectSSE(app, { message: 'hi', stream: true, timeout_ms: 120000 });
+    await collectSSE(app, { message: 'hi', chat_id: 'test-chat', stream: true, timeout_ms: 120000 });
 
     expect(capturedOpts!.timeoutMs).toBe(120000);
   });
@@ -629,7 +632,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   it('T-ALLOW-TOOLS-4: timeout_ms over max is clamped to default', async () => {
     let capturedOpts: { timeoutMs: number } | undefined;
     const runner = new MockAgentRunner(async () => 'ok');
-    runner.sendApiMessageStream = async (sid, msg, cbs, opts) => {
+    runner.sendApiMessageStream = async (sid, chatId, msg, cbs, opts) => {
       capturedOpts = opts as { timeoutMs: number };
       cbs.onDone('done');
       return () => {};
@@ -641,7 +644,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     app.use(express.json());
     app.use('/api', createApiRouter(runners, configs, apiKeys));
 
-    await collectSSE(app, { message: 'hi', stream: true, timeout_ms: 999999 });
+    await collectSSE(app, { message: 'hi', chat_id: 'test-chat', stream: true, timeout_ms: 999999 });
 
     expect(capturedOpts!.timeoutMs).toBe(60000); // DEFAULT_TIMEOUT_MS
   });
@@ -649,7 +652,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   // I-API-14: key with allow_tools=true passes allowTools=true to sync runner
   it('I-API-14: key with allow_tools=true passes allowTools=true to sync sendApiMessage', async () => {
     let capturedAllowTools: boolean | undefined;
-    const runner = new MockAgentRunner(async (_sid, _msg, opts) => {
+    const runner = new MockAgentRunner(async (_sid, _chatId, _msg, opts) => {
       capturedAllowTools = opts?.allowTools;
       return 'ok';
     });
@@ -662,7 +665,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/messages`)
       .set('Authorization', 'Bearer sk-test-tools')
-      .send({ message: 'run job' });
+      .send({ message: 'run job', chat_id: 'test-chat' });
 
     expect(res.status).toBe(200);
     expect(capturedAllowTools).toBe(true);
@@ -671,7 +674,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   // I-API-15: key without allow_tools passes allowTools=false to sync runner
   it('I-API-15: key without allow_tools passes allowTools=false to sync sendApiMessage', async () => {
     let capturedAllowTools: boolean | undefined;
-    const runner = new MockAgentRunner(async (_sid, _msg, opts) => {
+    const runner = new MockAgentRunner(async (_sid, _chatId, _msg, opts) => {
       capturedAllowTools = opts?.allowTools;
       return 'ok';
     });
@@ -684,7 +687,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/messages`)
       .set('Authorization', 'Bearer sk-test-app')
-      .send({ message: 'hello' });
+      .send({ message: 'hello', chat_id: 'test-chat' });
 
     expect(res.status).toBe(200);
     expect(capturedAllowTools).toBe(false);
@@ -692,13 +695,13 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
 
   // T-API-STREAM-TCP: TCP_NODELAY is set on SSE connections (regression test)
   it('T-API-STREAM-TCP: SSE streaming works correctly with TCP_NODELAY set', async () => {
-    const { app } = buildStreamApp(async (_sid, _msg, cb) => {
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       cb.onChunk({ type: 'text_delta', text: 'fast' });
       cb.onChunk({ type: 'text_delta', text: ' response' });
       cb.onDone('fast response');
       return () => {};
     });
-    const { status, headers, data } = await collectSSE(app, { message: 'hi', stream: true });
+    const { status, headers, data } = await collectSSE(app, { message: 'hi', chat_id: 'test-chat', stream: true });
     expect(status).toBe(200);
     expect(headers['content-type']).toBe('text/event-stream');
 

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -183,6 +183,7 @@ describe('T6-T10: Agent type payload', () => {
 
     expect(runner.sendApiMessage).toHaveBeenCalledWith(
       expect.stringContaining('cron-'),
+      'cron',
       'hello agent',
       expect.objectContaining({ timeoutMs: expect.any(Number) }),
     );

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -183,7 +183,7 @@ describe('T6-T10: Agent type payload', () => {
 
     expect(runner.sendApiMessage).toHaveBeenCalledWith(
       expect.stringContaining('cron-'),
-      'cron',
+      expect.stringContaining('cron-'),
       'hello agent',
       expect.objectContaining({ timeoutMs: expect.any(Number) }),
     );


### PR DESCRIPTION
## Summary
- **GET /api/v1/commands** — list available commands for UI chat interface
- **POST /api/v1/agents/:agentId/messages** — now supports inline commands (`/session`, `/clear`, `/compact`, `/stop`, `/restart`, `/model`) using same logic as Telegram; requires `chat_id` in body
- **Session management REST endpoints** — full CRUD for sessions via API:
  - `POST /sessions` (create with auto-summarized name)
  - `GET/DELETE /sessions/:sessionId` (info & delete)
  - `POST /sessions/:sessionId/rename|clear|compact|stop|restart`
- **GET/POST /api/v1/agents/:agentId/models** — list and set model per agent
- **`chat_id` is now required** in API message body — sessions stored at `sessions/api-{chat_id}/` matching `telegram-{chatId}` / `discord-{chatId}` pattern
- `SessionStore` extended to support `'api'` as a channel type

## Breaking change
`POST /agents/:agentId/messages` now requires `chat_id` field in the request body. Existing callers without `chat_id` will receive 400.

## Test plan
- [ ] All 1195 tests pass (70 suites)
- [ ] `GET /api/v1/commands` returns command list
- [ ] `POST .../messages` with command prefix executes correctly
- [ ] Session create returns new sessionId with summarized name
- [ ] Session rename/clear/compact/stop/restart work via REST
- [ ] `sessions/api-{chat_id}/` directory created correctly on first message

🤖 Generated with [Claude Code](https://claude.com/claude-code)