### PR TITLE
fix: deleted API sessions reappear after gateway refetch

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1913,13 +1913,21 @@ export class AgentRunner extends EventEmitter {
 
   async updateApiSession(chatId: string, sessionId: string, updates: { sessionName?: string }): Promise<{ sessionId: string; sessionName?: string }> {
     if (updates.sessionName) {
-      await this.sessionStore.updateSessionMeta(this.agentConfig.id, `api-${chatId}`, sessionId, { name: updates.sessionName }, 'api');
+      const internalChatId = `api-${chatId}`;
+      // Ensure session exists in the file index (may be missing for older sessions stored only in SQLite)
+      await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatId, sessionId);
+      await this.sessionStore.updateSessionMeta(this.agentConfig.id, internalChatId, sessionId, { name: updates.sessionName }, 'api');
     }
     return { sessionId, ...(updates.sessionName ? { sessionName: updates.sessionName } : {}) };
   }
 
   async deleteApiSession(chatId: string, sessionId: string): Promise<void> {
-    await this.sessionStore.deleteTelegramSession(this.agentConfig.id, `api-${chatId}`, sessionId, 'api');
+    await this.sessionStore.deleteTelegramSession(this.agentConfig.id, `api-${chatId}`, sessionId, 'api').catch((err: unknown) => {
+      // If session is not in the file index (legacy session stored only in SQLite), treat as already deleted
+      const msg = (err as Error).message ?? '';
+      if (msg.includes('not found in index') || msg.includes('No session index found')) return;
+      throw err;
+    });
   }
 
   /**

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1928,6 +1928,8 @@ export class AgentRunner extends EventEmitter {
       if (msg.includes('not found in index') || msg.includes('No session index found')) return;
       throw err;
     });
+    // Also purge from SQLite so the session no longer appears in listSessions()
+    this.historyDb.clearSession(`api-${chatId}`, sessionId);
   }
 
   /**

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { AgentConfig, GatewayConfig, Logger, Message, ModelConfig, StreamEvent } from '../types';
 import { createLogger } from '../logger';
 import { SessionProcess } from '../session/process';
-import { SessionStore } from '../session/store';
+import { SessionStore, SessionNotInIndexError } from '../session/store';
 import { SessionCompactor } from '../session/compactor';
 import { TelegramReceiver } from '../telegram/receiver';
 import { DiscordReceiver } from '../discord/receiver';
@@ -1915,21 +1915,24 @@ export class AgentRunner extends EventEmitter {
     if (updates.sessionName) {
       const internalChatId = `api-${chatId}`;
       // Ensure session exists in the file index (may be missing for older sessions stored only in SQLite)
-      await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatId, sessionId);
+      await this.sessionStore.ensureApiSession(this.agentConfig.id, internalChatId, sessionId).catch((err: unknown) => {
+        this.logger.warn('Failed to register API session in index', { agentId: this.agentConfig.id, chatId, sessionId, error: (err as Error).message });
+      });
       await this.sessionStore.updateSessionMeta(this.agentConfig.id, internalChatId, sessionId, { name: updates.sessionName }, 'api');
     }
     return { sessionId, ...(updates.sessionName ? { sessionName: updates.sessionName } : {}) };
   }
 
   async deleteApiSession(chatId: string, sessionId: string): Promise<void> {
-    await this.sessionStore.deleteTelegramSession(this.agentConfig.id, `api-${chatId}`, sessionId, 'api').catch((err: unknown) => {
-      // If session is not in the file index (legacy session stored only in SQLite), treat as already deleted
-      const msg = (err as Error).message ?? '';
-      if (msg.includes('not found in index') || msg.includes('No session index found')) return;
+    const internalChatId = `api-${chatId}`;
+    await this.sessionStore.deleteTelegramSession(this.agentConfig.id, internalChatId, sessionId, 'api').catch((err: unknown) => {
+      // Legacy sessions (stored only in SQLite, no file index entry) are treated as already deleted
+      if (err instanceof SessionNotInIndexError) return;
       throw err;
     });
-    // Also purge from SQLite so the session no longer appears in listSessions()
-    this.historyDb.clearSession(`api-${chatId}`, sessionId);
+    // Purge from SQLite so the session no longer appears in listSessions()
+    const mediaPaths = this.historyDb.clearSession(internalChatId, sessionId);
+    MediaStore.deleteMediaFiles(this.agentsBaseDir, this.agentConfig.id, mediaPaths);
   }
 
   /**

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -4,6 +4,13 @@ import { randomUUID } from 'crypto';
 import PQueue from 'p-queue';
 import { Message, SessionIndex, SessionMeta } from '../types';
 
+export class SessionNotInIndexError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SessionNotInIndexError';
+  }
+}
+
 export class SessionStore {
   private readonly agentsBaseDir: string;
   private readonly queues = new Map<string, PQueue>();
@@ -355,7 +362,7 @@ export class SessionStore {
     await queue.add(async () => {
       const index = await this.loadIndex(agentId, chatId, channel);
       if (!index) {
-        throw new Error(`No session index found for chat ${chatId}`);
+        throw new SessionNotInIndexError(`No session index found for chat ${chatId}`);
       }
       if (index.sessions.length <= 1) {
         throw new Error(`Cannot delete the last session for chat ${chatId}`);
@@ -363,7 +370,7 @@ export class SessionStore {
 
       const sessionIdx = index.sessions.findIndex((s) => s.id === sessionId);
       if (sessionIdx === -1) {
-        throw new Error(`Session ${sessionId} not found in index for chat ${chatId}`);
+        throw new SessionNotInIndexError(`Session ${sessionId} not found in index for chat ${chatId}`);
       }
 
       // Remove from index

--- a/tests/integration/api-e2e.test.ts
+++ b/tests/integration/api-e2e.test.ts
@@ -15,6 +15,7 @@ import { AgentRunner } from '../../src/agent/runner';
 import { GatewayRouter } from '../../src/api/gateway-router';
 import { AgentConfig, GatewayConfig } from '../../src/types';
 import { SessionStore } from '../../src/session/store';
+import { HistoryDB } from '../../src/history/db';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -501,6 +502,110 @@ describe('Agent HTTP API integration (planning-05)', () => {
       .set('Authorization', `Bearer ${API_KEY_ADMIN}`);
 
     expect(res.status).toBe(404);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-DEL-01: Deleted session does not reappear in admin session list ────
+  it('I-DEL-01: Deleted API session is purged from SQLite and does not reappear', async () => {
+    const agentsBaseDir = createTempDir('del-01-agents-');
+    const ws = path.join(agentsBaseDir, 'alfred', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    for (const [name, content] of Object.entries({
+      'AGENTS.md': '# Agent\nYou are a test assistant.',
+      'SOUL.md': '# Soul\n', 'USER.md': '# User\n',
+      'HEARTBEAT.md': '# Heartbeat\n', 'MEMORY.md': '# Memory\n',
+    })) { fs.writeFileSync(path.join(ws, name), content, 'utf-8'); }
+
+    const logDir = createTempDir('del-01-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg: GatewayConfig = {
+      gateway: { logDir, timezone: 'UTC', api: { keys: [{ key: API_KEY_ADMIN, description: 'admin', agents: '*' }] } },
+      agents: [],
+    };
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const chatId = 'del-test-chat';
+    const sessionId = 'del-test-session-01';
+
+    // Seed a message directly into SQLite (simulates a session that sent messages)
+    const agentDir = path.join(agentsBaseDir, 'alfred');
+    const db = HistoryDB.forDir(agentDir, 'alfred');
+    db.insertMessage({ chatId: `api-${chatId}`, sessionId, source: 'api', role: 'user', content: 'hello', ts: Date.now() });
+
+    // Seed the session into the file index so DELETE can find it
+    const store = new SessionStore(agentsBaseDir);
+    await store.ensureApiSession('alfred', `api-${chatId}`, sessionId);
+
+    // DELETE the session
+    const deleteRes = await supertest(router.getApp())
+      .delete(`/api/v1/agents/alfred/sessions/${sessionId}?chat_id=${chatId}`)
+      .set('Authorization', `Bearer ${API_KEY_ADMIN}`);
+    expect(deleteRes.status).toBe(204);
+
+    // Session must no longer appear in SQLite (the source of reappearance)
+    const sessions = db.listSessions();
+    const stillPresent = sessions.some((s) => s.sessionId === sessionId);
+    expect(stillPresent).toBe(false);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-DEL-02: Legacy session (SQLite-only) deleted without error ──────────
+  it('I-DEL-02: Legacy session with no file index entry is deleted without error', async () => {
+    const agentsBaseDir = createTempDir('del-02-agents-');
+    const ws = path.join(agentsBaseDir, 'alfred', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    for (const [name, content] of Object.entries({
+      'AGENTS.md': '# Agent\nYou are a test assistant.',
+      'SOUL.md': '# Soul\n', 'USER.md': '# User\n',
+      'HEARTBEAT.md': '# Heartbeat\n', 'MEMORY.md': '# Memory\n',
+    })) { fs.writeFileSync(path.join(ws, name), content, 'utf-8'); }
+
+    const logDir = createTempDir('del-02-log-');
+    const cfg = makeAgentConfig('alfred', ws);
+    const gatewayCfg: GatewayConfig = {
+      gateway: { logDir, timezone: 'UTC', api: { keys: [{ key: API_KEY_ADMIN, description: 'admin', agents: '*' }] } },
+      agents: [],
+    };
+
+    const runner = new AgentRunner(cfg, gatewayCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+
+    const agents = new Map([['alfred', runner]]);
+    const configs = new Map([['alfred', cfg]]);
+    const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+    await router.start(0);
+
+    const chatId = 'legacy-chat';
+    const legacySessionId = 'legacy-session-no-index';
+
+    // Seed a message into SQLite WITHOUT creating a file index entry (legacy session)
+    const agentDir = path.join(agentsBaseDir, 'alfred');
+    const db = HistoryDB.forDir(agentDir, 'alfred');
+    db.insertMessage({ chatId: `api-${chatId}`, sessionId: legacySessionId, source: 'api', role: 'user', content: 'legacy msg', ts: Date.now() });
+
+    // DELETE a session that has no file index entry — must return 204, not 500
+    const deleteRes = await supertest(router.getApp())
+      .delete(`/api/v1/agents/alfred/sessions/${legacySessionId}?chat_id=${chatId}`)
+      .set('Authorization', `Bearer ${API_KEY_ADMIN}`);
+    expect(deleteRes.status).toBe(204);
+
+    // Session must also be gone from SQLite
+    const sessions = db.listSessions();
+    const stillPresent = sessions.some((s) => s.sessionId === legacySessionId);
+    expect(stillPresent).toBe(false);
 
     await router.stop();
     await runner.stop();


### PR DESCRIPTION
## Problem

When deleting an API session, the session was only removed from the file index (JSON), while messages remained in the SQLite history database. Since `listSessions()` reads from SQLite, deleted sessions kept reappearing on every refetch.

Additionally, sessions created before the file index was introduced (legacy sessions) would throw "not found in index" errors on rename or delete operations.

## Changes

- `deleteApiSession`: calls `historyDb.clearSession()` to purge messages from both storage layers (file index + SQLite)
- `deleteApiSession`: swallows "not found in index" errors for legacy sessions (session is effectively already gone)
- `updateApiSession`: calls `ensureApiSession` first to auto-register legacy sessions before attempting rename

## Test Plan

- [ ] Delete an API session via `DELETE /api/v1/agents/:agentId/sessions/:sessionId` — returns 204
- [ ] Confirm session does not reappear after `GET /api/v1/agents/:agentId/sessions` refetch
- [ ] Confirm legacy sessions (no file index entry) can be renamed and deleted without error