### PR TITLE
feat(api): add package self-update endpoints

### DIFF
--- a/API.md
+++ b/API.md
@@ -105,7 +105,7 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 Health check. No auth required.
 
 ```bash
-curl http://localhost:3000/health
+curl http://localhost:10850/health
 ```
 
 ```json
@@ -119,7 +119,7 @@ curl http://localhost:3000/health
 Per-agent stats and heartbeat history. No auth required.
 
 ```bash
-curl http://localhost:3000/status | jq
+curl http://localhost:10850/status | jq
 ```
 
 ```json
@@ -160,7 +160,7 @@ Serves the web UI dashboard. No auth required.
 List the slash commands available in the chat UI. No auth required.
 
 ```bash
-curl http://localhost:3000/api/v1/commands | jq
+curl http://localhost:10850/api/v1/commands | jq
 ```
 
 ```json
@@ -229,7 +229,7 @@ List agents accessible by the provided API key.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/agents | jq
+  http://localhost:10850/api/v1/agents | jq
 ```
 
 ```json
@@ -259,7 +259,7 @@ curl -X POST \
   -H "X-Api-Key: admin-key-456" \
   -H "Content-Type: application/json" \
   -d '{"id": "my-bot", "description": "My new bot", "model": "claude-sonnet-4-6"}' \
-  http://localhost:3000/api/v1/agents | jq
+  http://localhost:10850/api/v1/agents | jq
 ```
 
 ```json
@@ -294,7 +294,7 @@ curl -X PATCH \
   -H "X-Api-Key: admin-key-456" \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-opus-4-7"}' \
-  http://localhost:3000/api/v1/agents/alfred | jq
+  http://localhost:10850/api/v1/agents/alfred | jq
 ```
 
 ```json
@@ -310,7 +310,7 @@ Remove an agent from `config.json` and stop the running process. Requires admin 
 ```bash
 curl -X DELETE \
   -H "X-Api-Key: admin-key-456" \
-  http://localhost:3000/api/v1/agents/my-bot | jq
+  http://localhost:10850/api/v1/agents/my-bot | jq
 ```
 
 ```json
@@ -370,7 +370,7 @@ curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"message": "Hello! What can you help me with?", "chat_id": "myapp"}' \
-  http://localhost:3000/api/v1/agents/alfred/messages | jq
+  http://localhost:10850/api/v1/agents/alfred/messages | jq
 ```
 
 ```json
@@ -390,7 +390,7 @@ curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"message": "What did I just ask you?", "chat_id": "myapp", "session_id": "da19d84a-6a36-4f57-b419-d322d82c4db8"}' \
-  http://localhost:3000/api/v1/agents/alfred/messages | jq
+  http://localhost:10850/api/v1/agents/alfred/messages | jq
 ```
 
 **Error responses:**
@@ -420,7 +420,7 @@ curl -N -X POST \
   -H "X-Api-Key: my-secret-key" \
   -H "Content-Type: application/json" \
   -d '{"message": "Explain this code", "chat_id": "myapp", "stream": true}' \
-  http://localhost:3000/api/v1/agents/alfred/messages
+  http://localhost:10850/api/v1/agents/alfred/messages
 ```
 
 **Response:**
@@ -448,7 +448,7 @@ curl -N -X POST \
     "stream": true,
     "timeout_ms": 120000
   }' \
-  http://localhost:3000/api/v1/agents/alfred/messages
+  http://localhost:10850/api/v1/agents/alfred/messages
 ```
 
 > Keys without `allow_tools: true` are always conversational — tools are never invoked regardless of what the request contains.
@@ -478,7 +478,7 @@ List all supported Claude models from gateway config.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/models | jq
+  http://localhost:10850/api/v1/models | jq
 ```
 
 ```json
@@ -507,7 +507,7 @@ curl -X PUT \
   -H "X-Api-Key: admin-key-456" \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-opus-4-7"}' \
-  http://localhost:3000/api/v1/agents/alfred/model | jq
+  http://localhost:10850/api/v1/agents/alfred/model | jq
 ```
 
 ```json
@@ -540,7 +540,7 @@ List all API sessions for a given `chat_id`.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/sessions?chat_id=myapp" | jq
+  "http://localhost:10850/api/v1/agents/alfred/sessions?chat_id=myapp" | jq
 ```
 
 ```json
@@ -575,7 +575,7 @@ curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"chat_id": "myapp", "prompt": "I want to discuss the deployment plan for Q3"}' \
-  http://localhost:3000/api/v1/agents/alfred/sessions | jq
+  http://localhost:10850/api/v1/agents/alfred/sessions | jq
 ```
 
 ```json
@@ -594,7 +594,7 @@ Get info for a specific session — name, message count, and context usage.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/info?chat_id=myapp" | jq
+  "http://localhost:10850/api/v1/agents/alfred/sessions/da19d84a/info?chat_id=myapp" | jq
 ```
 
 ```json
@@ -632,7 +632,7 @@ curl -X PATCH \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"chat_id": "myapp", "sessionName": "Q3 Infra Discussion"}' \
-  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a | jq
+  http://localhost:10850/api/v1/agents/alfred/sessions/da19d84a | jq
 ```
 
 ```json
@@ -651,7 +651,7 @@ Delete a session. Returns 204 No Content on success.
 ```bash
 curl -X DELETE \
   -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a?chat_id=myapp"
