### PR TITLE
fix: use readdirSync for case-sensitive filename matching on Windows

### DIFF
--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -61,17 +61,22 @@ function truncateFile(content: string): { content: string; truncated: boolean } 
  * Also handles bootstrap.md.done → BOOTSTRAP.md.done
  */
 export function migrateWorkspaceFiles(workspaceDir: string): void {
-  for (const [lower, upper] of Object.entries(LOWERCASE_TO_UPPERCASE)) {
-    const lowerPath = path.join(workspaceDir, lower);
-    const upperPath = path.join(workspaceDir, upper);
+  // Use readdirSync for case-sensitive filename matching on all platforms.
+  // fs.existsSync is case-insensitive on Windows, causing both lowerExists and
+  // upperExists to resolve to the same file and delete the only copy.
+  const dirFiles = new Set(fs.readdirSync(workspaceDir));
 
-    const lowerExists = fs.existsSync(lowerPath);
-    const upperExists = fs.existsSync(upperPath);
+  for (const [lower, upper] of Object.entries(LOWERCASE_TO_UPPERCASE)) {
+    const lowerExists = dirFiles.has(lower);
+    const upperExists = dirFiles.has(upper);
 
     if (lowerExists && !upperExists) {
+      const lowerPath = path.join(workspaceDir, lower);
+      const upperPath = path.join(workspaceDir, upper);
       fs.renameSync(lowerPath, upperPath);
       console.log(`[workspace] Migrated: ${lower} → ${upper}`);
     } else if (lowerExists && upperExists) {
+      const lowerPath = path.join(workspaceDir, lower);
       console.log(
         `[workspace] WARNING: both ${lower} and ${upper} exist — keeping ${upper}, removing ${lower}`
       );


### PR DESCRIPTION
## Problem

`fs.existsSync` is case-insensitive on Windows. In `migrateWorkspaceFiles`, both `lowerExists` and `upperExists` would resolve to the same file, causing the only copy to be deleted during migration.

## Solution

Replace `fs.existsSync` with `fs.readdirSync` + `Set` to perform exact, case-sensitive filename matching. This works correctly on Windows, macOS, and Linux.

## Changes

- `src/agent/workspace-loader.ts`: Read directory listing once into a `Set`, then use `Set.has()` for case-sensitive checks instead of `fs.existsSync`.