### PR TITLE
feat: expose tool input in SSE stream and extract shared tool-labels utility

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1686,6 +1686,7 @@ export class AgentRunner extends EventEmitter {
             type: 'tool_use',
             name: (obj['name'] as string) ?? '',
             id: (obj['id'] as string) ?? '',
+            input: (obj['input'] as Record<string, unknown>) ?? {},
           });
         }
 

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -7,6 +7,12 @@ import chokidar from 'chokidar';
 import { AgentConfig, GatewayConfig } from '../types';
 import { SessionStore } from './store';
 import { createLogger } from '../logger';
+import {
+  CODING_TOOLS as SHARED_CODING_TOOLS,
+  TOOL_LABELS as SHARED_TOOL_LABELS,
+  extractToolDetail,
+  truncateDetail,
+} from '../utils/tool-labels';
 
 const MAX_HISTORY_MESSAGES = 50;
 const AUTO_RESTART_DELAY_MS = 5_000;
@@ -372,99 +378,8 @@ export class SessionProcess extends EventEmitter {
       }
     };
 
-    const CODING_TOOLS = new Set(['Write', 'Edit', 'NotebookEdit', 'MultiEdit']);
-
-    const TOOL_LABELS: Record<string, { emoji: string; verb: string }> = {
-      Read:         { emoji: '📖', verb: 'Reading' },
-      Edit:         { emoji: '✏️', verb: 'Editing' },
-      Write:        { emoji: '📝', verb: 'Writing' },
-      MultiEdit:    { emoji: '❤️‍🔥', verb: 'Editing' },
-      NotebookEdit: { emoji: '📕', verb: 'Editing notebook' },
-      Grep:         { emoji: '🔦', verb: 'Searching for' },
-      Glob:         { emoji: '📂', verb: 'Finding files' },
-      Bash:         { emoji: '💻', verb: 'Running' },
-      WebFetch:     { emoji: '🌐', verb: 'Fetching' },
-      WebSearch:    { emoji: '🔎', verb: 'Searching' },
-      Agent:        { emoji: '🤖', verb: 'Running agent' },
-      Task:         { emoji: '👉', verb: 'Running task' },
-      TodoWrite:    { emoji: '📋', verb: 'Updating tasks' },
-    };
-
-    function shortenPath(p: string): string {
-      // Keep last 2 segments for context (e.g. "src/api-router.ts" not just "api-router.ts")
-      const parts = p.split('/');
-      return parts.length > 2 ? parts.slice(-2).join('/') : parts[parts.length - 1] || p;
-    }
-
-    function truncateDetail(s: string, maxLines = 5, maxChars = 300): string {
-      const lines = s.split('\n').filter(l => l.trim());
-      const trimmedByLines = lines.length > maxLines;
-      const kept = lines.slice(0, maxLines);
-      let result = kept.join('\n');
-      if (result.length > maxChars) {
-        result = result.slice(0, maxChars) + '...';
-      } else if (trimmedByLines) {
-        result += '\n...';
-      }
-      return result;
-    }
-
-    function extractToolDetail(name: string, input: Record<string, unknown>): string {
-      const label = TOOL_LABELS[name] ?? { emoji: '🔧', verb: name };
-      const { emoji, verb } = label;
-
-      // Build context parts based on tool type
-      switch (name) {
-        case 'Read':
-        case 'Edit':
-        case 'Write':
-        case 'MultiEdit':
-        case 'NotebookEdit': {
-          const file = typeof input.file_path === 'string' ? shortenPath(input.file_path) : '';
-          const desc = typeof input.description === 'string' ? ` — ${input.description}` : '';
-          return truncateDetail(`${emoji} ${verb}: ${file}${desc}`);
-        }
-        case 'Grep': {
-          const pattern = typeof input.pattern === 'string' ? `"${input.pattern}"` : '';
-          const path = typeof input.path === 'string' ? ` in ${shortenPath(input.path)}` : '';
-          return truncateDetail(`${emoji} ${verb}: ${pattern}${path}`);
-        }
-        case 'Glob': {
-          const pattern = typeof input.pattern === 'string' ? `"${input.pattern}"` : '';
-          return truncateDetail(`${emoji} ${verb}: ${pattern}`);
-        }
-        case 'Bash': {
-          const desc = typeof input.description === 'string' ? input.description : '';
-          const cmd = typeof input.command === 'string' ? input.command : '';
-          return truncateDetail(`${emoji} ${verb}: ${desc || cmd}`);
-        }
-        case 'WebFetch': {
-          const url = typeof input.url === 'string' ? input.url : '';
-          return truncateDetail(`${emoji} ${verb}: ${url}`);
-        }
-        case 'WebSearch': {
-          const query = typeof input.query === 'string' ? input.query : '';
-          return truncateDetail(`${emoji} ${verb}: "${query}"`);
-        }
-        case 'Agent':
-        case 'Task': {
-          const desc = typeof input.description === 'string' ? input.description : '';
-          const prompt = typeof input.prompt === 'string' ? input.prompt : '';
-          return truncateDetail(`${emoji} ${verb}: ${desc || prompt}`);
-        }
-        case 'TodoWrite': {
-          const todos = Array.isArray(input.todos) ? input.todos as { content?: string; status?: string }[] : [];
-          const active = todos.find(t => t.status === 'in_progress');
-          const detail = active?.content ?? `${todos.length} items`;
-          return truncateDetail(`${emoji} ${verb}: ${detail}`);
-        }
-        default: {
-          // Generic fallback: try description, then name
-          const desc = typeof input.description === 'string' ? input.description : '';
-          return truncateDetail(`${emoji} ${verb}: ${desc || '...'}`);
-        }
-      }
-    }
+    const CODING_TOOLS = SHARED_CODING_TOOLS;
+    const TOOL_LABELS = SHARED_TOOL_LABELS;
 
     let assistantBuffer = '';
     // Track partial message text to avoid double-counting when --include-partial-messages is active.

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -8,8 +8,8 @@ import { AgentConfig, GatewayConfig } from '../types';
 import { SessionStore } from './store';
 import { createLogger } from '../logger';
 import {
-  CODING_TOOLS as SHARED_CODING_TOOLS,
-  TOOL_LABELS as SHARED_TOOL_LABELS,
+  CODING_TOOLS,
+  TOOL_LABELS,
   extractToolDetail,
   truncateDetail,
 } from '../utils/tool-labels';
