### PR TITLE
fix(browser): always return file path from browser_screenshot for api_reply compatibility

### DIFF
--- a/mcp/tools/browser/module.ts
+++ b/mcp/tools/browser/module.ts
@@ -39,8 +39,8 @@ export class BrowserModule implements ToolModule {
 
     if (name === 'browser_screenshot' && !result.isError) {
       // getpod-browser returns {type:"image", data: base64, mimeType:"image/jpeg"}.
-      // Decode and save so callers can attach the file path directly.
-      // For API sessions, save to the session media dir so files are HTTP-accessible.
+      // Always return the absolute file path — callers use api_reply(files=[path])
+      // and the gateway converts the path to an attachment URL in the response.
       const block = result.content[0] as Record<string, string> | undefined;
       const b64 = block?.['data'] ?? '';
       const mime = block?.['mimeType'] ?? 'image/jpeg';

--- a/mcp/tools/browser/module.ts
+++ b/mcp/tools/browser/module.ts
@@ -54,19 +54,6 @@ export class BrowserModule implements ToolModule {
           const filename = `browser_shot_${sid}_${Date.now()}.${ext}`;
           filePath = path.join(mediaDir, filename);
           fs.writeFileSync(filePath, Buffer.from(b64, 'base64'));
-          const apiUrl = process.env.GATEWAY_API_URL;
-          const agentId = process.env.GATEWAY_AGENT_ID;
-          if (apiUrl && agentId) {
-            // mediaDir is <agentBase>/media/<subdir>; parent is the agent's media root
-            const agentMediaRoot = path.dirname(mediaDir);
-            const relPath = path.relative(agentMediaRoot, filePath)
-              .split(path.sep)
-              .map(encodeURIComponent)
-              .join('/');
-            return {
-              content: [{ type: 'text', text: `${apiUrl}/v1/agents/${encodeURIComponent(agentId)}/media/${relPath}` }],
-            };
-          }
           return { content: [{ type: 'text', text: filePath }] };
         }
         filePath = path.join('/tmp', `browser_shot_${sid}.${ext}`);

--- a/mcp/tools/browser/skills/open-browser/SKILL.md
+++ b/mcp/tools/browser/skills/open-browser/SKILL.md
@@ -53,16 +53,15 @@ If `browser_navigate` or `browser_navigate_tab` returns error like `tab "t99" no
 
 ### Step 5 — Screenshot and confirm
 
-Call `mcp__gateway__browser_screenshot` → `result` is either an HTTP URL or an absolute file path.
+Call `mcp__gateway__browser_screenshot` → `result` is an **absolute file path**.
 
 Detect channel: `api_reply` tool available = API session; `telegram_reply` tool available = Telegram session.
 
-| Channel | Condition | Action |
-|---------|-----------|--------|
-| API | result starts with `http` | `api_reply(text=result)` |
-| API | result is a file path | `api_reply(attachments=[result])` |
-| Telegram | — | `telegram_reply(files=[result])` |
-| Other | — | include path in text response |
+| Channel | Action |
+|---------|--------|
+| API | `api_reply(files=[result])` — caller receives it as an attachment with a URL |
+| Telegram | `telegram_reply(files=[result])` |
+| Other | include path in text response |
 
 ## Multi-tab Management
 

--- a/tests/unit/browser-module.test.ts
+++ b/tests/unit/browser-module.test.ts
@@ -318,7 +318,7 @@ describe('BrowserModule', () => {
       expect(text).toMatch(/browser_shot_sess1.*\.jpg$/);
     });
 
-    it('returns HTTP URL when GATEWAY_SESSION_MEDIA_DIR, GATEWAY_API_URL, GATEWAY_AGENT_ID are set', async () => {
+    it('returns file path inside mediaDir regardless of GATEWAY_API_URL and GATEWAY_AGENT_ID', async () => {
       const mediaDir = path.join(tmpDir, 'api-sess2');
       process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
       process.env.GATEWAY_API_URL = 'http://127.0.0.1:10850';
@@ -330,15 +330,14 @@ describe('BrowserModule', () => {
       const result = await mod.handleTool('browser_screenshot', { session_id: 'sess2' });
       expect(result.isError).toBeFalsy();
       const text = result.content[0].text as string;
-      expect(text).toMatch(/^http:\/\/127\.0\.0\.1:10850\/v1\/agents\/my-agent\/media\/api-sess2\/browser_shot_sess2_/);
-      expect(text).toMatch(/\.jpg$/);
-      // File must exist on disk — decode percent-encoded filename from URL
-      const encodedFilename = text.split('/').pop()!;
-      const filename = decodeURIComponent(encodedFilename);
-      expect(fs.existsSync(path.join(mediaDir, filename))).toBe(true);
+      // Always returns absolute file path — agent uses api_reply(files=[path]) to attach
+      expect(text).not.toMatch(/^http/);
+      expect(text.startsWith(mediaDir)).toBe(true);
+      expect(text).toMatch(/browser_shot_sess2.*\.jpg$/);
+      expect(fs.existsSync(text)).toBe(true);
     });
 
-    it('falls back to filesystem path in mediaDir when GATEWAY_API_URL is missing', async () => {
+    it('returns file path inside mediaDir when GATEWAY_API_URL is missing', async () => {
       const mediaDir = path.join(tmpDir, 'api-sess3');
       process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
       delete process.env.GATEWAY_API_URL;
@@ -350,49 +349,14 @@ describe('BrowserModule', () => {
       const result = await mod.handleTool('browser_screenshot', { session_id: 'sess3' });
       expect(result.isError).toBeFalsy();
       const text = result.content[0].text as string;
-      // No URL available → returns absolute filesystem path inside mediaDir
       expect(text).not.toMatch(/^http/);
       expect(text).toMatch(/browser_shot_sess3.*\.jpg$/);
       expect(text.startsWith(mediaDir)).toBe(true);
     });
 
-    it('falls back to filesystem path in mediaDir when GATEWAY_AGENT_ID is missing', async () => {
-      const mediaDir = path.join(tmpDir, 'api-sess4');
-      process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
-      process.env.GATEWAY_API_URL = 'http://127.0.0.1:10850';
-      delete process.env.GATEWAY_AGENT_ID;
-      fetchMock.mockResolvedValue(
-        new Response(`data: ${JSON.stringify(makeScreenshotRpc(smallJpegB64))}\n\n`, { status: 200 }),
-      );
-      const mod = new BrowserModule();
-      const result = await mod.handleTool('browser_screenshot', { session_id: 'sess4' });
-      expect(result.isError).toBeFalsy();
-      const text = result.content[0].text as string;
-      // No agent ID → cannot build URL → returns absolute filesystem path inside mediaDir
-      expect(text).not.toMatch(/^http/);
-      expect(text).toMatch(/browser_shot_sess4.*\.jpg$/);
-      expect(text.startsWith(mediaDir)).toBe(true);
-    });
-
-    it('URL-encodes agent ID with special characters', async () => {
-      const mediaDir = path.join(tmpDir, 'api-sess5');
-      process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
-      process.env.GATEWAY_API_URL = 'http://localhost:10850';
-      process.env.GATEWAY_AGENT_ID = 'my agent/v2';
-      fetchMock.mockResolvedValue(
-        new Response(`data: ${JSON.stringify(makeScreenshotRpc(smallJpegB64))}\n\n`, { status: 200 }),
-      );
-      const mod = new BrowserModule();
-      const result = await mod.handleTool('browser_screenshot', { session_id: 'sess5' });
-      const text = result.content[0].text as string;
-      expect(text).toContain('/v1/agents/my%20agent%2Fv2/media/');
-    });
-
     it('saves PNG when mimeType is image/png', async () => {
       const mediaDir = path.join(tmpDir, 'api-sess6');
       process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
-      process.env.GATEWAY_API_URL = 'http://localhost:10850';
-      process.env.GATEWAY_AGENT_ID = 'agent1';
       fetchMock.mockResolvedValue(
         new Response(
           `data: ${JSON.stringify(makeScreenshotRpc('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==', 'image/png'))}\n\n`,

--- a/tests/unit/browser-module.test.ts
+++ b/tests/unit/browser-module.test.ts
@@ -337,7 +337,7 @@ describe('BrowserModule', () => {
       expect(fs.existsSync(text)).toBe(true);
     });
 
-    it('returns file path inside mediaDir when GATEWAY_API_URL is missing', async () => {
+    it('returns file path inside mediaDir regardless of env vars', async () => {
       const mediaDir = path.join(tmpDir, 'api-sess3');
       process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
       delete process.env.GATEWAY_API_URL;


### PR DESCRIPTION
## Problem

`browser_screenshot` was returning an HTTP URL (from PR #122) when `GATEWAY_API_URL` was set. But `api_reply(files=[...])` only accepts absolute file paths — not URLs. As a result, agents embedded the URL in text instead of sending a proper attachment.

**Before:**
```
browser_screenshot → HTTP URL string
agent: embed URL in text message (attachment dropped)
```

**After:**
```
browser_screenshot → absolute file path (always)
agent: api_reply(files=[path]) → gateway registers file
response: attachments: [{type:"image", url:"/v1/agents/.../media/..."}]
caller: GET /api/v1/agents/:id/media/... to fetch image
```

## Changes

- `mcp/tools/browser/module.ts`: removed HTTP URL construction, always return `filePath`
- `mcp/tools/browser/skills/open-browser/SKILL.md`: Step 5 updated — API sessions use `api_reply(files=[result])`, Telegram uses `telegram_reply(files=[result])`
- `tests/unit/browser-module.test.ts`: rewritten to assert file path return in all cases

## Test

1680/1680 tests pass.

Fixes screenshot attachment flow for API sessions.

Related: #119 (api_reply attachments), #122 (browser_screenshot save), #123 (SKILL.md channel handling)