### PR TITLE
fix(browser): return HTTP URL for screenshots in API sessions

### DIFF
--- a/mcp/tools/browser/module.ts
+++ b/mcp/tools/browser/module.ts
@@ -51,10 +51,22 @@ export class BrowserModule implements ToolModule {
         let filePath: string;
         if (mediaDir) {
           fs.mkdirSync(mediaDir, { recursive: true });
-          filePath = path.join(mediaDir, `browser_shot_${sid}_${Date.now()}.${ext}`);
-        } else {
-          filePath = path.join('/tmp', `browser_shot_${sid}.${ext}`);
+          const filename = `browser_shot_${sid}_${Date.now()}.${ext}`;
+          filePath = path.join(mediaDir, filename);
+          fs.writeFileSync(filePath, Buffer.from(b64, 'base64'));
+          const apiUrl = process.env.GATEWAY_API_URL;
+          const agentId = process.env.GATEWAY_AGENT_ID;
+          if (apiUrl && agentId) {
+            // mediaDir is <agentBase>/media/<subdir>; parent is the agent's media root
+            const agentMediaRoot = path.dirname(mediaDir);
+            const relPath = path.relative(agentMediaRoot, filePath);
+            return {
+              content: [{ type: 'text', text: `${apiUrl}/v1/agents/${encodeURIComponent(agentId)}/media/${relPath}` }],
+            };
+          }
+          return { content: [{ type: 'text', text: filePath }] };
         }
+        filePath = path.join('/tmp', `browser_shot_${sid}.${ext}`);
         fs.writeFileSync(filePath, Buffer.from(b64, 'base64'));
         return { content: [{ type: 'text', text: filePath }] };
       }