@@ -378,8 +378,7 @@ export class SessionProcess extends EventEmitter {
       }
     };
 
-    const CODING_TOOLS = SHARED_CODING_TOOLS;
-    const TOOL_LABELS = SHARED_TOOL_LABELS;
+    // CODING_TOOLS and TOOL_LABELS imported from shared utility above
 
     let assistantBuffer = '';
     // Track partial message text to avoid double-counting when --include-partial-messages is active.

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,7 +150,7 @@ export interface SessionIndex {
 
 export type StreamEvent =
   | { type: 'text_delta'; text: string }
-  | { type: 'tool_use'; name: string; id: string }
+  | { type: 'tool_use'; name: string; id: string; input?: Record<string, unknown> }
   | { type: 'thinking'; text: string }
   | { type: 'result'; text: string }
   | { type: 'error'; message: string };

--- a/src/utils/tool-labels.ts
+++ b/src/utils/tool-labels.ts
@@ -82,7 +82,7 @@ export function extractToolDetail(name: string, input: Record<string, unknown>):
       return truncateDetail(`${emoji} ${verb}: ${desc || cmd}`);
     }
     case 'WebFetch':
-    case 'mcp__browser__navigate': {
+    case 'mcp__browser__navigate': { // both use input.url
       const url = typeof input.url === 'string' ? input.url : '';
       return truncateDetail(`${emoji} ${verb}: ${url}`);
     }

--- a/src/utils/tool-labels.ts
+++ b/src/utils/tool-labels.ts
@@ -1,0 +1,123 @@
+export interface ToolLabel {
+  emoji: string;
+  verb: string;
+}
+
+export const TOOL_LABELS: Record<string, ToolLabel> = {
+  Read:         { emoji: '📖', verb: 'Reading' },
+  Edit:         { emoji: '✏️', verb: 'Editing' },
+  Write:        { emoji: '📝', verb: 'Writing' },
+  MultiEdit:    { emoji: '❤️‍🔥', verb: 'Editing' },
+  NotebookEdit: { emoji: '📕', verb: 'Editing notebook' },
+  Grep:         { emoji: '🔦', verb: 'Searching for' },
+  Glob:         { emoji: '📂', verb: 'Finding files' },
+  Bash:         { emoji: '💻', verb: 'Running' },
+  WebFetch:     { emoji: '🌐', verb: 'Fetching' },
+  WebSearch:    { emoji: '🔎', verb: 'Searching' },
+  Agent:        { emoji: '🤖', verb: 'Running agent' },
+  Task:         { emoji: '👉', verb: 'Running task' },
+  TodoWrite:    { emoji: '📋', verb: 'Updating tasks' },
+  // MCP tools
+  'mcp__browser__navigate':        { emoji: '🌐', verb: 'Opening' },
+  'mcp__browser__screenshot':      { emoji: '📸', verb: 'Screenshot' },
+  'mcp__browser__click':           { emoji: '🖱️', verb: 'Clicking' },
+  'mcp__browser__type':            { emoji: '⌨️', verb: 'Typing' },
+  'mcp__browser__scroll':          { emoji: '↕️', verb: 'Scrolling' },
+  'mcp__browser__hover':           { emoji: '🖱️', verb: 'Hovering' },
+  'mcp__gateway__telegram_reply':  { emoji: '✈️', verb: 'Replying on Telegram' },
+  'mcp__gateway__discord_reply':   { emoji: '💬', verb: 'Replying on Discord' },
+};
+
+export const DEFAULT_TOOL_LABEL: ToolLabel = { emoji: '🔧', verb: 'Using tool' };
+
+export function getToolLabel(name: string): ToolLabel {
+  return TOOL_LABELS[name] ?? DEFAULT_TOOL_LABEL;
+}
+
+export const CODING_TOOLS = new Set(['Write', 'Edit', 'NotebookEdit', 'MultiEdit']);
+
+export function shortenPath(p: string): string {
+  const parts = p.split('/');
+  return parts.length > 2 ? parts.slice(-2).join('/') : parts[parts.length - 1] || p;
+}
+
+export function truncateDetail(s: string, maxLines = 5, maxChars = 300): string {
+  const lines = s.split('\n').filter(l => l.trim());
+  const trimmedByLines = lines.length > maxLines;
+  const kept = lines.slice(0, maxLines);
+  let result = kept.join('\n');
+  if (result.length > maxChars) {
+    result = result.slice(0, maxChars) + '...';
+  } else if (trimmedByLines) {
+    result += '\n...';
+  }
+  return result;
+}
+
+export function extractToolDetail(name: string, input: Record<string, unknown>): string {
+  const { emoji, verb } = getToolLabel(name);
+
+  switch (name) {
+    case 'Read':
+    case 'Edit':
+    case 'Write':
+    case 'MultiEdit':
+    case 'NotebookEdit': {
+      const file = typeof input.file_path === 'string' ? shortenPath(input.file_path) : '';
+      const desc = typeof input.description === 'string' ? ` — ${input.description}` : '';
+      return truncateDetail(`${emoji} ${verb}: ${file}${desc}`);
+    }
+    case 'Grep': {
+      const pattern = typeof input.pattern === 'string' ? `"${input.pattern}"` : '';
+      const path = typeof input.path === 'string' ? ` in ${shortenPath(input.path)}` : '';
+      return truncateDetail(`${emoji} ${verb}: ${pattern}${path}`);
+    }
+    case 'Glob': {
+      const pattern = typeof input.pattern === 'string' ? `"${input.pattern}"` : '';
+      return truncateDetail(`${emoji} ${verb}: ${pattern}`);
+    }
+    case 'Bash': {
+      const desc = typeof input.description === 'string' ? input.description : '';
+      const cmd = typeof input.command === 'string' ? input.command : '';
+      return truncateDetail(`${emoji} ${verb}: ${desc || cmd}`);
+    }
+    case 'WebFetch':
+    case 'mcp__browser__navigate': {
+      const url = typeof input.url === 'string' ? input.url : '';
+      return truncateDetail(`${emoji} ${verb}: ${url}`);
+    }
+    case 'WebSearch': {
+      const query = typeof input.query === 'string' ? input.query : '';
+      return truncateDetail(`${emoji} ${verb}: "${query}"`);
+    }
+    case 'Agent':
+    case 'Task': {
+      const desc = typeof input.description === 'string' ? input.description : '';
+      const prompt = typeof input.prompt === 'string' ? input.prompt : '';
+      return truncateDetail(`${emoji} ${verb}: ${desc || prompt}`);
+    }
+    case 'TodoWrite': {
+      const todos = Array.isArray(input.todos) ? input.todos as { content?: string; status?: string }[] : [];
+      const active = todos.find(t => t.status === 'in_progress');
+      const detail = active?.content ?? `${todos.length} items`;
+      return truncateDetail(`${emoji} ${verb}: ${detail}`);
+    }
+    case 'mcp__browser__click': {
+      const selector = typeof input.selector === 'string' ? input.selector : '';
+      return truncateDetail(`${emoji} ${verb}: ${selector}`);
+    }
+    case 'mcp__browser__type': {
+      const text = typeof input.text === 'string' ? input.text : '';
+      return truncateDetail(`${emoji} ${verb}: "${text}"`);
+    }
+    case 'mcp__gateway__telegram_reply':
+    case 'mcp__gateway__discord_reply': {
+      const msg = typeof input.message === 'string' ? input.message : '';
+      return truncateDetail(`${emoji} ${verb}: ${msg}`);
+    }
+    default: {
+      const desc = typeof input.description === 'string' ? input.description : '';
+      return truncateDetail(`${emoji} ${verb}: ${desc || '...'}`);
+    }
+  }
+}

--- a/tests/unit/tool-labels.test.ts
+++ b/tests/unit/tool-labels.test.ts
@@ -1,0 +1,254 @@
+import {
+  TOOL_LABELS,
+  DEFAULT_TOOL_LABEL,
+  CODING_TOOLS,
+  getToolLabel,
+  shortenPath,
+  truncateDetail,
+  extractToolDetail,
+} from '../../src/utils/tool-labels';
+
+describe('TOOL_LABELS', () => {
+  it('contains all built-in Claude Code tools', () => {
+    const expected = ['Read', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit', 'Grep', 'Glob', 'Bash', 'WebFetch', 'WebSearch', 'Agent', 'Task', 'TodoWrite'];
+    for (const name of expected) {
+      expect(TOOL_LABELS[name]).toBeDefined();
+      expect(TOOL_LABELS[name].emoji).toBeTruthy();
+      expect(TOOL_LABELS[name].verb).toBeTruthy();
+    }
+  });
+
+  it('contains MCP browser tools', () => {
+    expect(TOOL_LABELS['mcp__browser__navigate']).toBeDefined();
+    expect(TOOL_LABELS['mcp__browser__screenshot']).toBeDefined();
+    expect(TOOL_LABELS['mcp__browser__click']).toBeDefined();
+    expect(TOOL_LABELS['mcp__browser__type']).toBeDefined();
+  });
+
+  it('contains MCP gateway channel tools', () => {
+    expect(TOOL_LABELS['mcp__gateway__telegram_reply']).toBeDefined();
+    expect(TOOL_LABELS['mcp__gateway__discord_reply']).toBeDefined();
+  });
+});
+
+describe('CODING_TOOLS', () => {
+  it('contains write-type tools', () => {
+    expect(CODING_TOOLS.has('Write')).toBe(true);
+    expect(CODING_TOOLS.has('Edit')).toBe(true);
+    expect(CODING_TOOLS.has('NotebookEdit')).toBe(true);
+    expect(CODING_TOOLS.has('MultiEdit')).toBe(true);
+  });
+
+  it('does not include read-only tools', () => {
+    expect(CODING_TOOLS.has('Read')).toBe(false);
+    expect(CODING_TOOLS.has('Grep')).toBe(false);
+    expect(CODING_TOOLS.has('Bash')).toBe(false);
+  });
+});
+
+describe('getToolLabel', () => {
+  it('returns label for known tool', () => {
+    expect(getToolLabel('Read')).toEqual(TOOL_LABELS['Read']);
+    expect(getToolLabel('Bash')).toEqual(TOOL_LABELS['Bash']);
+  });
+
+  it('returns DEFAULT_TOOL_LABEL for unknown tool', () => {
+    expect(getToolLabel('UnknownTool')).toEqual(DEFAULT_TOOL_LABEL);
+    expect(getToolLabel('mcp__some__unknown')).toEqual(DEFAULT_TOOL_LABEL);
+  });
+
+  it('returns label for MCP browser tool', () => {
+    const label = getToolLabel('mcp__browser__navigate');
+    expect(label.emoji).toBeTruthy();
+    expect(label.verb).toBe('Opening');
+  });
+});
+
+describe('shortenPath', () => {
+  it('returns last 2 segments for long paths', () => {
+    expect(shortenPath('/home/user/projects/src/utils/file.ts')).toBe('utils/file.ts');
+    expect(shortenPath('/a/b/c/d')).toBe('c/d');
+  });
+
+  it('returns filename for 2-segment paths (not enough segments to slice)', () => {
+    expect(shortenPath('src/file.ts')).toBe('file.ts');
+  });
+
+  it('returns filename for single segment', () => {
+    expect(shortenPath('file.ts')).toBe('file.ts');
+  });
+
+  it('handles empty string', () => {
+    expect(shortenPath('')).toBe('');
+  });
+});
+
+describe('truncateDetail', () => {
+  it('returns string as-is when within limits', () => {
+    const s = 'short string';
+    expect(truncateDetail(s)).toBe(s);
+  });
+
+  it('truncates by line count and appends ellipsis', () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line ${i}`).join('\n');
+    const result = truncateDetail(lines, 5);
+    expect(result.endsWith('\n...')).toBe(true);
+    expect(result.split('\n').length).toBeLessThanOrEqual(6);
+  });
+
+  it('truncates by char count and appends ellipsis', () => {
+    const long = 'x'.repeat(400);
+    const result = truncateDetail(long, 5, 300);
+    expect(result.endsWith('...')).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(303);
+  });
+
+  it('filters empty lines', () => {
+    const s = 'line1\n\n\nline2';
+    const result = truncateDetail(s);
+    expect(result).toBe('line1\nline2');
+  });
+});
+
+describe('extractToolDetail', () => {
+  describe('file tools', () => {
+    it('formats Read with file path', () => {
+      const result = extractToolDetail('Read', { file_path: '/home/user/src/api/router.ts' });
+      expect(result).toContain('api/router.ts');
+      expect(result).toContain('📖');
+    });
+
+    it('formats Edit with file path and description', () => {
+      const result = extractToolDetail('Edit', { file_path: '/src/app.ts', description: 'fix null check' });
+      expect(result).toContain('app.ts');
+      expect(result).toContain('fix null check');
+      expect(result).toContain('✏️');
+    });
+
+    it('formats Write with file path', () => {
+      const result = extractToolDetail('Write', { file_path: '/src/new-file.ts' });
+      expect(result).toContain('new-file.ts');
+      expect(result).toContain('📝');
+    });
+
+    it('handles missing file_path gracefully', () => {
+      const result = extractToolDetail('Read', {});
+      expect(result).toContain('📖');
+    });
+  });
+
+  describe('search tools', () => {
+    it('formats Grep with pattern and path', () => {
+      const result = extractToolDetail('Grep', { pattern: 'tool_use', path: '/src/agent' });
+      expect(result).toContain('"tool_use"');
+      expect(result).toContain('agent');
+      expect(result).toContain('🔦');
+    });
+
+    it('formats Glob with pattern', () => {
+      const result = extractToolDetail('Glob', { pattern: '**/*.ts' });
+      expect(result).toContain('"**/*.ts"');
+      expect(result).toContain('📂');
+    });
+
+    it('formats WebSearch with query', () => {
+      const result = extractToolDetail('WebSearch', { query: 'typescript generics' });
+      expect(result).toContain('"typescript generics"');
+      expect(result).toContain('🔎');
+    });
+  });
+
+  describe('execution tools', () => {
+    it('formats Bash with description', () => {
+      const result = extractToolDetail('Bash', { description: 'Run tests', command: 'npm test' });
+      expect(result).toContain('Run tests');
+      expect(result).toContain('💻');
+    });
+
+    it('formats Bash with command when no description', () => {
+      const result = extractToolDetail('Bash', { command: 'npm test' });
+      expect(result).toContain('npm test');
+    });
+
+    it('formats WebFetch with url', () => {
+      const result = extractToolDetail('WebFetch', { url: 'https://example.com/api' });
+      expect(result).toContain('https://example.com/api');
+      expect(result).toContain('🌐');
+    });
+  });
+
+  describe('agent tools', () => {
+    it('formats Agent with description', () => {
+      const result = extractToolDetail('Agent', { description: 'Search codebase' });
+      expect(result).toContain('Search codebase');
+      expect(result).toContain('🤖');
+    });
+
+    it('formats TodoWrite with active task', () => {
+      const result = extractToolDetail('TodoWrite', {
+        todos: [
+          { content: 'Done task', status: 'completed' },
+          { content: 'Active task', status: 'in_progress' },
+          { content: 'Pending task', status: 'pending' },
+        ],
+      });
+      expect(result).toContain('Active task');
+      expect(result).toContain('📋');
+    });
+
+    it('formats TodoWrite with item count when no active task', () => {
+      const result = extractToolDetail('TodoWrite', {
+        todos: [
+          { content: 'Task 1', status: 'pending' },
+          { content: 'Task 2', status: 'pending' },
+        ],
+      });
+      expect(result).toContain('2 items');
+    });
+  });
+
+  describe('MCP tools', () => {
+    it('formats mcp__browser__navigate with url', () => {
+      const result = extractToolDetail('mcp__browser__navigate', { url: 'https://google.com' });
+      expect(result).toContain('https://google.com');
+      expect(result).toContain('🌐');
+    });
+
+    it('formats mcp__browser__click with selector', () => {
+      const result = extractToolDetail('mcp__browser__click', { selector: '#submit-btn' });
+      expect(result).toContain('#submit-btn');
+      expect(result).toContain('🖱️');
+    });
+
+    it('formats mcp__browser__type with text', () => {
+      const result = extractToolDetail('mcp__browser__type', { text: 'hello world' });
+      expect(result).toContain('"hello world"');
+      expect(result).toContain('⌨️');
+    });
+
+    it('formats mcp__gateway__telegram_reply with message', () => {
+      const result = extractToolDetail('mcp__gateway__telegram_reply', { message: 'Hello!' });
+      expect(result).toContain('Hello!');
+      expect(result).toContain('✈️');
+    });
+
+    it('formats mcp__gateway__discord_reply with message', () => {
+      const result = extractToolDetail('mcp__gateway__discord_reply', { message: 'Hi Discord' });
+      expect(result).toContain('Hi Discord');
+      expect(result).toContain('💬');
+    });
+  });
+
+  describe('unknown tools', () => {
+    it('uses fallback emoji for unknown tool', () => {
+      const result = extractToolDetail('mcp__some__unknown', { description: 'doing something' });
+      expect(result).toContain('🔧');
+      expect(result).toContain('doing something');
+    });
+
+    it('uses ellipsis when no description for unknown tool', () => {
+      const result = extractToolDetail('mcp__some__unknown', {});
+      expect(result).toContain('...');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `input` field to `tool_use` StreamEvent — API consumers can now see what parameters the agent passed to each tool (file path, URL, query, search pattern, etc.)
- Extract `TOOL_LABELS`, `CODING_TOOLS`, `extractToolDetail`, `shortenPath`, `truncateDetail` from `session/process.ts` into `src/utils/tool-labels.ts` — Telegram renderer and SSE stream share a single source of truth
- Add MCP tool entries (browser navigate/screenshot/click/type, telegram_reply, discord_reply) to the shared label map
- Add 36 unit tests covering all tool types, edge cases, and utility helpers

## Motivation

The UI (via `POST /v1/agents/:id/messages?stream=true`) receives `tool_use` SSE events but previously had no `input` field — it could see *that* a tool was called but not *what* was passed to it. This blocks features like:
- Showing browser URL when agent navigates
- Showing file path when agent reads/edits code
- Triggering browser panel when `mcp__browser__*` is called

Related planning doc: `planning-57-tool-use-input-sse.md`

## Changes

| File | Change |
|---|---|
| `src/utils/tool-labels.ts` | New shared utility — tool label map + detail extractor |
| `src/types.ts` | Add `input?: Record<string, unknown>` to `tool_use` StreamEvent |
| `src/agent/runner.ts` | Forward `input` from raw event into `tool_use` SSE chunk |
| `src/session/process.ts` | Import from shared utility (removes ~85 lines of duplication) |
| `tests/unit/tool-labels.test.ts` | 36 unit tests for the new utility |

## Test plan

- [ ] `npm test` — 79 suites / 1384 tests pass
- [ ] `tool_use` SSE event now includes `input` with real tool parameters
- [ ] Existing consumers that ignore `input` field are unaffected (backward compatible)