### PR TITLE
feat(api): make POST /greeting async (202), standardize chat_id/session_name

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,7 +26,7 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 | `PATCH` | `/api/v1/agents/:agentId` | Write | Update agent description, model, or allow_tools |
 | `DELETE` | `/api/v1/agents/:agentId` | Admin | Delete an agent |
 | `POST` | `/api/v1/agents/:agentId/messages` | Key | Send a message — sync JSON or SSE stream; supports slash commands |
-| `POST` | `/api/v1/agents/:agentId/greeting` | Write | Create a proactive welcome session from `GREETING.md`; returns 204 if file absent |
+| `POST` | `/api/v1/agents/:agentId/greeting` | Write | Create a proactive welcome session from `GREETING.md`; returns 202 immediately, generates greeting in background; returns 204 if file absent |
 | `GET` | `/api/v1/models` | Key | List all supported Claude models |
 | `PUT` | `/api/v1/agents/:agentId/model` | Admin | Set the active model for an agent |
 
@@ -790,7 +790,7 @@ Returns `204 No Content` (no session created) if `GREETING.md` does not exist or
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `chat_id` | Yes | Caller identity — same as other session endpoints |
+| `chat_id` | Yes | Caller identity — same as other session endpoints. Accepted in request body (preferred) or as a query param for backward compatibility |
 | `session_name` | No | Explicit session title (max 200 chars); skips the LLM auto-naming call (~15s) when provided |
 
 ```bash
@@ -801,7 +801,7 @@ curl -X POST \
   http://localhost:10850/api/v1/agents/getpod/greeting
 ```
 
-**Response `201`** — session created, agent responded:
+**Response `202`** — session created; greeting is generating in the background:
 
 ```json
 {
@@ -810,6 +810,8 @@ curl -X POST \
   "sessionName": "Welcome to GetPod"
 }
 ```
+
+The session exists immediately and the client can redirect to it. The assistant's greeting message arrives asynchronously (poll `GET /sessions/:id/messages` or open the chat UI to receive it).
 
 **Response `204`** — `GREETING.md` not found or empty; no session created.
 
@@ -823,8 +825,9 @@ introducing yourself and what you can help with.
 ```
 
 **Notes:**
-- `GREETING.md` is **deleted after a successful greeting** (201 response). Subsequent calls return 204 immediately, making the endpoint idempotent. Re-provisioning GREETING.md will trigger a new greeting on next call.
+- `GREETING.md` is **deleted before the `202` response** is sent. Subsequent calls return 204 immediately, making the endpoint idempotent. Re-provisioning GREETING.md will trigger a new greeting on next call.
 - Pass `session_name` to avoid the ~15s LLM title-generation call. If omitted, the session is auto-named from the greeting prompt content (same logic as `POST /sessions`).
+- Greeting generation runs in the background. If generation fails, the empty session is cleaned up automatically; the client should handle the case where the session has no messages yet.
 
 ---
 
@@ -919,13 +922,13 @@ Rename a session.
 | Field | Required | Description |
 |-------|----------|-------------|
 | `chat_id` | Yes | Caller identity |
-| `sessionName` | Yes | New session name |
+| `session_name` | Yes | New session name (snake_case preferred; `sessionName` also accepted for backward compatibility) |
 
 ```bash
 curl -X PATCH \
   -H "X-Api-Key: my-secret-key-123" \
   -H "Content-Type: application/json" \
-  -d '{"chat_id": "myapp", "sessionName": "Q3 Infra Discussion"}' \
+  -d '{"chat_id": "myapp", "session_name": "Q3 Infra Discussion"}' \
   http://localhost:10850/api/v1/agents/alfred/sessions/da19d84a | jq
 ```
 

--- a/API.md
+++ b/API.md
@@ -939,6 +939,10 @@ curl -X PATCH \
 }
 ```
 
