### PR TITLE
fix: add lib/ to package.json files to fix MCP server crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "dist/",
+    "lib/",
     "resource/",
     "mcp/",
     "README.md",


### PR DESCRIPTION
## Summary

- `mcp/tools/agent/handlers.ts` imports `../../../lib/pairing` which exists in the source tree but `lib/` was missing from the `files` array in `package.json`
- When installed as an npm package, the MCP server crashed immediately on startup with `Cannot find module '../../../lib/pairing'`
- This made **all** MCP tools unavailable in every agent session (not just browser tools)

## Root Cause

```json
// before
"files": ["dist/", "resource/", "mcp/", "README.md", "config.template.json"]

// after  
"files": ["dist/", "lib/", "resource/", "mcp/", "README.md", "config.template.json"]
```

## Test plan

- [ ] After publish, verify MCP server starts without error: `bun mcp/server.ts`
- [ ] Confirm browser tools appear in agent tool list for sessions with `allow_tools: true`
- [ ] Confirm cron, skills, and agent MCP tools also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)