### PR TITLE
feat: add claude-opus-4-8 model support

### DIFF
--- a/API.md
+++ b/API.md
@@ -312,12 +312,12 @@ Update an agent's description, model, or allow_tools flag. Requires write access
 curl -X PATCH \
   -H "X-Api-Key: admin-key-456" \
   -H "Content-Type: application/json" \
-  -d '{"model": "claude-opus-4-7"}' \
+  -d '{"model": "claude-opus-4-8"}' \
   http://localhost:10850/api/v1/agents/alfred | jq
 ```
 
 ```json
-{ "agent": { "id": "alfred", "description": "Personal assistant", "model": "claude-opus-4-7", "allow_tools": false } }
+{ "agent": { "id": "alfred", "description": "Personal assistant", "model": "claude-opus-4-8", "allow_tools": false } }
 ```
 
 ---
@@ -728,8 +728,9 @@ curl -H "X-Api-Key: my-secret-key-123" \
 ```json
 {
   "models": [
-    { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "alias": "sonnet", "contextWindow": 200000, "multiplier": 1 },
-    { "id": "claude-opus-4-7", "name": "Claude Opus 4.7", "alias": "opus", "contextWindow": 200000, "multiplier": 3 }
+    { "id": "claude-opus-4-8", "name": "Claude Opus 4.8", "alias": "opus",   "contextWindow": 1000000, "multiplier": 3 },
+    { "id": "claude-opus-4-7", "name": "Claude Opus 4.7", "alias": "opus47", "contextWindow": 1000000, "multiplier": 3 },
+    { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "alias": "sonnet", "contextWindow": 1000000, "multiplier": 1 }
   ]
 }
 ```
@@ -744,18 +745,18 @@ Set the active model for a specific agent. Persists to `config.json`. Requires a
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `model` | Yes | Claude model ID (e.g. `"claude-opus-4-7"`) |
+| `model` | Yes | Claude model ID (e.g. `"claude-opus-4-8"`) |
 
 ```bash
 curl -X PUT \
   -H "X-Api-Key: admin-key-456" \
   -H "Content-Type: application/json" \
-  -d '{"model": "claude-opus-4-7"}' \
+  -d '{"model": "claude-opus-4-8"}' \
   http://localhost:10850/api/v1/agents/alfred/model | jq
 ```
 
 ```json
