### PR TITLE
fix: add /api prefix to api_reply attachments endpoint URL

### DIFF
--- a/mcp/tools/api/module.ts
+++ b/mcp/tools/api/module.ts
@@ -58,7 +58,7 @@ export class ApiModule implements ToolModule {
 
     try {
       const res = await fetch(
-        `${apiUrl}/v1/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/attachments`,
+        `${apiUrl}/api/v1/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/attachments`,
         {
           method: 'POST',
           headers: {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -265,6 +265,8 @@ export class SessionProcess extends EventEmitter {
             DISCORD_DM_POLICY: this.agentConfig.discord?.dmPolicy ?? 'disabled',
             DISCORD_DM_ALLOWLIST: (this.agentConfig.discord?.dmAllowlist ?? []).join(','),
             GATEWAY_AGENT_ID: this.agentConfig.id,
+            // Must be the base URL without /api suffix (e.g. http://127.0.0.1:10850).
+            // MCP tools append /api/v1/... themselves — a trailing /api here causes double-prefix 404s.
             GATEWAY_API_URL: process.env.GATEWAY_API_URL ?? `http://127.0.0.1:${process.env.PORT ?? '10850'}`,
             GATEWAY_API_KEY: this.findApiKeyForAgent(this.agentConfig.id),
             GATEWAY_ORIGIN_CHANNEL: this.source,

--- a/tests/unit/api-module.test.ts
+++ b/tests/unit/api-module.test.ts
@@ -107,7 +107,7 @@ describe('ApiModule', () => {
       expect(result.content[0].text).toContain('2 file(s)');
 
       const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/v1/agents/test-agent/sessions/sess-123/attachments');
+      expect(url).toBe('http://localhost:10850/api/v1/agents/test-agent/sessions/sess-123/attachments');
       const body = JSON.parse(init.body as string) as { files: string[] };
       expect(body.files).toEqual(['/abs/path/a.jpg', '/abs/path/b.jpg']);
       const headers = init.headers as Record<string, string>;


### PR DESCRIPTION
## Problem

`api_reply` MCP tool was calling the wrong URL when registering file attachments. The gateway router mounts all API routes at the `/api` prefix, but `api_reply` was building the URL without it:

```
# Actual endpoint:
POST /api/v1/agents/:agentId/sessions/:sessionId/attachments

# What api_reply was calling:
POST /v1/agents/:agentId/sessions/:sessionId/attachments  ← 404
```

This caused agents using the `open-browser` skill to fall back to embedding file paths as plain text in `content` instead of returning them as proper attachments.

## Root Cause

`cron/client.ts` and `apps/client.ts` already build URLs with `/api/v1/...` correctly. Only `mcp/tools/api/module.ts` was missing the prefix.

## Fix

- `mcp/tools/api/module.ts`: add `/api` prefix to the fetch URL
- `tests/unit/api-module.test.ts`: tighten assertion to `toBe(full URL)` so this regression is caught in future (previously `toContain('/v1/...')` would pass even without the `/api` prefix)

## Related PRs
- #119 — added `api_reply` + attachments endpoint
- #122 — browser screenshot returns file path (not HTTP URL)
- #123, #124 — fixed browser skill Step 5 to use `api_reply(files=[path])`

🤖 Generated with [Claude Code](https://claude.com/claude-code)