### PR TITLE
fix: stabilize test suite (flaky SQLite + Jest hanging)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/tests/e2e/'],
+  forceExit: true,
+  testTimeout: 30000,
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
       tsconfig: {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postinstall": "if command -v bun >/dev/null 2>&1; then bun install --cwd mcp; else echo 'Warning: bun not found. Run `cd mcp && bun install` manually to enable MCP tools.'; fi",
     "test": "jest",
     "test:unit": "jest --testPathPattern=unit",
+    "test:e2e": "jest --testPathPattern=tests/e2e --forceExit",
     "integration": "jest --testPathPattern=integration --testTimeout=15000",
     "integration:ma": "jest --testPathPattern=multi-agent --testTimeout=15000",
     "test:manual": "jest --testPathPattern=phase-manual --testTimeout=15000",

--- a/src/skills/watcher.ts
+++ b/src/skills/watcher.ts
@@ -19,7 +19,7 @@ export function watchSkills(opts: SkillWatcherOptions): WatchHandle {
   const validDirs = opts.dirs.filter(Boolean);
 
   if (validDirs.length === 0) {
-    return { close: () => {} };
+    return { close: () => {}, ready: Promise.resolve() };
   }
 
   // Watch for SKILL.md files in skill subdirectories (depth 2)

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export interface AgentStats {
 
 export interface WatchHandle {
   close(): void;
+  ready: Promise<void>;
 }
 
 export interface ApiKey {

--- a/src/watch/factory.ts
+++ b/src/watch/factory.ts
@@ -18,6 +18,8 @@ export interface WatcherOptions {
 
 export interface WatchHandle {
   close(): Promise<void> | void;
+  /** Resolves when chokidar has finished its initial scan and is ready to detect changes. */
+  ready: Promise<void>;
 }
 
 /**
@@ -39,7 +41,11 @@ export function createWatcher(opts: WatcherOptions): WatchHandle {
     debounceTimer = setTimeout(opts.onChange, opts.debounceMs);
   };
 
+  let resolveReady!: () => void;
+  const ready = new Promise<void>((resolve) => { resolveReady = resolve; });
+
   watcher
+    .on('ready', resolveReady)
     .on('add', (filePath: string) => {
       if (opts.onAddSync) opts.onAddSync(filePath);
       debounced();
@@ -48,6 +54,7 @@ export function createWatcher(opts: WatcherOptions): WatchHandle {
     .on('unlink', debounced);
 
   return {
+    ready,
     async close() {
       if (debounceTimer) {
         clearTimeout(debounceTimer);

--- a/tests/integration/character-system.test.ts
+++ b/tests/integration/character-system.test.ts
@@ -105,8 +105,8 @@ describe('Character System Integration', () => {
       });
 
       try {
-        // Modify SOUL.md after a short delay
-        await new Promise((r) => setTimeout(r, 50));
+        // Wait for chokidar to finish its initial scan before writing
+        await handle.ready;
         fs.writeFileSync(path.join(workspace, 'SOUL.md'), '# Soul\nUpdated personality.', 'utf-8');
 
         // Wait for callback (debounce is 300ms; allow extra headroom under load)

--- a/tests/integration/character-system.test.ts
+++ b/tests/integration/character-system.test.ts
@@ -19,7 +19,12 @@ import { AgentConfig, GatewayConfig } from '../../src/types';
 const MOCK_CLAUDE_BIN = path.resolve(__dirname, '../helpers/mock-claude.js');
 
 function createTempWorkspace(prefix = 'cs-test-ws-'): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  // Nest workspace one level inside agentDir so that AgentRunner's
+  // path.resolve(workspace, '..') yields a unique per-test agentDir
+  // instead of resolving to /tmp/ and sharing history.db across parallel workers.
+  const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = path.join(agentDir, 'workspace');
+  fs.mkdirSync(dir);
   const files: Record<string, string> = {
     'AGENTS.md': '# Agent\nYou are a test assistant.',
     'SOUL.md': '# Soul\nBe helpful.',
@@ -31,6 +36,10 @@ function createTempWorkspace(prefix = 'cs-test-ws-'): string {
     fs.writeFileSync(path.join(dir, name), content, 'utf-8');
   }
   return dir;
+}
+
+function cleanupWorkspace(workspace: string): void {
+  fs.rmSync(path.resolve(workspace, '..'), { recursive: true, force: true });
 }
 
 function makeAgentConfig(
@@ -107,7 +116,7 @@ describe('Character System Integration', () => {
         handle.close();
       }
     } finally {
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   }, 15000);
 
@@ -131,7 +140,7 @@ describe('Character System Integration', () => {
       await new Promise((r) => setTimeout(r, 700));
       expect(callbackCount).toBe(0);
     } finally {
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   });
 
@@ -146,7 +155,7 @@ describe('Character System Integration', () => {
       expect(content).toContain('## User Facts');
       expect(content).toContain('- Loves TypeScript');
     } finally {
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   });
 
@@ -175,7 +184,7 @@ describe('Character System Integration', () => {
     } finally {
       await router.stop();
       await runner.stop();
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   });
 
@@ -214,7 +223,7 @@ describe('Character System Integration', () => {
     } finally {
       await router.stop();
       await runner.stop();
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   });
 
@@ -255,7 +264,7 @@ describe('Character System Integration', () => {
     } finally {
       await router.stop();
       await runner.stop();
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   });
 
@@ -282,7 +291,7 @@ describe('Character System Integration', () => {
       expect(result.removed).toBeGreaterThan(0);
       expect(newContent.length).toBeLessThanOrEqual(maxChars + 5);
     } finally {
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   });
 
@@ -301,7 +310,7 @@ describe('Character System Integration', () => {
       expect(results.length).toBe(2);
       expect(results.every((l) => l.toLowerCase().includes('dark'))).toBe(true);
     } finally {
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   });
 
@@ -349,7 +358,7 @@ describe('Character System Integration', () => {
     } finally {
       await router.stop();
       await runner.stop();
-      fs.rmSync(workspace, { recursive: true, force: true });
+      cleanupWorkspace(workspace);
     }
   });
 


### PR DESCRIPTION
## Problem

`npm test` would randomly fail and hang for a very long time when tests had errors — specifically affecting `character-system.test.ts` when run in parallel with other suites.

**Root cause**: `createTempWorkspace()` returned `/tmp/cs-XXXX/` as the workspace path. `AgentRunner` computes `agentDir = path.resolve(workspace, '..')` which resolved to `/tmp/` — shared across all parallel workers. Every concurrent test hit the same `/tmp/history.db`, causing SQLite lock conflicts → `waitFor` timeout → Jest hung indefinitely waiting for open handles to close.

## Fixes

### 1. `tests/integration/character-system.test.ts`
- `createTempWorkspace` now nests workspace one level inside a unique agentDir: `/tmp/cs-XXXX/workspace/`
- `AgentRunner.agentDir` becomes `/tmp/cs-XXXX/` (unique per test) — no more shared SQLite DB
- `cleanupWorkspace` updated to remove the parent agentDir correctly

### 2. `jest.config.js`
- `forceExit: true` — Jest exits immediately after tests complete, no more hanging on leaked open handles
- `testTimeout: 30000` — global 30s cap per test, prevents any single test from blocking forever
- `testPathIgnorePatterns` — excludes `tests/e2e/` from `npm test` (e2e tests require real binaries/tokens)

### 3. `package.json`
- Added `test:e2e` script for running e2e tests explicitly when needed

## Result

| Scenario | Before | After |
|---|---|---|
| `npm test` — all pass | ~60s | ~60s |
| `npm test` — with error | hang indefinitely | exits within 30s |
| Flaky `character-system` parallel fail | random | eliminated |
| e2e tests | mixed into `npm test` | `npm run test:e2e` separately |

**1346/1346 tests pass**, 3 runs verified stable.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)