### PR TITLE
Fix: auto-recover from corrupted thinking-block 400 loop

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -798,7 +798,11 @@ export class AgentRunner extends EventEmitter {
             // sending a duplicate message to the channel.
             // Skip forwarding when session is in query mode (internal image summary request).
             const resultText = typeof obj['result'] === 'string' ? obj['result'] : '';
-            if (resultText.trim() && !proc.queryMode && !replyCalled) {
+            // Suppress the corrupted-thinking 400: the session auto-respawns to recover,
+            // so the raw API error must not reach the user's chat or the history DB.
+            const isThinkingCorruption =
+              obj['is_error'] === true && SessionProcess.isThinkingCorruptionError(resultText);
+            if (resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption) {
               const text = resultText.trim();
               const channelSrcForResult = this.channelSourceMap.get(mapKey) ?? 'telegram';
               // Persist assistant reply to permanent history DB

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -45,9 +45,6 @@ export class SessionProcess extends EventEmitter {
   private readonly configPath: string;
   private readonly restartSignalPath: string;
   queryMode = false;
-  // Set when a corrupted-thinking-block 400 is detected, so the trailing result
-  // event skips persisting the API error text and we respawn with clean history.
-  private _recovering = false;
   private thinkingRecoveryCount = 0;
   private _queryResolve?: (text: string) => void;
   private _queryBuffer = '';
@@ -333,7 +330,6 @@ export class SessionProcess extends EventEmitter {
   }
 
   private async spawnProcess(): Promise<void> {
-    this._recovering = false;
     const { historyPrompt, loadedAtSpawn, archivedCount, messageCountAtSpawn } = await this.buildInitialPrompt();
     this.spawnContext = { loadedAtSpawn, archivedCount, messageCountAtSpawn };
 
@@ -449,12 +445,6 @@ export class SessionProcess extends EventEmitter {
         if (!line.trim()) continue;
         this.emit('output', line);
         this.logger.debug('session output', { line });
-        // A previous turn's thinking block was corrupted (e.g. interrupted mid-stream),
-        // and Claude Code keeps replaying it from in-memory history → every turn 400s.
-        // Respawn to reload clean text-only history and break the loop.
-        if (this.source !== 'api' && !this.queryMode && SessionProcess.isThinkingCorruptionError(line)) {
-          this.recoverFromCorruptedThinking();
-        }
         // Try to capture assistant text for SessionStore + update status file
         try {
           const obj = JSON.parse(line);
@@ -533,6 +523,15 @@ export class SessionProcess extends EventEmitter {
             writeStatus(obj.is_error ? 'error' : 'done');
             // A clean turn means the in-memory history is healthy again — refill the budget.
             if (!obj.is_error) this.thinkingRecoveryCount = 0;
+            // A previous turn's thinking block was corrupted (e.g. interrupted mid-stream),
+            // and Claude Code keeps replaying it from in-memory history → every turn 400s.
+            // Detect strictly on the failed result's error text (not assistant deltas) so an
+            // agent merely discussing the error phrase can never trigger a spurious respawn.
+            const corruptedThinking =
+              this.source !== 'api' &&
+              !this.queryMode &&
+              obj.is_error === true &&
+              SessionProcess.isThinkingCorruptionError(typeof obj.result === 'string' ? obj.result : '');
             if (this.queryMode) {
               if (this._queryTimer) clearTimeout(this._queryTimer);
               if (!this._querySettled) {
@@ -544,11 +543,12 @@ export class SessionProcess extends EventEmitter {
               }
               this._queryBuffer = '';
               assistantBuffer = '';
-            } else if (this._recovering) {
-              // Don't persist the 400 API error text as an assistant message — we're
-              // about to respawn with clean history.
+            } else if (corruptedThinking) {
+              // Don't persist the 400 API error text as an assistant message — respawn
+              // to reload clean text-only history and break the loop.
               assistantBuffer = '';
               lastMessageStartContext = 0;
+              this.recoverFromCorruptedThinking();
             } else {
               if (assistantBuffer.trim()) {
                 // For non-API sessions (Telegram/Discord), persist here via appendTelegramMessage.
@@ -622,11 +622,12 @@ export class SessionProcess extends EventEmitter {
 
   /**
    * Detect the Anthropic API 400 raised when a previously-emitted thinking block
-   * is sent back altered. Claude Code surfaces the raw API error text on stdout,
-   * so a substring match is the most robust signal across output formats.
+   * is sent back altered. Match the full API signature (not loose keywords) so it
+   * only fires on the genuine error text, never on prose that mentions thinking blocks.
+   * Callers must gate this on a failed result (is_error === true).
    */
-  private static isThinkingCorruptionError(line: string): boolean {
-    return line.includes('cannot be modified') && line.includes('thinking');
+  static isThinkingCorruptionError(errorText: string): boolean {
+    return errorText.includes('blocks in the latest assistant message cannot be modified');
   }
 
   /**
@@ -644,7 +645,6 @@ export class SessionProcess extends EventEmitter {
       return;
     }
     this.thinkingRecoveryCount++;
-    this._recovering = true;
     this.logger.warn('Corrupted thinking block detected (400) — respawning to restore clean history', {
       sessionId: this.sessionId,
       attempt: this.thinkingRecoveryCount,

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -17,6 +17,9 @@ import {
 const MAX_HISTORY_MESSAGES = 50;
 const AUTO_RESTART_DELAY_MS = 5_000;
 const MAX_RESTARTS = 3;
+// Bound how many times a single session may auto-respawn to recover from a
+// corrupted thinking block, so a recovery that never helps can't loop forever.
+const MAX_THINKING_RECOVERIES = 2;
 const CHANNELS_ACTIVATION_PROMPT =
   'Channels mode is active. Wait for incoming messages from your channels and respond to them.';
 
@@ -42,6 +45,10 @@ export class SessionProcess extends EventEmitter {
   private readonly configPath: string;
   private readonly restartSignalPath: string;
   queryMode = false;
+  // Set when a corrupted-thinking-block 400 is detected, so the trailing result
+  // event skips persisting the API error text and we respawn with clean history.
+  private _recovering = false;
+  private thinkingRecoveryCount = 0;
   private _queryResolve?: (text: string) => void;
   private _queryBuffer = '';
   private _queryTimer?: ReturnType<typeof setTimeout>;
@@ -326,6 +333,7 @@ export class SessionProcess extends EventEmitter {
   }
 
   private async spawnProcess(): Promise<void> {
+    this._recovering = false;
     const { historyPrompt, loadedAtSpawn, archivedCount, messageCountAtSpawn } = await this.buildInitialPrompt();
     this.spawnContext = { loadedAtSpawn, archivedCount, messageCountAtSpawn };
 
@@ -441,6 +449,12 @@ export class SessionProcess extends EventEmitter {
         if (!line.trim()) continue;
         this.emit('output', line);
         this.logger.debug('session output', { line });
+        // A previous turn's thinking block was corrupted (e.g. interrupted mid-stream),
+        // and Claude Code keeps replaying it from in-memory history → every turn 400s.
+        // Respawn to reload clean text-only history and break the loop.
+        if (this.source !== 'api' && !this.queryMode && SessionProcess.isThinkingCorruptionError(line)) {
+          this.recoverFromCorruptedThinking();
+        }
         // Try to capture assistant text for SessionStore + update status file
         try {
           const obj = JSON.parse(line);
@@ -517,6 +531,8 @@ export class SessionProcess extends EventEmitter {
           if (obj.type === 'result') {
             lastPartialText = ''; // reset for next turn
             writeStatus(obj.is_error ? 'error' : 'done');
+            // A clean turn means the in-memory history is healthy again — refill the budget.
+            if (!obj.is_error) this.thinkingRecoveryCount = 0;
             if (this.queryMode) {
               if (this._queryTimer) clearTimeout(this._queryTimer);
               if (!this._querySettled) {
@@ -528,6 +544,11 @@ export class SessionProcess extends EventEmitter {
               }
               this._queryBuffer = '';
               assistantBuffer = '';
+            } else if (this._recovering) {
+              // Don't persist the 400 API error text as an assistant message — we're
+              // about to respawn with clean history.
+              assistantBuffer = '';
+              lastMessageStartContext = 0;
             } else {
               if (assistantBuffer.trim()) {
                 // For non-API sessions (Telegram/Discord), persist here via appendTelegramMessage.
@@ -597,6 +618,41 @@ export class SessionProcess extends EventEmitter {
         );
       }
     }, AUTO_RESTART_DELAY_MS);
+  }
+
+  /**
+   * Detect the Anthropic API 400 raised when a previously-emitted thinking block
+   * is sent back altered. Claude Code surfaces the raw API error text on stdout,
+   * so a substring match is the most robust signal across output formats.
+   */
+  private static isThinkingCorruptionError(line: string): boolean {
+    return line.includes('cannot be modified') && line.includes('thinking');
+  }
+
+  /**
+   * Recover from a corrupted thinking block by respawning the subprocess.
+   * The gateway stores history as plain text, so buildInitialPrompt() reloads a
+   * thinking-block-free prompt on respawn — clearing the offending in-memory turn
+   * that Claude Code was replaying on every request.
+   */
+  private recoverFromCorruptedThinking(): void {
+    if (this.restartRequested || this.stopping) return; // already respawning
+    if (this.thinkingRecoveryCount >= MAX_THINKING_RECOVERIES) {
+      this.logger.error('Thinking-block recovery limit reached — not respawning again', {
+        sessionId: this.sessionId,
+      });
+      return;
+    }
+    this.thinkingRecoveryCount++;
+    this._recovering = true;
+    this.logger.warn('Corrupted thinking block detected (400) — respawning to restore clean history', {
+      sessionId: this.sessionId,
+      attempt: this.thinkingRecoveryCount,
+    });
+    // Reuse graceful-restart semantics so the respawn doesn't count as a crash.
+    this.restartRequested = true;
+    this.setProcessing(false);
+    if (this.process) this.process.kill('SIGTERM');
   }
 
   sendMessage(text: string): void {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1550,4 +1550,102 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
 
     await sp.stop();
   });
+
+  // R8: after recovery, the respawned subprocess rebuilds its prompt from clean
+  // text-only history — proving the loop is actually broken, not just the kill issued.
+  it('R8: respawn after recovery reloads clean text-only history (no thinking blocks)', async () => {
+    await sessionStore.appendTelegramMessage('alfred', 'chat:rec8', 'chat:rec8', {
+      role: 'user', content: 'hello boss', ts: Date.now(),
+    });
+    await sessionStore.appendTelegramMessage('alfred', 'chat:rec8', 'chat:rec8', {
+      role: 'assistant', content: 'clean reply', ts: Date.now(),
+    });
+
+    const sp = new SessionProcess('chat:rec8', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    const firstProcess = lastProcess!;
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // Fake timers make the respawn deterministic and isolate this test from any
+    // real auto-restart timers left pending by earlier tests in the suite.
+    jest.useFakeTimers();
+    try {
+      // 400 → recovery kills the subprocess
+      firstProcess.stdout!.emit('data', Buffer.from(errorResultLine() + '\n'));
+      expect(firstProcess.kill).toHaveBeenCalledWith('SIGTERM');
+
+      // mock kill() scheduled 'exit' on (faked) nextTick → flush it so the exit
+      // handler runs scheduleRestart() and arms the AUTO_RESTART_DELAY_MS timer.
+      jest.advanceTimersByTime(1);
+      // fire the auto-restart timer → spawnProcess() (its fs reads are synchronous)
+      jest.advanceTimersByTime(6000);
+      // drain the microtasks from spawnProcess's awaits (promises are not faked)
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+    } finally {
+      jest.useRealTimers();
+    }
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    const respawned = lastProcess!;
+    expect(respawned).not.toBe(firstProcess);
+
+    // The respawned subprocess gets a fresh prompt rebuilt from text history —
+    // clean, with no corrupted thinking content.
+    const initialWrite = respawned.stdin!.write.mock.calls[0][0] as string;
+    const text: string = JSON.parse(initialWrite).message.content[0].text;
+    expect(text).toContain('Conversation history');
+    expect(text).toContain('clean reply');
+    expect(text).not.toContain('cannot be modified');
+
+    await sp.stop();
+  });
+
+  // R9: the whole point of the tightened detection — an agent whose own reply
+  // discusses the error phrase must NOT be misread as a real 400.
+  it('R9: assistant text mentioning the error phrase in a clean turn does not trigger recovery', async () => {
+    const sp = new SessionProcess('chat:rec9', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const chatty = JSON.stringify({
+      type: 'assistant',
+      stop_reason: 'end_turn',
+      message: {
+        role: 'assistant',
+        content: [{
+          type: 'text',
+          text: 'The 400 error "blocks in the latest assistant message cannot be modified" happens when thinking blocks change mid-stream.',
+        }],
+      },
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(chatty + '\n'));
+    // Successful result whose text also echoes the phrase
+    const okResult = JSON.stringify({
+      type: 'result', is_error: false,
+      result: 'Explained why thinking blocks cannot be modified once sent.',
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(okResult + '\n'));
+
+    expect(lastProcess!.kill).not.toHaveBeenCalled();
+    expect((sp as unknown as { restartRequested: boolean }).restartRequested).toBe(false);
+
+    await sp.stop();
+  });
+
+  // R10: a failed result that mentions the loose keywords but lacks the full API
+  // signature must not trigger recovery (no two-word substring match anymore).
+  it('R10: a failed result lacking the full signature does not trigger recovery', async () => {
+    const sp = new SessionProcess('chat:rec10', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const loose = JSON.stringify({
+      type: 'result', is_error: true,
+      result: 'I was thinking, but this file cannot be modified.',
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(loose + '\n'));
+
+    expect(lastProcess!.kill).not.toHaveBeenCalled();
+    expect((sp as unknown as { restartRequested: boolean }).restartRequested).toBe(false);
+
+    await sp.stop();
+  });
 });

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1406,3 +1406,148 @@ describe('SessionProcess — API model-switch history injection', () => {
     expect(text).not.toContain('Conversation history');
   });
 });
+
+// ── Corrupted thinking-block recovery (issue #114) ──────────────────────────────
+
+describe('SessionProcess — corrupted thinking-block recovery', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+
+  // The exact Anthropic 400 surfaced by Claude Code on stdout, wrapped as a result event.
+  const THINKING_400 =
+    'API Error: 400 messages.1.content.11: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.';
+
+  function errorResultLine(): string {
+    return JSON.stringify({ type: 'result', is_error: true, result: THINKING_400 });
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-recover-'));
+    agentConfig = makeAgentConfig({ workspace: path.join(tmpDir, 'workspace') });
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions'));
+    lastProcess = null;
+    spawnMock = require('child_process').spawn as jest.Mock;
+    spawnMock.mockClear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // R1: a 400 thinking-block error triggers a respawn (kill + restart marker)
+  it('R1: thinking-block 400 on stdout kills the subprocess to respawn with clean history', async () => {
+    const sp = new SessionProcess('chat:rec', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    lastProcess!.stdout!.emit('data', Buffer.from(errorResultLine() + '\n'));
+
+    expect(lastProcess!.kill).toHaveBeenCalledWith('SIGTERM');
+    expect((sp as unknown as { restartRequested: boolean }).restartRequested).toBe(true);
+    expect((sp as unknown as { thinkingRecoveryCount: number }).thinkingRecoveryCount).toBe(1);
+
+    await sp.stop();
+  });
+
+  // R2: the 400 error text is not persisted as an assistant message
+  it('R2: API error text is not persisted to the session store during recovery', async () => {
+    const sp = new SessionProcess('chat:rec2', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // Assistant text carrying the error, then the result event.
+    const assistantErr = JSON.stringify({
+      type: 'assistant',
+      stop_reason: 'end_turn',
+      message: { role: 'assistant', content: [{ type: 'text', text: THINKING_400 }] },
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(assistantErr + '\n'));
+    lastProcess!.stdout!.emit('data', Buffer.from(errorResultLine() + '\n'));
+
+    await new Promise(r => setTimeout(r, 100));
+
+    const messages = await sessionStore.loadTelegramSession('alfred', 'chat:rec2', 'chat:rec2');
+    const assistantMsgs = messages.filter(m => m.role === 'assistant');
+    expect(assistantMsgs.some(m => m.content.includes('cannot be modified'))).toBe(false);
+
+    await sp.stop();
+  });
+
+  // R3: recovery is bounded — once the budget is spent, no further respawn
+  it('R3: recovery stops after MAX_THINKING_RECOVERIES to avoid an infinite respawn loop', async () => {
+    const sp = new SessionProcess('chat:rec3', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // Simulate the budget already being exhausted by prior respawns.
+    (sp as unknown as { thinkingRecoveryCount: number }).thinkingRecoveryCount = 2;
+
+    lastProcess!.stdout!.emit('data', Buffer.from(errorResultLine() + '\n'));
+
+    // No respawn attempted: neither killed nor flagged for restart.
+    expect(lastProcess!.kill).not.toHaveBeenCalled();
+    expect((sp as unknown as { restartRequested: boolean }).restartRequested).toBe(false);
+
+    await sp.stop();
+  });
+
+  // R4: a clean turn refills the recovery budget
+  it('R4: a successful result resets the recovery budget', async () => {
+    const sp = new SessionProcess('chat:rec4', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    (sp as unknown as { thinkingRecoveryCount: number }).thinkingRecoveryCount = 1;
+
+    lastProcess!.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'ok' }) + '\n'));
+
+    expect((sp as unknown as { thinkingRecoveryCount: number }).thinkingRecoveryCount).toBe(0);
+
+    await sp.stop();
+  });
+
+  // R5: API sessions are not auto-respawned by this path (runner owns API error handling)
+  it('R5: api source does not auto-respawn on a thinking-block 400', async () => {
+    const sp = new SessionProcess('api:rec', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    lastProcess!.stdout!.emit('data', Buffer.from(errorResultLine() + '\n'));
+
+    expect(lastProcess!.kill).not.toHaveBeenCalled();
+    expect((sp as unknown as { restartRequested: boolean }).restartRequested).toBe(false);
+
+    await sp.stop();
+  });
+
+  // R6: recovery does not fire while serving an internal query()
+  it('R6: query mode does not trigger recovery', async () => {
+    const sp = new SessionProcess('chat:rec6', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const queryPromise = sp.query('describe images', 1000);
+    lastProcess!.stdout!.emit('data', Buffer.from(errorResultLine() + '\n'));
+
+    expect(lastProcess!.kill).not.toHaveBeenCalled();
+    expect((sp as unknown as { restartRequested: boolean }).restartRequested).toBe(false);
+
+    // Settle the query so the test doesn't leak a pending timer.
+    lastProcess!.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: '' }) + '\n'));
+    await queryPromise;
+    await sp.stop();
+  });
+
+  // R7: an ordinary (non-thinking) error does not trigger a respawn
+  it('R7: a generic error result does not trigger recovery', async () => {
+    const sp = new SessionProcess('chat:rec7', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const generic = JSON.stringify({ type: 'result', is_error: true, result: 'API Error: 500 internal server error' });
+    lastProcess!.stdout!.emit('data', Buffer.from(generic + '\n'));
+
+    expect(lastProcess!.kill).not.toHaveBeenCalled();
+    expect((sp as unknown as { restartRequested: boolean }).restartRequested).toBe(false);
+
+    await sp.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the permanent `400` error loop reported in #114. When a session turn is interrupted mid-stream, Claude Code keeps an incomplete/altered `thinking` block in its in-memory history and replays it on every subsequent request, so the Anthropic API rejects each turn:

```
API Error: 400 messages.1.content.11: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified.
```

The subprocess stays alive and never recovers on its own — the only fix was a manual context reset.

## Root cause

The gateway stores conversation history as **plain text** and rebuilds it as a flattened, thinking-block-free prompt on every spawn (`buildInitialPrompt`). So a respawn always yields clean history. The bug is that the gateway never killed the subprocess on the 400 — it just wrote an `error` status and let the corrupted in-memory turn replay forever.

## Fix

In `src/session/process.ts`:

- Detect the corrupted-thinking-block 400 on subprocess stdout (substring match — robust across output formats).
- Respawn the subprocess, which reloads clean text-only history via `buildInitialPrompt` and breaks the loop.
- Reuse graceful-restart semantics so the respawn is **not** counted as a crash against `MAX_RESTARTS`.
- **Bounded** to `MAX_THINKING_RECOVERIES` (2) so a recovery that never helps can't loop forever; the budget refills after a clean turn.
- Skip persisting the API error text as an assistant message (keeps stored history clean).
- Scoped to `telegram`/`discord` sources — API sessions keep their existing runner-side error handling.

## Tests

Added 7 unit cases (`R1`–`R7`) in `tests/unit/session-process.test.ts`:

- R1 detection triggers respawn (kill + restart flag)
- R2 error text is not persisted to the session store
- R3 recovery is bounded after `MAX_THINKING_RECOVERIES`
- R4 a clean result resets the recovery budget
- R5 `api` source is not auto-respawned by this path
- R6 `query()` mode does not trigger recovery
- R7 a generic (non-thinking) error does not trigger recovery

## Test plan

- [x] `npx jest tests/unit/session-process.test.ts` — 67/67 pass
- [x] `npm test` — 1641/1642 (the one failure is a pre-existing flaky chokidar test in `workspace-loader.test.ts`; passes in isolation, unrelated to this change)
- [x] `npx tsc --noEmit` — clean

Closes #114