--- a/mcp/tools/browser/module.ts
+++ b/mcp/tools/browser/module.ts
@@ -59,7 +59,10 @@ export class BrowserModule implements ToolModule {
           if (apiUrl && agentId) {
             // mediaDir is <agentBase>/media/<subdir>; parent is the agent's media root
             const agentMediaRoot = path.dirname(mediaDir);
-            const relPath = path.relative(agentMediaRoot, filePath);
+            const relPath = path.relative(agentMediaRoot, filePath)
+              .split(path.sep)
+              .map(encodeURIComponent)
+              .join('/');
             return {
               content: [{ type: 'text', text: `${apiUrl}/v1/agents/${encodeURIComponent(agentId)}/media/${relPath}` }],
             };

--- a/tests/unit/browser-module.test.ts
+++ b/tests/unit/browser-module.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { BrowserModule } from '../../mcp/tools/browser/module';
 
 describe('BrowserModule', () => {
@@ -277,6 +280,125 @@ describe('BrowserModule', () => {
       const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
       const headers = init.headers as Record<string, string>;
       expect(headers['Authorization']).toBeUndefined();
+    });
+  });
+
+  // --- browser_screenshot URL construction ---
+
+  describe('browser_screenshot', () => {
+    const smallJpegB64 = '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAARC';
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bm-screenshot-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function makeScreenshotRpc(b64: string, mime = 'image/jpeg') {
+      return {
+        jsonrpc: '2.0',
+        id: 1,
+        result: { content: [{ type: 'image', data: b64, mimeType: mime }] },
+      };
+    }
+
+    it('returns filesystem path when GATEWAY_SESSION_MEDIA_DIR is not set', async () => {
+      delete process.env.GATEWAY_SESSION_MEDIA_DIR;
+      fetchMock.mockResolvedValue(
+        new Response(`data: ${JSON.stringify(makeScreenshotRpc(smallJpegB64))}\n\n`, { status: 200 }),
+      );
+      const mod = new BrowserModule();
+      const result = await mod.handleTool('browser_screenshot', { session_id: 'sess1' });
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0].text as string;
+      expect(text).toMatch(/^\/tmp\//);
+      expect(text).toMatch(/browser_shot_sess1.*\.jpg$/);
+    });
+
+    it('returns HTTP URL when GATEWAY_SESSION_MEDIA_DIR, GATEWAY_API_URL, GATEWAY_AGENT_ID are set', async () => {
+      const mediaDir = path.join(tmpDir, 'api-sess2');
+      process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
+      process.env.GATEWAY_API_URL = 'http://127.0.0.1:10850';
+      process.env.GATEWAY_AGENT_ID = 'my-agent';
+      fetchMock.mockResolvedValue(
+        new Response(`data: ${JSON.stringify(makeScreenshotRpc(smallJpegB64))}\n\n`, { status: 200 }),
+      );
+      const mod = new BrowserModule();
+      const result = await mod.handleTool('browser_screenshot', { session_id: 'sess2' });
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0].text as string;
+      expect(text).toMatch(/^http:\/\/127\.0\.0\.1:10850\/v1\/agents\/my-agent\/media\/api-sess2\/browser_shot_sess2_/);
+      expect(text).toMatch(/\.jpg$/);
+      // File must exist on disk
+      const filename = path.basename(text.split('/').pop()!);
+      expect(fs.existsSync(path.join(mediaDir, filename))).toBe(true);
+    });
+
+    it('falls back to filesystem path when GATEWAY_API_URL is missing', async () => {
+      const mediaDir = path.join(tmpDir, 'api-sess3');
+      process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
+      delete process.env.GATEWAY_API_URL;
+      process.env.GATEWAY_AGENT_ID = 'my-agent';
+      fetchMock.mockResolvedValue(
+        new Response(`data: ${JSON.stringify(makeScreenshotRpc(smallJpegB64))}\n\n`, { status: 200 }),
+      );
+      const mod = new BrowserModule();
+      const result = await mod.handleTool('browser_screenshot', { session_id: 'sess3' });
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0].text as string;
+      expect(text).toMatch(/^\/tmp\//);
+    });
+
+    it('falls back to filesystem path when GATEWAY_AGENT_ID is missing', async () => {
+      const mediaDir = path.join(tmpDir, 'api-sess4');
+      process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
+      process.env.GATEWAY_API_URL = 'http://127.0.0.1:10850';
+      delete process.env.GATEWAY_AGENT_ID;
+      fetchMock.mockResolvedValue(
+        new Response(`data: ${JSON.stringify(makeScreenshotRpc(smallJpegB64))}\n\n`, { status: 200 }),
+      );
+      const mod = new BrowserModule();
+      const result = await mod.handleTool('browser_screenshot', { session_id: 'sess4' });
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0].text as string;
+      // When GATEWAY_AGENT_ID missing → no URL → falls back to filepath in mediaDir
+      expect(text).toMatch(/browser_shot_sess4.*\.jpg$/);
+      // Should be a filesystem path, not a URL
+      expect(text).not.toMatch(/^http/);
+    });
+
+    it('URL-encodes agent ID with special characters', async () => {
+      const mediaDir = path.join(tmpDir, 'api-sess5');
+      process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
+      process.env.GATEWAY_API_URL = 'http://localhost:10850';
+      process.env.GATEWAY_AGENT_ID = 'my agent/v2';
+      fetchMock.mockResolvedValue(
+        new Response(`data: ${JSON.stringify(makeScreenshotRpc(smallJpegB64))}\n\n`, { status: 200 }),
+      );
+      const mod = new BrowserModule();
+      const result = await mod.handleTool('browser_screenshot', { session_id: 'sess5' });
+      const text = result.content[0].text as string;
+      expect(text).toContain('/v1/agents/my%20agent%2Fv2/media/');
+    });
+
+    it('saves PNG when mimeType is image/png', async () => {
+      const mediaDir = path.join(tmpDir, 'api-sess6');
+      process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
+      process.env.GATEWAY_API_URL = 'http://localhost:10850';
+      process.env.GATEWAY_AGENT_ID = 'agent1';
+      fetchMock.mockResolvedValue(
+        new Response(
+          `data: ${JSON.stringify(makeScreenshotRpc('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==', 'image/png'))}\n\n`,
+          { status: 200 },
+        ),
+      );
+      const mod = new BrowserModule();
+      const result = await mod.handleTool('browser_screenshot', { session_id: 'sess6' });
+      const text = result.content[0].text as string;
+      expect(text).toMatch(/\.png$/);
     });
   });
 });

