### PR TITLE
fix: auto-install mcp deps on postinstall, change default port to 10850

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@
 # Path to gateway config (default: ~/.claude-gateway/config.json)
 # GATEWAY_CONFIG=~/.claude-gateway/config.json
 
-# HTTP port for the gateway web UI / health check (default: 3000)
-# PORT=3000
+# HTTP port for the gateway web UI / health check (default: 10850)
+# PORT=10850
 
 # ── Advanced ─────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ Once paired, the following bot commands are available in a private chat:
 
 ## Monitoring
 
-The gateway runs an HTTP server on port 3000 (set `PORT` env var to change):
+The gateway runs an HTTP server on port 10850 (set `PORT` env var to change):
 
 | Endpoint | Description |
 |----------|-------------|

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 
 ## Quick Start
 
-### Option A — Install via npm (for users)
+### Install via npm (for users)
 
 **1. Install**
 
@@ -70,7 +70,7 @@ All variables are optional. Full list: [`.env.example`](.env.example)
 
 **3. Create an agent**
 
-Add an agent entry to `~/.claude-gateway/config.json` manually, or clone the repo and run `make create-agent` for the interactive wizard (see Option B).
+Add an agent entry to `~/.claude-gateway/config.json` manually, or clone the repo and run `make create-agent` for the interactive wizard (see **For development** below).
 
 **4. Start**
 
@@ -101,7 +101,7 @@ pm2 delete gateway   # remove from PM2
 
 ---
 
-### Option B — Clone repo (for development)
+### For development
 
 ```bash
 git clone https://github.com/0xMaxMa/claude-gateway

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ npm run build
 
 ### 2. Configure environment (optional)
 
-Create a `.env` file in your working directory (or set env vars in your shell):
+Create `~/.claude-gateway/.env` — the gateway loads this automatically on startup:
 
 ```bash
+mkdir -p ~/.claude-gateway
+cat > ~/.claude-gateway/.env << 'EOF'
 # HTTP port (default: 10850)
 PORT=10850
 
@@ -78,6 +80,7 @@ PORT=10850
 # Browser module (optional)
 # GETPOD_BROWSER_URL=http://127.0.0.1:10880
 # GETPOD_BROWSER_DISABLED=true
+EOF
 ```
 
 All variables are optional — the gateway works out of the box with defaults. Full list: [`.env.example`](.env.example)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All variables are optional. Full list: [`.env.example`](.env.example)
 
 **3. Create an agent**
 
-Add an agent entry to `~/.claude-gateway/config.json` manually, or clone the repo and run `make create-agent` for the interactive wizard (see **For development** below).
+Add an agent entry to `~/.claude-gateway/config.json` manually (see [`config.template.json`](config.template.json) for the format), or clone the repo and run `make create-agent` for the interactive wizard (see **For development** below).
 
 **4. Start**
 
@@ -84,7 +84,7 @@ To keep the gateway running after logout or system restarts, use [PM2](https://p
 
 ```bash
 npm install -g pm2
-pm2 start claude-gateway --name gateway
+pm2 start $(which claude-gateway) --name gateway
 pm2 save       # persist the process list
 pm2 startup    # register PM2 to start on boot (follow the printed command)
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ Add an agent entry to `~/.claude-gateway/config.json` manually, or clone the rep
 claude-gateway
 ```
 
+**Run as a service with PM2 (optional)**
+
+To keep the gateway running after logout or system restarts, use [PM2](https://pm2.keymetrics.io):
+
+```bash
+npm install -g pm2
+pm2 start claude-gateway --name gateway
+pm2 save       # persist the process list
+pm2 startup    # register PM2 to start on boot (follow the printed command)
+```
+
+Useful commands:
+
+```bash
+pm2 status           # check gateway status
+pm2 logs gateway     # tail logs
+pm2 restart gateway  # restart
+pm2 stop gateway     # stop
+pm2 delete gateway   # remove from PM2
+```
+
 ---
 
 ### Option B — Clone repo (for development)

--- a/README.md
+++ b/README.md
@@ -41,21 +41,50 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 
 ## Quick Start
 
-### 1. Install
+### Option A — Install via npm (for users)
 
-**Via npm (recommended)**
+**1. Install**
 
 ```bash
 npm install -g @0xmaxma/claude-gateway
 ```
 
-MCP server dependencies (`grammy`, `@modelcontextprotocol/sdk`) are installed automatically via `postinstall`. Requires [Bun](https://bun.sh) — if Bun is not available, run manually:
+MCP server dependencies are installed automatically. Requires [Bun](https://bun.sh) — if not available, run manually:
 
 ```bash
 cd $(npm root -g)/@0xmaxma/claude-gateway && bun install --cwd mcp
 ```
 
-**Via git (for development)**
+**2. Configure environment (optional)**
+
+The gateway auto-loads `~/.claude-gateway/.env` on startup:
+
+```bash
+mkdir -p ~/.claude-gateway
+cat > ~/.claude-gateway/.env << 'EOF'
+# HTTP port (default: 10850)
+# PORT=10850
+
+# Path to gateway config (default: ~/.claude-gateway/config.json)
+# GATEWAY_CONFIG=~/.claude-gateway/config.json
+EOF
+```
+
+All variables are optional. Full list: [`.env.example`](.env.example)
+
+**3. Create an agent**
+
+Add an agent entry to `~/.claude-gateway/config.json` manually, or clone the repo and run `make create-agent` for the interactive wizard (see Option B).
+
+**4. Start**
+
+```bash
+claude-gateway
+```
+
+---
+
+### Option B — Clone repo (for development)
 
 ```bash
 git clone https://github.com/0xMaxMa/claude-gateway