+  "http://localhost:10850/api/v1/agents/alfred/sessions/da19d84a?chat_id=myapp"
 ```
 
 ---
@@ -667,7 +667,7 @@ curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"chat_id": "myapp"}' \
-  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/clear | jq
+  http://localhost:10850/api/v1/agents/alfred/sessions/da19d84a/clear | jq
 ```
 
 ```json
@@ -687,7 +687,7 @@ curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"chat_id": "myapp"}' \
-  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/compact | jq
+  http://localhost:10850/api/v1/agents/alfred/sessions/da19d84a/compact | jq
 ```
 
 ```json
@@ -707,7 +707,7 @@ curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"chat_id": "myapp"}' \
-  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/stop | jq
+  http://localhost:10850/api/v1/agents/alfred/sessions/da19d84a/stop | jq
 ```
 
 ```json
@@ -727,7 +727,7 @@ curl -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"chat_id": "myapp"}' \
-  http://localhost:3000/api/v1/agents/alfred/sessions/da19d84a/restart | jq
+  http://localhost:10850/api/v1/agents/alfred/sessions/da19d84a/restart | jq
 ```
 
 ```json
@@ -748,7 +748,7 @@ Read a workspace file. Returns empty `content` if the file does not exist yet (n
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/agents/alfred/files/SOUL.md | jq
+  http://localhost:10850/api/v1/agents/alfred/files/SOUL.md | jq
 ```
 
 ```json
@@ -772,7 +772,7 @@ curl -X PUT \
   -H "X-Api-Key: admin-key-456" \
   -H "Content-Type: application/json" \
   -d '{"content": "# Soul\n\nAlfred is warm, helpful, and precise."}' \
-  http://localhost:3000/api/v1/agents/alfred/files/SOUL.md | jq
+  http://localhost:10850/api/v1/agents/alfred/files/SOUL.md | jq
 ```
 
 ```json
@@ -800,7 +800,7 @@ List all skills for an agent (workspace + module + shared).
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/agents/alfred/skills | jq
+  http://localhost:10850/api/v1/agents/alfred/skills | jq
 ```
 
 ```json
@@ -828,7 +828,7 @@ Get a single skill's content. Optional query param `?scope=workspace|shared` to 
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/skills/my-helper" | jq
+  "http://localhost:10850/api/v1/agents/alfred/skills/my-helper" | jq
 ```
 
 ```json
@@ -867,7 +867,7 @@ curl -X POST \
     "description": "Does something useful",
     "content": "When invoked, do the following:\n1. Step one\n2. Step two"
   }' \
-  http://localhost:3000/api/v1/agents/alfred/skills | jq
+  http://localhost:10850/api/v1/agents/alfred/skills | jq
 ```
 
 ```json
@@ -915,7 +915,7 @@ curl -X POST \
     "url": "https://github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
     "scope": "shared"
   }' \
-  http://localhost:3000/api/v1/agents/alfred/skills/install | jq
+  http://localhost:10850/api/v1/agents/alfred/skills/install | jq
 ```
 
 ```json
@@ -950,7 +950,7 @@ Delete a skill by name. Requires write access. Use `?scope=shared` (admin only) 
 ```bash
 curl -X DELETE \
   -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/skills/my-helper" | jq
+  "http://localhost:10850/api/v1/agents/alfred/skills/my-helper" | jq
 ```
 
 ```json
