### PR TITLE
feat: fetch available models dynamically from gateway config in Telegram /models

### DIFF
--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -975,16 +975,25 @@ bot.command('models', async ctx => {
   if (!CALLBACK_URL_BASE) return
 
   try {
-    const res = await fetch(CALLBACK_URL_BASE + '/command', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command: 'get_model', chat_id: String(ctx.chat.id) }),
-    })
-    const data = (await res.json()) as { model?: string }
-    const currentModel = data.model ?? ''
+    const [modelRes, modelsRes] = await Promise.all([
+      fetch(CALLBACK_URL_BASE + '/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'get_model', chat_id: String(ctx.chat.id) }),
+      }),
+      fetch(CALLBACK_URL_BASE + '/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'get_models', chat_id: String(ctx.chat.id) }),
+      }),
+    ])
+    const modelData = (await modelRes.json()) as { model?: string }
+    const modelsData = (await modelsRes.json()) as { models?: { id: string; label: string; alias: string }[] }
+    const currentModel = modelData.model ?? ''
+    const availableModels = modelsData.models ?? AVAILABLE_MODELS
 
     const keyboard = new InlineKeyboard()
-    for (const m of AVAILABLE_MODELS) {
+    for (const m of availableModels) {
       const prefix = m.id === currentModel ? '\u2705 ' : ''
       keyboard.text(`${prefix}${m.label}`, `model:${m.id}`).row()
     }

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -984,11 +984,11 @@ bot.command('models', async ctx => {
       fetch(CALLBACK_URL_BASE + '/command', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ command: 'get_models', chat_id: String(ctx.chat.id) }),
+        body: JSON.stringify({ command: 'get_models' }),
       }),
     ])
     const modelData = (await modelRes.json()) as { model?: string }
-    const modelsData = (await modelsRes.json()) as { models?: { id: string; label: string; alias: string }[] }
+    const modelsData = (await modelsRes.json()) as { models?: { id: string; label: string }[] }
     const currentModel = modelData.model ?? ''
     const availableModels = modelsData.models ?? AVAILABLE_MODELS
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -356,6 +356,12 @@ export class AgentRunner extends EventEmitter {
       return;
     }
 
+    if (command === 'get_models') {
+      const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
+      respond({ models: availableModels.map(m => ({ id: m.id, label: m.label, alias: m.alias })) });
+      return;
+    }
+
     if (command === 'set_model') {
       const newModel = typeof body.payload?.model === 'string' ? body.payload.model : '';
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -358,7 +358,7 @@ export class AgentRunner extends EventEmitter {
 
     if (command === 'get_models') {
       const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
-      respond({ models: availableModels.map(m => ({ id: m.id, label: m.label, alias: m.alias })) });
+      respond({ models: availableModels.map(m => ({ id: m.id, label: m.label })) });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Add `get_models` callback command in `runner.ts` that returns the model list from `gatewayConfig.gateway.models` (falls back to `DEFAULT_MODELS`)
- Update `receiver-server.ts` `/models` command to fetch model list dynamically from gateway instead of using hardcoded `AVAILABLE_MODELS`, with fallback to hardcoded list on failure

## Why
Previously adding a new model to config (e.g. `claude-fable-5`) would not appear in Telegram's `/models` selection keyboard — the list was hardcoded and required a code change for every new model.

## Test plan
- [ ] Restart gateway and type `/models` in Telegram — Fable 5 should appear in the list
- [ ] Model selection (✅ checkmark on current model) should still work correctly
- [ ] If runner callback is unavailable, keyboard falls back to hardcoded list gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)