### PR TITLE
fix(browser): handle API session screenshots in open-browser skill

### DIFF
--- a/mcp/tools/browser/skills/open-browser/SKILL.md
+++ b/mcp/tools/browser/skills/open-browser/SKILL.md
@@ -53,16 +53,14 @@ If `browser_navigate` or `browser_navigate_tab` returns error like `tab "t99" no
 
 ### Step 5 — Screenshot and confirm
 
-Call `mcp__gateway__browser_screenshot`.
+Call `mcp__gateway__browser_screenshot` → `result` is either an HTTP URL or an absolute file path.
 
-Choose the reply method based on available tools and the result:
-
-**If `api_reply` tool is available** (API session):
-- Result is HTTP URL (starts with `http`) → `api_reply(text="Screenshot: <url>")`
-- Result is absolute file path → `api_reply(attachments=["/absolute/path/to/file.jpg"])`
-
-**If `api_reply` is NOT available** (Telegram/terminal session):
-- Use `mcp__gateway__telegram_reply` with `files=[result_path]`
+| Channel | Condition | Action |
+|---------|-----------|--------|
+| API | result starts with `http` | `api_reply(text=result)` |
+| API | result is a file path | `api_reply(attachments=[result])` |
+| Telegram | — | `telegram_reply(files=[result])` |
+| Other | — | include path in text response |
 
 ## Multi-tab Management
 

--- a/mcp/tools/browser/skills/open-browser/SKILL.md
+++ b/mcp/tools/browser/skills/open-browser/SKILL.md
@@ -55,9 +55,14 @@ If `browser_navigate` or `browser_navigate_tab` returns error like `tab "t99" no
 
 Call `mcp__gateway__browser_screenshot`.
 
-The result determines how to reply:
-- **HTTP URL** (API session — result starts with `http`): Call `api_reply` with the URL in the text field, e.g. `api_reply(text="Screenshot: <url>")`
-- **Absolute file path** (Telegram/terminal session): Call `mcp__gateway__telegram_reply` with `files=[result_path]`
+Choose the reply method based on available tools and the result:
+
+**If `api_reply` tool is available** (API session):
+- Result is HTTP URL (starts with `http`) → `api_reply(text="Screenshot: <url>")`
+- Result is absolute file path → `api_reply(attachments=["/absolute/path/to/file.jpg"])`
+
+**If `api_reply` is NOT available** (Telegram/terminal session):
+- Use `mcp__gateway__telegram_reply` with `files=[result_path]`
 
 ## Multi-tab Management
 

--- a/mcp/tools/browser/skills/open-browser/SKILL.md
+++ b/mcp/tools/browser/skills/open-browser/SKILL.md
@@ -55,6 +55,8 @@ If `browser_navigate` or `browser_navigate_tab` returns error like `tab "t99" no
 
 Call `mcp__gateway__browser_screenshot` → `result` is either an HTTP URL or an absolute file path.
 
+Detect channel: `api_reply` tool available = API session; `telegram_reply` tool available = Telegram session.
+
 | Channel | Condition | Action |
 |---------|-----------|--------|
 | API | result starts with `http` | `api_reply(text=result)` |

--- a/mcp/tools/browser/skills/open-browser/SKILL.md
+++ b/mcp/tools/browser/skills/open-browser/SKILL.md
@@ -53,9 +53,11 @@ If `browser_navigate` or `browser_navigate_tab` returns error like `tab "t99" no
 
 ### Step 5 — Screenshot and confirm
 
-Call `mcp__gateway__browser_screenshot` — result is absolute file path.
+Call `mcp__gateway__browser_screenshot`.
 
-Send to Telegram with the screenshot attached.
+The result determines how to reply:
+- **HTTP URL** (API session — result starts with `http`): Call `api_reply` with the URL in the text field, e.g. `api_reply(text="Screenshot: <url>")`
+- **Absolute file path** (Telegram/terminal session): Call `mcp__gateway__telegram_reply` with `files=[result_path]`
 
 ## Multi-tab Management
 


### PR DESCRIPTION
## Problem

In API sessions, \`browser_screenshot\` returns an HTTP URL (since #122) or an absolute file path (when \`GATEWAY_API_URL\` is not set).
The \`open-browser\` skill's Step 5 always instructed the agent to send via
\`telegram_reply\` — which API agents can't use, so screenshots were silently dropped.

## Fix

Update Step 5 with a decision table covering all 4 cases:

| Channel | Condition | Action |
|---------|-----------|--------|
| API | result starts with \`http\` | \`api_reply(text=result)\` |
| API | result is a file path | \`api_reply(attachments=[result])\` |
| Telegram | — | \`telegram_reply(files=[result])\` |
| Other | — | include path in text response |

Also adds a channel-detection hint: \`api_reply\` available = API session; \`telegram_reply\` available = Telegram session.

## Related

- Depends on #122 (browser_screenshot HTTP URL for API sessions)
- Depends on #119 (api_reply attachment support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)