### PR TITLE
fix(browser): strip stream_url from create_session response

### DIFF
--- a/mcp/tools/browser/module.ts
+++ b/mcp/tools/browser/module.ts
@@ -24,6 +24,19 @@ export class BrowserModule implements ToolModule {
 
     const result = await callGetpodBrowser(name, args);
 
+    if (name === 'browser_create_session' && !result.isError) {
+      const textBlock = result.content[0] as { type: string; text: string } | undefined;
+      if (textBlock?.type === 'text') {
+        try {
+          const parsed = JSON.parse(textBlock.text) as Record<string, unknown>;
+          delete parsed['stream_url'];
+          return { content: [{ type: 'text', text: JSON.stringify(parsed) }] };
+        } catch {
+          // return as-is if parsing fails
+        }
+      }
+    }
+
     if (name === 'browser_screenshot' && !result.isError) {
       // getpod-browser returns {type:"image", data: base64, mimeType:"image/jpeg"}.
       // Decode and save to /tmp so callers can attach the file path directly.
@@ -136,9 +149,7 @@ async function callGetpodBrowser(
 const browserToolDefs: McpToolDefinition[] = [
   {
     name: 'browser_create_session',
-    description:
-      'Create or resume a browser session. Returns stream_url and status. ' +
-      'IMPORTANT: After creating a session, always share the stream_url with the user so they can open the browser in their client.',
+    description: 'Create or resume a browser session. Returns session status.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/mcp/tools/browser/skills/open-browser/SKILL.md
+++ b/mcp/tools/browser/skills/open-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-browser
-description: "Open a URL in the agent's persistent browser session via MCP browser tools"
+description: "ALWAYS invoke this skill when user says 'เปิด [site]', 'open [site]', or asks to navigate to a website. Never call MCP browser tools directly."
 user-invocable: true
 ---
 
@@ -21,13 +21,9 @@ When user says "เปิด X", "navigate to X", "open X in browser", "switch t
 
 Call `mcp__gateway__browser_create_session` with NO arguments (session_id is auto-injected).
 
-Result contains `stream_url` — use it to build the browser URL for the user.
+Result contains `stream_url` — ignore it, do NOT send it to the user.
 
-### Step 2 — Send browser URL to user IMMEDIATELY (no waiting)
-
-Reply on Telegram right away with the stream_url so the user can open the browser.
-
-### Step 3 — Check current tabs
+### Step 2 — Check current tabs
 
 Call `mcp__gateway__browser_tabs` — returns list of `{tab_id, url, title}`.
 

--- a/mcp/tools/browser/skills/open-browser/SKILL.md
+++ b/mcp/tools/browser/skills/open-browser/SKILL.md
@@ -21,7 +21,7 @@ When user says "เปิด X", "navigate to X", "open X in browser", "switch t
 
 Call `mcp__gateway__browser_create_session` with NO arguments (session_id is auto-injected).
 
-Result contains `stream_url` — ignore it, do NOT send it to the user.
+Result contains session status only.
 
 ### Step 2 — Check current tabs
 


### PR DESCRIPTION
## Summary
- Strip `stream_url` from `browser_create_session` tool response before returning to agent — agents were relaying this WebSocket URL to users in chat replies
- Update `browser_create_session` tool description to remove mention of stream_url
- Update `open-browser` SKILL.md: remove Step 2 that instructed agents to relay stream_url, tighten description to enforce skill-only invocation

## Test plan
- [ ] Call `browser_create_session` via MCP — verify response contains only `{"session_id":"...","status":"..."}` (no `stream_url`)
- [ ] Open a website via agent — verify Telegram reply does not include stream URL
- [ ] Verify screenshot flow still works correctly after session create

🤖 Generated with [Claude Code](https://claude.com/claude-code)