### PR TITLE
feat(api): refactor POST /greeting to SSE stream using caller-provided session_id

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,7 +26,7 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 | `PATCH` | `/api/v1/agents/:agentId` | Write | Update agent description, model, or allow_tools |
 | `DELETE` | `/api/v1/agents/:agentId` | Admin | Delete an agent |
 | `POST` | `/api/v1/agents/:agentId/messages` | Key | Send a message — sync JSON or SSE stream; supports slash commands |
-| `POST` | `/api/v1/agents/:agentId/greeting` | Write | Create a proactive welcome session from `GREETING.md`; returns 202 immediately, generates greeting in background; returns 204 if file absent |
+| `POST` | `/api/v1/agents/:agentId/greeting` | Write | Stream a proactive welcome from `GREETING.md` into an existing session (SSE); returns 204 if file absent |
 | `GET` | `/api/v1/models` | Key | List all supported Claude models |
 | `PUT` | `/api/v1/agents/:agentId/model` | Admin | Set the active model for an agent |
 
@@ -780,40 +780,43 @@ Manage API sessions for a specific agent and `chat_id`. Sessions are stored at `
 
 ### POST /api/v1/agents/:agentId/greeting
 
-Create a proactive welcome session. The endpoint reads `GREETING.md` from the agent's workspace directory and sends its content to the agent as a trigger prompt. Only the **assistant response** is stored in session history — the trigger prompt itself is invisible to the session (uses `store_user_message: false` internally).
+Stream a proactive welcome into an **existing** session. The endpoint reads `GREETING.md` from the agent's workspace and sends its content to the agent as a trigger prompt via SSE. Only the **assistant response** is stored in session history — the trigger prompt is invisible (uses `store_user_message: false` internally).
 
-Returns `204 No Content` (no session created) if `GREETING.md` does not exist or is empty.
+Returns `204 No Content` if `GREETING.md` does not exist or is empty.
 
 **Auth:** Write or Admin key required.
+
+**Two-step flow:**
+
+1. Create the session first: `POST /api/v1/agents/:agentId/sessions` → redirect the user to the chat UI with the returned `session_id`.
+2. Once in the chat UI, trigger the greeting: `POST /api/v1/agents/:agentId/greeting` with `session_id` → stream the assistant's opening message as SSE with typing animation visible to the user.
 
 **Request:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `chat_id` | Yes | Caller identity — same as other session endpoints. Accepted in request body (preferred) or as a query param for backward compatibility |
-| `session_name` | No | Explicit session title (max 200 chars); skips the LLM auto-naming call (~15s) when provided |
+| `session_id` | Yes | ID of an existing session to deliver the greeting into |
 
 ```bash
-curl -X POST \
+curl -N -X POST \
   -H "X-Api-Key: my-write-key" \
   -H "Content-Type: application/json" \
-  -d '{"chat_id": "getpod", "session_name": "Welcome to GetPod"}' \
+  -d '{"session_id": "7f3a1c2d-89ab-4def-b012-345678901234"}' \
   http://localhost:10850/api/v1/agents/getpod/greeting
 ```
 
-**Response `202`** — session created; greeting is generating in the background:
+**Response `200` (SSE stream)** — greeting is streaming:
 
-```json
-{
-  "greeted": true,
-  "sessionId": "7f3a1c2d-89ab-4def-b012-345678901234",
-  "sessionName": "Welcome to GetPod"
-}
+```
+data: {"type":"text_delta","text":"Hello! "}
+data: {"type":"text_delta","text":"Welcome to GetPod."}
+data: {"type":"result","text":"Hello! Welcome to GetPod.","session_id":"7f3a1c2d-..."}
+data: [DONE]
 ```
 
-The session exists immediately and the client can redirect to it. The assistant's greeting message arrives asynchronously (poll `GET /sessions/:id/messages` or open the chat UI to receive it).
+If the session has an active request in flight, the endpoint returns `409` before sending SSE headers.
 
-**Response `204`** — `GREETING.md` not found or empty; no session created.
+**Response `204`** — `GREETING.md` not found or empty; nothing sent to session.
 
 **`GREETING.md` format:**
 
