### PR TITLE
fix(telegram): prevent message drop from race condition and failed reply tool

### DIFF
--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -174,6 +174,12 @@ export function createWorkingStateManager(
       await botApi.deleteMessage(chatId, state.statusMessageId).catch(() => {})
     }
     states.delete(chatId)
+
+    // If runner already wrote a new signal file for a queued turn, restart the loop.
+    // This handles the case where stop() ran for turn N while turn N+1 was already injected.
+    if (fsApi.existsSync(typingFilePath(chatId))) {
+      start(chatId)
+    }
   }
 
   async function notifyError(chatId: string, code: string): Promise<void> {

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -165,6 +165,14 @@ export function createWorkingStateManager(
       fsApi.rmSync(forwardPath, { force: true })
     }
     fsApi.rmSync(repliedPath, { force: true })
+    // Read signal file timestamp before deleting — process.ts overwrites it with a newer
+    // timestamp when a queued turn is injected; if newer than this turn's startedAt it means
+    // another turn is waiting and the loop must be restarted after cleanup.
+    const signalRaw = fsApi.existsSync(typingFilePath(chatId))
+      ? fsApi.readFileSync(typingFilePath(chatId), 'utf8').trim()
+      : null
+    const signalTs = signalRaw ? parseInt(signalRaw, 10) : 0
+    const hasQueuedTurn = signalTs > state.startedAt
     fsApi.rmSync(typingFilePath(chatId), { force: true })
     fsApi.rmSync(errorFilePath(chatId), { force: true })
     fsApi.rmSync(heartbeatFilePath(chatId), { force: true })
@@ -175,9 +183,7 @@ export function createWorkingStateManager(
     }
     states.delete(chatId)
 
-    // If runner already wrote a new signal file for a queued turn, restart the loop.
-    // This handles the case where stop() ran for turn N while turn N+1 was already injected.
-    if (fsApi.existsSync(typingFilePath(chatId))) {
+    if (hasQueuedTurn) {
       start(chatId)
     }
   }

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -168,9 +168,8 @@ export function createWorkingStateManager(
     // Read signal file timestamp before deleting — process.ts overwrites it with a newer
     // timestamp when a queued turn is injected; if newer than this turn's startedAt it means
     // another turn is waiting and the loop must be restarted after cleanup.
-    const signalRaw = fsApi.existsSync(typingFilePath(chatId))
-      ? fsApi.readFileSync(typingFilePath(chatId), 'utf8').trim()
-      : null
+    let signalRaw: string | null = null
+    try { signalRaw = fsApi.readFileSync(typingFilePath(chatId), 'utf8').trim() } catch {}
     const signalTs = signalRaw ? parseInt(signalRaw, 10) : 0
     const hasQueuedTurn = signalTs > state.startedAt
     fsApi.rmSync(typingFilePath(chatId), { force: true })

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -664,6 +664,7 @@ export class AgentRunner extends EventEmitter {
       // the delay, the timer is cancelled so typing persists during multi-step work.
       // Auto-forward result text to channel if agent didn't call reply tool.
       let replyCalled = false;
+      let replyToolUseId: string | null = null; // track id to detect failed tool calls
       let typingDoneTimer: ReturnType<typeof setTimeout> | null = null;
       const TYPING_DONE_DELAY_MS = 3000;
       const replyToolName = source === 'discord' ? 'mcp__gateway__discord_reply' : 'mcp__gateway__telegram_reply';
@@ -685,6 +686,7 @@ export class AgentRunner extends EventEmitter {
               for (const block of msg!.content) {
                 if (block.type === 'tool_use' && block.name === replyToolName && !replyCalled) {
                   replyCalled = true;
+                  replyToolUseId = (block as Record<string, unknown>)['id'] as string ?? null;
                   // Persist the reply text to history so it appears in chat history API
                   const replyText = typeof block.input?.['text'] === 'string' ? block.input['text'].trim() : '';
                   if (replyText) {
@@ -698,6 +700,18 @@ export class AgentRunner extends EventEmitter {
                       ts: Date.now(),
                     });
                   }
+                }
+              }
+            }
+          }
+          // If reply tool was called but returned an error, unblock auto-forward
+          if (obj['type'] === 'user' && replyToolUseId && replyCalled) {
+            const msg = obj['message'] as { content?: Array<{ type: string; tool_use_id?: string; is_error?: boolean }> } | undefined;
+            if (Array.isArray(msg?.content)) {
+              for (const block of msg!.content) {
+                if (block.type === 'tool_result' && block.tool_use_id === replyToolUseId && block.is_error) {
+                  replyCalled = false;
+                  replyToolUseId = null;
                 }
               }
             }
@@ -749,6 +763,7 @@ export class AgentRunner extends EventEmitter {
               }
             }
             replyCalled = false; // reset for next turn
+            replyToolUseId = null;
             // Delay typing done — agent may continue with more work
             typingDoneTimer = setTimeout(() => {
               this.writeTypingDone(mapKey);

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -635,16 +635,19 @@ export class SessionProcess extends EventEmitter {
       });
       return;
     }
-    // Signal queued state so the typing loop can update the reaction immediately
+    // Signal queued state + ensure typing signal file exists for this turn.
+    // If the previous turn already called stop() and cleared the typing loop,
+    // re-creating the signal file here lets stop() restart the loop for queued turns.
     if (this.source !== 'api') {
       const stateSubDir = this.source === 'discord' ? '.discord-state' : '.telegram-state';
-      const statusPath = path.join(
-        this.agentConfig.workspace,
-        stateSubDir,
-        'typing',
-        `${this.sessionId}.status`,
-      );
-      try { fs.writeFileSync(statusPath, 'queued') } catch {}
+      const typingDir = path.join(this.agentConfig.workspace, stateSubDir, 'typing');
+      const typingSignalPath = path.join(typingDir, this.chatId);
+      const statusPath = path.join(typingDir, `${this.sessionId}.status`);
+      try {
+        fs.mkdirSync(typingDir, { recursive: true });
+        fs.writeFileSync(typingSignalPath, String(Date.now()));
+        fs.writeFileSync(statusPath, 'queued');
+      } catch {}
     }
     this.process.stdin.write(SessionProcess.toStreamJsonTurn(text) + '\n');
   }


### PR DESCRIPTION
## Summary

- **process.ts**: re-write typing signal file on each injected message so the typing loop is re-armed for back-to-back messages (race condition fix)
- **typing.ts**: restart typing loop in `stop()` if a new signal file appeared while the current turn was processing — handles the case where a second message arrives during a slow response
- **runner.ts**: reset `replyCalled` when `telegram_reply` tool_result contains an error so the auto-forward fallback can still deliver the message

## Root cause

When message B arrives while message A is still being processed:
1. `start(chatId)` is a no-op (loop already running for A)
2. A finishes → `stop(chatId)` → deletes signal file, clears state
3. B finishes → writes `.forward`, tries to delete signal file (already gone)
4. No typing loop watching for B → `.forward` never sent → **message silently dropped**

## Test plan
- [ ] Send a message, get a slow response — verify reply arrives
- [ ] Send two messages in quick succession — verify both receive replies
- [ ] Simulate `telegram_reply` tool failure — verify auto-forward still delivers

🤖 Generated with [Claude Code](https://claude.com/claude-code)