### PR TITLE
[Feature] Add Claude Fable 5 Model

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -9,11 +9,12 @@
       "telegram.dmPolicy"
     ]
   },
-  "configVersion": "1.0.5",
+  "configVersion": "1.0.6",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "models": [
+      { "id": "claude-fable-5",            "label": "Fable 5",    "alias": "fable",  "contextWindow": 1000000 },
       { "id": "claude-opus-4-8",           "label": "Opus 4.8",   "alias": "opus",   "contextWindow": 1000000 },
       { "id": "claude-opus-4-7",           "label": "Opus 4.7",   "alias": "opus47", "contextWindow": 1000000 },
       { "id": "claude-opus-4-6",           "label": "Opus 4.6",   "alias": "opus46", "contextWindow": 1000000 },


### PR DESCRIPTION
## Summary
Add `claude-fable-5` (Fable 5, 1M context) to the models list in `config.template.json` and bump the config version to `1.0.6`. On next gateway restart, the migration will automatically add the new model to existing `config.json` instances.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor / Tech debt
- [ ] Documentation

## Changes Made
- `config.template.json`: add `claude-fable-5` model entry, bump `configVersion` from `1.0.5` to `1.0.6`

## How to Test
1. Checkout this branch
2. Restart the gateway — observe log: `Config migrated to v1.0.6, added: gateway.models[claude-fable-5]`
3. Call `GET /api/v1/models` — verify `claude-fable-5` appears in the response

## Checklist
- [x] Reviewed my own code
- [x] Tests pass (if applicable)
- [x] No console errors