@@ -825,9 +828,9 @@ introducing yourself and what you can help with.
 ```
 
 **Notes:**
-- `GREETING.md` is **deleted before the `202` response** is sent. Subsequent calls return 204 immediately, making the endpoint idempotent. Re-provisioning GREETING.md will trigger a new greeting on next call.
-- Pass `session_name` to avoid the ~15s LLM title-generation call. If omitted, the session is auto-named from the greeting prompt content (same logic as `POST /sessions`).
-- Greeting generation runs in the background. If generation fails, the empty session is cleaned up automatically; the client should handle the case where the session has no messages yet.
+- `GREETING.md` is **deleted before streaming begins**. Subsequent calls return 204 immediately, making the endpoint idempotent. Re-provisioning `GREETING.md` enables a new greeting on the next call.
+- The SSE stream format matches `POST /messages` with `stream: true` — use the same client-side handler.
+- If the agent errors mid-stream, an `{"type":"error","message":"..."}` SSE event is sent and the stream closes.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -796,6 +796,7 @@ Returns `204 No Content` if `GREETING.md` does not exist or is empty.
 | Field | Required | Description |
 |-------|----------|-------------|
 | `session_id` | Yes | ID of an existing session to deliver the greeting into |
+| `chat_id` | No | Same `chat_id` used when the session was created; ensures the greeting message is stored in the correct history bucket. Defaults to `session_id` when omitted (creates a secondary index entry) |
 
 ```bash
 curl -N -X POST \

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2090,7 +2090,7 @@ export function createApiRouter(
     }
   });
 
-  // POST /api/v1/agents/:agentId/greeting — one-shot proactive welcome from GREETING.md
+  // POST /api/v1/agents/:agentId/greeting — stream a proactive welcome from GREETING.md into an existing session
   router.post('/v1/agents/:agentId/greeting', auth, async (req: Request, res: Response) => {
     const { agentId } = req.params as { agentId: string };
     const apiKey = (req as AuthedRequest).apiKey;
@@ -2103,20 +2103,17 @@ export function createApiRouter(
     const runner = agentRunners.get(agentId);
     if (!runner) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return; }
 
-    const body = req.body as { chat_id?: unknown; session_name?: unknown };
-    // Accept chat_id from body (preferred) or query param (backward compat)
-    const rawChatId = (body.chat_id ?? req.query['chat_id']) as string | undefined;
-    const resolvedChatId = typeof rawChatId === 'string' ? rawChatId.trim() : '';
-    if (!resolvedChatId) {
-      res.status(400).json({ error: 'chat_id is required' });
+    const body = req.body as { session_id?: unknown };
+    const sessionId = typeof body.session_id === 'string' ? body.session_id.trim() : '';
+    if (!sessionId) {
+      res.status(400).json({ error: 'session_id is required' });
       return;
     }
-    if (!/^[a-zA-Z0-9_-]{1,64}$/.test(resolvedChatId)) {
-      res.status(400).json({ error: 'chat_id must be 1-64 alphanumeric characters, hyphens, or underscores' });
+
+    if (runner.hasActiveApiSession(sessionId)) {
+      res.status(409).json({ error: 'Session already has a pending request' });
       return;
     }
-    const rawSessionName = typeof body.session_name === 'string' ? body.session_name.trim() : undefined;
-    const sessionName = rawSessionName ? rawSessionName.slice(0, 200) : undefined;
 
     const greetingPath = path.join(runner.workspacePath, 'GREETING.md');
     let content: string;
@@ -2136,29 +2133,66 @@ export function createApiRouter(
       return;
     }
 
-    let meta: SessionMeta | undefined;
-    try {
-      meta = await runner.createApiSession(resolvedChatId, content, sessionName);
-    } catch (err) {
-      res.status(500).json({ error: (err as Error).message });
-      return;
-    }
-
-    // Unlink before responding — prevents re-read race if the client retries immediately
+    // Unlink before streaming — prevents re-read race if the client retries immediately
     try { await fsp.unlink(greetingPath); } catch (e) {
       console.error(`[api] Failed to delete GREETING.md for '${agentId}': ${(e as Error).message}`);
     }
 
-    // Return 202 immediately so the client can redirect while the greeting generates in the background
-    res.status(202).json({ greeted: true, sessionId: meta.id, sessionName: meta.name });
+    let cleanup: (() => void) | undefined;
+    try {
+      const sseCallbacks = {
+        onChunk: (event: import('../types').StreamEvent) => {
+          try { res.write(`data: ${JSON.stringify(event)}\n\n`); } catch { /* client gone */ }
+        },
+        onDone: (fullText: string) => {
+          try {
+            res.write(`data: ${JSON.stringify({ type: 'result', text: fullText, session_id: sessionId })}\n\n`);
+            res.write('data: [DONE]\n\n');
+            res.end();
+          } catch { /* client gone */ }
+        },
+        onError: (err: Error) => {
+          try {
+            res.write(`data: ${JSON.stringify({ type: 'error', message: err.message })}\n\n`);
+            res.end();
+          } catch { /* client gone */ }
+        },
+      };
 
-    runner.sendApiMessage(meta.id, resolvedChatId, content, {
-      timeoutMs: DEFAULT_TIMEOUT_MS,
-      skipUserMessage: true,
-    }).catch((err: Error) => {
-      console.error(`[api] Greeting background processing failed for '${agentId}': ${err.message}`);
-      runner.deleteApiSession(resolvedChatId, meta.id).catch(() => undefined);
-    });
+      // Preflight conflict check already done above; throw-based check catches races after headers
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      });
+      res.flushHeaders();
+      res.socket?.setNoDelay(true);
+
+      cleanup = await runner.sendApiMessageStream(
+        sessionId,
+        sessionId,
+        content,
+        sseCallbacks,
+        { timeoutMs: DEFAULT_TIMEOUT_MS, skipUserMessage: true },
+      );
+
+      res.on('close', cleanup);
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (!res.headersSent) {
+        if (code === 'CONFLICT') {
+          res.status(409).json({ error: 'Session already has a pending request' });
+        } else {
+          res.status(500).json({ error: (err as Error).message ?? 'Internal error' });
+        }
+      } else {
+        try {
+          res.write(`data: ${JSON.stringify({ type: 'error', message: (err as Error).message ?? 'Internal error' })}\n\n`);
+          res.end();
+        } catch { /* client gone */ }
+      }
+    }
   });
 
   return router;

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2103,12 +2103,16 @@ export function createApiRouter(
     const runner = agentRunners.get(agentId);
     if (!runner) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return; }
 
