### PR TITLE
fix: auto-migrate config.json on startup without user prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ When the config schema changes (new fields added in `config.template.json`), the
 
 - Preserves all existing values
 - Adds missing fields with defaults from the template
-- Prompts for confirmation before writing (use `--auto-migrate` to skip)
+- Migrates automatically on startup (no confirmation needed)
 - Tracks schema version for future migrations
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ import * as os from 'os';
   }
 })();
 
-import * as readline from 'readline';
 import { loadConfig } from './config/loader';
 import { detectMigration, applyMigration, loadCleanTemplate } from './config/migrator';
 import { loadWorkspace, watchWorkspace, migrateWorkspaceFiles } from './agent/workspace-loader';
@@ -341,45 +340,20 @@ async function main(): Promise<void> {
   try {
     const detection = detectMigration(CONFIG_PATH, templatePath, templateVersion);
     if (detection.needed) {
-      let shouldMigrate = false;
-
-      if (args['auto-migrate']) {
-        shouldMigrate = true;
-      } else {
-        // Prompt user for confirmation
-        const rl = readline.createInterface({
-          input: process.stdin,
-          output: process.stdout,
-        });
-        const answer = await new Promise<string>((resolve) => {
-          rl.question(
-            `[gateway] Config migration available (v${detection.fromVersion} -> v${detection.toVersion}). Migrate config? (y/n) [y]: `,
-            (ans) => {
-              rl.close();
-              resolve(ans.trim().toLowerCase());
-            },
-          );
-        });
-        shouldMigrate = answer === '' || answer === 'y' || answer === 'yes';
-      }
-
-      if (shouldMigrate) {
-        const { ignorePaths, removePaths } = loadCleanTemplate(templatePath);
-        const migration = applyMigration(
-          CONFIG_PATH,
-          detection.config,
-          detection.template,
-          templateVersion,
-          ignorePaths,
-          removePaths,
-        );
-        const parts = [`migrated to v${templateVersion}`];
-        if (migration.addedFields.length) parts.push(`added: ${migration.addedFields.join(', ')}`);
-        if (migration.removedFields.length) parts.push(`removed: ${migration.removedFields.join(', ')}`);
-        console.log(`[gateway] Config ${parts.join(', ')}.`);
-      } else {
-        console.warn(`[gateway] Config migration skipped by user. Running with current config.`);
-      }
+      console.log(`[gateway] Config migration available (v${detection.fromVersion} -> v${detection.toVersion}). Auto-migrating...`);
+      const { ignorePaths, removePaths } = loadCleanTemplate(templatePath);
+      const migration = applyMigration(
+        CONFIG_PATH,
+        detection.config,
+        detection.template,
+        templateVersion,
+        ignorePaths,
+        removePaths,
+      );
+      const parts = [`migrated to v${templateVersion}`];
+      if (migration.addedFields.length) parts.push(`added: ${migration.addedFields.join(', ')}`);
+      if (migration.removedFields.length) parts.push(`removed: ${migration.removedFields.join(', ')}`);
+      console.log(`[gateway] Config ${parts.join(', ')}.`);
     }
   } catch (err) {
     console.warn(`[gateway] Config migration skipped: ${(err as Error).message}`);

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -692,4 +692,76 @@ describe('config-migrator', () => {
       expect((agents[0].telegram as Record<string, unknown>).allowedUsers).toEqual([1]);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // auto-migration flow (simulates gateway startup behaviour)
+  // ---------------------------------------------------------------------------
+  describe('auto-migration flow', () => {
+    it('migrates automatically when version mismatch detected', () => {
+      const config = { configVersion: '1.0.0', gateway: { port: 3000 }, agents: [] };
+      const template = {
+        configVersion: '1.1.0',
+        _migration: { ignorePaths: [], removePaths: [] },
+        gateway: { port: 3000, newField: 'default' },
+        agents: [],
+      };
+      const configPath = writeJson('config.json', config);
+      const templatePath = writeJson('config.template.json', template);
+
+      const detection = detectMigration(configPath, templatePath, '1.1.0');
+      expect(detection.needed).toBe(true);
+
+      // simulate gateway auto-migrate (no prompt)
+      const { ignorePaths, removePaths } = loadCleanTemplate(templatePath);
+      const migration = applyMigration(
+        configPath,
+        detection.config,
+        detection.template,
+        '1.1.0',
+        ignorePaths,
+        removePaths,
+      );
+
+      expect(migration.addedFields).toContain('gateway.newField');
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(written.configVersion).toBe('1.1.0');
+      expect(written.gateway.newField).toBe('default');
+      expect(written.gateway.port).toBe(3000); // existing value preserved
+    });
+
+    it('does not migrate when versions match', () => {
+      const config = { configVersion: '1.1.0', gateway: { port: 3000 }, agents: [] };
+      const template = {
+        configVersion: '1.1.0',
+        _migration: { ignorePaths: [], removePaths: [] },
+        gateway: { port: 3000 },
+        agents: [],
+      };
+      const configPath = writeJson('config.json', config);
+      const templatePath = writeJson('config.template.json', template);
+
+      const detection = detectMigration(configPath, templatePath, '1.1.0');
+      expect(detection.needed).toBe(false);
+    });
+
+    it('creates a .bak backup before writing', () => {
+      const config = { configVersion: '1.0.0', gateway: {}, agents: [] };
+      const template = {
+        configVersion: '1.1.0',
+        _migration: { ignorePaths: [], removePaths: [] },
+        gateway: { newField: 'x' },
+        agents: [],
+      };
+      const configPath = writeJson('config.json', config);
+      const templatePath = writeJson('config.template.json', template);
+
+      const detection = detectMigration(configPath, templatePath, '1.1.0');
+      const { ignorePaths, removePaths } = loadCleanTemplate(templatePath);
+      applyMigration(configPath, detection.config, detection.template, '1.1.0', ignorePaths, removePaths);
+
+      expect(fs.existsSync(`${configPath}.bak`)).toBe(true);
+      const bak = JSON.parse(fs.readFileSync(`${configPath}.bak`, 'utf-8'));
+      expect(bak.configVersion).toBe('1.0.0'); // backup has original
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Remove readline confirmation prompt for config migration
- Remove `--auto-migrate` CLI flag (no longer needed)
- Migration now runs automatically when version mismatch is detected

## Why

Running in pm2 means there's no interactive terminal — the readline prompt would hang the process forever. Auto-migration is the correct default for unattended deployments.

## Behaviour

**Before:** Gateway prompts `Migrate config? (y/n) [y]:` and waits for user input (or requires `--auto-migrate` flag)

**After:** Gateway logs `Auto-migrating...` and proceeds immediately — no interaction needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)