@@ -1004,7 +1004,7 @@ List all jobs accessible by the API key (filtered to key's agent scope).
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/crons | jq
+  http://localhost:10850/api/v1/crons | jq
 ```
 
 ```json
@@ -1041,7 +1041,7 @@ Scheduler health summary.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/crons/status | jq
+  http://localhost:10850/api/v1/crons/status | jq
 ```
 
 ```json
@@ -1061,7 +1061,7 @@ curl -H "X-Api-Key: my-secret-key-123" \
 Run every day at 09:00 — agent sends a morning summary to Telegram.
 
 ```bash
-curl -s -X POST http://localhost:3000/api/v1/crons \
+curl -s -X POST http://localhost:10850/api/v1/crons \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1080,7 +1080,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
 Run every day at 09:00 — agent sends a morning summary to a Discord channel.
 
 ```bash
-curl -s -X POST http://localhost:3000/api/v1/crons \
+curl -s -X POST http://localhost:10850/api/v1/crons \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1097,7 +1097,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
 #### Example: Deliver to both Telegram and Discord
 
 ```bash
-curl -s -X POST http://localhost:3000/api/v1/crons \
+curl -s -X POST http://localhost:10850/api/v1/crons \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1117,7 +1117,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
 Runs once at the given time, then auto-deletes.
 
 ```bash
-curl -s -X POST http://localhost:3000/api/v1/crons \
+curl -s -X POST http://localhost:10850/api/v1/crons \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1137,7 +1137,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
 Run a shell command every minute.
 
 ```bash
-curl -s -X POST http://localhost:3000/api/v1/crons \
+curl -s -X POST http://localhost:10850/api/v1/crons \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1153,7 +1153,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
 #### Example: One-shot shell command at a specific time
 
 ```bash
-curl -s -X POST http://localhost:3000/api/v1/crons \
+curl -s -X POST http://localhost:10850/api/v1/crons \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1170,7 +1170,7 @@ curl -s -X POST http://localhost:3000/api/v1/crons \
 #### Example: Create a disabled job (enable later)
 
 ```bash
-curl -s -X POST http://localhost:3000/api/v1/crons \
+curl -s -X POST http://localhost:10850/api/v1/crons \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1193,7 +1193,7 @@ Get a single job by ID.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/crons/8f787a4b-eaa8-4ace-a0b3-ff3d0004f2df | jq
+  http://localhost:10850/api/v1/crons/8f787a4b-eaa8-4ace-a0b3-ff3d0004f2df | jq
 ```
 
 ---
@@ -1205,7 +1205,7 @@ Only the fields you include are updated. All fields are optional.
 #### Example: Change schedule
 
 ```bash
-curl -s -X PUT http://localhost:3000/api/v1/crons/<id> \
+curl -s -X PUT http://localhost:10850/api/v1/crons/<id> \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1216,7 +1216,7 @@ curl -s -X PUT http://localhost:3000/api/v1/crons/<id> \
 #### Example: Change prompt
 
 ```bash
-curl -s -X PUT http://localhost:3000/api/v1/crons/<id> \
+curl -s -X PUT http://localhost:10850/api/v1/crons/<id> \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1227,7 +1227,7 @@ curl -s -X PUT http://localhost:3000/api/v1/crons/<id> \
 #### Example: Disable a job
 
 ```bash
-curl -s -X PUT http://localhost:3000/api/v1/crons/<id> \
+curl -s -X PUT http://localhost:10850/api/v1/crons/<id> \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"enabled": false}' | jq
@@ -1236,7 +1236,7 @@ curl -s -X PUT http://localhost:3000/api/v1/crons/<id> \
 #### Example: Re-enable a job
 
 ```bash
-curl -s -X PUT http://localhost:3000/api/v1/crons/<id> \
+curl -s -X PUT http://localhost:10850/api/v1/crons/<id> \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"enabled": true}' | jq
@@ -1249,7 +1249,7 @@ curl -s -X PUT http://localhost:3000/api/v1/crons/<id> \
 Delete a job permanently.
 
 ```bash
-curl -s -X DELETE http://localhost:3000/api/v1/crons/<id> \
+curl -s -X DELETE http://localhost:10850/api/v1/crons/<id> \
   -H "X-Api-Key: my-secret-key-123" | jq
 ```
 
@@ -1264,7 +1264,7 @@ curl -s -X DELETE http://localhost:3000/api/v1/crons/<id> \
 Trigger a job immediately, regardless of its schedule.
 
 ```bash
-curl -s -X POST http://localhost:3000/api/v1/crons/<id>/run \
+curl -s -X POST http://localhost:10850/api/v1/crons/<id>/run \
   -H "X-Api-Key: my-secret-key-123" | jq
 ```
 
@@ -1280,7 +1280,7 @@ Get the run history of a job (last 20 runs by default).
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/crons/<id>/runs | jq
+  http://localhost:10850/api/v1/crons/<id>/runs | jq
 ```
 
 ```json
@@ -1339,7 +1339,7 @@ List all sessions across **all agents** in a single call. Admin key required. Qu
 
 ```bash
 curl -H "X-Api-Key: admin-key-456" \
-  http://localhost:3000/api/v1/agents/sessions | jq
+  http://localhost:10850/api/v1/agents/sessions | jq
 ```
 
 ```json
@@ -1392,7 +1392,7 @@ List all chats (across all channels) for an agent.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  http://localhost:3000/api/v1/agents/alfred/chats | jq
+  http://localhost:10850/api/v1/agents/alfred/chats | jq
 ```
 
 ```json
@@ -1411,7 +1411,7 @@ List sessions for a specific chat. Supports `telegram`, `discord`, and `api` cha
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/sessions" | jq
+  "http://localhost:10850/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/sessions" | jq
 ```
 
 ```json
@@ -1446,7 +1446,7 @@ Paginated message history (cursor-based). Returns messages in reverse chronologi
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages?limit=20" | jq
+  "http://localhost:10850/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages?limit=20" | jq
 ```
 
 ```json
@@ -1475,7 +1475,7 @@ Full-text search across messages using SQLite FTS5.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages/search?q=meeting" | jq
+  "http://localhost:10850/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages/search?q=meeting" | jq
 ```
 
 ```json
@@ -1511,7 +1511,7 @@ curl -N -X POST \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
   -d '{"content": "Continue from where we left off", "senderName": "API"}' \
-  "http://localhost:3000/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/sessions/abc-123/messages"
+  "http://localhost:10850/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/sessions/abc-123/messages"
 ```
 
 **Response** (SSE stream):
@@ -1553,7 +1553,7 @@ curl -X POST \
   -H "Content-Type: image/jpeg" \
   -H "X-Filename: photo.jpg" \
   --data-binary @/path/to/photo.jpg \
-  http://localhost:3000/api/v1/agents/alfred/media | jq
+  http://localhost:10850/api/v1/agents/alfred/media | jq
 ```
 
 ```json
@@ -1578,7 +1578,7 @@ Serve a media file by path. The path must stay within the agent's media director
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
-  "http://localhost:3000/api/v1/agents/alfred/media/ui-upload/2026-05-10/gw-1746837600000.jpg" \
+  "http://localhost:10850/api/v1/agents/alfred/media/ui-upload/2026-05-10/gw-1746837600000.jpg" \
   --output photo.jpg
 ```
 
@@ -1604,7 +1604,7 @@ Returns the current and latest version for both packages. Result is cached for 5
 
 ```bash
 curl -H "X-Api-Key: admin-secret" \
-  http://localhost:3000/api/v1/packages | jq
+  http://localhost:10850/api/v1/packages | jq
 ```
 
 ```json
@@ -1648,7 +1648,7 @@ If the package is already on the latest version the call is a no-op (`updated: f
 ```bash
 curl -X POST \
   -H "X-Api-Key: admin-secret" \
-  http://localhost:3000/api/v1/packages/claude-gateway/update | jq
+  http://localhost:10850/api/v1/packages/claude-gateway/update | jq
 ```
 
 ```json

--- a/API.md
+++ b/API.md
@@ -1589,3 +1589,92 @@ curl -H "X-Api-Key: my-secret-key-123" \
 | 400 | Path traversal attempt or invalid path |
 | 403 | Key has no access to agent |
 | 404 | Agent or file not found |
+
+---
+
+## Package Updates
+
+Endpoints for checking and installing newer versions of `@0xmaxma/claude-gateway` and `@anthropic-ai/claude-code`. All package endpoints require an **admin** API key (`admin: true` in config).
+
+---
+
+### GET /api/v1/packages
+
+Returns the current and latest version for both packages. Result is cached for 5 minutes to avoid hammering the npm registry.
+
+```bash
+curl -H "X-Api-Key: admin-secret" \
+  http://localhost:3000/api/v1/packages | jq
+```
+
+```json
+{
+  "packages": [
+    {
+      "package": "@0xmaxma/claude-gateway",
+      "current": "1.2.0",
+      "latest": "1.3.1",
+      "hasUpdate": true
+    },
+    {
+      "package": "@anthropic-ai/claude-code",
+      "current": "1.0.5",
+      "latest": "1.1.0",
+      "hasUpdate": true
+    }
+  ]
+}
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 401 | No API key provided |
+| 403 | Non-admin API key |
+| 503 | npm registry unreachable |
+
+---
+
+### POST /api/v1/packages/:name/update
+
+Installs the latest version of the specified package. `:name` accepts `claude-gateway` or `claude-code`.
+
+- **claude-gateway**: runs `npm install @0xmaxma/claude-gateway@latest` then calls `process.exit(0)` so the process manager (systemd/pm2) restarts the service.
+- **claude-code**: runs `npm install -g @anthropic-ai/claude-code@latest`. No restart needed.
+
+If the package is already on the latest version the call is a no-op (`updated: false`).
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: admin-secret" \
+  http://localhost:3000/api/v1/packages/claude-gateway/update | jq
+```
+
+```json
+{
+  "package": "@0xmaxma/claude-gateway",
+  "from": "1.2.0",
+  "to": "1.3.1",
+  "updated": true,
+  "warning": "service will restart"
+}
+```
+
+`warning` values:
+
+| Value | Meaning |
+|-------|---------|
+| `"service will restart"` | Running under systemd or pm2 — process manager will auto-restart |
+| `"process will stop — restart manually"` | Plain process (dev) — will exit after update |
+| `null` | No restart needed (claude-code) |
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 401 | No API key provided |
+| 403 | Non-admin API key |
+| 404 | Unknown package name |
+| 500 | `npm install` failed — body contains stderr |
+| 503 | npm registry unreachable |

--- a/API.md
+++ b/API.md
@@ -1640,7 +1640,7 @@ curl -H "X-Api-Key: admin-secret" \
 
 Installs the latest version of the specified package. `:name` accepts `claude-gateway` or `claude-code`.
 
-- **claude-gateway**: runs `npm install @0xmaxma/claude-gateway@latest` then calls `process.exit(0)` so the process manager (systemd/pm2) restarts the service.
+- **claude-gateway**: runs `npm install -g @0xmaxma/claude-gateway@latest` then calls `process.exit(0)` so the process manager (systemd/pm2) restarts the service.
 - **claude-code**: runs `npm install -g @anthropic-ai/claude-code@latest`. No restart needed.
 
 If the package is already on the latest version the call is a no-op (`updated: false`).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 - **Config auto-migration** — automatic schema migration when config format changes
 - **Access control** — allowlist, open, or pairing-based Telegram access policies
 - **HTTP API** — REST API with key-based auth for external integrations
+- **Self-update API** — check for newer versions of `claude-gateway` and `claude-code` and trigger an update via a single API call; no SSH or shell access needed
 - **Session persistence** — conversation history saved and restored across restarts
 
 ---

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -9,6 +9,7 @@ import { createApiRouter } from './router';
 import { createCronRouter } from './cron-router';
 import { createWorkspaceRouter } from './workspace-router';
 import { createSkillsRouter } from './skills-router';
+import { createPackagesRouter } from './packages';
 
 export class GatewayRouter {
   private readonly agents: Map<string, AgentRunner>;
@@ -112,6 +113,12 @@ export class GatewayRouter {
         this.agents,
       );
       this.app.use('/api', skillsRouter);
+    }
+
+    // Mount package update routes (admin-only)
+    if (this.gatewayConfig?.gateway?.api?.keys?.length) {
+      const packagesRouter = createPackagesRouter(this.gatewayConfig.gateway.api.keys);
+      this.app.use('/api', packagesRouter);
     }
 
     // Mount cron manager routes with same API key auth as agent router

--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -36,6 +36,7 @@ function getNpmListVersion(packageName: string): string | null {
     const output = execSync(`npm list -g ${packageName} --depth=0 --json`, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10_000,
     });
     const parsed = JSON.parse(output) as { dependencies?: Record<string, { version: string }> };
     return parsed.dependencies?.[packageName]?.version ?? null;
@@ -53,9 +54,12 @@ async function getLatestVersion(packageName: string): Promise<string | null> {
 }
 
 async function fetchAllPackageVersions(): Promise<PackageInfo[]> {
+  const pkgs = Object.values(PACKAGE_MAP);
+  // Run all synchronous npm list calls before entering async Promise.all
+  const currents = pkgs.map(getNpmListVersion);
   return Promise.all(
-    Object.values(PACKAGE_MAP).map(async (pkg) => {
-      const current = getNpmListVersion(pkg);
+    pkgs.map(async (pkg, i) => {
+      const current = currents[i];
       const latest = await getLatestVersion(pkg);
       return {
         package: pkg,
@@ -143,6 +147,7 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
     try {
       execSync(`npm install -g ${packageName}@latest`, {
         stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 120_000,
       });
     } catch (err) {
       const stderr = (err as { stderr?: Buffer }).stderr?.toString() ?? 'install failed';

--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -1,0 +1,178 @@
+import { Router, Request, Response } from 'express';
+import { execSync } from 'child_process';
+import { ApiKey } from '../types';
+import { createApiAuthMiddleware, isAdmin } from './auth';
+
+type AuthedRequest = Request & { apiKey: ApiKey };
+
+// URL param "name" → npm package name
+const PACKAGE_MAP: Record<string, string> = {
+  'claude-gateway': '@0xmaxma/claude-gateway',
+  'claude-code': '@anthropic-ai/claude-code',
+};
+
+interface PackageInfo {
+  package: string;
+  current: string | null;
+  latest: string | null;
+  hasUpdate: boolean;
+}
+
+interface CacheEntry {
+  data: PackageInfo[];
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let versionCache: CacheEntry | null = null;
+
+export function _resetCache(): void {
+  versionCache = null;
+}
+
+function getNpmListVersion(packageName: string): string | null {
+  try {
+    const output = execSync(`npm list -g ${packageName} --depth=0 --json`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const parsed = JSON.parse(output) as { dependencies?: Record<string, { version: string }> };
+    return parsed.dependencies?.[packageName]?.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function getLatestVersion(packageName: string): Promise<string | null> {
+  const encodedName = packageName.replace('/', '%2F');
+  const res = await fetch(`https://registry.npmjs.org/${encodedName}/latest`);
+  if (!res.ok) return null;
+  const data = (await res.json()) as { version?: string };
+  return data.version ?? null;
+}
+
+async function fetchAllPackageVersions(): Promise<PackageInfo[]> {
+  return Promise.all(
+    Object.values(PACKAGE_MAP).map(async (pkg) => {
+      const current = getNpmListVersion(pkg);
+      const latest = await getLatestVersion(pkg);
+      return {
+        package: pkg,
+        current,
+        latest,
+        hasUpdate: !!(current && latest && current !== latest),
+      };
+    }),
+  );
+}
+
+export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
+  const router = Router();
+
+  if (apiKeys?.length) {
+    router.use(createApiAuthMiddleware(apiKeys));
+  }
+
+  // GET /api/v1/packages — version check for both packages (cached 5 min)
+  router.get('/v1/packages', async (req: Request, res: Response) => {
+    if (apiKeys?.length) {
+      const apiKey = (req as AuthedRequest).apiKey;
+      if (!isAdmin(apiKey)) {
+        res.status(403).json({ error: 'admin API key required' });
+        return;
+      }
+    }
+
+    if (versionCache && versionCache.expiresAt > Date.now()) {
+      res.json({ packages: versionCache.data });
+      return;
+    }
+
+    let packages: PackageInfo[];
+    try {
+      packages = await fetchAllPackageVersions();
+    } catch {
+      res.status(503).json({ error: 'registry unavailable' });
+      return;
+    }
+
+    versionCache = { data: packages, expiresAt: Date.now() + CACHE_TTL_MS };
+    res.json({ packages });
+  });
+
+  // POST /api/v1/packages/:name/update — install latest and restart if needed
+  router.post('/v1/packages/:name/update', async (req: Request, res: Response) => {
+    if (apiKeys?.length) {
+      const apiKey = (req as AuthedRequest).apiKey;
+      if (!isAdmin(apiKey)) {
+        res.status(403).json({ error: 'admin API key required' });
+        return;
+      }
+    }
+
+    const { name } = req.params as { name: string };
+    const packageName = PACKAGE_MAP[name];
+    if (!packageName) {
+      res.status(404).json({ error: `unknown package: ${name}` });
+      return;
+    }
+
+    const from = getNpmListVersion(packageName);
+
+    let latest: string | null;
+    try {
+      latest = await getLatestVersion(packageName);
+    } catch {
+      res.status(503).json({ error: 'registry unavailable' });
+      return;
+    }
+
+    if (!latest) {
+      res.status(503).json({ error: 'registry unavailable' });
+      return;
+    }
+
+    // Already on latest — no install needed
+    if (from === latest) {
+      res.json({ package: packageName, from, to: from, updated: false, warning: null });
+      return;
+    }
+
+    // Run npm install
+    try {
+      execSync(`npm install -g ${packageName}@latest`, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      const stderr = (err as { stderr?: Buffer }).stderr?.toString() ?? 'install failed';
+      res.status(500).json({ error: stderr });
+      return;
+    }
+
+    // Invalidate version cache after successful install
+    versionCache = null;
+
+    const to = getNpmListVersion(packageName);
+
+    if (name === 'claude-gateway') {
+      const isSystemd = !!process.env.INVOCATION_ID;
+      const isPm2 = !!process.env.PM2_HOME || process.env.pm_id !== undefined;
+      const isManaged = isSystemd || isPm2;
+
+      res.json({
+        package: packageName,
+        from,
+        to,
+        updated: true,
+        warning: isManaged ? 'service will restart' : 'process will stop — restart manually',
+      });
+
+      setTimeout(() => process.exit(0), 500);
+    } else {
+      res.json({ package: packageName, from, to, updated: true, warning: null });
+    }
+  });
+
+  return router;
+}

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Unit tests for packages-router (Planning-54: Package Update API)
+ *
+ * T1:  GET /api/v1/packages — returns version info for both packages
+ * T2:  GET /api/v1/packages — 401 when no API key
+ * T3:  GET /api/v1/packages — 403 when non-admin key
+ * T4:  GET /api/v1/packages — admin key allowed
+ * T5:  GET /api/v1/packages — serves cached response on second call
+ * T6:  GET /api/v1/packages — 503 when registry fetch throws
+ * T7:  POST /api/v1/packages/claude-gateway/update — 404 for unknown name
+ * T8:  POST /api/v1/packages/unknown/update — 404
+ * T9:  POST /api/v1/packages/claude-gateway/update — already on latest → updated: false
+ * T10: POST /api/v1/packages/claude-gateway/update — success, plain process warning
+ * T11: POST /api/v1/packages/claude-gateway/update — success, systemd warning
+ * T12: POST /api/v1/packages/claude-gateway/update — npm install fails → 500
+ * T13: POST /api/v1/packages/claude-gateway/update — registry unavailable → 503
+ * T14: POST /api/v1/packages/claude-code/update — success, warning: null
+ * T15: POST /api/v1/packages/claude-gateway/update — 403 when non-admin key
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { ApiKey } from '../../src/types';
+
+// Must mock child_process before importing the module under test
+jest.mock('child_process', () => ({ execSync: jest.fn() }));
+
+import { execSync } from 'child_process';
+import { createPackagesRouter, _resetCache } from '../../src/api/packages';
+
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+const ADMIN_KEY = 'admin-secret';
+const USER_KEY = 'user-secret';
+
+const apiKeys: ApiKey[] = [
+  { key: ADMIN_KEY, description: 'admin', agents: '*', admin: true },
+  { key: USER_KEY, description: 'user', agents: ['agent-1'] },
+];
+
+function makeApp(withAuth = true) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createPackagesRouter(withAuth ? apiKeys : undefined));
+  return app;
+}
+
+// Keep track of the exit spy
+let exitSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  _resetCache();
+  jest.clearAllMocks();
+  // Prevent process.exit from actually exiting during tests
+  exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  // Suppress timer-based exit: fast-forward timers
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+  jest.useRealTimers();
+});
+
+// Default mock: npm list returns version, fetch returns latest
+function mockNpmList(pkg: string, version: string) {
+  mockExecSync.mockImplementation((cmd: unknown) => {
+    const cmdStr = cmd as string;
+    if (cmdStr.includes(pkg)) {
+      return JSON.stringify({ dependencies: { [pkg]: { version } } });
+    }
+    return '{}';
+  });
+}
+
+function mockFetch(latestVersions: Record<string, string>) {
+  global.fetch = jest.fn().mockImplementation((url: string) => {
+    for (const [pkg, version] of Object.entries(latestVersions)) {
+      const encoded = pkg.replace('/', '%2F');
+      if (url.includes(encoded)) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ version }),
+        });
+      }
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  }) as typeof fetch;
+}
+
+// ─── T1-T6: GET /api/v1/packages ────────────────────────────────────────────
+
+describe('T1-T6: GET /api/v1/packages', () => {
+  it('T1: returns version info for both packages', async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('@0xmaxma/claude-gateway')) {
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.2.0' } } });
+      }
+      if (cmdStr.includes('@anthropic-ai/claude-code')) {
+        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version: '1.0.5' } } });
+      }
+      return '{}';
+    });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.3.1', '@anthropic-ai/claude-code': '1.1.0' });
+
+    const res = await request(makeApp())
+      .get('/api/v1/packages')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.packages).toHaveLength(2);
+
+    const gw = res.body.packages.find((p: { package: string }) => p.package === '@0xmaxma/claude-gateway');
+    expect(gw).toMatchObject({ current: '1.2.0', latest: '1.3.1', hasUpdate: true });
+
+    const cc = res.body.packages.find((p: { package: string }) => p.package === '@anthropic-ai/claude-code');
+    expect(cc).toMatchObject({ current: '1.0.5', latest: '1.1.0', hasUpdate: true });
+  });
+
+  it('T2: 401 when no API key', async () => {
+    const res = await request(makeApp()).get('/api/v1/packages');
+    expect(res.status).toBe(401);
+  });
+
+  it('T3: 403 when non-admin key', async () => {
+    const res = await request(makeApp())
+      .get('/api/v1/packages')
+      .set('X-Api-Key', USER_KEY);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('admin API key required');
+  });
+
+  it('T4: admin key is allowed', async () => {
+    mockExecSync.mockReturnValue('{}');
+    mockFetch({ '@0xmaxma/claude-gateway': '1.0.0', '@anthropic-ai/claude-code': '1.0.0' });
+
+    const res = await request(makeApp())
+      .get('/api/v1/packages')
+      .set('X-Api-Key', ADMIN_KEY);
+    expect(res.status).toBe(200);
+  });
+
+  it('T5: serves cached response on second call without re-fetching', async () => {
+    mockExecSync.mockReturnValue(JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.0.0' }, '@anthropic-ai/claude-code': { version: '1.0.0' } } }));
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: '1.0.0' }),
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const app = makeApp();
+    await request(app).get('/api/v1/packages').set('X-Api-Key', ADMIN_KEY);
+    await request(app).get('/api/v1/packages').set('X-Api-Key', ADMIN_KEY);
+
+    // fetch called for 2 packages on first request; second request uses cache
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('T6: 503 when registry fetch throws', async () => {
+    mockExecSync.mockReturnValue(JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.0.0' } } }));
+    global.fetch = jest.fn().mockRejectedValue(new Error('network error')) as typeof fetch;
+
+    const res = await request(makeApp())
+      .get('/api/v1/packages')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('registry unavailable');
+  });
+});
+
+// ─── T7-T15: POST /api/v1/packages/:name/update ─────────────────────────────
+
+describe('T7-T15: POST /api/v1/packages/:name/update', () => {
+  it('T7: 404 for unrecognised name', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/packages/unknown-pkg/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('unknown package: unknown-pkg');
+  });
+
+  it('T8: 404 for completely unknown name "foo"', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/packages/foo/update')
+      .set('X-Api-Key', ADMIN_KEY);
+    expect(res.status).toBe(404);
+  });
+
+  it('T9: already on latest — updated: false, no restart', async () => {
+    mockNpmList('@0xmaxma/claude-gateway', '1.3.1');
+    mockFetch({ '@0xmaxma/claude-gateway': '1.3.1' });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-gateway/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      package: '@0xmaxma/claude-gateway',
+      from: '1.3.1',
+      to: '1.3.1',
+      updated: false,
+      warning: null,
+    });
+    expect(mockExecSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('npm install -g'),
+      expect.anything(),
+    );
+  });
+
+  it('T10: claude-gateway updated — plain process warning', async () => {
+    // Remove systemd/pm2 env vars to simulate plain process
+    const savedInvocationId = process.env.INVOCATION_ID;
+    const savedPm2Home = process.env.PM2_HOME;
+    const savedPmId = process.env.pm_id;
+    delete process.env.INVOCATION_ID;
+    delete process.env.PM2_HOME;
+    delete process.env.pm_id;
+
+    let callCount = 0;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm list')) {
+        callCount++;
+        // First call: current; second call (after install): to
+        const version = callCount === 1 ? '1.2.0' : '1.3.1';
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version } } });
+      }
+      // npm install — no output
+      return '';
+    });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.3.1' });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-gateway/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      package: '@0xmaxma/claude-gateway',
+      from: '1.2.0',
+      to: '1.3.1',
+      updated: true,
+      warning: 'process will stop — restart manually',
+    });
+
+    // Restore
+    if (savedInvocationId !== undefined) process.env.INVOCATION_ID = savedInvocationId;
+    if (savedPm2Home !== undefined) process.env.PM2_HOME = savedPm2Home;
+    if (savedPmId !== undefined) process.env.pm_id = savedPmId;
+
+    // process.exit(0) should be scheduled
+    jest.runAllTimers();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('T11: claude-gateway updated — systemd managed warning', async () => {
+    const savedInvocationId = process.env.INVOCATION_ID;
+    process.env.INVOCATION_ID = 'abc123';
+
+    let callCount = 0;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm list')) {
+        callCount++;
+        const version = callCount === 1 ? '1.2.0' : '1.3.1';
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version } } });
+      }
+      return '';
+    });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.3.1' });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-gateway/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.warning).toBe('service will restart');
+
+    if (savedInvocationId !== undefined) process.env.INVOCATION_ID = savedInvocationId;
+    else delete process.env.INVOCATION_ID;
+  });
+
+  it('T12: npm install fails → 500 with stderr', async () => {
+    mockNpmList('@0xmaxma/claude-gateway', '1.2.0');
+    mockFetch({ '@0xmaxma/claude-gateway': '1.3.1' });
+
+    const installError = Object.assign(new Error('npm ERR!'), {
+      stderr: Buffer.from('npm ERR! 404 Not Found'),
+    });
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm list')) {
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.2.0' } } });
+      }
+      throw installError;
+    });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-gateway/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain('npm ERR!');
+  });
+
+  it('T13: registry unavailable during update → 503', async () => {
+    mockNpmList('@0xmaxma/claude-gateway', '1.2.0');
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED')) as typeof fetch;
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-gateway/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('registry unavailable');
+  });
+
+  it('T14: claude-code updated — warning is null, no process exit', async () => {
+    let callCount = 0;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm list')) {
+        callCount++;
+        const version = callCount === 1 ? '1.0.5' : '1.1.0';
+        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version } } });
+      }
+      return '';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      package: '@anthropic-ai/claude-code',
+      from: '1.0.5',
+      to: '1.1.0',
+      updated: true,
+      warning: null,
+    });
+
+    jest.runAllTimers();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('T15: 403 when non-admin key attempts update', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-gateway/update')
+      .set('X-Api-Key', USER_KEY);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('admin API key required');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/packages` — returns current and latest version for `@0xmaxma/claude-gateway` and `@anthropic-ai/claude-code`, cached 5 min
- Add `POST /api/v1/packages/:name/update` — installs latest via `npm install -g`, sends response, then calls `process.exit(0)` for process manager restart (claude-gateway only)
- Both endpoints require an **admin** API key

## Details

- Process manager detection: `INVOCATION_ID` (systemd) / `PM2_HOME` or `pm_id` (pm2) → `warning: "service will restart"` vs `"process will stop — restart manually"`
- `claude-code` update: no restart needed → `warning: null`
- Registry fetch errors → 503; npm install failure → 500 with stderr; unknown package name → 404; already on latest → `updated: false` (no install, no restart)
- `execSync` timeouts: 10s for `npm list`, 2 min for `npm install -g`

## API Examples

### Check versions

```bash
curl -H "X-Api-Key: <admin-key>" http://localhost:10850/api/v1/packages | jq
```

```json
{
  "packages": [
    {
      "package": "@0xmaxma/claude-gateway",
      "current": "1.2.0",
      "latest": "1.3.1",
      "hasUpdate": true
    },
    {
      "package": "@anthropic-ai/claude-code",
      "current": "1.0.5",
      "latest": "1.1.0",
      "hasUpdate": true
    }
  ]
}
```

### Update claude-gateway

```bash
curl -X POST -H "X-Api-Key: <admin-key>" \
  http://localhost:10850/api/v1/packages/claude-gateway/update | jq
```

```json
{
  "package": "@0xmaxma/claude-gateway",
  "from": "1.2.0",
  "to": "1.3.1",
  "updated": true,
  "warning": "service will restart"
}
```

### Update claude-code

```bash
curl -X POST -H "X-Api-Key: <admin-key>" \
  http://localhost:10850/api/v1/packages/claude-code/update | jq
```

```json
{
  "package": "@anthropic-ai/claude-code",
  "from": "1.0.5",
  "to": "1.1.0",
  "updated": true,
  "warning": null
}
```

### Already on latest

```json
{
  "package": "@0xmaxma/claude-gateway",
  "from": "1.3.1",
  "to": "1.3.1",
  "updated": false,
  "warning": null
}
```

## Tests

15 unit tests covering all cases (auth, cache, update flow, error paths). All 1059 tests pass.

## Note

`provision.sh` in the getpod repo also needs `Restart=on-failure` → `Restart=always` for the systemd service — that change is out of scope for this repo.

Closes planning-54-package-update-api.md + planning-54.1-package-update-fixes.md