-    const body = req.body as { session_id?: unknown };
+    const body = req.body as { session_id?: unknown; chat_id?: unknown };
     const sessionId = typeof body.session_id === 'string' ? body.session_id.trim() : '';
     if (!sessionId) {
       res.status(400).json({ error: 'session_id is required' });
       return;
     }
+    // chat_id is optional — provide the same value used when creating the session via POST /sessions
+    // so the greeting message lands in the correct historyDb bucket (api-{chatId}).
+    // If omitted, sessionId is used as the bucket key, which creates a secondary index entry.
+    const chatId = typeof body.chat_id === 'string' && body.chat_id.trim() ? body.chat_id.trim() : sessionId;
 
     if (runner.hasActiveApiSession(sessionId)) {
       res.status(409).json({ error: 'Session already has a pending request' });
@@ -2171,7 +2175,7 @@ export function createApiRouter(
 
       cleanup = await runner.sendApiMessageStream(
         sessionId,
-        sessionId,
+        chatId,
         content,
         sseCallbacks,
         { timeoutMs: DEFAULT_TIMEOUT_MS, skipUserMessage: true },
@@ -2180,6 +2184,9 @@ export function createApiRouter(
       res.on('close', cleanup);
     } catch (err: unknown) {
       const code = (err as { code?: string }).code;
+      // res.headersSent is always true here (writeHead is called before sendApiMessageStream),
+      // so the !res.headersSent branches below are kept for parity with the /messages endpoint
+      // pattern — they guard against future code reordering, not any current reachable path.
       if (!res.headersSent) {
         if (code === 'CONFLICT') {
           res.status(409).json({ error: 'Session already has a pending request' });

--- a/tests/unit/api-greeting.test.ts
+++ b/tests/unit/api-greeting.test.ts
@@ -23,6 +23,7 @@ class MockGreetingRunner extends EventEmitter {
   activeSession = false;
   cleanupCalled = false;
   capturedCallbacks: SseCallbacks | null = null;
+  capturedChatId: string | null = null;
 
   constructor(workspacePath: string) {
     super();
@@ -39,13 +40,14 @@ class MockGreetingRunner extends EventEmitter {
 
   async sendApiMessageStream(
     _sessionId: string,
-    _chatId: string,
+    chatId: string,
     _message: string,
     callbacks: SseCallbacks,
     _opts: { timeoutMs: number; skipUserMessage?: boolean },
   ): Promise<() => void> {
     if (this.sendStreamThrow) throw this.sendStreamThrow;
     this.capturedCallbacks = callbacks;
+    this.capturedChatId = chatId;
     // Fire callbacks asynchronously to simulate streaming
     setImmediate(() => {
       if (this.sendStreamResult instanceof Error) {
@@ -321,5 +323,40 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
     const events = parseSseEvents(res.text);
     const errEvent = events.find(e => e['type'] === 'error');
     expect(errEvent?.['message']).toMatch(/spawn failed/);
+  });
+
+  // ── chatId routing ─────────────────────────────────────────────────────────
+
+  it('T-GREETING-CHATID-PROVIDED: chat_id passed to sendApiMessageStream when present', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ session_id: 'sess-abc', chat_id: 'user-123' });
+    expect(runner.capturedChatId).toBe('user-123');
+  });
+
+  it('T-GREETING-CHATID-FALLBACK: sessionId used as chatId when chat_id is absent', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ session_id: 'sess-abc' });
+    expect(runner.capturedChatId).toBe('sess-abc');
+  });
+
+  // ── Disconnect cleanup ─────────────────────────────────────────────────────
+
+  it('T-GREETING-CLEANUP: cleanup function is called when response closes', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ session_id: 'sess-abc' });
+    // After res.end() the socket closes, firing 'close' which invokes the cleanup
+    expect(runner.cleanupCalled).toBe(true);
   });
 });