+**Notes:**
+- Request body accepts `session_name` (snake_case, preferred) or `sessionName` (camelCase, backward compatibility). When both are present, `session_name` takes priority.
+- The response body always uses camelCase (`sessionName`), consistent with all other API responses.
+
 ---
 
 ### DELETE /api/v1/agents/:agentId/sessions/:sessionId

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1997,9 +1997,11 @@ export function createApiRouter(
     if (!ctx) return;
     const { runner, chatId } = ctx;
     const { sessionId } = req.params as { sessionId: string };
-    const body = req.body as { sessionName?: unknown };
-    const sessionName = typeof body.sessionName === 'string' ? body.sessionName.trim() : undefined;
-    if (!sessionName) { res.status(400).json({ error: 'sessionName is required' }); return; }
+    const body = req.body as { session_name?: unknown; sessionName?: unknown };
+    // Accept session_name (preferred, snake_case) or sessionName (camelCase, backward compat)
+    const rawName = body.session_name ?? body.sessionName;
+    const sessionName = typeof rawName === 'string' ? rawName.trim() : undefined;
+    if (!sessionName) { res.status(400).json({ error: 'session_name is required' }); return; }
     try {
       const result = await runner.updateApiSession(chatId, sessionId, { sessionName });
       res.json(result);
@@ -2102,7 +2104,8 @@ export function createApiRouter(
     if (!runner) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return; }
 
     const body = req.body as { chat_id?: unknown; session_name?: unknown };
-    const rawChatId = (req.query['chat_id'] ?? body.chat_id) as string | undefined;
+    // Accept chat_id from body (preferred) or query param (backward compat)
+    const rawChatId = (body.chat_id ?? req.query['chat_id']) as string | undefined;
     const resolvedChatId = typeof rawChatId === 'string' ? rawChatId.trim() : '';
     if (!resolvedChatId) {
       res.status(400).json({ error: 'chat_id is required' });
@@ -2136,25 +2139,26 @@ export function createApiRouter(
     let meta: SessionMeta | undefined;
     try {
       meta = await runner.createApiSession(resolvedChatId, content, sessionName);
-      await runner.sendApiMessage(meta.id, resolvedChatId, content, {
-        timeoutMs: DEFAULT_TIMEOUT_MS,
-        skipUserMessage: true,
-      });
     } catch (err) {
-      const code = (err as { code?: string }).code;
-      if (code === 'CONFLICT' && meta) {
-        res.status(409).json({ error: 'session already has a pending request', sessionId: meta.id });
-        return;
-      }
-      if (meta) runner.deleteApiSession(resolvedChatId, meta.id).catch(() => undefined);
       res.status(500).json({ error: (err as Error).message });
       return;
     }
-    // Await unlink so a rapid second request doesn't race and re-read the file
+
+    // Unlink before responding — prevents re-read race if the client retries immediately
     try { await fsp.unlink(greetingPath); } catch (e) {
       console.error(`[api] Failed to delete GREETING.md for '${agentId}': ${(e as Error).message}`);
     }
-    res.status(201).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
+
+    // Return 202 immediately so the client can redirect while the greeting generates in the background
+    res.status(202).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
+
+    runner.sendApiMessage(meta.id, resolvedChatId, content, {
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+      skipUserMessage: true,
+    }).catch((err: Error) => {
+      console.error(`[api] Greeting background processing failed for '${agentId}': ${err.message}`);
+      if (meta) runner.deleteApiSession(resolvedChatId, meta.id).catch(() => undefined);
+    });
   });
 
   return router;

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2157,7 +2157,7 @@ export function createApiRouter(
       skipUserMessage: true,
     }).catch((err: Error) => {
       console.error(`[api] Greeting background processing failed for '${agentId}': ${err.message}`);
-      if (meta) runner.deleteApiSession(resolvedChatId, meta.id).catch(() => undefined);
+      runner.deleteApiSession(resolvedChatId, meta.id).catch(() => undefined);
     });
   });
 

--- a/tests/unit/api-greeting.test.ts
+++ b/tests/unit/api-greeting.test.ts
@@ -81,7 +81,7 @@ function buildApp(runner: MockGreetingRunner) {
   return app;
 }
 
-// Poll until the file is gone (avoids arbitrary setTimeout for fire-and-forget unlink)
+// Poll until the file is gone (avoids arbitrary setTimeout for async unlink)
 async function waitForFileDeleted(filePath: string, timeoutMs = 2000): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
