### PR TITLE
feat(api): add POST /v1/agents/:agentId/greeting endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,6 +26,7 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 | `PATCH` | `/api/v1/agents/:agentId` | Write | Update agent description, model, or allow_tools |
 | `DELETE` | `/api/v1/agents/:agentId` | Admin | Delete an agent |
 | `POST` | `/api/v1/agents/:agentId/messages` | Key | Send a message — sync JSON or SSE stream; supports slash commands |
+| `POST` | `/api/v1/agents/:agentId/greeting` | Write | Create a proactive welcome session from `GREETING.md`; returns 204 if file absent |
 | `GET` | `/api/v1/models` | Key | List all supported Claude models |
 | `PUT` | `/api/v1/agents/:agentId/model` | Admin | Set the active model for an agent |
 
@@ -577,6 +578,7 @@ Send a message to an agent. Returns a JSON response or SSE stream.
 | `stream` | No | `true` to enable SSE streaming (default `false`) |
 | `timeout_ms` | No | Override the default response timeout in milliseconds (default 60000) |
 | `media_files` | No | Array of `mediaPath` strings returned by the Media Upload endpoint |
+| `store_user_message` | No | Set to `false` to skip persisting the user message in session history — only the assistant response is stored. Requires a write or admin key. Useful for proactive/trigger prompts where the user trigger should be invisible. |
 
 #### Slash command dispatch
 