--- a/tests/unit/browser-module.test.ts
+++ b/tests/unit/browser-module.test.ts
@@ -332,12 +332,13 @@ describe('BrowserModule', () => {
       const text = result.content[0].text as string;
       expect(text).toMatch(/^http:\/\/127\.0\.0\.1:10850\/v1\/agents\/my-agent\/media\/api-sess2\/browser_shot_sess2_/);
       expect(text).toMatch(/\.jpg$/);
-      // File must exist on disk
-      const filename = path.basename(text.split('/').pop()!);
+      // File must exist on disk — decode percent-encoded filename from URL
+      const encodedFilename = text.split('/').pop()!;
+      const filename = decodeURIComponent(encodedFilename);
       expect(fs.existsSync(path.join(mediaDir, filename))).toBe(true);
     });
 
-    it('falls back to filesystem path when GATEWAY_API_URL is missing', async () => {
+    it('falls back to filesystem path in mediaDir when GATEWAY_API_URL is missing', async () => {
       const mediaDir = path.join(tmpDir, 'api-sess3');
       process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
       delete process.env.GATEWAY_API_URL;
@@ -349,10 +350,13 @@ describe('BrowserModule', () => {
       const result = await mod.handleTool('browser_screenshot', { session_id: 'sess3' });
       expect(result.isError).toBeFalsy();
       const text = result.content[0].text as string;
-      expect(text).toMatch(/^\/tmp\//);
+      // No URL available → returns absolute filesystem path inside mediaDir
+      expect(text).not.toMatch(/^http/);
+      expect(text).toMatch(/browser_shot_sess3.*\.jpg$/);
+      expect(text.startsWith(mediaDir)).toBe(true);
     });
 
-    it('falls back to filesystem path when GATEWAY_AGENT_ID is missing', async () => {
+    it('falls back to filesystem path in mediaDir when GATEWAY_AGENT_ID is missing', async () => {
       const mediaDir = path.join(tmpDir, 'api-sess4');
       process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
       process.env.GATEWAY_API_URL = 'http://127.0.0.1:10850';
@@ -364,10 +368,10 @@ describe('BrowserModule', () => {
       const result = await mod.handleTool('browser_screenshot', { session_id: 'sess4' });
       expect(result.isError).toBeFalsy();
       const text = result.content[0].text as string;
-      // When GATEWAY_AGENT_ID missing → no URL → falls back to filepath in mediaDir
-      expect(text).toMatch(/browser_shot_sess4.*\.jpg$/);
-      // Should be a filesystem path, not a URL
+      // No agent ID → cannot build URL → returns absolute filesystem path inside mediaDir
       expect(text).not.toMatch(/^http/);
+      expect(text).toMatch(/browser_shot_sess4.*\.jpg$/);
+      expect(text.startsWith(mediaDir)).toBe(true);
     });
 
     it('URL-encodes agent ID with special characters', async () => {


### PR DESCRIPTION
## Summary

- When `GATEWAY_SESSION_MEDIA_DIR` is set (API sessions), `browser_screenshot` now returns an HTTP URL instead of a raw filesystem path
- URL is constructed as `${GATEWAY_API_URL}/v1/agents/${agentId}/media/${relPath}` pointing to the existing media endpoint
- Falls back to filesystem path when `GATEWAY_API_URL` or `GATEWAY_AGENT_ID` are not available

## Root Cause

`browser_screenshot` decoded the base64 image and saved it to the media directory, but always returned `filePath` regardless of whether the file was in a HTTP-accessible location. Agents embedding the path in markdown (`![alt](/abs/path)`) produced broken images in the browser.

## Test Plan

- [x] Returns HTTP URL when `GATEWAY_SESSION_MEDIA_DIR`, `GATEWAY_API_URL`, and `GATEWAY_AGENT_ID` are all set
- [x] Falls back to filesystem path when `GATEWAY_API_URL` is missing
- [x] Falls back to filesystem path when `GATEWAY_AGENT_ID` is missing
- [x] Returns filesystem path when `GATEWAY_SESSION_MEDIA_DIR` is not set (Telegram/Discord sessions unchanged)
- [x] URL-encodes agent ID with special characters
- [x] Saves PNG when mimeType is `image/png`
- [x] 1680/1680 tests pass

Closes #121