-{ "model": "claude-opus-4-7" }
+{ "model": "claude-opus-4-8" }
 ```
 
 **Error responses:**

--- a/config.template.json
+++ b/config.template.json
@@ -14,7 +14,8 @@
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "models": [
-      { "id": "claude-opus-4-7",           "label": "Opus 4.7",   "alias": "opus",   "contextWindow": 1000000 },
+      { "id": "claude-opus-4-8",           "label": "Opus 4.8",   "alias": "opus",   "contextWindow": 1000000 },
+      { "id": "claude-opus-4-7",           "label": "Opus 4.7",   "alias": "opus47", "contextWindow": 1000000 },
       { "id": "claude-opus-4-6",           "label": "Opus 4.6",   "alias": "opus46", "contextWindow": 1000000 },
       { "id": "claude-sonnet-4-6",         "label": "Sonnet 4.6", "alias": "sonnet", "contextWindow": 1000000 },
       { "id": "claude-haiku-4-5-20251001", "label": "Haiku 4.5",  "alias": "haiku",  "contextWindow": 200000 }

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -689,9 +689,10 @@ const BOT_COMMANDS = [
 
 // Available AI models for /models command
 const AVAILABLE_MODELS = [
-  { id: 'claude-opus-4-7', label: 'Opus 4.7', alias: 'opus' },
-  { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus46' },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', alias: 'sonnet' },
+  { id: 'claude-opus-4-8',          label: 'Opus 4.8',   alias: 'opus' },
+  { id: 'claude-opus-4-7',          label: 'Opus 4.7',   alias: 'opus47' },
+  { id: 'claude-opus-4-6',          label: 'Opus 4.6',   alias: 'opus46' },
+  { id: 'claude-sonnet-4-6',        label: 'Sonnet 4.6', alias: 'sonnet' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', alias: 'haiku' },
 ]
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -25,10 +25,11 @@ const DEFAULT_MAX_CONCURRENT = 20;
 export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
 export const DEFAULT_MODELS: ModelConfig[] = [
-  { id: 'claude-opus-4-7', label: 'Opus 4.7', alias: 'opus', contextWindow: 1000000 },
-  { id: 'claude-opus-4-6', label: 'Opus 4.6', alias: 'opus46', contextWindow: 1000000 },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', alias: 'sonnet', contextWindow: 1000000 },
-  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', alias: 'haiku', contextWindow: 200000 },
+  { id: 'claude-opus-4-8',          label: 'Opus 4.8',   alias: 'opus',   contextWindow: 1000000 },
+  { id: 'claude-opus-4-7',          label: 'Opus 4.7',   alias: 'opus47', contextWindow: 1000000 },
+  { id: 'claude-opus-4-6',          label: 'Opus 4.6',   alias: 'opus46', contextWindow: 1000000 },
+  { id: 'claude-sonnet-4-6',        label: 'Sonnet 4.6', alias: 'sonnet', contextWindow: 1000000 },
+  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', alias: 'haiku',  contextWindow: 200000 },
 ];
 
 const PROTECTED_WORKSPACE_FILES = [
@@ -1325,8 +1326,12 @@ export class AgentRunner extends EventEmitter {
     }
     this.cancelCleanup?.();
     this.cancelCleanup = null;
-    this.callbackServer?.close();
-    this.callbackServer = null;
+    if (this.callbackServer) {
+      const srv = this.callbackServer;
+      this.callbackServer = null;
+      srv.closeAllConnections?.();
+      await new Promise<void>((resolve) => srv.close(() => resolve()));
+    }
     this.receiver?.stop();
     this.discordReceiver?.stop();
     await Promise.all([...this.sessions.values()].map((s) => s.stop()));

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -713,12 +713,18 @@ export class SessionProcess extends EventEmitter {
 
     return new Promise((resolve) => {
       const proc = this.process!;
+      let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
       proc.once('exit', () => {
+        if (forceKillTimer !== null) {
+          clearTimeout(forceKillTimer);
+          forceKillTimer = null;
+        }
         this.process = null;
         resolve();
       });
       proc.kill('SIGTERM');
-      setTimeout(() => {
+      forceKillTimer = setTimeout(() => {
+        forceKillTimer = null;
         if (this.process) proc.kill('SIGKILL');
       }, 10_000);
     });


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-8` as the new primary `opus` alias (released May 28, 2026, 1M context window)
- Demote `claude-opus-4-7` to alias `opus47` across all model lists
- Fix `AgentRunner.stop()` to properly drain HTTP keep-alive connections — eliminates I-TP-03/04 timeout flakes
- Clear 10-second SIGKILL fallback timer in `SessionProcess.stop()` when process exits cleanly

## Files changed

| File | Change |
|------|--------|
| `src/agent/runner.ts` | Add opus 4.8 to `DEFAULT_MODELS`; fix `stop()` to `closeAllConnections()` + await `server.close()` |
| `mcp/tools/telegram/receiver-server.ts` | Add opus 4.8 to `AVAILABLE_MODELS` |
| `config.template.json` | Add opus 4.8 to `models` list |
| `src/session/process.ts` | Clear 10-second SIGKILL timer when process exits cleanly |
| `API.md` | Update model examples to reference `claude-opus-4-8` |

## Test plan

- [x] All 1635 tests pass (`npm test`)
- [x] I-TP-03 and I-TP-04 timing-persistence tests now pass reliably
- [x] Typing-persistence suite: 4/4 ✓

Closes #112