### PR TITLE
fix(api): reduce greeting latency and make endpoint idempotent

### DIFF
--- a/API.md
+++ b/API.md
@@ -791,12 +791,13 @@ Returns `204 No Content` (no session created) if `GREETING.md` does not exist or
 | Field | Required | Description |
 |-------|----------|-------------|
 | `chat_id` | Yes | Caller identity — same as other session endpoints |
+| `session_name` | No | Explicit session title; skips the LLM auto-naming call (~15s) when provided |
 
 ```bash
 curl -X POST \
   -H "X-Api-Key: my-write-key" \
   -H "Content-Type: application/json" \
-  -d '{"chat_id": "getpod"}' \
+  -d '{"chat_id": "getpod", "session_name": "Welcome to GetPod"}' \
   http://localhost:10850/api/v1/agents/getpod/greeting
 ```
 
@@ -822,8 +823,8 @@ introducing yourself and what you can help with.
 ```
 
 **Notes:**
-- Calling this endpoint twice creates two separate sessions (idempotency is the caller's responsibility — check session list first if needed).
-- The session is auto-named from the greeting prompt content (same logic as `POST /sessions`).
+- `GREETING.md` is **deleted after a successful greeting** (201 response). Subsequent calls return 204 immediately, making the endpoint idempotent. Re-provisioning GREETING.md will trigger a new greeting on next call.
+- Pass `session_name` to avoid the ~15s LLM title-generation call. If omitted, the session is auto-named from the greeting prompt content (same logic as `POST /sessions`).
 
 ---
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2088,16 +2088,7 @@ export function createApiRouter(
     }
   });
 
-  /**
-   * POST /api/v1/agents/:agentId/greeting
-   * Read GREETING.md from the agent workspace and create a new session where the
-   * agent sends a proactive welcome message.  The trigger prompt is NOT stored in
-   * the session history (skipUserMessage: true), so the conversation looks as if
-   * the agent reached out first.
-   *
-   * Returns 204 (no body) when GREETING.md does not exist — no session is created.
-   * Requires a write or admin API key.
-   */
+  // POST /api/v1/agents/:agentId/greeting — one-shot proactive welcome from GREETING.md
   router.post('/v1/agents/:agentId/greeting', auth, async (req: Request, res: Response) => {
     const { agentId } = req.params as { agentId: string };
     const apiKey = (req as AuthedRequest).apiKey;
@@ -2110,51 +2101,57 @@ export function createApiRouter(
     const runner = agentRunners.get(agentId);
     if (!runner) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return; }
 
-    const chatId = (req.query['chat_id'] ?? (req.body as Record<string, unknown>)?.['chat_id']) as string | undefined;
-    if (!chatId || typeof chatId !== 'string' || !chatId.trim()) {
+    const body = req.body as { chat_id?: unknown; session_name?: unknown };
+    const rawChatId = (req.query['chat_id'] ?? body.chat_id) as string | undefined;
+    const resolvedChatId = typeof rawChatId === 'string' ? rawChatId.trim() : '';
+    if (!resolvedChatId) {
       res.status(400).json({ error: 'chat_id is required' });
       return;
     }
-    if (!/^[a-zA-Z0-9_-]{1,64}$/.test(chatId.trim())) {
+    if (!/^[a-zA-Z0-9_-]{1,64}$/.test(resolvedChatId)) {
       res.status(400).json({ error: 'chat_id must be 1-64 alphanumeric characters, hyphens, or underscores' });
       return;
     }
-    const resolvedChatId = chatId.trim();
-    const sessionName = (req.body as Record<string, unknown>)?.['session_name'] as string | undefined;
+    const sessionName = typeof body.session_name === 'string' ? body.session_name : undefined;
 
     const greetingPath = path.join(runner.workspacePath, 'GREETING.md');
-    let greetingContent: string;
+    let content: string;
     try {
-      greetingContent = await fsp.readFile(greetingPath, 'utf-8');
-    } catch {
+      content = (await fsp.readFile(greetingPath, 'utf-8')).trim();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        res.status(500).json({ error: `Failed to read GREETING.md: ${(err as Error).message}` });
+        return;
+      }
       res.status(204).send();
       return;
     }
 
-    if (!greetingContent.trim()) {
+    if (!content) {
       res.status(204).send();
       return;
     }
 
-    const meta = await runner.createApiSession(resolvedChatId, greetingContent, sessionName);
+    let meta: { id: string; name: string } | undefined;
     try {
-      await runner.sendApiMessage(meta.id, resolvedChatId, greetingContent, {
+      meta = await runner.createApiSession(resolvedChatId, content, sessionName);
+      await runner.sendApiMessage(meta.id, resolvedChatId, content, {
         timeoutMs: DEFAULT_TIMEOUT_MS,
         skipUserMessage: true,
       });
     } catch (err) {
       const code = (err as { code?: string }).code;
-      if (code === 'CONFLICT') {
+      if (code === 'CONFLICT' && meta) {
         res.status(409).json({ error: 'session already has a pending request', sessionId: meta.id });
         return;
       }
-      // Clean up the orphaned session so the caller does not need to
-      runner.deleteApiSession(resolvedChatId, meta.id).catch(() => undefined);
+      if (meta) runner.deleteApiSession(resolvedChatId, meta.id).catch(() => undefined);
       res.status(500).json({ error: (err as Error).message });
       return;
     }
-    // Delete GREETING.md so subsequent calls return 204 (one-shot sentinel)
-    fsp.unlink(greetingPath).catch(() => {});
+    fsp.unlink(greetingPath).catch((e) =>
+      console.error(`[api] Failed to delete GREETING.md for '${agentId}': ${(e as Error).message}`)
+    );
     res.status(201).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
   });
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { AgentRunner, DEFAULT_MODELS } from '../agent/runner';
-import { AgentConfig, ApiKey, ModelConfig } from '../types';
+import { AgentConfig, ApiKey, ModelConfig, SessionMeta } from '../types';
 import { createApiAuthMiddleware, canAccessAgent, canWriteAgent, isAdmin } from './auth';
 import { MediaStore } from '../history/media-store';
 import { HistoryDB } from '../history/db';
@@ -2112,18 +2112,19 @@ export function createApiRouter(
       res.status(400).json({ error: 'chat_id must be 1-64 alphanumeric characters, hyphens, or underscores' });
       return;
     }
-    const sessionName = typeof body.session_name === 'string' ? body.session_name : undefined;
+    const rawSessionName = typeof body.session_name === 'string' ? body.session_name.trim() : undefined;
+    const sessionName = rawSessionName ? rawSessionName.slice(0, 200) : undefined;
 
     const greetingPath = path.join(runner.workspacePath, 'GREETING.md');
     let content: string;
     try {
       content = (await fsp.readFile(greetingPath, 'utf-8')).trim();
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        res.status(500).json({ error: `Failed to read GREETING.md: ${(err as Error).message}` });
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        res.status(204).send();
         return;
       }
-      res.status(204).send();
+      res.status(500).json({ error: `Failed to read GREETING.md: ${(err as Error).message}` });
       return;
     }
 
@@ -2132,7 +2133,7 @@ export function createApiRouter(
       return;
     }
 
-    let meta: { id: string; name: string } | undefined;
+    let meta: SessionMeta | undefined;
     try {
       meta = await runner.createApiSession(resolvedChatId, content, sessionName);
       await runner.sendApiMessage(meta.id, resolvedChatId, content, {
@@ -2149,9 +2150,10 @@ export function createApiRouter(
       res.status(500).json({ error: (err as Error).message });
       return;
     }
-    fsp.unlink(greetingPath).catch((e) =>
-      console.error(`[api] Failed to delete GREETING.md for '${agentId}': ${(e as Error).message}`)
-    );
+    // Await unlink so a rapid second request doesn't race and re-read the file
+    try { await fsp.unlink(greetingPath); } catch (e) {
+      console.error(`[api] Failed to delete GREETING.md for '${agentId}': ${(e as Error).message}`);
+    }
     res.status(201).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
   });
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2120,6 +2120,7 @@ export function createApiRouter(
       return;
     }
     const resolvedChatId = chatId.trim();
+    const sessionName = (req.body as Record<string, unknown>)?.['session_name'] as string | undefined;
 
     const greetingPath = path.join(runner.workspacePath, 'GREETING.md');
     let greetingContent: string;
@@ -2135,7 +2136,7 @@ export function createApiRouter(
       return;
     }
 
-    const meta = await runner.createApiSession(resolvedChatId, greetingContent);
+    const meta = await runner.createApiSession(resolvedChatId, greetingContent, sessionName);
     try {
       await runner.sendApiMessage(meta.id, resolvedChatId, greetingContent, {
         timeoutMs: DEFAULT_TIMEOUT_MS,
@@ -2152,6 +2153,8 @@ export function createApiRouter(
       res.status(500).json({ error: (err as Error).message });
       return;
     }
+    // Delete GREETING.md so subsequent calls return 204 (one-shot sentinel)
+    fsp.unlink(greetingPath).catch(() => {});
     res.status(201).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
   });
 

--- a/tests/unit/api-greeting.test.ts
+++ b/tests/unit/api-greeting.test.ts
@@ -1,0 +1,252 @@
+import express from 'express';
+import * as supertest from 'supertest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { EventEmitter } from 'events';
+import { createApiRouter } from '../../src/api/router';
+import { AgentConfig, ApiKey, SessionMeta } from '../../src/types';
+
+// ── Mock AgentRunner for greeting tests ─────────────────────────────────────
+
+class MockGreetingRunner extends EventEmitter {
+  private _workspacePath: string;
+  sendApiMessageResult: string | Error = 'Hello!';
+  createApiSessionResult: SessionMeta = {
+    id: 'sess-abc123',
+    name: 'Welcome to GetPod',
+    createdAt: Date.now(),
+    lastActive: Date.now(),
+    messageCount: 0,
+    totalTokensUsed: 0,
+  };
+  createApiSessionCalls: Array<{ chatId: string; prompt?: string; name?: string }> = [];
+  deleteApiSessionCalls: Array<{ chatId: string; sessionId: string }> = [];
+
+  constructor(workspacePath: string) {
+    super();
+    this._workspacePath = workspacePath;
+  }
+
+  get workspacePath(): string {
+    return this._workspacePath;
+  }
+
+  async createApiSession(chatId: string, prompt?: string, name?: string): Promise<SessionMeta> {
+    this.createApiSessionCalls.push({ chatId, prompt, name });
+    return this.createApiSessionResult;
+  }
+
+  async sendApiMessage(
+    _sessionId: string,
+    _chatId: string,
+    _message: string,
+    _opts: { timeoutMs: number; skipUserMessage?: boolean },
+  ): Promise<string> {
+    if (this.sendApiMessageResult instanceof Error) throw this.sendApiMessageResult;
+    return this.sendApiMessageResult;
+  }
+
+  async deleteApiSession(_chatId: string, _sessionId: string): Promise<void> {
+    this.deleteApiSessionCalls.push({ chatId: _chatId, sessionId: _sessionId });
+  }
+
+  hasActiveApiSession(_sessionId: string): boolean { return false; }
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const AGENT_ID = 'getpod';
+
+const agentConfig: AgentConfig = {
+  id: AGENT_ID,
+  description: 'Test agent',
+  workspace: '/tmp/test-agent',
+  env: '',
+  claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+};
+
+const apiKeys: ApiKey[] = [
+  { key: 'sk-read-only', agents: [AGENT_ID] },
+  { key: 'sk-write', agents: [AGENT_ID], write: true },
+  { key: 'sk-admin', agents: '*', admin: true },
+];
+
+function buildApp(runner: MockGreetingRunner) {
+  const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+  const configs = new Map([[AGENT_ID, agentConfig]]);
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createApiRouter(runners, configs, apiKeys));
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/agents/:agentId/greeting', () => {
+  let tmpDir: string;
+  let runner: MockGreetingRunner;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'greeting-test-'));
+    runner = new MockGreetingRunner(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // T-GREETING-204-NO-FILE: returns 204 when GREETING.md does not exist
+  it('T-GREETING-204-NO-FILE: returns 204 when GREETING.md is absent', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat' });
+    expect(res.status).toBe(204);
+    expect(runner.createApiSessionCalls).toHaveLength(0);
+  });
+
+  // T-GREETING-204-EMPTY: returns 204 when GREETING.md is empty/whitespace
+  it('T-GREETING-204-EMPTY: returns 204 when GREETING.md is empty', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), '   \n  ');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat' });
+    expect(res.status).toBe(204);
+    expect(runner.createApiSessionCalls).toHaveLength(0);
+  });
+
+  // T-GREETING-201-NO-NAME: returns 201 and passes name=undefined (triggers LLM naming)
+  it('T-GREETING-201-NO-NAME: returns 201 without session_name, passes undefined to createApiSession', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome, the VM is ready!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat' });
+    expect(res.status).toBe(201);
+    expect(res.body.greeted).toBe(true);
+    expect(res.body.sessionId).toBe('sess-abc123');
+    expect(res.body.sessionName).toBe('Welcome to GetPod');
+    expect(runner.createApiSessionCalls[0].name).toBeUndefined();
+  });
+
+  // T-GREETING-201-WITH-NAME: passes session_name to createApiSession, skipping LLM naming
+  it('T-GREETING-201-WITH-NAME: passes session_name to createApiSession when provided', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome, the VM is ready!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat', session_name: 'My Custom Title' });
+    expect(res.status).toBe(201);
+    expect(runner.createApiSessionCalls[0].name).toBe('My Custom Title');
+  });
+
+  // T-GREETING-DELETES-FILE: GREETING.md is deleted after successful greeting
+  it('T-GREETING-DELETES-FILE: GREETING.md is deleted after 201 response', async () => {
+    const greetingPath = path.join(tmpDir, 'GREETING.md');
+    await fs.writeFile(greetingPath, 'Welcome, the VM is ready!');
+    const app = buildApp(runner);
+    await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat', session_name: 'Welcome' });
+    // Give fire-and-forget unlink time to complete
+    await new Promise(r => setTimeout(r, 50));
+    await expect(fs.access(greetingPath)).rejects.toThrow();
+  });
+
+  // T-GREETING-IDEMPOTENT: second call returns 204 because GREETING.md was deleted
+  it('T-GREETING-IDEMPOTENT: second call returns 204 after first success', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    const first = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat', session_name: 'Welcome' });
+    expect(first.status).toBe(201);
+    await new Promise(r => setTimeout(r, 50));
+    const second = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat', session_name: 'Welcome' });
+    expect(second.status).toBe(204);
+    expect(runner.createApiSessionCalls).toHaveLength(1);
+  });
+
+  // T-GREETING-403-READ-KEY: read-only key returns 403
+  it('T-GREETING-403-READ-KEY: read-only key is rejected with 403', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-read-only')
+      .send({ chat_id: 'testchat' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/write or admin/i);
+  });
+
+  // T-GREETING-403-ADMIN-OK: admin key succeeds
+  it('T-GREETING-403-ADMIN-OK: admin key is accepted', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-admin')
+      .send({ chat_id: 'testchat', session_name: 'Welcome' });
+    expect(res.status).toBe(201);
+  });
+
+  // T-GREETING-400-NO-CHAT: missing chat_id returns 400
+  it('T-GREETING-400-NO-CHAT: missing chat_id returns 400', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/chat_id/i);
+  });
+
+  // T-GREETING-404-UNKNOWN-AGENT: unknown agent returns 404
+  it('T-GREETING-404-UNKNOWN-AGENT: unknown agent returns 404', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post('/api/v1/agents/nonexistent/greeting')
+      .set('X-Api-Key', 'sk-admin')
+      .send({ chat_id: 'testchat' });
+    expect(res.status).toBe(404);
+  });
+
+  // T-GREETING-409-CONFLICT: sendApiMessage CONFLICT maps to 409
+  it('T-GREETING-409-CONFLICT: concurrent greeting returns 409', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const err = Object.assign(new Error('conflict'), { code: 'CONFLICT' });
+    runner.sendApiMessageResult = err;
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat', session_name: 'Welcome' });
+    expect(res.status).toBe(409);
+    expect(res.body.sessionId).toBe('sess-abc123');
+  });
+
+  // T-GREETING-500-ERROR: non-CONFLICT error deletes orphaned session and returns 500
+  it('T-GREETING-500-ERROR: unexpected error cleans up session and returns 500', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    runner.sendApiMessageResult = new Error('internal failure');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat', session_name: 'Welcome' });
+    expect(res.status).toBe(500);
+    expect(runner.deleteApiSessionCalls).toHaveLength(1);
+    expect(runner.deleteApiSessionCalls[0].sessionId).toBe('sess-abc123');
+  });
+});

--- a/tests/unit/api-greeting.test.ts
+++ b/tests/unit/api-greeting.test.ts
@@ -81,6 +81,20 @@ function buildApp(runner: MockGreetingRunner) {
   return app;
 }
 
+// Poll until the file is gone (avoids arbitrary setTimeout for fire-and-forget unlink)
+async function waitForFileDeleted(filePath: string, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await fs.access(filePath);
+      await new Promise(r => setTimeout(r, 20));
+    } catch {
+      return;
+    }
+  }
+  throw new Error(`File ${filePath} still exists after ${timeoutMs}ms`);
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('POST /api/v1/agents/:agentId/greeting', () => {
@@ -116,6 +130,26 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
       .set('X-Api-Key', 'sk-write')
       .send({ chat_id: 'testchat' });
     expect(res.status).toBe(204);
+    expect(runner.createApiSessionCalls).toHaveLength(0);
+  });
+
+  // T-GREETING-500-EACCES: non-ENOENT readFile error (e.g. EACCES) returns 500, not 204
+  it('T-GREETING-500-EACCES: permission error on GREETING.md returns 500', async () => {
+    const greetingPath = path.join(tmpDir, 'GREETING.md');
+    await fs.writeFile(greetingPath, 'Welcome!');
+    await fs.chmod(greetingPath, 0o000);
+    // root can read any file — skip assertion in that environment
+    if ((process.getuid?.() ?? -1) === 0) {
+      await fs.chmod(greetingPath, 0o644);
+      return;
+    }
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'testchat' });
+    await fs.chmod(greetingPath, 0o644);
+    expect(res.status).toBe(500);
     expect(runner.createApiSessionCalls).toHaveLength(0);
   });
 
@@ -155,21 +189,20 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
       .send({ chat_id: 'testchat', session_name: 'Welcome' });
-    // Give fire-and-forget unlink time to complete
-    await new Promise(r => setTimeout(r, 50));
-    await expect(fs.access(greetingPath)).rejects.toThrow();
+    await waitForFileDeleted(greetingPath);
   });
 
   // T-GREETING-IDEMPOTENT: second call returns 204 because GREETING.md was deleted
   it('T-GREETING-IDEMPOTENT: second call returns 204 after first success', async () => {
-    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const greetingPath = path.join(tmpDir, 'GREETING.md');
+    await fs.writeFile(greetingPath, 'Welcome!');
     const app = buildApp(runner);
     const first = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
       .send({ chat_id: 'testchat', session_name: 'Welcome' });
     expect(first.status).toBe(201);
-    await new Promise(r => setTimeout(r, 50));
+    await waitForFileDeleted(greetingPath);
     const second = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')


### PR DESCRIPTION
## Summary

- Accept optional `session_name` in `POST /v1/agents/:agentId/greeting` body; when provided, skips the ~15s Claude Haiku title-generation call in `createApiSession()` entirely
- Delete `GREETING.md` after a successful 201 response so subsequent calls (e.g. page refresh) return 204 immediately — acting as a one-shot sentinel
- Update API.md to document `session_name` field and the new idempotency behavior

Closes #106

## Test plan

- [ ] `T-GREETING-204-NO-FILE` — returns 204 when GREETING.md is absent
- [ ] `T-GREETING-204-EMPTY` — returns 204 when GREETING.md is empty/whitespace
- [ ] `T-GREETING-201-NO-NAME` — returns 201, `name` is undefined → LLM naming preserved
- [ ] `T-GREETING-201-WITH-NAME` — `session_name` forwarded to `createApiSession`, skips Haiku call
- [ ] `T-GREETING-DELETES-FILE` — GREETING.md deleted after 201
- [ ] `T-GREETING-IDEMPOTENT` — second call returns 204 (file gone)
- [ ] `T-GREETING-403-READ-KEY` — read-only key rejected
- [ ] `T-GREETING-403-ADMIN-OK` — admin key accepted
- [ ] `T-GREETING-400-NO-CHAT` — missing chat_id → 400
- [ ] `T-GREETING-404-UNKNOWN-AGENT` — unknown agent → 404
- [ ] `T-GREETING-409-CONFLICT` — concurrent session → 409
- [ ] `T-GREETING-500-ERROR` — failure cleans up orphaned session → 500