@@ -153,35 +153,59 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
     expect(runner.createApiSessionCalls).toHaveLength(0);
   });
 
-  // T-GREETING-201-NO-NAME: returns 201 and passes name=undefined (triggers LLM naming)
-  it('T-GREETING-201-NO-NAME: returns 201 without session_name, passes undefined to createApiSession', async () => {
+  // T-GREETING-202-NO-NAME: returns 202 immediately without waiting for LLM
+  it('T-GREETING-202-NO-NAME: returns 202 without session_name, passes undefined to createApiSession', async () => {
     await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome, the VM is ready!');
     const app = buildApp(runner);
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
       .send({ chat_id: 'testchat' });
-    expect(res.status).toBe(201);
+    expect(res.status).toBe(202);
     expect(res.body.greeted).toBe(true);
     expect(res.body.sessionId).toBe('sess-abc123');
     expect(res.body.sessionName).toBe('Welcome to GetPod');
     expect(runner.createApiSessionCalls[0].name).toBeUndefined();
   });
 
-  // T-GREETING-201-WITH-NAME: passes session_name to createApiSession, skipping LLM naming
-  it('T-GREETING-201-WITH-NAME: passes session_name to createApiSession when provided', async () => {
+  // T-GREETING-202-WITH-NAME: passes session_name to createApiSession, skipping LLM naming
+  it('T-GREETING-202-WITH-NAME: passes session_name to createApiSession when provided', async () => {
     await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome, the VM is ready!');
     const app = buildApp(runner);
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
       .send({ chat_id: 'testchat', session_name: 'My Custom Title' });
-    expect(res.status).toBe(201);
+    expect(res.status).toBe(202);
     expect(runner.createApiSessionCalls[0].name).toBe('My Custom Title');
   });
 
-  // T-GREETING-DELETES-FILE: GREETING.md is deleted after successful greeting
-  it('T-GREETING-DELETES-FILE: GREETING.md is deleted after 201 response', async () => {
+  // T-GREETING-CHAT-ID-QUERY: chat_id as query param is accepted for backward compat
+  it('T-GREETING-CHAT-ID-QUERY: chat_id as query param is accepted (backward compat)', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting?chat_id=testchat`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ session_name: 'Welcome' });
+    expect(res.status).toBe(202);
+    expect(runner.createApiSessionCalls[0].chatId).toBe('testchat');
+  });
+
+  // T-GREETING-CHAT-ID-BODY-PREFERRED: body chat_id takes priority over query param
+  it('T-GREETING-CHAT-ID-BODY-PREFERRED: body chat_id takes priority over query param', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting?chat_id=query-id`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ chat_id: 'body-id', session_name: 'Welcome' });
+    expect(res.status).toBe(202);
+    expect(runner.createApiSessionCalls[0].chatId).toBe('body-id');
+  });
+
+  // T-GREETING-DELETES-FILE: GREETING.md is deleted before the 202 response
+  it('T-GREETING-DELETES-FILE: GREETING.md is deleted before 202 response', async () => {
     const greetingPath = path.join(tmpDir, 'GREETING.md');
     await fs.writeFile(greetingPath, 'Welcome, the VM is ready!');
     const app = buildApp(runner);
@@ -201,7 +225,7 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
       .send({ chat_id: 'testchat', session_name: 'Welcome' });
-    expect(first.status).toBe(201);
+    expect(first.status).toBe(202);
     await waitForFileDeleted(greetingPath);
     const second = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
@@ -230,7 +254,7 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-admin')
       .send({ chat_id: 'testchat', session_name: 'Welcome' });
-    expect(res.status).toBe(201);
+    expect(res.status).toBe(202);
   });
 
   // T-GREETING-400-NO-CHAT: missing chat_id returns 400
@@ -255,30 +279,25 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
     expect(res.status).toBe(404);
   });
 
-  // T-GREETING-409-CONFLICT: sendApiMessage CONFLICT maps to 409
-  it('T-GREETING-409-CONFLICT: concurrent greeting returns 409', async () => {
-    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
-    const err = Object.assign(new Error('conflict'), { code: 'CONFLICT' });
-    runner.sendApiMessageResult = err;
-    const app = buildApp(runner);
-    const res = await supertest.default(app)
-      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
-      .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat', session_name: 'Welcome' });
-    expect(res.status).toBe(409);
-    expect(res.body.sessionId).toBe('sess-abc123');
-  });
-
-  // T-GREETING-500-ERROR: non-CONFLICT error deletes orphaned session and returns 500
-  it('T-GREETING-500-ERROR: unexpected error cleans up session and returns 500', async () => {
+  // T-GREETING-BG-CLEANUP: background sendApiMessage failure cleans up orphaned session
+  it('T-GREETING-BG-CLEANUP: background failure cleans up orphaned session', async () => {
     await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
     runner.sendApiMessageResult = new Error('internal failure');
+    let cleanupResolve!: () => void;
+    const cleanupDone = new Promise<void>(r => { cleanupResolve = r; });
+    const origDelete = runner.deleteApiSession.bind(runner);
+    runner.deleteApiSession = async (...args: Parameters<typeof runner.deleteApiSession>) => {
+      await origDelete(...args);
+      cleanupResolve();
+    };
     const app = buildApp(runner);
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
       .send({ chat_id: 'testchat', session_name: 'Welcome' });
-    expect(res.status).toBe(500);
+    // Response is 202 immediately; cleanup happens in background
+    expect(res.status).toBe(202);
+    await cleanupDone;
     expect(runner.deleteApiSessionCalls).toHaveLength(1);
     expect(runner.deleteApiSessionCalls[0].sessionId).toBe('sess-abc123');
   });

--- a/tests/unit/api-sessions-rename.test.ts
+++ b/tests/unit/api-sessions-rename.test.ts
@@ -1,0 +1,135 @@
+import express from 'express';
+import * as supertest from 'supertest';
+import { EventEmitter } from 'events';
+import { createApiRouter } from '../../src/api/router';
+import { AgentConfig, ApiKey } from '../../src/types';
+
+// ── Mock runner ───────────────────────────────────────────────────────────────
+
+class MockRenameRunner extends EventEmitter {
+  updateApiSessionCalls: Array<{ chatId: string; sessionId: string; updates: { sessionName?: string } }> = [];
+  updateApiSessionResult: { sessionId: string; sessionName?: string } = {
+    sessionId: 'sess-rename-01',
+    sessionName: 'Updated Name',
+  };
+
+  async updateApiSession(
+    chatId: string,
+    sessionId: string,
+    updates: { sessionName?: string },
+  ): Promise<{ sessionId: string; sessionName?: string }> {
+    this.updateApiSessionCalls.push({ chatId, sessionId, updates });
+    return this.updateApiSessionResult;
+  }
+
+  hasActiveApiSession(_sessionId: string): boolean { return false; }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const AGENT_ID = 'alfred';
+const SESSION_ID = 'sess-rename-01';
+
+const agentConfig: AgentConfig = {
+  id: AGENT_ID,
+  description: 'Test agent',
+  workspace: '/tmp/test-agent',
+  env: '',
+  claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+};
+
+const apiKeys: ApiKey[] = [
+  { key: 'sk-read', agents: [AGENT_ID] },
+  { key: 'sk-admin', agents: '*', admin: true },
+];
+
+function buildApp(runner: MockRenameRunner) {
+  const runners = new Map([[AGENT_ID, runner as unknown as import('../../src/agent/runner').AgentRunner]]);
+  const configs = new Map([[AGENT_ID, agentConfig]]);
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createApiRouter(runners, configs, apiKeys));
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/v1/agents/:agentId/sessions/:sessionId', () => {
+  let runner: MockRenameRunner;
+
+  beforeEach(() => {
+    runner = new MockRenameRunner();
+  });
+
+  // T-RENAME-200-SNAKE: snake_case session_name is accepted (preferred field)
+  it('T-RENAME-200-SNAKE: session_name (snake_case) is accepted and passed to updateApiSession', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}/sessions/${SESSION_ID}`)
+      .set('X-Api-Key', 'sk-admin')
+      .query({ chat_id: 'testchat' })
+      .send({ session_name: 'New Session Name' });
+    expect(res.status).toBe(200);
+    expect(runner.updateApiSessionCalls).toHaveLength(1);
+    expect(runner.updateApiSessionCalls[0].updates.sessionName).toBe('New Session Name');
+  });
+
+  // T-RENAME-200-CAMEL: camelCase sessionName is accepted (backward compat)
+  it('T-RENAME-200-CAMEL: sessionName (camelCase) is accepted for backward compatibility', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}/sessions/${SESSION_ID}`)
+      .set('X-Api-Key', 'sk-admin')
+      .query({ chat_id: 'testchat' })
+      .send({ sessionName: 'Old Style Name' });
+    expect(res.status).toBe(200);
+    expect(runner.updateApiSessionCalls[0].updates.sessionName).toBe('Old Style Name');
+  });
+
+  // T-RENAME-SNAKE-PREFERRED: when both fields are present, session_name takes priority
+  it('T-RENAME-SNAKE-PREFERRED: session_name takes priority over sessionName when both are sent', async () => {
+    const app = buildApp(runner);
+    await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}/sessions/${SESSION_ID}`)
+      .set('X-Api-Key', 'sk-admin')
+      .query({ chat_id: 'testchat' })
+      .send({ session_name: 'snake wins', sessionName: 'camel loses' });
+    expect(runner.updateApiSessionCalls[0].updates.sessionName).toBe('snake wins');
+  });
+
+  // T-RENAME-400-NO-NAME: missing both fields returns 400
+  it('T-RENAME-400-NO-NAME: missing session_name and sessionName returns 400', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}/sessions/${SESSION_ID}`)
+      .set('X-Api-Key', 'sk-admin')
+      .query({ chat_id: 'testchat' })
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/session_name/i);
+    expect(runner.updateApiSessionCalls).toHaveLength(0);
+  });
+
+  // T-RENAME-400-EMPTY-STRING: empty string is rejected
+  it('T-RENAME-400-EMPTY-STRING: empty session_name (whitespace) is rejected', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}/sessions/${SESSION_ID}`)
+      .set('X-Api-Key', 'sk-admin')
+      .query({ chat_id: 'testchat' })
+      .send({ session_name: '   ' });
+    expect(res.status).toBe(400);
+    expect(runner.updateApiSessionCalls).toHaveLength(0);
+  });
+
+  // T-RENAME-200-TRIMS: leading/trailing whitespace is trimmed
+  it('T-RENAME-200-TRIMS: session_name is trimmed before passing to runner', async () => {
+    const app = buildApp(runner);
+    await supertest.default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}/sessions/${SESSION_ID}`)
+      .set('X-Api-Key', 'sk-admin')
+      .query({ chat_id: 'testchat' })
+      .send({ session_name: '  Padded Name  ' });
+    expect(runner.updateApiSessionCalls[0].updates.sessionName).toBe('Padded Name');
+  });
+});


### PR DESCRIPTION
Closes #108

## Summary

- **Async greeting**: `POST /greeting` now returns `202 Accepted` immediately after creating the session. `sendApiMessage` runs in the background — the client can redirect to the chat page in ~100ms instead of waiting ~8s for LLM generation.
- **Race prevention**: `GREETING.md` is unlinked *before* the 202 response is sent, so a rapid retry hits 204 and never triggers a duplicate greeting.
- **Background cleanup**: If background generation fails, the orphaned session is deleted automatically via `.catch()`.
- **`chat_id` in body**: Body `chat_id` now takes priority over query param; query param still accepted for backward compatibility.
- **`session_name` standardization**: `PATCH /sessions/:id` now accepts `session_name` (snake_case, preferred) in addition to `sessionName` (camelCase, kept for backward compat).

## Test plan

- [ ] 14 greeting unit tests pass (updated 201→202, added CHAT-ID-QUERY, CHAT-ID-BODY-PREFERRED, BG-CLEANUP; removed CONFLICT which no longer applies)
- [ ] Full suite: 88 suites, 1626 tests — all pass
- [ ] TypeScript: `npx tsc --noEmit` clean