### PR TITLE
[Fix] Preserve SSE Stream On Client Disconnect

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1579,8 +1579,8 @@ export class AgentRunner extends EventEmitter {
   /**
    * Send a message to an API session and stream back events via callbacks.
    *
-   * Returns a cleanup function that removes all listeners and frees the session slot.
-   * The caller MUST invoke cleanup on client disconnect or when done.
+   * Returns a disconnect handler for the caller to wire to the SSE close event.
+   * On client disconnect the stream continues server-side until the result is saved to DB.
    */
   async sendApiMessageStream(
     sessionId: string,
@@ -1642,6 +1642,7 @@ export class AgentRunner extends EventEmitter {
 
     const buffer: string[] = [];
     let settled = false;
+    let clientGone = false;
     // Track partial message text for delta computation (--include-partial-messages)
     let lastPartialText = '';
     // Accumulate tool_use blocks from stream_event (content_block_start → delta → stop)
@@ -1652,7 +1653,7 @@ export class AgentRunner extends EventEmitter {
       settled = true;
       cleanup();
       const attachments = this.popApiAttachments(sessionId);
-      // Persist assistant reply
+      // Persist assistant reply regardless of whether the SSE client is still connected
       if (result.trim()) {
         const streamAssistantTs = Date.now();
         this.sessionStore
@@ -1687,6 +1688,10 @@ export class AgentRunner extends EventEmitter {
       this.pendingApiSessions.delete(sessionId);
     };
 
+    // Called when the SSE client disconnects. Marks clientGone so SSE writes
+    // fail silently, but keeps onOutput listening so the result is still saved to DB.
+    const onClientDisconnect = () => { clientGone = true; };
+
     const onOutput = (line: string) => {
       try {
         const obj = JSON.parse(line) as Record<string, unknown>;
@@ -1703,7 +1708,7 @@ export class AgentRunner extends EventEmitter {
             if (fullText.length > lastPartialText.length) {
               const delta = fullText.slice(lastPartialText.length);
               buffer.push(delta);
-              callbacks.onChunk({ type: 'text_delta', text: delta });
+              if (!clientGone) callbacks.onChunk({ type: 'text_delta', text: delta });
             }
             lastPartialText = fullText;
           }
@@ -1714,16 +1719,16 @@ export class AgentRunner extends EventEmitter {
           const text = (obj['text'] as string) ?? '';
           if (text) {
             buffer.push(text);
-            callbacks.onChunk({ type: 'text_delta', text });
+            if (!clientGone) callbacks.onChunk({ type: 'text_delta', text });
           }
         }
 
         // stream_event from --output-format stream-json (tool_use + text_delta)
-        this._applyStreamEvent(obj, toolBlocks, callbacks.onChunk, (text) => {
+        this._applyStreamEvent(obj, toolBlocks, clientGone ? () => {} : callbacks.onChunk, (text) => {
           buffer.push(text);
           // Update lastPartialText so the final 'assistant' message won't re-send the full text
           lastPartialText += text;
-          callbacks.onChunk({ type: 'text_delta', text });
+          if (!clientGone) callbacks.onChunk({ type: 'text_delta', text });
         });
 
         // Text from delta field (other formats)
@@ -1731,13 +1736,13 @@ export class AgentRunner extends EventEmitter {
           const deltaText = (obj['delta'] as Record<string, unknown> | undefined)?.['text'] as string | undefined;
           if (deltaText) {
             buffer.push(deltaText);
-            callbacks.onChunk({ type: 'text_delta', text: deltaText });
+            if (!clientGone) callbacks.onChunk({ type: 'text_delta', text: deltaText });
           }
         }
 
         // Thinking
         if (obj['type'] === 'thinking') {
-          callbacks.onChunk({
+          if (!clientGone) callbacks.onChunk({
             type: 'thinking',
             text: (obj['text'] as string) ?? '',
           });
@@ -1793,13 +1798,7 @@ export class AgentRunner extends EventEmitter {
     session.setProcessing(true);
     session.sendMessage(channelXml);
 
-    // Return cleanup function for client disconnect
-    return () => {
-      if (!settled) {
-        settled = true;
-        cleanup();
-      }
-    };
+    return onClientDisconnect;
   }
 
   /**
@@ -2061,6 +2060,7 @@ export class AgentRunner extends EventEmitter {
 
     const buffer: string[] = [];
     let settled = false;
+    let clientGone = false;
     let lastPartialText = '';
     const toolBlocks = new Map<number, { id: string; name: string; chunks: string[] }>();
 
@@ -2101,6 +2101,8 @@ export class AgentRunner extends EventEmitter {
       session.off('output', onOutput);
     };
 
+    const onClientDisconnect = () => { clientGone = true; };
+
     const onOutput = (line: string) => {
       try {
         const obj = JSON.parse(line) as Record<string, unknown>;
@@ -2114,21 +2116,21 @@ export class AgentRunner extends EventEmitter {
             if (fullText.length > lastPartialText.length) {
               const delta = fullText.slice(lastPartialText.length);
               buffer.push(delta);
-              callbacks.onChunk({ type: 'text_delta', text: delta });
+              if (!clientGone) callbacks.onChunk({ type: 'text_delta', text: delta });
             }
             lastPartialText = fullText;
           }
         }
         if (obj['type'] === 'text') {
           const text = (obj['text'] as string) ?? '';
-          if (text) { buffer.push(text); callbacks.onChunk({ type: 'text_delta', text }); }
+          if (text) { buffer.push(text); if (!clientGone) callbacks.onChunk({ type: 'text_delta', text }); }
         }
         // stream_event from --output-format stream-json (tool_use + text_delta)
-        this._applyStreamEvent(obj, toolBlocks, callbacks.onChunk, (text) => {
+        this._applyStreamEvent(obj, toolBlocks, clientGone ? () => {} : callbacks.onChunk, (text) => {
           buffer.push(text);
           // Update lastPartialText so the final 'assistant' message won't re-send the full text
           lastPartialText += text;
-          callbacks.onChunk({ type: 'text_delta', text });
+          if (!clientGone) callbacks.onChunk({ type: 'text_delta', text });
         });
         if (obj['type'] === 'result') {
           session.setProcessing(false);
@@ -2153,9 +2155,7 @@ export class AgentRunner extends EventEmitter {
     session.setProcessing(true);
     session.sendMessage(channelXml);
 
-    return () => {
-      if (!settled) { settled = true; cleanup(); }
-    };
+    return onClientDisconnect;
   }
 
   private _applyStreamEvent(

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -419,7 +419,7 @@ export function createApiRouter(
           { timeoutMs, allowTools, mediaFiles: validatedMediaFiles, model: modelStr, skipUserMessage },
         );
 
-        // Client disconnect -> cleanup
+        // Client disconnect — marks SSE writes as no-op; stream continues server-side until result is saved to DB
         res.on('close', cleanup);
       } catch (err: unknown) {
         const code = (err as { code?: string }).code;

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2001,10 +2001,23 @@ export function createApiRouter(
   router.get('/v1/agents/:agentId/sessions', auth, async (req: Request, res: Response) => {
     const ctx = resolveApiSession(req, res);
     if (!ctx) return;
-    const { runner, agentId, chatId } = ctx;
+    const { runner, chatId } = ctx;
     try {
       const index = await runner.listApiSessions(chatId);
-      res.json(index);
+      const historySessions = runner.getHistoryDb().listSessions();
+      const roleMap = new Map(
+        historySessions
+          .filter((s) => s.chatId === `api-${chatId}`)
+          .map((s) => [s.sessionId, s.lastMessageRole]),
+      );
+      const enriched = {
+        ...index,
+        sessions: index.sessions.map((s) => ({
+          ...s,
+          lastMessageRole: roleMap.get(s.id) ?? null,
+        })),
+      };
+      res.json(enriched);
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -371,7 +371,7 @@ export function createApiRouter(
 
     if (stream) {
       // SSE streaming mode
-      let cleanup: (() => void) | undefined;
+      let onClientDisconnect: (() => void) | undefined;
       try {
         const sseCallbacks = {
           onChunk: (event: import('../types').StreamEvent) => {
@@ -411,7 +411,7 @@ export function createApiRouter(
 
         const agentCfg = agentConfigs.get(agentId)!;
         const allowTools = agentCfg.allow_tools ?? !!apiKey.allow_tools;
-        cleanup = await runner.sendApiMessageStream(
+        onClientDisconnect = await runner.sendApiMessageStream(
           sessionId,
           chatIdStr,
           trimmedMessage,
@@ -420,7 +420,7 @@ export function createApiRouter(
         );
 
         // Client disconnect — marks SSE writes as no-op; stream continues server-side until result is saved to DB
-        res.on('close', cleanup);
+        res.on('close', onClientDisconnect);
       } catch (err: unknown) {
         const code = (err as { code?: string }).code;
         if (!res.headersSent) {
@@ -2004,18 +2004,14 @@ export function createApiRouter(
     const { runner, chatId } = ctx;
     try {
       const index = await runner.listApiSessions(chatId);
-      const historySessions = runner.getHistoryDb().listSessions();
-      const roleMap = new Map(
-        historySessions
-          .filter((s) => s.chatId === `api-${chatId}`)
-          .map((s) => [s.sessionId, s.lastMessageRole]),
-      );
+      const historySessions = runner.getHistoryDb().listSessions(`api-${chatId}`);
+      const roleMap = new Map(historySessions.map((s) => [s.sessionId, s.lastMessageRole]));
       const enriched = {
         ...index,
-        sessions: index.sessions.map((s) => ({
-          ...s,
-          lastMessageRole: roleMap.get(s.id) ?? null,
-        })),
+        sessions: index.sessions.map((s) => {
+          const lastMessageRole = roleMap.get(s.id) ?? undefined;
+          return lastMessageRole !== undefined ? { ...s, lastMessageRole } : s;
+        }),
       };
       res.json(enriched);
     } catch (err) {
@@ -2213,7 +2209,7 @@ export function createApiRouter(
       console.error(`[api] Failed to delete GREETING.md for '${agentId}': ${(e as Error).message}`);
     }
 
-    let cleanup: (() => void) | undefined;
+    let onClientDisconnect: (() => void) | undefined;
     try {
       const sseCallbacks = {
         onChunk: (event: import('../types').StreamEvent) => {
@@ -2244,7 +2240,7 @@ export function createApiRouter(
       res.flushHeaders();
       res.socket?.setNoDelay(true);
 
-      cleanup = await runner.sendApiMessageStream(
+      onClientDisconnect = await runner.sendApiMessageStream(
         sessionId,
         chatId,
         content,
@@ -2252,7 +2248,7 @@ export function createApiRouter(
         { timeoutMs: DEFAULT_TIMEOUT_MS, skipUserMessage: true },
       );
 
-      res.on('close', cleanup);
+      res.on('close', onClientDisconnect);
     } catch (err: unknown) {
       const code = (err as { code?: string }).code;
       // res.headersSent is always true here (writeHead is called before sendApiMessageStream),

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -266,7 +266,10 @@ export class HistoryDB {
         MAX(ts)   AS last_activity,
         (SELECT content FROM messages m2
          WHERE m2.session_id = m.session_id
-         ORDER BY ts DESC LIMIT 1) AS last_message
+         ORDER BY ts DESC LIMIT 1) AS last_message,
+        (SELECT role FROM messages m3
+         WHERE m3.session_id = m.session_id
+         ORDER BY ts DESC LIMIT 1) AS last_message_role
       FROM messages m
       GROUP BY session_id
       ORDER BY last_activity DESC
@@ -278,6 +281,7 @@ export class HistoryDB {
       created_at: number;
       last_activity: number;
       last_message: string | null;
+      last_message_role: string | null;
     }>;
 
     return rows.map((row) => ({
@@ -288,6 +292,7 @@ export class HistoryDB {
       createdAt: row.created_at,
       lastActivity: row.last_activity,
       lastMessage: row.last_message ?? null,
+      lastMessageRole: (row.last_message_role as MessageRole) ?? null,
       sessionName: null,
     }));
   }

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -255,7 +255,9 @@ export class HistoryDB {
     }
   }
 
-  listSessions(): SessionSummary[] {
+  listSessions(chatId?: string): SessionSummary[] {
+    const where = chatId ? 'WHERE m.chat_id = ?' : '';
+    const params = chatId ? [chatId] : [];
     const rows = this.db.prepare(`
       SELECT
         chat_id,
@@ -271,9 +273,10 @@ export class HistoryDB {
          WHERE m3.session_id = m.session_id
          ORDER BY ts DESC LIMIT 1) AS last_message_role
       FROM messages m
+      ${where}
       GROUP BY session_id
       ORDER BY last_activity DESC
-    `).all() as Array<{
+    `).all(...params) as Array<{
       chat_id: string;
       session_id: string;
       source: string;

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -60,6 +60,7 @@ export interface SessionSummary {
   createdAt: number;
   lastActivity: number;
   lastMessage: string | null;
+  lastMessageRole: MessageRole | null;
   sessionName: string | null;
 }
 

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -8,6 +8,7 @@
  */
 
 import * as fs from 'fs';
+import * as http from 'http';
 import * as path from 'path';
 import * as os from 'os';
 import { randomUUID } from 'crypto';
@@ -486,4 +487,67 @@ describe('Chat History API integration (planning-50)', () => {
     await router.stop();
     await runner.stop();
   });
+
+  // ─── I-HIST-13: SSE disconnect — assistant reply still persists ──────────
+  it('I-HIST-13: assistant reply persisted after SSE client disconnects mid-stream', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-13-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-13-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const sid = randomUUID();
+    const chatId = `api-${sid}`;
+    const port = ((router as unknown as { server: http.Server }).server.address() as { port: number }).port;
+
+    // Stream request — disconnect right after first data arrives, then wait for Claude to finish
+    await new Promise<void>((resolve) => {
+      const reqBody = JSON.stringify({ message: 'disconnect test message', chat_id: sid, session_id: sid, stream: true });
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port,
+          path: '/api/v1/agents/alfred/messages',
+          method: 'POST',
+          headers: {
+            'X-Api-Key': API_KEY_ADMIN,
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(reqBody),
+          },
+        },
+        (res) => {
+          res.once('data', () => { res.destroy(); });
+        },
+      );
+      req.on('error', () => {});
+      req.write(reqBody);
+      req.end();
+      // Allow time for claude to finish processing after disconnect
+      setTimeout(resolve, 600);
+    });
+
+    const res = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(200);
+    const userMsg = (res.body.messages as Array<{ role: string; content: string }>)
+      .find(m => m.role === 'user');
+    expect(userMsg).toBeDefined();
+    expect(userMsg!.content).toBe('disconnect test message');
+
+    const assistantMsg = (res.body.messages as Array<{ role: string; content: string }>)
+      .find(m => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.content).toContain('disconnect test message');
+
+    await router.stop();
+    await runner.stop();
+  }, 15000);
 });

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -506,7 +506,7 @@ describe('Chat History API integration (planning-50)', () => {
     const chatId = `api-${sid}`;
     const port = ((router as unknown as { server: http.Server }).server.address() as { port: number }).port;
 
-    // Stream request — disconnect right after first data arrives, then wait for Claude to finish
+    // Stream request — disconnect right after first data arrives
     await new Promise<void>((resolve) => {
       const reqBody = JSON.stringify({ message: 'disconnect test message', chat_id: sid, session_id: sid, stream: true });
       const req = http.request(
@@ -522,28 +522,30 @@ describe('Chat History API integration (planning-50)', () => {
           },
         },
         (res) => {
-          res.once('data', () => { res.destroy(); });
+          res.once('data', () => { res.destroy(); resolve(); });
         },
       );
       req.on('error', () => {});
       req.write(reqBody);
       req.end();
-      // Allow time for claude to finish processing after disconnect
-      setTimeout(resolve, 600);
     });
 
-    const res = await supertest(router.getApp())
-      .get(`/api/v1/agents/alfred/chats/${chatId}/messages`)
-      .set('X-Api-Key', API_KEY_ADMIN);
+    // Poll until Claude finishes server-side and persists the assistant reply
+    const app = router.getApp();
+    let messages: Array<{ role: string; content: string }> = [];
+    await waitFor(async () => {
+      const res = await supertest(app)
+        .get(`/api/v1/agents/alfred/chats/${chatId}/messages`)
+        .set('X-Api-Key', API_KEY_ADMIN);
+      messages = (res.body.messages as Array<{ role: string; content: string }>) ?? [];
+      return messages.some(m => m.role === 'assistant');
+    }, 10000, 200);
 
-    expect(res.status).toBe(200);
-    const userMsg = (res.body.messages as Array<{ role: string; content: string }>)
-      .find(m => m.role === 'user');
+    const userMsg = messages.find(m => m.role === 'user');
     expect(userMsg).toBeDefined();
     expect(userMsg!.content).toBe('disconnect test message');
 
-    const assistantMsg = (res.body.messages as Array<{ role: string; content: string }>)
-      .find(m => m.role === 'assistant');
+    const assistantMsg = messages.find(m => m.role === 'assistant');
     expect(assistantMsg).toBeDefined();
     expect(assistantMsg!.content).toContain('disconnect test message');
 

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -834,6 +834,51 @@ describe('AgentRunner — sendApiMessageStream', () => {
     ).resolves.toBeDefined();
   }, 15000);
 
+  // T14b: response is persisted to history DB after client disconnect
+  it('T14b: response persisted to history DB after client disconnect', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    let onClientDisconnect: (() => void) | undefined;
+    let doneText = '';
+    let doneFiredResolve!: () => void;
+    const doneFired = new Promise<void>((res) => { doneFiredResolve = res; });
+
+    runner.sendApiMessageStream(
+      'stream-t14b',
+      'test-chat',
+      'persist after disconnect',
+      {
+        onChunk: () => {},
+        onDone: (text) => { doneText = text; doneFiredResolve(); },
+        onError: () => {},
+      },
+      { timeoutMs: 10000 },
+    ).then((fn) => { onClientDisconnect = fn; });
+
+    // Wait for stream to start and disconnect fn to be available
+    await new Promise(r => setTimeout(r, 200));
+    expect(onClientDisconnect).toBeDefined();
+
+    // Simulate SSE client disconnect before result arrives
+    onClientDisconnect!();
+
+    // Simulate Claude completing the response after disconnect
+    const session = getSessions(runner).get('stream-t14b')!;
+    session.emit('output', JSON.stringify({ type: 'result', result: 'Persisted response' }));
+
+    // onDone must still fire even though client disconnected
+    await doneFired;
+    expect(doneText).toBe('Persisted response');
+
+    // History DB must contain the assistant message
+    const page = runner.getHistoryDb().getMessages('api-test-chat');
+    const msgs = page.messages as Array<{ role: string; content: string }>;
+    const assistantMsg = msgs.find(m => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.content).toBe('Persisted response');
+  }, 15000);
+
   // --------------------------------------------------------------------------
   // T-AR-STREAM-15: Partial assistant messages produce incremental text_delta chunks
   // --------------------------------------------------------------------------

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -781,17 +781,17 @@ describe('AgentRunner — sendApiMessageStream', () => {
     expect((err as Error & { code: string }).code).toBe('TIMEOUT');
   }, 15000);
 
-  // T14: cleanup function removes listeners
-  it('T14: cleanup function removes listeners and frees session slot', async () => {
+  // T14: onClientDisconnect keeps stream alive; session freed only after result
+  it('T14: onClientDisconnect keeps session active; slot freed on result', async () => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
     await runner.start();
 
-    let cleanup: (() => void) | undefined;
-    const cleanupReady = new Promise<void>((resolve) => {
+    let onClientDisconnect: (() => void) | undefined;
+    const streamStarted = new Promise<void>((resolve) => {
       runner.sendApiMessageStream(
         'stream-t14',
         'test-chat',
-        'cleanup test',
+        'disconnect test',
         {
           onChunk: () => {},
           onDone: () => {},
@@ -799,20 +799,27 @@ describe('AgentRunner — sendApiMessageStream', () => {
         },
         { timeoutMs: 10000 },
       ).then((fn) => {
-        cleanup = fn;
+        onClientDisconnect = fn;
         resolve();
       });
     });
 
     await new Promise(r => setTimeout(r, 200));
-    await cleanupReady;
+    await streamStarted;
 
     expect(runner.hasActiveApiSession('stream-t14')).toBe(true);
 
-    // Call cleanup
-    cleanup!();
+    // Simulate SSE client disconnect — session must stay active server-side
+    onClientDisconnect!();
+    expect(runner.hasActiveApiSession('stream-t14')).toBe(true);
 
-    // Session slot should be freed
+    // Simulate Claude completing the response after disconnect
+    const session = getSessions(runner).get('stream-t14')!;
+    session.emit('output', JSON.stringify({ type: 'result', result: 'Response after disconnect' }));
+
+    await new Promise(r => setTimeout(r, 100));
+
+    // Session slot freed once result arrives
     expect(runner.hasActiveApiSession('stream-t14')).toBe(false);
 
     // Should be able to start a new stream on same session
@@ -820,7 +827,7 @@ describe('AgentRunner — sendApiMessageStream', () => {
       runner.sendApiMessageStream(
         'stream-t14',
         'test-chat',
-        'after cleanup',
+        'after result',
         { onChunk: () => {}, onDone: () => {}, onError: () => {} },
         { timeoutMs: 5000 },
       ),

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -609,6 +609,55 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
     expect(cleanupCalled).toBe(true);
   }, 10000);
 
+  // T8b: onDone fires after SSE client disconnects — no crash, router stays stable
+  it('T8b: onDone fires after SSE client disconnects — no crash', async () => {
+    let onDoneCalled = false;
+    let savedCallbacks: StreamCallbacks | undefined;
+
+    const { app } = buildStreamApp(async (_sid, _chatId, _msg, cb) => {
+      savedCallbacks = cb;
+      cb.onChunk({ type: 'text_delta', text: 'partial' });
+      // Disconnect handler: simulate Claude finishing after client leaves
+      return () => {
+        setTimeout(() => {
+          savedCallbacks!.onDone('full response after disconnect');
+          onDoneCalled = true;
+        }, 50);
+      };
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const server = app.listen(0, () => {
+        const addr = server.address() as { port: number };
+        const reqBody = JSON.stringify({ message: 'hi', chat_id: 'test-chat', stream: true });
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port: addr.port,
+            path: POST_URL,
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer sk-test-app',
+              'Content-Length': Buffer.byteLength(reqBody),
+            },
+          },
+          (res) => {
+            res.once('data', () => { res.destroy(); });
+          },
+        );
+        req.on('error', () => {});
+        req.write(reqBody);
+        req.end();
+        setTimeout(() => { server.close(); resolve(); }, 500);
+      });
+      server.on('error', reject);
+    });
+
+    await new Promise(r => setTimeout(r, 200));
+    expect(onDoneCalled).toBe(true);
+  }, 10000);
+
   // T-ALLOW-TOOLS-1: key with allow_tools=true passes allowTools=true to runner
   it('T-ALLOW-TOOLS-1: key with allow_tools=true passes allowTools=true to runner', async () => {
     let capturedOpts: { timeoutMs: number; allowTools?: boolean } | undefined;

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -620,7 +620,7 @@ describe('POST /api/v1/agents/:agentId/messages (stream: true)', () => {
       // Disconnect handler: simulate Claude finishing after client leaves
       return () => {
         setTimeout(() => {
-          savedCallbacks!.onDone('full response after disconnect');
+          savedCallbacks!.onDone('full response after disconnect', []);
           onDoneCalled = true;
         }, 50);
       };

--- a/tests/unit/history-cleanup.test.ts
+++ b/tests/unit/history-cleanup.test.ts
@@ -398,4 +398,25 @@ describe('HistoryDB.listSessions', () => {
     expect(session!.createdAt).toBe(early);
     expect(session!.lastActivity).toBe(late);
   });
+
+  it('returns lastMessageRole as the role of the most recent message', () => {
+    const db = makeDb();
+    const ts = Date.now();
+    insertMsg(db, { sessionId: 'sess-r', ts: ts - 2000, content: 'hello', role: 'user' });
+    insertMsg(db, { sessionId: 'sess-r', ts: ts - 1000, content: 'hi there', role: 'assistant' });
+    insertMsg(db, { sessionId: 'sess-r', ts, content: 'follow-up', role: 'user' });
+
+    const [session] = db.listSessions();
+    expect(session!.lastMessageRole).toBe('user');
+  });
+
+  it('returns lastMessageRole as assistant when last message is from assistant', () => {
+    const db = makeDb();
+    const ts = Date.now();
+    insertMsg(db, { sessionId: 'sess-a', ts: ts - 1000, content: 'question', role: 'user' });
+    insertMsg(db, { sessionId: 'sess-a', ts, content: 'answer', role: 'assistant' });
+
+    const [session] = db.listSessions();
+    expect(session!.lastMessageRole).toBe('assistant');
+  });
 });


### PR DESCRIPTION
## Problem

When an API client closes the SSE connection before the LLM finishes responding, the assistant reply is silently discarded — never saved to the database. On the next page reload, the conversation shows only the user message with no response, leaving the session in a permanently broken state.

**Root Cause:** `sendApiMessageStream` and `sendGreetingStream` returned the same `cleanup()` function for both "done" and "client disconnect" paths. Calling cleanup on disconnect marked the stream as `settled = true` and removed all listeners, so the LLM result that arrived later was dropped.

## Solution

Separate the two responsibilities:

- **`cleanup()`** — called internally when the LLM finishes (or errors). Saves the result to DB and frees the session slot.
- **`onClientDisconnect()`** — called by the SSE route handler on `res.on('close')`. Sets `clientGone = true` to silence all outbound SSE writes, but does **not** stop the stream or remove the `output` listener. The LLM continues processing server-side and cleanup runs normally when it finishes.

This ensures the assistant reply is always persisted regardless of whether the client is still connected.

## Changes

- `src/agent/runner.ts`: introduce `clientGone` flag in `sendApiMessageStream` and `sendGreetingStream`; guard all `callbacks.onChunk()` calls with `if (!clientGone)`; return `onClientDisconnect` instead of `cleanup`
- `src/history/db.ts`: add `last_message_role` subquery to `listSessions()` SQL — returns the role of the most recent message per session
- `src/history/types.ts`: add `lastMessageRole` field to `SessionSummary`
- `src/api/router.ts`: expose `lastMessageRole` in `GET /v1/agents/:agentId/sessions` response
- `tests/integration/chat-history-api.test.ts`: add I-HIST-13 — verifies assistant reply is saved after SSE client disconnects mid-stream
- `tests/unit/history-cleanup.test.ts`: add two cases for `lastMessageRole` — last message from user and from assistant

## How to Test

1. Start gateway and send a message via `POST /v1/agents/:id/messages?stream=true`
2. Close the SSE connection immediately after receiving the first chunk
3. Wait a few seconds for the LLM to finish
4. Fetch `GET /v1/agents/:id/chats/:chatId/messages`

**Expected:** the assistant reply is present in message history

For `lastMessageRole`:
1. Call `GET /v1/agents/:id/sessions`
2. Check the `lastMessageRole` field on each session

**Expected:** `"user"` if the last message is from the user (awaiting response), `"assistant"` if the last message is a reply

## Checklist
- [x] Reviewed my own code
- [x] Tests pass (1,686/1,686)
- [x] No console errors