### PR TITLE
fix: eliminate race condition in callback server port allocation

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -172,15 +172,6 @@ export class AgentRunner extends EventEmitter {
    * Each payload is routed to the appropriate SessionProcess by chat_id.
    */
   private async startCallbackServer(): Promise<void> {
-    this.callbackPort = await new Promise<number>((resolve, reject) => {
-      const srv = net.createServer();
-      srv.listen(0, '127.0.0.1', () => {
-        const addr = srv.address() as net.AddressInfo;
-        srv.close(() => resolve(addr.port));
-      });
-      srv.on('error', reject);
-    });
-
     this.callbackServer = http.createServer((req, res) => {
       if (req.method !== 'POST') {
         res.writeHead(405);
@@ -320,7 +311,14 @@ export class AgentRunner extends EventEmitter {
       });
     });
 
-    this.callbackServer.listen(this.callbackPort, '127.0.0.1');
+    // listen(0) lets the OS assign a free port atomically — no race window between allocate and bind
+    this.callbackPort = await new Promise<number>((resolve, reject) => {
+      const server = this.callbackServer!;
+      server.listen(0, '127.0.0.1', () => {
+        resolve((server.address() as import('net').AddressInfo).port);
+      });
+      server.on('error', reject);
+    });
     this.logger.info('Channel callback server listening', { port: this.callbackPort });
   }
 


### PR DESCRIPTION
## Summary

- **Bug**: `startCallbackServer()` allocated a port by opening a temporary server, closing it, then calling `listen()` on that port with the real HTTP server. The gap between close and listen allowed another agent process to claim the same port — causing messages for one agent to arrive at another agent's callback handler.
- **Fix**: Create the HTTP server first, then call `listen(0)` directly on it so the OS assigns an available port atomically with no release window.

## Root Cause

```typescript
// BEFORE (race condition):
const srv = net.createServer();
srv.listen(0, ...);         // get port
srv.close(() => resolve(port)); // ← PORT RELEASED HERE — another process can steal it
// ... create real server ...
this.callbackServer.listen(port); // ← may now be the wrong agent's port
```

```typescript
// AFTER (atomic):
this.callbackServer = http.createServer(handler);
// listen(0) binds atomically — port never released
this.callbackServer.listen(0, '127.0.0.1', () => {
  resolve((server.address() as AddressInfo).port);
});
```

## Test plan
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Start two agents simultaneously — verify each receives only its own messages
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)