@@ -773,6 +775,55 @@ Manage API sessions for a specific agent and `chat_id`. Sessions are stored at `
 **`chat_id`** identifies the caller. Use any stable string (e.g. `"myapp"`, `"user-123"`, `"getpod"`). It is **required** on all session endpoints — pass it as:
 - Query string for `GET` and `DELETE` requests: `?chat_id=myapp`
 - Request body for `POST` and `PATCH` requests: `{"chat_id": "myapp", ...}`
+
+---
+
+### POST /api/v1/agents/:agentId/greeting
+
+Create a proactive welcome session. The endpoint reads `GREETING.md` from the agent's workspace directory and sends its content to the agent as a trigger prompt. Only the **assistant response** is stored in session history — the trigger prompt itself is invisible to the session (uses `store_user_message: false` internally).
+
+Returns `204 No Content` (no session created) if `GREETING.md` does not exist or is empty.
+
+**Auth:** Write or Admin key required.
+
+**Request:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `chat_id` | Yes | Caller identity — same as other session endpoints |
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: my-write-key" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "getpod"}' \
+  http://localhost:10850/api/v1/agents/getpod/greeting
+```
+
+**Response `201`** — session created, agent responded:
+
+```json
+{
+  "greeted": true,
+  "sessionId": "7f3a1c2d-89ab-4def-b012-345678901234",
+  "sessionName": "Welcome to GetPod"
+}
+```
+
+**Response `204`** — `GREETING.md` not found or empty; no session created.
+
+**`GREETING.md` format:**
+
+Place the file at `~/.claude-gateway/agents/{agentId}/workspace/GREETING.md`. Its content is used as the prompt sent to the agent. It is **not** concatenated into the agent system prompt — it is a one-time trigger only.
+
+```markdown
+The user's environment is ready. Send a warm, concise welcome message
+introducing yourself and what you can help with.
+```
+
+**Notes:**
+- Calling this endpoint twice creates two separate sessions (idempotency is the caller's responsibility — check session list first if needed).
+- The session is auto-named from the greeting prompt content (same logic as `POST /sessions`).
 
 ---
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -168,6 +168,10 @@ export class AgentRunner extends EventEmitter {
     return this.skillRegistry;
   }
 
+  get workspacePath(): string {
+    return this.agentConfig.workspace;
+  }
+
   /**
    * Bind a local HTTP server that receives POST /channel from TelegramReceiver.
    * Each payload is routed to the appropriate SessionProcess by chat_id.

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2088,6 +2088,69 @@ export function createApiRouter(
     }
   });
 
+  /**
+   * POST /api/v1/agents/:agentId/greeting
+   * Read GREETING.md from the agent workspace and create a new session where the
+   * agent sends a proactive welcome message.  The trigger prompt is NOT stored in
+   * the session history (skipUserMessage: true), so the conversation looks as if
+   * the agent reached out first.
+   *
+   * Returns 204 (no body) when GREETING.md does not exist — no session is created.
+   * Requires a write or admin API key.
+   */
+  router.post('/v1/agents/:agentId/greeting', auth, async (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    if (!apiKey.write && !apiKey.admin) {
+      res.status(403).json({ error: 'greeting requires a write or admin API key' });
+      return;
+    }
+
+    const runner = agentRunners.get(agentId);
+    if (!runner) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return; }
+
+    const chatId = (req.query['chat_id'] ?? (req.body as Record<string, unknown>)?.['chat_id']) as string | undefined;
+    if (!chatId || typeof chatId !== 'string' || !chatId.trim()) {
+      res.status(400).json({ error: 'chat_id is required' });
+      return;
+    }
+    if (!/^[a-zA-Z0-9_-]{1,64}$/.test(chatId.trim())) {
+      res.status(400).json({ error: 'chat_id must be 1-64 alphanumeric characters, hyphens, or underscores' });
+      return;
+    }
+    const resolvedChatId = chatId.trim();
+
+    const greetingPath = path.join(runner.workspacePath, 'GREETING.md');
+    let greetingContent: string;
+    try {
+      greetingContent = await fsp.readFile(greetingPath, 'utf-8');
+    } catch {
+      res.status(204).send();
+      return;
+    }
+
+    if (!greetingContent.trim()) {
+      res.status(204).send();
+      return;
+    }
+
+    try {
+      const meta = await runner.createApiSession(resolvedChatId, greetingContent);
+      await runner.sendApiMessage(meta.id, resolvedChatId, greetingContent, {
+        timeoutMs: DEFAULT_TIMEOUT_MS,
+        skipUserMessage: true,
+      });
+      res.status(201).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   return router;
 }
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2102,12 +2102,8 @@ export function createApiRouter(
     const { agentId } = req.params as { agentId: string };
     const apiKey = (req as AuthedRequest).apiKey;
 
-    if (!canAccessAgent(apiKey, agentId)) {
-      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
-      return;
-    }
-    if (!apiKey.write && !apiKey.admin) {
-      res.status(403).json({ error: 'greeting requires a write or admin API key' });
+    if (!canWriteAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `greeting requires write or admin access to agent '${agentId}'` });
       return;
     }
 
@@ -2139,16 +2135,24 @@ export function createApiRouter(
       return;
     }
 
+    const meta = await runner.createApiSession(resolvedChatId, greetingContent);
     try {
-      const meta = await runner.createApiSession(resolvedChatId, greetingContent);
       await runner.sendApiMessage(meta.id, resolvedChatId, greetingContent, {
         timeoutMs: DEFAULT_TIMEOUT_MS,
         skipUserMessage: true,
       });
-      res.status(201).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
     } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === 'CONFLICT') {
+        res.status(409).json({ error: 'session already has a pending request', sessionId: meta.id });
+        return;
+      }
+      // Clean up the orphaned session so the caller does not need to
+      runner.deleteApiSession(resolvedChatId, meta.id).catch(() => undefined);
       res.status(500).json({ error: (err as Error).message });
+      return;
     }
+    res.status(201).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
   });
 
   return router;


### PR DESCRIPTION
## Summary

Adds `POST /v1/agents/:agentId/greeting` — an endpoint that reads `GREETING.md` from the agent workspace and creates a session where the agent proactively sends a welcome message. The trigger prompt is never stored in history, so the conversation looks as if the agent initiated contact.

Closes #104

## Changes

- **`src/agent/runner.ts`** — add `workspacePath` getter to expose workspace path
- **`src/api/router.ts`** — new `POST /v1/agents/:agentId/greeting` route

## Behavior

| Condition | Response |
|-----------|----------|
| `GREETING.md` missing or empty | `204 No Content` — no session created |
| API key lacks write/admin | `403 Forbidden` |
| Agent not found | `404 Not Found` |
| Success | `201 { greeted: true, sessionId, sessionName }` |

## Flow

```
POST /v1/agents/:agentId/greeting?chat_id=<id>

1. Check write/admin API key
2. Read GREETING.md from workspace → 204 if missing/empty
3. runner.createApiSession(chatId, greetingContent)   ← auto-names session
4. runner.sendApiMessage(sessionId, chatId, greetingContent, { skipUserMessage: true })
5. return 201 { greeted: true, sessionId, sessionName }
```

## Test Results

```
Test Suites: 87 passed, 87 total
Tests:       1612 passed, 1612 total
```