### PR TITLE
fix(runner): use || instead of ?? for result text fallback to buffer

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1527,7 +1527,10 @@ export class AgentRunner extends EventEmitter {
           // result event = end of turn
           if (obj['type'] === 'result') {
             session.setProcessing(false);
-            const resultText = (obj['result'] as string | undefined) ?? buffer.join('');
+            // Use || instead of ?? so an empty-string result falls back to the
+            // accumulated buffer (needed for non-Anthropic models e.g. OpenRouter,
+            // which emit result:"" even though the text arrived via stream_event chunks).
+            const resultText = (obj['result'] as string | undefined) || buffer.join('');
             done(resultText);
           }
         } catch {
@@ -1733,7 +1736,8 @@ export class AgentRunner extends EventEmitter {
         if (obj['type'] === 'result') {
           session.setProcessing(false);
           lastPartialText = ''; // reset for next turn
-          const resultText = (obj['result'] as string | undefined) ?? buffer.join('');
+          // Use || so empty-string result falls back to buffer (OpenRouter emits result:"").
+          const resultText = (obj['result'] as string | undefined) || buffer.join('');
           done(resultText);
         }
       } catch {
@@ -2071,7 +2075,8 @@ export class AgentRunner extends EventEmitter {
         }
         if (obj['type'] === 'result') {
           session.setProcessing(false);
-          const resultText = (obj['result'] as string | undefined) ?? buffer.join('');
+          // Use || so empty-string result falls back to buffer (OpenRouter emits result:"").
+          const resultText = (obj['result'] as string | undefined) || buffer.join('');
           done(resultText);
         }
       } catch { /* non-JSON */ }


### PR DESCRIPTION
## Problem

When claude CLI emits `result: ""` (empty string) — which happens for non-Anthropic models such as OpenRouter's `qwen/qwen3.7-max` — the nullish coalescing operator (`??`) does **not** fall back to the accumulated buffer because `""` is not `null`/`undefined`.

This means:
1. User sends message → user message saved to historyDb ✓
2. Claude CLI streams partial chunks via `stream_event` → UI shows response ✓ (buffer accumulates)
3. Claude CLI emits `result: ""` → `resultText = "" ?? buffer = ""` → `done("")`
4. `if (result.trim())` is falsy → **assistant message NOT saved to historyDb** ✗
5. After refresh, the response is gone (only user message persists)

## Fix

Replace `??` with `||` at all 3 call sites (`sendApiMessage`, `sendApiMessageStream`, `sendMessageToSession`):

```ts
// Before
const resultText = (obj['result'] as string | undefined) ?? buffer.join('');

// After
const resultText = (obj['result'] as string | undefined) || buffer.join('');
```

With `||`, an empty-string result falls back to the buffer accumulated from `stream_event`/`content_block_delta` chunks, so the response is persisted correctly.

## Impact

- OpenRouter models (qwen, gemini, etc. via BYOK) now persist assistant messages to historyDb
- No change for Anthropic models (their `result.result` is always non-empty on success)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)