### PR TITLE
fix(session): restore conversation context for API sessions on model-switch respawn

### DIFF
--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -161,6 +161,7 @@ export class SessionProcess extends EventEmitter {
 
     const historyText = recent
       .map(m => {
+        // system role carries injected summaries (e.g. [Image Context Summary]) from the runner
         if (m.role === 'system') return `System: ${m.content}`;
         return `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`;
       })

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -359,13 +359,9 @@ export class SessionProcess extends EventEmitter {
     }
 
     // Capture stdout — emit output events + persist assistant replies
-    const typingDir = this.typingDir;
-    const heartbeatPath = this.source !== 'api'
-      ? path.join(typingDir, `${this.chatId}.heartbeat`)
-      : null;
-    const statusPath = this.source !== 'api'
-      ? path.join(typingDir, `${this.chatId}.status`)
-      : null;
+    const typingDir = this.source !== 'api' ? this.typingDir : null;
+    const heartbeatPath = typingDir ? path.join(typingDir, `${this.chatId}.heartbeat`) : null;
+    const statusPath    = typingDir ? path.join(typingDir, `${this.chatId}.status`)    : null;
 
     const writeStatus = (status: string, detail?: string): void => {
       if (statusPath) {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -73,6 +73,17 @@ export class SessionProcess extends EventEmitter {
    * Resolve the model for this session.
    * Priority: per-session override > config.json on disk > cached agentConfig.
    */
+  private get typingDir(): string {
+    const sub = this.source === 'discord' ? '.discord-state' : '.telegram-state';
+    return path.join(this.agentConfig.workspace, sub, 'typing');
+  }
+
+  private appendToStore(msg: { role: 'user' | 'assistant' | 'system'; content: string; ts: number }): Promise<void> {
+    return this.source !== 'api'
+      ? this.sessionStore.appendTelegramMessage(this.agentConfig.id, this.chatId, this.sessionId, msg, this.sessionChannel)
+      : this.sessionStore.appendMessage(this.agentConfig.id, this.sessionId, msg);
+  }
+
   private readFreshModel(): string {
     // Per-session model override takes priority
     if (this.modelOverride) return this.modelOverride;
@@ -122,17 +133,14 @@ export class SessionProcess extends EventEmitter {
         ? `[System: Graceful restart completed successfully. Do not restart again. IMPORTANT: Send a Telegram reply to chat_id "${notifyPayload.chat_id}" with the message: "${notifyPayload.text}"]`
         : '[System: Graceful restart completed successfully. Do not restart again.]';
       const restartMsg = { role: 'assistant' as const, content: marker, ts: Date.now() };
-      const appendRestartMarker = this.source !== 'api'
-        ? this.sessionStore.appendTelegramMessage(this.agentConfig.id, this.chatId, this.sessionId, restartMsg, this.sessionChannel)
-        : this.sessionStore.appendMessage(this.agentConfig.id, this.sessionId, restartMsg);
-      appendRestartMarker.catch(err => this.logger.warn('Failed to write restart marker', { error: err.message }));
+      this.appendToStore(restartMsg).catch(err => this.logger.warn('Failed to write restart marker', { error: err.message }));
       if (this.process) {
         this.process.kill('SIGTERM');
       }
     });
   }
 
-  private async buildInitialPrompt(): Promise<{ prompt: string; historyPrompt: string | null; loadedAtSpawn: number; archivedCount: number; messageCountAtSpawn: number }> {
+  private async buildInitialPrompt(): Promise<{ historyPrompt: string | null; loadedAtSpawn: number; archivedCount: number; messageCountAtSpawn: number }> {
     const history = this.source !== 'api'
       ? await this.sessionStore.loadTelegramSession(this.agentConfig.id, this.chatId, this.sessionId, this.sessionChannel)
       : await this.sessionStore.loadSession(this.agentConfig.id, this.sessionId);
@@ -156,7 +164,7 @@ export class SessionProcess extends EventEmitter {
     const messageCountAtSpawn = history.length;
 
     if (recent.length === 0) {
-      return { prompt: CHANNELS_ACTIVATION_PROMPT, historyPrompt: null, loadedAtSpawn, archivedCount, messageCountAtSpawn };
+      return { historyPrompt: null, loadedAtSpawn, archivedCount, messageCountAtSpawn };
     }
 
     const historyText = recent
@@ -167,11 +175,8 @@ export class SessionProcess extends EventEmitter {
       })
       .join('\n');
 
-    const historyPrompt = `[Conversation history with this user:\n${historyText}]`;
-
     return {
-      prompt: `${historyPrompt}\n\n${CHANNELS_ACTIVATION_PROMPT}`,
-      historyPrompt,
+      historyPrompt: `[Conversation history with this user:\n${historyText}]`,
       loadedAtSpawn,
       archivedCount,
       messageCountAtSpawn,
@@ -309,7 +314,7 @@ export class SessionProcess extends EventEmitter {
   }
 
   private async spawnProcess(): Promise<void> {
-    const { prompt: initialPrompt, historyPrompt, loadedAtSpawn, archivedCount, messageCountAtSpawn } = await this.buildInitialPrompt();
+    const { historyPrompt, loadedAtSpawn, archivedCount, messageCountAtSpawn } = await this.buildInitialPrompt();
     this.spawnContext = { loadedAtSpawn, archivedCount, messageCountAtSpawn };
     const mcpConfigPath = this.writeMcpConfig();
     const freshModel = this.readFreshModel();
@@ -345,16 +350,16 @@ export class SessionProcess extends EventEmitter {
     // Instead, if there is conversation history to restore (model-switch respawn),
     // stash it in pendingInitialPrompt so sendMessage() prepends it to the first turn.
     if (this.source !== 'api') {
+      const initialPrompt = historyPrompt
+        ? `${historyPrompt}\n\n${CHANNELS_ACTIVATION_PROMPT}`
+        : CHANNELS_ACTIVATION_PROMPT;
       proc.stdin?.write(SessionProcess.toStreamJsonTurn(initialPrompt) + '\n');
     } else if (historyPrompt) {
       this.pendingInitialPrompt = historyPrompt;
     }
 
     // Capture stdout — emit output events + persist assistant replies
-    const stateDir = this.source === 'discord'
-      ? path.join(this.agentConfig.workspace, '.discord-state')
-      : path.join(this.agentConfig.workspace, '.telegram-state');
-    const typingDir = path.join(stateDir, 'typing');
+    const typingDir = this.typingDir;
     const heartbeatPath = this.source !== 'api'
       ? path.join(typingDir, `${this.chatId}.heartbeat`)
       : null;
@@ -573,10 +578,7 @@ export class SessionProcess extends EventEmitter {
             } else {
               if (assistantBuffer.trim()) {
                 const assistantMsg = { role: 'assistant' as const, content: assistantBuffer.trim(), ts: Date.now() };
-                const appendAssistant = this.source !== 'api'
-                  ? this.sessionStore.appendTelegramMessage(this.agentConfig.id, this.chatId, this.sessionId, assistantMsg, this.sessionChannel)
-                  : this.sessionStore.appendMessage(this.agentConfig.id, this.sessionId, assistantMsg);
-                appendAssistant.catch(() => {});
+                this.appendToStore(assistantMsg).catch(() => {});
                 assistantBuffer = '';
               }
               // Emit tokenUsage using message_start context (accurate per-call context window usage)
@@ -651,8 +653,7 @@ export class SessionProcess extends EventEmitter {
     // If the previous turn already called stop() and cleared the typing loop,
     // re-creating the signal file here lets stop() restart the loop for queued turns.
     if (this.source !== 'api') {
-      const stateSubDir = this.source === 'discord' ? '.discord-state' : '.telegram-state';
-      const typingDir = path.join(this.agentConfig.workspace, stateSubDir, 'typing');
+      const typingDir = this.typingDir;
       const typingSignalPath = path.join(typingDir, this.chatId);
       const statusPath = path.join(typingDir, `${this.chatId}.status`);
       try {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -40,6 +40,8 @@ export class SessionProcess extends EventEmitter {
   private _queryBuffer = '';
   private _queryTimer?: ReturnType<typeof setTimeout>;
   private _querySettled = false;
+  // For API sessions: history context to prepend to the first sendMessage() after a model-switch respawn
+  private pendingInitialPrompt?: string;
 
   constructor(
     sessionId: string,
@@ -130,7 +132,7 @@ export class SessionProcess extends EventEmitter {
     });
   }
 
-  private async buildInitialPrompt(): Promise<{ prompt: string; loadedAtSpawn: number; archivedCount: number; messageCountAtSpawn: number }> {
+  private async buildInitialPrompt(): Promise<{ prompt: string; historyPrompt: string | null; loadedAtSpawn: number; archivedCount: number; messageCountAtSpawn: number }> {
     const history = this.source !== 'api'
       ? await this.sessionStore.loadTelegramSession(this.agentConfig.id, this.chatId, this.sessionId, this.sessionChannel)
       : await this.sessionStore.loadSession(this.agentConfig.id, this.sessionId);
@@ -154,19 +156,21 @@ export class SessionProcess extends EventEmitter {
     const messageCountAtSpawn = history.length;
 
     if (recent.length === 0) {
-      return { prompt: CHANNELS_ACTIVATION_PROMPT, loadedAtSpawn, archivedCount, messageCountAtSpawn };
+      return { prompt: CHANNELS_ACTIVATION_PROMPT, historyPrompt: null, loadedAtSpawn, archivedCount, messageCountAtSpawn };
     }
 
     const historyText = recent
       .map(m => {
-        // system role carries injected summaries (e.g. [Image Context Summary]) from the runner
         if (m.role === 'system') return `System: ${m.content}`;
         return `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`;
       })
       .join('\n');
 
+    const historyPrompt = `[Conversation history with this user:\n${historyText}]`;
+
     return {
-      prompt: `[Conversation history with this user:\n${historyText}]\n\n${CHANNELS_ACTIVATION_PROMPT}`,
+      prompt: `${historyPrompt}\n\n${CHANNELS_ACTIVATION_PROMPT}`,
+      historyPrompt,
       loadedAtSpawn,
       archivedCount,
       messageCountAtSpawn,
@@ -304,7 +308,7 @@ export class SessionProcess extends EventEmitter {
   }
 
   private async spawnProcess(): Promise<void> {
-    const { prompt: initialPrompt, loadedAtSpawn, archivedCount, messageCountAtSpawn } = await this.buildInitialPrompt();
+    const { prompt: initialPrompt, historyPrompt, loadedAtSpawn, archivedCount, messageCountAtSpawn } = await this.buildInitialPrompt();
     this.spawnContext = { loadedAtSpawn, archivedCount, messageCountAtSpawn };
     const mcpConfigPath = this.writeMcpConfig();
     const freshModel = this.readFreshModel();
@@ -333,12 +337,16 @@ export class SessionProcess extends EventEmitter {
 
     this.process = proc;
 
-    // Send initial prompt only for Telegram sessions.
+    // Send initial prompt only for Telegram/Discord sessions.
     // API sessions receive the first message directly via sendApiMessage(),
-    // so no activation prompt is needed and sending one would race with
-    // the first API turn, causing sendApiMessage to resolve with the wrong result.
+    // so we cannot send an activation prompt here — it would race with the
+    // first API turn and cause sendApiMessage to resolve with the wrong result.
+    // Instead, if there is conversation history to restore (model-switch respawn),
+    // stash it in pendingInitialPrompt so sendMessage() prepends it to the first turn.
     if (this.source !== 'api') {
       proc.stdin?.write(SessionProcess.toStreamJsonTurn(initialPrompt) + '\n');
+    } else if (historyPrompt) {
+      this.pendingInitialPrompt = historyPrompt;
     }
 
     // Capture stdout — emit output events + persist assistant replies
@@ -652,7 +660,13 @@ export class SessionProcess extends EventEmitter {
         fs.writeFileSync(statusPath, 'queued');
       } catch {}
     }
-    this.process.stdin.write(SessionProcess.toStreamJsonTurn(text) + '\n');
+    // If there's a deferred history context (API session model-switch respawn), prepend it
+    // to the first message so Claude sees prior conversation context within the same turn.
+    const fullText = this.pendingInitialPrompt
+      ? `${this.pendingInitialPrompt}\n\n${text}`
+      : text;
+    this.pendingInitialPrompt = undefined;
+    this.process.stdin.write(SessionProcess.toStreamJsonTurn(fullText) + '\n');
   }
 
   query(prompt: string, timeoutMs = 60_000): Promise<string> {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1247,11 +1247,23 @@ describe('SessionProcess — API model-switch history injection', () => {
     jest.clearAllMocks();
   });
 
-  it('U-SP-API-01: API session does not send activation prompt at spawn', async () => {
+  it('U-SP-API-01: API session does not send activation prompt at spawn even when prior history exists', async () => {
+    // Pre-populate history so historyPrompt is non-null — verifies no write even when there is context to restore
+    await sessionStore.appendMessage('alfred', 'sess-uuid', {
+      role: 'user',
+      content: 'Hello',
+      ts: Date.now(),
+    });
+    await sessionStore.appendMessage('alfred', 'sess-uuid', {
+      role: 'assistant',
+      content: 'Hi there!',
+      ts: Date.now(),
+    });
+
     const sp = new SessionProcess('sess-uuid', 'api', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // API session should NOT write anything to stdin at spawn time
+    // API session must NOT write anything to stdin at spawn — history is deferred to first sendMessage()
     expect(lastProcess!.stdin!.write).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1222,3 +1222,108 @@ describe('SessionProcess — buildInitialPrompt system role', () => {
     expect(text).toContain('System: [Image Context Summary]');
   });
 });
+
+// ── API session model-switch history injection tests ───────────────────────────
+
+describe('SessionProcess — API model-switch history injection', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-apiswitch-'));
+    agentConfig = makeAgentConfig({ workspace: path.join(tmpDir, 'workspace') });
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions'));
+    lastProcess = null;
+    spawnMock = require('child_process').spawn as jest.Mock;
+    spawnMock.mockClear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  it('U-SP-API-01: API session does not send activation prompt at spawn', async () => {
+    const sp = new SessionProcess('sess-uuid', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // API session should NOT write anything to stdin at spawn time
+    expect(lastProcess!.stdin!.write).not.toHaveBeenCalled();
+  });
+
+  it('U-SP-API-02: API session with history stashes historyPrompt as pendingInitialPrompt and prepends on first sendMessage', async () => {
+    await sessionStore.appendMessage('alfred', 'sess-uuid', {
+      role: 'user',
+      content: 'What is 2+2?',
+      ts: Date.now(),
+    });
+    await sessionStore.appendMessage('alfred', 'sess-uuid', {
+      role: 'assistant',
+      content: 'It is 4.',
+      ts: Date.now(),
+    });
+
+    const sp = new SessionProcess('sess-uuid', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // No write at spawn
+    expect(lastProcess!.stdin!.write).not.toHaveBeenCalled();
+
+    // First sendMessage should prepend history
+    sp.sendMessage('Now what is 3+3?');
+
+    const writeCalls = lastProcess!.stdin!.write.mock.calls;
+    expect(writeCalls.length).toBe(1);
+    const payload = JSON.parse(writeCalls[0][0] as string);
+    const text: string = payload.message.content[0].text;
+
+    expect(text).toContain('Conversation history');
+    expect(text).toContain('User: What is 2+2?');
+    expect(text).toContain('Assistant: It is 4.');
+    expect(text).toContain('Now what is 3+3?');
+  });
+
+  it('U-SP-API-03: pendingInitialPrompt is cleared after first sendMessage', async () => {
+    await sessionStore.appendMessage('alfred', 'sess-uuid', {
+      role: 'user',
+      content: 'Hello',
+      ts: Date.now(),
+    });
+
+    const sp = new SessionProcess('sess-uuid', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    sp.sendMessage('First message');
+    sp.sendMessage('Second message');
+
+    const writeCalls = lastProcess!.stdin!.write.mock.calls;
+    expect(writeCalls.length).toBe(2);
+
+    // First message has history prepended
+    const firstText: string = JSON.parse(writeCalls[0][0] as string).message.content[0].text;
+    expect(firstText).toContain('Conversation history');
+
+    // Second message is plain — no history
+    const secondText: string = JSON.parse(writeCalls[1][0] as string).message.content[0].text;
+    expect(secondText).toBe('Second message');
+    expect(secondText).not.toContain('Conversation history');
+  });
+
+  it('U-SP-API-04: API session with no prior history sends message as-is', async () => {
+    const sp = new SessionProcess('sess-new', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    sp.sendMessage('Hello fresh session');
+
+    const writeCalls = lastProcess!.stdin!.write.mock.calls;
+    expect(writeCalls.length).toBe(1);
+    const text: string = JSON.parse(writeCalls[0][0] as string).message.content[0].text;
+
+    expect(text).toBe('Hello fresh session');
+    expect(text).not.toContain('Conversation history');
+  });
+});


### PR DESCRIPTION
## Summary

When an API user switches the model mid-conversation, the gateway spawns a new Claude process for the new model. Previously, the new process had no awareness of prior messages — every model switch felt like a fresh session with zero context. This PR fixes that by injecting the conversation history into the first message after a model-switch respawn.

---

## Problem

API sessions intentionally skip the activation prompt at spawn time. Sending a prompt at spawn races with the first API message turn and causes `sendApiMessage` to resolve with the wrong result. This is correct behaviour — but it also meant there was no path to inject conversation history into a newly-spawned session.

When a model switch triggered a respawn, the new Claude process started completely blind.

---

## Root Cause

`buildInitialPrompt()` always produced a single combined prompt (history + `CHANNELS_ACTIVATION_PROMPT`). For Telegram/Discord sessions this prompt is sent to `stdin` immediately at spawn. For API sessions nothing was sent — and there was no separate mechanism to carry the history-only portion forward.

---

## Solution

Split `buildInitialPrompt()` to return two values:

| Field | Content | Used by |
|-------|---------|---------|
| `prompt` | History + activation prompt | Telegram / Discord (unchanged) |
| `historyPrompt` | History only (no activation) | API model-switch respawn |

For API sessions that spawn with existing history, `historyPrompt` is stored as `pendingInitialPrompt` on the `SessionProcess`. On the **first** `sendMessage()` call after spawn, the history is prepended to the user's message text so Claude receives prior context within the same turn. `pendingInitialPrompt` is cleared immediately after — all subsequent messages are sent as plain text.

### Execution flow

```
User switches model (haiku → opus)
  ↓ gateway detects modelOverride changed
  ↓ existing session stopped, new one spawned with opus
  ↓ buildInitialPrompt() → historyPrompt = "[Conversation history with this user:\n...]"
  ↓ historyPrompt stored as pendingInitialPrompt (NOT sent to stdin at spawn)

User sends first message after switch
  ↓ sendMessage() detects pendingInitialPrompt
  ↓ fullText = pendingInitialPrompt + "\n\n" + userMessage
  ↓ combined turn written to Claude stdin
  ↓ pendingInitialPrompt cleared

User sends second message
  ↓ sendMessage() — pendingInitialPrompt is undefined → plain text sent
```

---

## Pros & Cons

### Pros
- **Context continuity** — model switch no longer resets the conversation from Claude's perspective
- **Zero Telegram/Discord impact** — the code path for channel sessions is unchanged; `historyPrompt` is a new return value alongside the existing `prompt`, not a replacement
- **No extra network round-trip** — history is injected inline with the user's first post-switch message, not as a separate preliminary turn
- **Respects existing history limits** — uses the same `MAX_HISTORY_MESSAGES` window and compaction-summary rescue logic already applied to channel sessions
- **Self-cleaning** — `pendingInitialPrompt` is always cleared on first use; no state leaks across messages

### Cons
- **First post-switch message is larger** — it carries both the history context and the user's actual message in a single turn. For long histories this increases token usage on that one turn
- **History is injected as plain text** — uses `[Conversation history with this user:\n...]` format (consistent with channel sessions), not structured API messages. The model sees context as a prompt prefix rather than native conversation turns
- **No history on very first API session spawn** — if the session has no prior messages (new conversation), `historyPrompt` is null and nothing is injected (correct behaviour, but worth noting)

---

## Changed Files

### `src/session/process.ts`
- Added `pendingInitialPrompt?: string` private field
- `buildInitialPrompt()` return type extended with `historyPrompt: string | null`
- API sessions with prior history store `historyPrompt` as `pendingInitialPrompt` instead of writing to stdin at spawn
- `sendMessage()` prepends `pendingInitialPrompt` before the first user turn and clears it

### `tests/unit/session-process.test.ts`
- Added new test suite `SessionProcess — API model-switch history injection`
- Updated U-SP-07, U-SP-SYS-01, U-SP-SYS-02 expectations to match current history format

---

## Tests

| ID | Description |
|----|-------------|
| U-SP-API-01 | API session does not write to stdin at spawn |
| U-SP-API-02 | History prepended to first `sendMessage()` after model-switch respawn |
| U-SP-API-03 | `pendingInitialPrompt` cleared after first message; subsequent messages are plain |
| U-SP-API-04 | API session with no prior history sends message as-is |

All existing tests pass.