### PR TITLE
feat(api): add store_user_message flag to suppress trigger message in history

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1399,8 +1399,12 @@ export class AgentRunner extends EventEmitter {
     // (same pattern as Telegram — Claude Code reads files via Read tool instead of base64 inline)
     const imagePaths = finalMediaFiles?.length ? this.resolveMediaPaths(finalMediaFiles) : [];
 
-    const apiUserTs = Date.now();
+    // skipUserMessage omits the trigger from both session context and history so only the
+    // assistant response is visible — intentional for system-initiated messages (e.g. cron welcome).
+    // Claude still receives the prompt via channelXml for this turn; session restarts will not
+    // replay it, which is the desired behaviour for one-shot proactive messages.
     if (!opts.skipUserMessage) {
+      const apiUserTs = Date.now();
       await this.sessionStore
         .appendMessage(this.agentConfig.id, sessionId, {
           role: 'user',
@@ -1594,8 +1598,8 @@ export class AgentRunner extends EventEmitter {
     // Resolve media files to absolute paths for file-path based image passing
     const imagePathsStream = finalMediaFilesStream?.length ? this.resolveMediaPaths(finalMediaFilesStream) : [];
 
-    const streamUserTs = Date.now();
     if (!opts.skipUserMessage) {
+      const streamUserTs = Date.now();
       await this.sessionStore
         .appendMessage(this.agentConfig.id, sessionId, {
           role: 'user',

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1372,7 +1372,7 @@ export class AgentRunner extends EventEmitter {
     sessionId: string,
     chatId: string,
     message: string,
-    opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[]; model?: string },
+    opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[]; model?: string; skipUserMessage?: boolean },
   ): Promise<string> {
     if (this.pendingApiSessions.has(sessionId)) {
       const err = Object.assign(
@@ -1399,24 +1399,25 @@ export class AgentRunner extends EventEmitter {
     // (same pattern as Telegram — Claude Code reads files via Read tool instead of base64 inline)
     const imagePaths = finalMediaFiles?.length ? this.resolveMediaPaths(finalMediaFiles) : [];
 
-    // Persist user message
     const apiUserTs = Date.now();
-    await this.sessionStore
-      .appendMessage(this.agentConfig.id, sessionId, {
+    if (!opts.skipUserMessage) {
+      await this.sessionStore
+        .appendMessage(this.agentConfig.id, sessionId, {
+          role: 'user',
+          content: message,
+          ts: apiUserTs,
+        })
+        .catch(() => {});
+      this.historyDb.insertMessage({
+        chatId: `api-${chatId}`,
+        sessionId,
+        source: 'api',
         role: 'user',
         content: message,
+        mediaFiles: finalMediaFiles?.length ? finalMediaFiles : undefined,
         ts: apiUserTs,
-      })
-      .catch(() => {});
-    this.historyDb.insertMessage({
-      chatId: `api-${chatId}`,
-      sessionId,
-      source: 'api',
-      role: 'user',
-      content: message,
-      mediaFiles: finalMediaFiles?.length ? finalMediaFiles : undefined,
-      ts: apiUserTs,
-    });
+      });
+    }
 
     this.pendingApiSessions.add(sessionId);
     session.touch();
@@ -1567,7 +1568,7 @@ export class AgentRunner extends EventEmitter {
       onDone: (fullText: string) => void;
       onError: (err: Error) => void;
     },
-    opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[]; model?: string },
+    opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[]; model?: string; skipUserMessage?: boolean },
   ): Promise<() => void> {
     if (this.pendingApiSessions.has(sessionId)) {
       const err = Object.assign(
@@ -1593,24 +1594,25 @@ export class AgentRunner extends EventEmitter {
     // Resolve media files to absolute paths for file-path based image passing
     const imagePathsStream = finalMediaFilesStream?.length ? this.resolveMediaPaths(finalMediaFilesStream) : [];
 
-    // Persist user message
     const streamUserTs = Date.now();
-    await this.sessionStore
-      .appendMessage(this.agentConfig.id, sessionId, {
+    if (!opts.skipUserMessage) {
+      await this.sessionStore
+        .appendMessage(this.agentConfig.id, sessionId, {
+          role: 'user',
+          content: message,
+          ts: streamUserTs,
+        })
+        .catch(() => {});
+      this.historyDb.insertMessage({
+        chatId: `api-${chatId}`,
+        sessionId,
+        source: 'api',
         role: 'user',
         content: message,
+        mediaFiles: finalMediaFilesStream?.length ? finalMediaFilesStream : undefined,
         ts: streamUserTs,
-      })
-      .catch(() => {});
-    this.historyDb.insertMessage({
-      chatId: `api-${chatId}`,
-      sessionId,
-      source: 'api',
-      role: 'user',
-      content: message,
-      mediaFiles: finalMediaFilesStream?.length ? finalMediaFilesStream : undefined,
-      ts: streamUserTs,
-    });
+      });
+    }
 
     this.pendingApiSessions.add(sessionId);
     session.touch();

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -331,6 +331,10 @@ export function createApiRouter(
       return;
     }
     const skipUserMessage = store_user_message === false;
+    if (skipUserMessage && !apiKey.write && !apiKey.admin) {
+      res.status(403).json({ error: 'store_user_message: false requires a write or admin API key' });
+      return;
+    }
 
     // Allow any model string — BYOK/third-party models (e.g. openrouter/*) are validated
     // by the upstream provider, not the local config list.

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -277,8 +277,9 @@ export function createApiRouter(
       timeout_ms?: unknown;
       media_files?: unknown;
       model?: unknown;
+      store_user_message?: unknown;
     };
-    const { message, chat_id, session_id, stream, timeout_ms, media_files, model: requestModel } = body;
+    const { message, chat_id, session_id, stream, timeout_ms, media_files, model: requestModel, store_user_message } = body;
 
     if (!message || typeof message !== 'string' || !message.trim()) {
       res.status(400).json({ error: 'message is required and must be a non-empty string' });
@@ -324,6 +325,12 @@ export function createApiRouter(
       }
       validatedMediaFiles = media_files as string[];
     }
+
+    if (store_user_message !== undefined && typeof store_user_message !== 'boolean') {
+      res.status(400).json({ error: 'store_user_message must be a boolean if provided' });
+      return;
+    }
+    const skipUserMessage = store_user_message === false;
 
     // Allow any model string — BYOK/third-party models (e.g. openrouter/*) are validated
     // by the upstream provider, not the local config list.
@@ -393,7 +400,7 @@ export function createApiRouter(
           chatIdStr,
           message.trim(),
           sseCallbacks,
-          { timeoutMs, allowTools, mediaFiles: validatedMediaFiles, model: modelStr },
+          { timeoutMs, allowTools, mediaFiles: validatedMediaFiles, model: modelStr, skipUserMessage },
         );
 
         // Client disconnect -> cleanup
@@ -423,6 +430,7 @@ export function createApiRouter(
           allowTools: allowToolsSync,
           mediaFiles: validatedMediaFiles,
           model: modelStr,
+          skipUserMessage,
         });
         res.json({
           request_id: requestId,


### PR DESCRIPTION
## Summary

Add `store_user_message: false` flag to `POST /v1/agents/:agentId/messages`. When set, only the assistant's response is persisted to chat history — the user/trigger message is skipped. Supports both sync and stream modes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor / Tech debt
- [ ] Documentation

## Related Issues

Closes #102

## Changes Made

- `src/agent/runner.ts`: Added `skipUserMessage?: boolean` to `sendApiMessage` and `sendApiMessageStream` opts. Wrapped user message persist blocks with `if (!opts.skipUserMessage)`.
- `src/api/router.ts`: Added `store_user_message?: unknown` to request body type. Validate it as boolean. Derive `skipUserMessage = store_user_message === false` and pass to both sync and stream paths.

## How to Test

1. Start the gateway
2. Send a message with `store_user_message: false`:
```bash
curl -X POST http://localhost:10850/v1/agents/getpod/messages \
  -H "X-Api-Key: $KEY" \
  -H "Content-Type: application/json" \
  -d '{"message":"Hello","chat_id":"test","stream":false,"store_user_message":false}'
```
3. Fetch chat history: `GET /v1/agents/getpod/chats/api-test/messages`

Expected: only the assistant response appears — no user message entry.

4. Repeat without the flag (or `store_user_message: true`) — both user and assistant messages should appear as normal.

## Checklist

- [x] Reviewed my own code
- [x] Tests pass (if applicable)
- [x] No console errors