--- a/tests/unit/api-greeting.test.ts
+++ b/tests/unit/api-greeting.test.ts
@@ -5,23 +5,24 @@ import * as path from 'path';
 import * as os from 'os';
 import { EventEmitter } from 'events';
 import { createApiRouter } from '../../src/api/router';
-import { AgentConfig, ApiKey, SessionMeta } from '../../src/types';
+import { AgentConfig, ApiKey, StreamEvent } from '../../src/types';
 
 // ── Mock AgentRunner for greeting tests ─────────────────────────────────────
 
+type SseCallbacks = {
+  onChunk: (event: StreamEvent) => void;
+  onDone: (text: string) => void;
+  onError: (err: Error) => void;
+};
+
 class MockGreetingRunner extends EventEmitter {
   private _workspacePath: string;
-  sendApiMessageResult: string | Error = 'Hello!';
-  createApiSessionResult: SessionMeta = {
-    id: 'sess-abc123',
-    name: 'Welcome to GetPod',
-    createdAt: Date.now(),
-    lastActive: Date.now(),
-    messageCount: 0,
-    totalTokensUsed: 0,
-  };
-  createApiSessionCalls: Array<{ chatId: string; prompt?: string; name?: string }> = [];
-  deleteApiSessionCalls: Array<{ chatId: string; sessionId: string }> = [];
+  sendStreamResult: string | Error = 'Hello from agent!';
+  // When set, sendApiMessageStream throws synchronously before returning
+  sendStreamThrow: Error | null = null;
+  activeSession = false;
+  cleanupCalled = false;
+  capturedCallbacks: SseCallbacks | null = null;
 
   constructor(workspacePath: string) {
     super();
@@ -32,26 +33,30 @@ class MockGreetingRunner extends EventEmitter {
     return this._workspacePath;
   }
 
-  async createApiSession(chatId: string, prompt?: string, name?: string): Promise<SessionMeta> {
-    this.createApiSessionCalls.push({ chatId, prompt, name });
-    return this.createApiSessionResult;
+  hasActiveApiSession(_sessionId: string): boolean {
+    return this.activeSession;
   }
 
-  async sendApiMessage(
+  async sendApiMessageStream(
     _sessionId: string,
     _chatId: string,
     _message: string,
+    callbacks: SseCallbacks,
     _opts: { timeoutMs: number; skipUserMessage?: boolean },
-  ): Promise<string> {
-    if (this.sendApiMessageResult instanceof Error) throw this.sendApiMessageResult;
-    return this.sendApiMessageResult;
+  ): Promise<() => void> {
+    if (this.sendStreamThrow) throw this.sendStreamThrow;
+    this.capturedCallbacks = callbacks;
+    // Fire callbacks asynchronously to simulate streaming
+    setImmediate(() => {
+      if (this.sendStreamResult instanceof Error) {
+        callbacks.onError(this.sendStreamResult);
+      } else {
+        callbacks.onChunk({ type: 'text_delta', text: this.sendStreamResult });
+        callbacks.onDone(this.sendStreamResult);
+      }
+    });
+    return () => { this.cleanupCalled = true; };
   }
-
-  async deleteApiSession(_chatId: string, _sessionId: string): Promise<void> {
-    this.deleteApiSessionCalls.push({ chatId: _chatId, sessionId: _sessionId });
-  }
-
-  hasActiveApiSession(_sessionId: string): boolean { return false; }
 }
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -81,7 +86,6 @@ function buildApp(runner: MockGreetingRunner) {
   return app;
 }
 
-// Poll until the file is gone (avoids arbitrary setTimeout for async unlink)
 async function waitForFileDeleted(filePath: string, timeoutMs = 2000): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
@@ -93,6 +97,17 @@ async function waitForFileDeleted(filePath: string, timeoutMs = 2000): Promise<v
     }
   }
   throw new Error(`File ${filePath} still exists after ${timeoutMs}ms`);
+}
+
+// Parse SSE response body into event objects
+function parseSseEvents(body: string): Array<Record<string, unknown>> {
+  return body
+    .split('\n\n')
+    .filter(chunk => chunk.startsWith('data: ') && chunk.slice(6) !== '[DONE]')
+    .map(chunk => {
+      try { return JSON.parse(chunk.slice(6)) as Record<string, unknown>; } catch { return {}; }
+    })
+    .filter(e => Object.keys(e).length > 0);
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -110,35 +125,106 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  // T-GREETING-204-NO-FILE: returns 204 when GREETING.md does not exist
+  // ── 204 no-op paths ────────────────────────────────────────────────────────
+
   it('T-GREETING-204-NO-FILE: returns 204 when GREETING.md is absent', async () => {
     const app = buildApp(runner);
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat' });
+      .send({ session_id: 'sess-abc' });
     expect(res.status).toBe(204);
-    expect(runner.createApiSessionCalls).toHaveLength(0);
+    expect(runner.capturedCallbacks).toBeNull();
   });
 
-  // T-GREETING-204-EMPTY: returns 204 when GREETING.md is empty/whitespace
   it('T-GREETING-204-EMPTY: returns 204 when GREETING.md is empty', async () => {
     await fs.writeFile(path.join(tmpDir, 'GREETING.md'), '   \n  ');
     const app = buildApp(runner);
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat' });
+      .send({ session_id: 'sess-abc' });
     expect(res.status).toBe(204);
-    expect(runner.createApiSessionCalls).toHaveLength(0);
+    expect(runner.capturedCallbacks).toBeNull();
   });
 
-  // T-GREETING-500-EACCES: non-ENOENT readFile error (e.g. EACCES) returns 500, not 204
+  // ── Input validation ───────────────────────────────────────────────────────
+
+  it('T-GREETING-400-NO-SESSION: missing session_id returns 400', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/session_id/i);
+  });
+
+  it('T-GREETING-400-EMPTY-SESSION: empty session_id returns 400', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ session_id: '   ' });
+    expect(res.status).toBe(400);
+  });
+
+  // ── Conflict ───────────────────────────────────────────────────────────────
+
+  it('T-GREETING-409-ACTIVE: returns 409 when session is already active', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    runner.activeSession = true;
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-write')
+      .send({ session_id: 'sess-abc' });
+    expect(res.status).toBe(409);
+    expect(runner.capturedCallbacks).toBeNull();
+  });
+
+  // ── Auth ───────────────────────────────────────────────────────────────────
+
+  it('T-GREETING-403-READ-KEY: read-only key is rejected with 403', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-read-only')
+      .send({ session_id: 'sess-abc' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/write or admin/i);
+  });
+
+  it('T-GREETING-403-ADMIN-OK: admin key is accepted', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
+      .set('X-Api-Key', 'sk-admin')
+      .send({ session_id: 'sess-abc' });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+  });
+
+  // ── 404 ────────────────────────────────────────────────────────────────────
+
+  it('T-GREETING-404-UNKNOWN-AGENT: unknown agent returns 404', async () => {
+    const app = buildApp(runner);
+    const res = await supertest.default(app)
+      .post('/api/v1/agents/nonexistent/greeting')
+      .set('X-Api-Key', 'sk-admin')
+      .send({ session_id: 'sess-abc' });
+    expect(res.status).toBe(404);
+  });
+
+  // ── 500 on read error ──────────────────────────────────────────────────────
+
   it('T-GREETING-500-EACCES: permission error on GREETING.md returns 500', async () => {
     const greetingPath = path.join(tmpDir, 'GREETING.md');
     await fs.writeFile(greetingPath, 'Welcome!');
     await fs.chmod(greetingPath, 0o000);
-    // root can read any file — skip assertion in that environment
     if ((process.getuid?.() ?? -1) === 0) {
       await fs.chmod(greetingPath, 0o644);
       return;
@@ -147,76 +233,58 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat' });
+      .send({ session_id: 'sess-abc' });
     await fs.chmod(greetingPath, 0o644);
     expect(res.status).toBe(500);
-    expect(runner.createApiSessionCalls).toHaveLength(0);
+    expect(runner.capturedCallbacks).toBeNull();
   });
 
-  // T-GREETING-202-NO-NAME: returns 202 immediately without waiting for LLM
-  it('T-GREETING-202-NO-NAME: returns 202 without session_name, passes undefined to createApiSession', async () => {
-    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome, the VM is ready!');
+  // ── SSE streaming ──────────────────────────────────────────────────────────
+
+  it('T-GREETING-200-SSE: happy path returns 200 SSE with text_delta + result + [DONE]', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome to the platform!');
     const app = buildApp(runner);
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat' });
-    expect(res.status).toBe(202);
-    expect(res.body.greeted).toBe(true);
-    expect(res.body.sessionId).toBe('sess-abc123');
-    expect(res.body.sessionName).toBe('Welcome to GetPod');
-    expect(runner.createApiSessionCalls[0].name).toBeUndefined();
+      .send({ session_id: 'sess-abc' });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+    const events = parseSseEvents(res.text);
+    const chunk = events.find(e => e['type'] === 'text_delta');
+    const result = events.find(e => e['type'] === 'result');
+    expect(chunk).toBeDefined();
+    expect(result?.['session_id']).toBe('sess-abc');
+    expect(res.text).toContain('[DONE]');
   });
 
-  // T-GREETING-202-WITH-NAME: passes session_name to createApiSession, skipping LLM naming
-  it('T-GREETING-202-WITH-NAME: passes session_name to createApiSession when provided', async () => {
-    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome, the VM is ready!');
+  it('T-GREETING-200-AGENT-ERROR: agent error during stream sends error SSE event', async () => {
+    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    runner.sendStreamResult = new Error('agent crashed');
     const app = buildApp(runner);
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat', session_name: 'My Custom Title' });
-    expect(res.status).toBe(202);
-    expect(runner.createApiSessionCalls[0].name).toBe('My Custom Title');
+      .send({ session_id: 'sess-abc' });
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(res.text);
+    const errEvent = events.find(e => e['type'] === 'error');
+    expect(errEvent?.['message']).toMatch(/agent crashed/);
   });
 
-  // T-GREETING-CHAT-ID-QUERY: chat_id as query param is accepted for backward compat
-  it('T-GREETING-CHAT-ID-QUERY: chat_id as query param is accepted (backward compat)', async () => {
-    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
-    const app = buildApp(runner);
-    const res = await supertest.default(app)
-      .post(`/api/v1/agents/${AGENT_ID}/greeting?chat_id=testchat`)
-      .set('X-Api-Key', 'sk-write')
-      .send({ session_name: 'Welcome' });
-    expect(res.status).toBe(202);
-    expect(runner.createApiSessionCalls[0].chatId).toBe('testchat');
-  });
+  // ── File lifecycle ─────────────────────────────────────────────────────────
 
-  // T-GREETING-CHAT-ID-BODY-PREFERRED: body chat_id takes priority over query param
-  it('T-GREETING-CHAT-ID-BODY-PREFERRED: body chat_id takes priority over query param', async () => {
-    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
-    const app = buildApp(runner);
-    const res = await supertest.default(app)
-      .post(`/api/v1/agents/${AGENT_ID}/greeting?chat_id=query-id`)
-      .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'body-id', session_name: 'Welcome' });
-    expect(res.status).toBe(202);
-    expect(runner.createApiSessionCalls[0].chatId).toBe('body-id');
-  });
-
-  // T-GREETING-DELETES-FILE: GREETING.md is deleted before the 202 response
-  it('T-GREETING-DELETES-FILE: GREETING.md is deleted before 202 response', async () => {
+  it('T-GREETING-DELETES-FILE: GREETING.md is deleted before streaming begins', async () => {
     const greetingPath = path.join(tmpDir, 'GREETING.md');
-    await fs.writeFile(greetingPath, 'Welcome, the VM is ready!');
+    await fs.writeFile(greetingPath, 'Welcome!');
     const app = buildApp(runner);
     await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat', session_name: 'Welcome' });
+      .send({ session_id: 'sess-abc' });
     await waitForFileDeleted(greetingPath);
   });
 
-  // T-GREETING-IDEMPOTENT: second call returns 204 because GREETING.md was deleted
   it('T-GREETING-IDEMPOTENT: second call returns 204 after first success', async () => {
     const greetingPath = path.join(tmpDir, 'GREETING.md');
     await fs.writeFile(greetingPath, 'Welcome!');
@@ -224,81 +292,34 @@ describe('POST /api/v1/agents/:agentId/greeting', () => {
     const first = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat', session_name: 'Welcome' });
-    expect(first.status).toBe(202);
+      .send({ session_id: 'sess-abc' });
+    expect(first.status).toBe(200);
     await waitForFileDeleted(greetingPath);
     const second = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat', session_name: 'Welcome' });
+      .send({ session_id: 'sess-abc' });
     expect(second.status).toBe(204);
-    expect(runner.createApiSessionCalls).toHaveLength(1);
   });
 
-  // T-GREETING-403-READ-KEY: read-only key returns 403
-  it('T-GREETING-403-READ-KEY: read-only key is rejected with 403', async () => {
-    const app = buildApp(runner);
-    const res = await supertest.default(app)
-      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
-      .set('X-Api-Key', 'sk-read-only')
-      .send({ chat_id: 'testchat' });
-    expect(res.status).toBe(403);
-    expect(res.body.error).toMatch(/write or admin/i);
-  });
+  // ── Sync throw after headers ───────────────────────────────────────────────
 
-  // T-GREETING-403-ADMIN-OK: admin key succeeds
-  it('T-GREETING-403-ADMIN-OK: admin key is accepted', async () => {
+  // SSE headers are written before sendApiMessageStream is called. If sendApiMessageStream
+  // throws synchronously (e.g. subprocess spawn failure), the error must be delivered as
+  // an SSE error event — JSON 500 is impossible once headers are flushed.
+  it('T-GREETING-SSE-ERROR-ON-THROW: sync throw from sendApiMessageStream delivers SSE error event', async () => {
     await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
-    const app = buildApp(runner);
-    const res = await supertest.default(app)
-      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
-      .set('X-Api-Key', 'sk-admin')
-      .send({ chat_id: 'testchat', session_name: 'Welcome' });
-    expect(res.status).toBe(202);
-  });
-
-  // T-GREETING-400-NO-CHAT: missing chat_id returns 400
-  it('T-GREETING-400-NO-CHAT: missing chat_id returns 400', async () => {
-    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
+    runner.sendStreamThrow = new Error('spawn failed');
     const app = buildApp(runner);
     const res = await supertest.default(app)
       .post(`/api/v1/agents/${AGENT_ID}/greeting`)
       .set('X-Api-Key', 'sk-write')
-      .send({});
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/chat_id/i);
-  });
-
-  // T-GREETING-404-UNKNOWN-AGENT: unknown agent returns 404
-  it('T-GREETING-404-UNKNOWN-AGENT: unknown agent returns 404', async () => {
-    const app = buildApp(runner);
-    const res = await supertest.default(app)
-      .post('/api/v1/agents/nonexistent/greeting')
-      .set('X-Api-Key', 'sk-admin')
-      .send({ chat_id: 'testchat' });
-    expect(res.status).toBe(404);
-  });
-
-  // T-GREETING-BG-CLEANUP: background sendApiMessage failure cleans up orphaned session
-  it('T-GREETING-BG-CLEANUP: background failure cleans up orphaned session', async () => {
-    await fs.writeFile(path.join(tmpDir, 'GREETING.md'), 'Welcome!');
-    runner.sendApiMessageResult = new Error('internal failure');
-    let cleanupResolve!: () => void;
-    const cleanupDone = new Promise<void>(r => { cleanupResolve = r; });
-    const origDelete = runner.deleteApiSession.bind(runner);
-    runner.deleteApiSession = async (...args: Parameters<typeof runner.deleteApiSession>) => {
-      await origDelete(...args);
-      cleanupResolve();
-    };
-    const app = buildApp(runner);
-    const res = await supertest.default(app)
-      .post(`/api/v1/agents/${AGENT_ID}/greeting`)
-      .set('X-Api-Key', 'sk-write')
-      .send({ chat_id: 'testchat', session_name: 'Welcome' });
-    // Response is 202 immediately; cleanup happens in background
-    expect(res.status).toBe(202);
-    await cleanupDone;
-    expect(runner.deleteApiSessionCalls).toHaveLength(1);
-    expect(runner.deleteApiSessionCalls[0].sessionId).toBe('sess-abc123');
+      .send({ session_id: 'sess-abc' });
+    // Headers already flushed — status is 200, error comes via SSE
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+    const events = parseSseEvents(res.text);
+    const errEvent = events.find(e => e['type'] === 'error');
+    expect(errEvent?.['message']).toMatch(/spawn failed/);
   });
 });


### PR DESCRIPTION
## Summary

- **Breaking change**: `POST /greeting` now accepts `session_id` only (drops `chat_id` and `session_name`). The caller must create the session first via `POST /sessions`, then trigger the greeting.
- Replaces fire-and-forget `202` with an SSE stream (`200 text/event-stream`) — same contract as `POST /messages?stream=true` — so the chat UI can show a typing animation while the greeting generates.
- `GREETING.md` is deleted **before** streaming starts to prevent replay on client retry.
- Preflight `hasActiveApiSession` check returns `409` before SSE headers are sent.

## Two-step flow

```
POST /sessions  { chat_id, name }  → { sessionId }   # client redirects to chat UI
POST /greeting  { session_id }     → SSE stream       # chat UI triggers greeting, shows animation
```

## Test plan

- [ ] `T-GREETING-204-NO-FILE` — absent `GREETING.md` → 204
- [ ] `T-GREETING-204-EMPTY` — empty `GREETING.md` → 204
- [ ] `T-GREETING-400-NO-SESSION` — missing `session_id` → 400
- [ ] `T-GREETING-400-EMPTY-SESSION` — blank `session_id` → 400
- [ ] `T-GREETING-409-ACTIVE` — session busy → 409 before SSE
- [ ] `T-GREETING-403-READ-KEY` → 403
- [ ] `T-GREETING-403-ADMIN-OK` → 200 SSE
- [ ] `T-GREETING-404-UNKNOWN-AGENT` → 404
- [ ] `T-GREETING-500-EACCES` — permission error on file → 500
- [ ] `T-GREETING-200-SSE` — happy path: 200 + text_delta + result + `[DONE]`
- [ ] `T-GREETING-200-AGENT-ERROR` — agent error mid-stream → SSE error event
- [ ] `T-GREETING-DELETES-FILE` — file removed before stream starts
- [ ] `T-GREETING-IDEMPOTENT` — second call → 204
- [ ] `T-GREETING-SSE-ERROR-ON-THROW` — sync throw after headers → SSE error event

All 1632 tests pass (89 suites).

Closes #110