@@ -64,28 +93,7 @@ npm install          # also runs bun install in mcp/
 npm run build
 ```
 
-### 2. Configure environment (optional)
-
-Create `~/.claude-gateway/.env` — the gateway loads this automatically on startup:
-
-```bash
-mkdir -p ~/.claude-gateway
-cat > ~/.claude-gateway/.env << 'EOF'
-# HTTP port (default: 10850)
-PORT=10850
-
-# Path to gateway config (default: ~/.claude-gateway/config.json)
-# GATEWAY_CONFIG=~/.claude-gateway/config.json
-
-# Browser module (optional)
-# GETPOD_BROWSER_URL=http://127.0.0.1:10880
-# GETPOD_BROWSER_DISABLED=true
-EOF
-```
-
-All variables are optional — the gateway works out of the box with defaults. Full list: [`.env.example`](.env.example)
-
-### 3. Create an agent
+### Create an agent
 
 The interactive wizard handles everything — workspace files, config, bot token, and pairing:
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,7 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 npm install -g @0xmaxma/claude-gateway
 ```
 
-MCP server dependencies are installed automatically. Requires [Bun](https://bun.sh) — if not available, run manually:
-
-```bash
-cd $(npm root -g)/@0xmaxma/claude-gateway && bun install --cwd mcp
-```
+Requires [Bun](https://bun.sh) — MCP server dependencies are installed automatically via `postinstall`.
 
 **2. Configure environment (optional)**
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 
 ## Requirements
 
-- Node.js 18+
+- Node.js 22+
 - [Claude Code CLI](https://claude.ai/code) v2.1.0+ installed and authenticated — `channels mode` is required (`claude --version`)
 - [Bun](https://bun.sh) — runs the MCP server subprocess (`mcp/server.ts`)
 - A bot token per agent — Telegram (from [@BotFather](https://t.me/BotFather)) or Discord (from [Discord Developer Portal](https://discord.com/developers/applications))
@@ -43,22 +43,44 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 
 ### 1. Install
 
+**Via npm (recommended)**
+
 ```bash
-git clone <repo>
+npm install -g @0xmaxma/claude-gateway
+```
+
+MCP server dependencies (`grammy`, `@modelcontextprotocol/sdk`) are installed automatically via `postinstall`. Requires [Bun](https://bun.sh) — if Bun is not available, run manually:
+
+```bash
+cd $(npm root -g)/@0xmaxma/claude-gateway && bun install --cwd mcp
+```
+
+**Via git (for development)**
+
+```bash
+git clone https://github.com/0xMaxMa/claude-gateway
 cd claude-gateway
-npm install
+npm install          # also runs bun install in mcp/
 npm run build
 ```
 
-### 2. Install MCP server dependencies
+### 2. Configure environment (optional)
 
-The gateway MCP server uses Bun with its own `package.json`. Install once:
+Create a `.env` file in your working directory (or set env vars in your shell):
 
 ```bash
-make mcp-install    # runs: cd mcp && bun install
+# HTTP port (default: 10850)
+PORT=10850
+
+# Path to gateway config (default: ~/.claude-gateway/config.json)
+# GATEWAY_CONFIG=~/.claude-gateway/config.json
+
+# Browser module (optional)
+# GETPOD_BROWSER_URL=http://127.0.0.1:10880
+# GETPOD_BROWSER_DISABLED=true
 ```
 
-This installs `grammy` (Telegram Bot API) and `@modelcontextprotocol/sdk` into `mcp/node_modules/`.
+All variables are optional — the gateway works out of the box with defaults. Full list: [`.env.example`](.env.example)
 
 ### 3. Create an agent
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node --no-warnings=ExperimentalWarning --env-file-if-exists=.env dist/index.js",
-    "postinstall": "command -v bun >/dev/null 2>&1 && bun install --cwd mcp || echo 'Warning: bun not found. Run `cd mcp && bun install` manually to enable MCP tools.'",
+    "postinstall": "if command -v bun >/dev/null 2>&1; then bun install --cwd mcp; else echo 'Warning: bun not found. Run `cd mcp && bun install` manually to enable MCP tools.'; fi",
     "test": "jest",
     "test:unit": "jest --testPathPattern=unit",
     "integration": "jest --testPathPattern=integration --testTimeout=15000",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node --no-warnings=ExperimentalWarning --env-file-if-exists=.env dist/index.js",
+    "postinstall": "bun install --cwd mcp 2>/dev/null || echo 'Warning: bun not found. Run `cd mcp && bun install` manually to enable MCP tools.'",
     "test": "jest",
     "test:unit": "jest --testPathPattern=unit",
     "integration": "jest --testPathPattern=integration --testTimeout=15000",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node --no-warnings=ExperimentalWarning --env-file-if-exists=.env dist/index.js",
-    "postinstall": "bun install --cwd mcp 2>/dev/null || echo 'Warning: bun not found. Run `cd mcp && bun install` manually to enable MCP tools.'",
+    "postinstall": "command -v bun >/dev/null 2>&1 && bun install --cwd mcp || echo 'Warning: bun not found. Run `cd mcp && bun install` manually to enable MCP tools.'",
     "test": "jest",
     "test:unit": "jest --testPathPattern=unit",
     "integration": "jest --testPathPattern=integration --testTimeout=15000",

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const CONFIG_PATH: string = expandTilde(
   path.join(os.homedir(), '.claude-gateway', 'config.json')
 );
 
-const PORT = parseInt((process.env.PORT ?? '3000'), 10);
+const PORT = parseInt((process.env.PORT ?? '10850'), 10);
 
 // ─── Startup summary table ────────────────────────────────────────────────────
 interface StartupResult {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,10 @@
 #!/usr/bin/env node
+
+// Must run before any other imports so env vars are set before modules read them.
+// TypeScript compiles imports to inline require() calls (CommonJS), so placement matters.
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import * as readline from 'readline';
-
-function expandTilde(p: string): string {
-  if (p === '~' || p.startsWith('~/')) {
-    return path.join(os.homedir(), p.slice(1));
-  }
-  return p;
-}
 
 // Load ~/.claude-gateway/.env so global installs pick up env vars without
 // needing shell exports or running via npm start.
@@ -26,6 +21,16 @@ function expandTilde(p: string): string {
     if (!(key in process.env)) process.env[key] = val;
   }
 })();
+
+import * as readline from 'readline';
+
+function expandTilde(p: string): string {
+  if (p === '~' || p.startsWith('~/')) {
+    return path.join(os.homedir(), p.slice(1));
+  }
+  return p;
+}
+
 import { loadConfig } from './config/loader';
 import { detectMigration, applyMigration, loadCleanTemplate } from './config/migrator';
 import { loadWorkspace, watchWorkspace, migrateWorkspaceFiles } from './agent/workspace-loader';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,14 +23,6 @@ import * as os from 'os';
 })();
 
 import * as readline from 'readline';
-
-function expandTilde(p: string): string {
-  if (p === '~' || p.startsWith('~/')) {
-    return path.join(os.homedir(), p.slice(1));
-  }
-  return p;
-}
-
 import { loadConfig } from './config/loader';
 import { detectMigration, applyMigration, loadCleanTemplate } from './config/migrator';
 import { loadWorkspace, watchWorkspace, migrateWorkspaceFiles } from './agent/workspace-loader';
@@ -45,6 +37,13 @@ import { ContextIsolationGuard } from './agent/context-isolation';
 import { createLogger } from './logger';
 import { ConfigWatcher, ConfigChange } from './config/watcher';
 import { AgentConfig, GatewayConfig } from './types';
+
+function expandTilde(p: string): string {
+  if (p === '~' || p.startsWith('~/')) {
+    return path.join(os.homedir(), p.slice(1));
+  }
+  return p;
+}
 
 // ─── Simple argument parsing (no heavy deps) ──────────────────────────────────
 function parseArgs(argv: string[]): Record<string, string | boolean> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,22 @@ function expandTilde(p: string): string {
   }
   return p;
 }
+
+// Load ~/.claude-gateway/.env so global installs pick up env vars without
+// needing shell exports or running via npm start.
+(function loadDotenv() {
+  const envFile = path.join(os.homedir(), '.claude-gateway', '.env');
+  if (!fs.existsSync(envFile)) return;
+  for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+    if (!(key in process.env)) process.env[key] = val;
+  }
+})();
 import { loadConfig } from './config/loader';
 import { detectMigration, applyMigration, loadCleanTemplate } from './config/migrator';
 import { loadWorkspace, watchWorkspace, migrateWorkspaceFiles } from './agent/workspace-loader';


### PR DESCRIPTION
## Summary

- Add `postinstall` script to run `bun install` in `mcp/` automatically after `npm install -g`. Without this, the MCP receiver crashes with "Cannot find module @modelcontextprotocol/sdk" when installed from npm. Falls back to a warning message if bun is not installed.
- Change default API port from `3000` → `10850` to avoid conflicts with common local dev servers (React, Express, etc.). Overridable via `PORT` env var.

## Test Plan

- [ ] `npm install -g @0xmaxma/claude-gateway` — verify MCP receiver starts without module error
- [ ] Confirm gateway listens on port 10850 by default
- [ ] Confirm `PORT=3000 claude-gateway` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)