### PR TITLE
fix: clean up BYOK follow-ups (blank line + stale test)

### DIFF
--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -325,10 +325,9 @@ export function createApiRouter(
       validatedMediaFiles = media_files as string[];
     }
 
-    // Model validation: warn if unknown but allow pass-through so BYOK/third-party
-    // models (e.g. openrouter/*) are not blocked by a stale local list.
+    // Allow any model string — BYOK/third-party models (e.g. openrouter/*) are validated
+    // by the upstream provider, not the local config list.
     const modelStr = typeof requestModel === 'string' ? requestModel.trim() : undefined;
-
     const requestId = randomUUID();
     const sessionId = (session_id as string | undefined) ?? randomUUID();
     const chatIdStr = (chat_id as string).trim();

--- a/tests/unit/command-endpoint.test.ts
+++ b/tests/unit/command-endpoint.test.ts
@@ -200,24 +200,24 @@ describe('AgentRunner /command endpoint', () => {
   });
 
   // --------------------------------------------------------------------------
-  // U-CMD-03: set_model with invalid model returns error
+  // U-CMD-03: set_model accepts unknown/third-party models as pass-through (BYOK)
   // --------------------------------------------------------------------------
-  it('U-CMD-03: set_model with invalid model returns error', async () => {
+  it('U-CMD-03: set_model accepts unknown model as pass-through', async () => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
     await runner.start();
     const port = getCallbackPort(runner);
 
     const { data } = await sendCommand(port, {
       command: 'set_model',
-      payload: { model: 'invalid-model' },
+      payload: { model: 'openrouter/meta-llama/llama-3.1-70b' },
     });
 
-    expect(data.success).toBe(false);
-    expect(data.error).toContain('Unknown model');
+    expect(data.success).toBe(true);
+    expect(data.model).toBe('openrouter/meta-llama/llama-3.1-70b');
 
-    // Verify model was NOT changed
+    // Verify model was changed
     const { data: getResult } = await sendCommand(port, { command: 'get_model' });
-    expect(getResult.model).toBe('claude-opus-4-6');
+    expect(getResult.model).toBe('openrouter/meta-llama/llama-3.1-70b');
   });
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #94 (feat: allow unknown models as pass-through):

- **router.ts**: Remove extra blank line left after validation block removal; fix misleading comment (`warn if unknown` → clearly states pass-through)
- **command-endpoint.test.ts**: Update `U-CMD-03` to verify the new pass-through behavior — unknown model string is now accepted and set, instead of rejected with `UNKNOWN_MODEL` error

## Test plan
- [x] `U-CMD-03` updated and passing — verifies `openrouter/meta-llama/llama-3.1-70b` is accepted as pass-through
- [x] All 9 command-endpoint tests pass