### PR TITLE
feat(api): allow image-only messages when media_files is provided

### DIFF
--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -281,11 +281,11 @@ export function createApiRouter(
     };
     const { message, chat_id, session_id, stream, timeout_ms, media_files, model: requestModel, store_user_message } = body;
 
-    if (!message || typeof message !== 'string' || !message.trim()) {
-      res.status(400).json({ error: 'message is required and must be a non-empty string' });
+    if (message !== undefined && typeof message !== 'string') {
+      res.status(400).json({ error: 'message must be a string if provided' });
       return;
     }
-    if (message.length > MAX_MESSAGE_LENGTH) {
+    if (typeof message === 'string' && message.length > MAX_MESSAGE_LENGTH) {
       res.status(400).json({ error: `message too long (max ${MAX_MESSAGE_LENGTH} characters)` });
       return;
     }
@@ -326,6 +326,15 @@ export function createApiRouter(
       validatedMediaFiles = media_files as string[];
     }
 
+    // Allow message OR media_files. Image-only sends pass an empty text
+    // alongside the image_path attribute on channelXml so Claude can Read the file.
+    const trimmedMessage = typeof message === 'string' ? message.trim() : '';
+    const hasMedia = !!(validatedMediaFiles && validatedMediaFiles.length);
+    if (!trimmedMessage && !hasMedia) {
+      res.status(400).json({ error: 'message is required and must be a non-empty string (or provide media_files)' });
+      return;
+    }
+
     if (store_user_message !== undefined && typeof store_user_message !== 'boolean') {
       res.status(400).json({ error: 'store_user_message must be a boolean if provided' });
       return;
@@ -348,11 +357,12 @@ export function createApiRouter(
         ? timeout_ms
         : DEFAULT_TIMEOUT_MS;
 
-    // Built-in command dispatch — only intercept known commands, let everything else reach Claude
-    if (AgentRunner.isApiBuiltinCommand(message.trim())) {
+    // Built-in command dispatch — only intercept known commands, let everything else reach Claude.
+    // Image-only sends have an empty trimmedMessage and never match built-in commands.
+    if (trimmedMessage && AgentRunner.isApiBuiltinCommand(trimmedMessage)) {
       try {
-        const result = await runner.executeApiCommand(sessionId, chatIdStr, message.trim());
-        res.json({ command: message.trim(), session_id: sessionId, result });
+        const result = await runner.executeApiCommand(sessionId, chatIdStr, trimmedMessage);
+        res.json({ command: trimmedMessage, session_id: sessionId, result });
       } catch (err: unknown) {
         res.status(500).json({ error: (err as Error).message ?? 'Command failed' });
       }
@@ -404,7 +414,7 @@ export function createApiRouter(
         cleanup = await runner.sendApiMessageStream(
           sessionId,
           chatIdStr,
-          message.trim(),
+          trimmedMessage,
           sseCallbacks,
           { timeoutMs, allowTools, mediaFiles: validatedMediaFiles, model: modelStr, skipUserMessage },
         );
@@ -431,7 +441,7 @@ export function createApiRouter(
       try {
         const agentCfgSync = agentConfigs.get(agentId)!;
         const allowToolsSync = agentCfgSync.allow_tools ?? !!apiKey.allow_tools;
-        const { text: responseText, attachments } = await runner.sendApiMessage(sessionId, chatIdStr, message.trim(), {
+        const { text: responseText, attachments } = await runner.sendApiMessage(sessionId, chatIdStr, trimmedMessage, {
           timeoutMs,
           allowTools: allowToolsSync,
           mediaFiles: validatedMediaFiles,

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -59,6 +59,7 @@ class MockAgentRunner extends EventEmitter {
     this._activeApiSessions.add(sessionId);
   }
 
+  // Required by media_files path validation in the router
   getAgentsBaseDir(): string {
     return '/tmp';
   }
@@ -503,6 +504,20 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
       .send({ chat_id: 'test-chat', stream: true });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/message is required/i);
+  });
+
+  // T4b: stream + image-only (no message) returns 200 SSE
+  it('T4b: stream with image-only (no message) returns 200', async () => {
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
+      cb.onDone('Saw the image.', []);
+      return () => {};
+    });
+    const { status } = await collectSSE(app, {
+      chat_id: 'test-chat',
+      stream: true,
+      media_files: ['ui-upload/abc/test.jpg'],
+    });
+    expect(status).toBe(200);
   });
 
   // T5: conflict returns 409 JSON

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -58,6 +58,10 @@ class MockAgentRunner extends EventEmitter {
   markSessionActive(sessionId: string): void {
     this._activeApiSessions.add(sessionId);
   }
+
+  getAgentsBaseDir(): string {
+    return '/tmp';
+  }
 }
 
 // ── Test fixtures ─────────────────────────────────────────────────────────────
@@ -152,23 +156,49 @@ describe('POST /api/v1/agents/:agentId/messages', () => {
     );
   });
 
-  it('returns 400 when message is missing', async () => {
+  it('returns 400 when message is missing and no media_files provided', async () => {
     const app = buildApp(async () => ({ text: 'ok', attachments: [] }));
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({});
+      .send({ chat_id: 'test-chat' });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/message is required/i);
   });
 
-  it('returns 400 when message is empty string', async () => {
+  it('returns 400 when message is empty string and no media_files provided', async () => {
     const app = buildApp(async () => ({ text: 'ok', attachments: [] }));
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ message: '   ' });
+      .send({ message: '   ', chat_id: 'test-chat' });
     expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/message is required/i);
+  });
+
+  it('returns 200 when message is missing but media_files is provided (image-only)', async () => {
+    let receivedMessage: string | undefined;
+    const app = buildApp(async (_sid, _chatId, msg) => {
+      receivedMessage = msg;
+      return { text: 'Saw the image.', attachments: [] };
+    });
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ chat_id: 'test-chat', media_files: ['ui-upload/abc/test.jpg'] });
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe('Saw the image.');
+    // Runner receives empty string when no text was provided
+    expect(receivedMessage).toBe('');
+  });
+
+  it('returns 200 when message is empty string but media_files is provided', async () => {
+    const app = buildApp(async () => ({ text: 'ok', attachments: [] }));
+    const res = await supertest.default(app)
+      .post(POST_URL)
+      .set(AUTH)
+      .send({ message: '   ', chat_id: 'test-chat', media_files: ['ui-upload/abc/test.jpg'] });
+    expect(res.status).toBe(200);
   });
 
   it('returns 400 when message exceeds 10,000 chars', async () => {
@@ -462,7 +492,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
   });
 
   // T4: no message returns 400 JSON
-  it('T4: stream with no message returns 400 JSON', async () => {
+  it('T4: stream with no message and no media_files returns 400 JSON', async () => {
     const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
       cb.onDone('ok', []);
       return () => {};
@@ -470,7 +500,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     const res = await supertest.default(app)
       .post(POST_URL)
       .set(AUTH)
-      .send({ stream: true });
+      .send({ chat_id: 'test-chat', stream: true });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/message is required/i);
   });


### PR DESCRIPTION
## Summary

`POST /api/v1/agents/:agentId/messages` currently rejects requests where `message` is empty/missing, even when valid `media_files` paths are supplied. This blocks the natural \"image-only\" send pattern (drop an image into the composer and hit send without typing anything) that web/mobile chat UIs need.

The runner already supports image-only turns under the hood — it builds `channelXml` with an `image_path` attribute and a system note instructing Claude to use the Read tool. The text body in `channelXml` is optional context; the image attribute carries the meaningful payload. This PR lifts the router-level gate so clients can use that path.

## Changes

- `message` is now optional when `media_files` contains ≥ 1 valid path. When both are absent/empty, the API still returns 400 (hint now points at `media_files` too).
- Built-in command dispatch (`!ping`, etc.) only runs on a non-empty trimmed message, so image-only sends bypass it without surprising behavior.
- Downstream `runner.sendApiMessage[Stream]` receives `trimmedMessage` (empty string when image-only). The runner already handles this — `channelXml` interpolates the empty body cleanly and `historyDb.content` is `TEXT NOT NULL` (empty string is allowed).

## Tests

- Existing \"message is required\" tests updated to send a valid `chat_id` so they keep testing the message-requirement path (previously they were also missing `chat_id`, masking the actual validation order).
- Two new positive tests verify image-only sends succeed:
  - `media_files` only → 200, runner receives empty string
  - empty `message` + valid `media_files` → 200

All 1680 tests in 90 suites pass.

## Backwards compatibility

Strictly additive — every existing valid request continues to behave the same. The only observable difference is that requests previously rejected with 400 (\"message is required\") will now succeed when `media_files` is present.

## Test plan

- [x] `npm test` — 1680/1680 passing
- [x] `npm run build` — clean
- [ ] Manual test in getpod web UI after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)