### PR TITLE
fix(migration): never copy credential/identity fields from template agents

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -9,7 +9,7 @@
       "telegram.dmPolicy"
     ]
   },
-  "configVersion": "1.0.6",
+  "configVersion": "1.0.7",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -201,8 +201,12 @@ export function loadConfig(configPath: string): GatewayConfig {
   }
 
   if (interpolatedAgents.length === 0) {
+    const bakPath = configPath + '.bak';
+    const migrationHint = fs.existsSync(bakPath)
+      ? ` A migration backup exists at "${bakPath}" — this may be a migration issue where credential fields were incorrectly injected into your agents. Check the backup and restore if needed.`
+      : '';
     throw new ConfigValidationError(
-      'No valid agents found in config. All agents were skipped due to configuration errors.'
+      `No valid agents found in config. All agents were skipped due to configuration errors.${migrationHint}`
     );
   }
 

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -65,9 +65,22 @@ function deepMerge(
   }
 }
 
+// Per-agent fields that are instance-specific and must never be copied from a
+// template agent into user agents during migration (credentials, identity, paths).
+const AGENT_CREDENTIAL_FIELDS = new Set([
+  'env',
+  'telegram',
+  'discord',
+  'workspace',
+  'avatar',
+  'id',
+  'description',
+]);
+
 /**
  * Merge missing fields from template agent into each user agent.
  * Uses the first agent in the template as the schema source.
+ * Instance-specific fields (credentials, paths, identity) are always excluded.
  */
 function mergeAgentArrays(
   userAgents: Array<Record<string, unknown>>,
@@ -78,7 +91,11 @@ function mergeAgentArrays(
   if (templateAgents.length === 0) return;
   const schema = templateAgents[0];
   for (let i = 0; i < userAgents.length; i++) {
-    deepMerge(userAgents[i], schema, `agents[${i}]`, added, ignorePaths);
+    const agentIgnorePaths = new Set(ignorePaths);
+    for (const field of AGENT_CREDENTIAL_FIELDS) {
+      agentIgnorePaths.add(`agents[${i}].${field}`);
+    }
+    deepMerge(userAgents[i], schema, `agents[${i}]`, added, agentIgnorePaths);
   }
 }
 

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -74,6 +74,7 @@ const AGENT_CREDENTIAL_FIELDS = new Set([
   'workspace',
   'avatar',
   'id',
+  'name',
   'description',
 ]);
 
@@ -126,6 +127,36 @@ function pruneAgentPaths(
         delete obj[leaf];
         const fullPath = `agents[${i}].${dotPath}`;
         if (!removed.includes(fullPath)) removed.push(fullPath);
+      }
+    }
+  }
+  return removed;
+}
+
+const PLACEHOLDER_RE = /^\$\{[^}]+\}$/;
+
+/**
+ * Remove channel blocks (telegram/discord) from agents where the botToken is an
+ * unresolved ${VAR} placeholder — a sign that the block was injected by a prior
+ * buggy migration rather than configured by the user.
+ * Returns the list of paths removed.
+ */
+export function repairInjectedAgentFields(
+  agents: Array<Record<string, unknown>>,
+): string[] {
+  const removed: string[] = [];
+  for (let i = 0; i < agents.length; i++) {
+    const agent = agents[i];
+    for (const channel of ['telegram', 'discord'] as const) {
+      const block = agent[channel];
+      if (
+        block &&
+        typeof block === 'object' &&
+        !Array.isArray(block) &&
+        PLACEHOLDER_RE.test(String((block as Record<string, unknown>).botToken ?? ''))
+      ) {
+        delete agent[channel];
+        removed.push(`agents[${i}].${channel}`);
       }
     }
   }
@@ -295,6 +326,11 @@ export function detectMigration(
     );
   }
 
+  // Repair credential fields that were incorrectly injected by earlier buggy migrations
+  if (Array.isArray(configClone.agents)) {
+    removed.push(...repairInjectedAgentFields(configClone.agents as Array<Record<string, unknown>>));
+  }
+
   // configVersion will always be updated
   if (!added.includes('configVersion')) {
     added.push('configVersion');
@@ -349,6 +385,11 @@ export function applyMigration(
     removed.push(
       ...pruneAgentPaths(config.agents as Array<Record<string, unknown>>, removePaths),
     );
+  }
+
+  // Repair credential fields that were incorrectly injected by earlier buggy migrations
+  if (Array.isArray(config.agents)) {
+    removed.push(...repairInjectedAgentFields(config.agents as Array<Record<string, unknown>>));
   }
 
   // Update configVersion
@@ -451,4 +492,4 @@ function migrateModels(
 }
 
 // Exported for testing
-export { compareSemver, deepMerge, migrateModels, pruneAgentPaths };
+export { compareSemver, deepMerge, migrateModels, pruneAgentPaths, AGENT_CREDENTIAL_FIELDS };

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -134,11 +134,16 @@ function pruneAgentPaths(
 }
 
 const PLACEHOLDER_RE = /^\$\{[^}]+\}$/;
+// Matches ~/.claude-gateway/agents/<id>/.env — captures the agent id in the path
+const AGENT_ENV_PATH_RE = /[/\\]agents[/\\]([^/\\]+)[/\\]\.env$/;
 
 /**
- * Remove channel blocks (telegram/discord) from agents where the botToken is an
- * unresolved ${VAR} placeholder — a sign that the block was injected by a prior
- * buggy migration rather than configured by the user.
+ * Remove fields from agents that were incorrectly injected by a prior buggy
+ * migration (where the template agent's credentials leaked into user agents).
+ *
+ * - telegram/discord: removed when botToken is an unresolved ${VAR} placeholder
+ * - env: removed when the path references a different agent's directory
+ *
  * Returns the list of paths removed.
  */
 export function repairInjectedAgentFields(
@@ -147,6 +152,8 @@ export function repairInjectedAgentFields(
   const removed: string[] = [];
   for (let i = 0; i < agents.length; i++) {
     const agent = agents[i];
+
+    // Remove channel blocks whose botToken is a ${VAR} placeholder
     for (const channel of ['telegram', 'discord'] as const) {
       const block = agent[channel];
       if (
@@ -157,6 +164,15 @@ export function repairInjectedAgentFields(
       ) {
         delete agent[channel];
         removed.push(`agents[${i}].${channel}`);
+      }
+    }
+
+    // Remove env paths that point to a different agent's directory
+    if (typeof agent.env === 'string') {
+      const match = AGENT_ENV_PATH_RE.exec(agent.env);
+      if (match && match[1] !== String(agent.id ?? '')) {
+        delete agent.env;
+        removed.push(`agents[${i}].env`);
       }
     }
   }

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -840,6 +840,20 @@ describe('config-migrator', () => {
       expect(removed).toHaveLength(0);
     });
 
+    it('removes env path that references a different agent directory', () => {
+      const agents: Array<Record<string, unknown>> = [
+        { id: 'getpod', env: '~/.claude-gateway/agents/alfred/.env' },
+        { id: 'alfred', env: '~/.claude-gateway/agents/alfred/.env' },
+      ];
+      const removed = repairInjectedAgentFields(agents);
+      // getpod's env references alfred — should be removed
+      expect(agents[0].env).toBeUndefined();
+      expect(removed).toContain('agents[0].env');
+      // alfred's env references itself — should be kept
+      expect(agents[1].env).toBe('~/.claude-gateway/agents/alfred/.env');
+      expect(removed).not.toContain('agents[1].env');
+    });
+
     it('repairs configs broken by the 1.2.26 bug during next migration', () => {
       const configPath = writeJson('config.json', {
         configVersion: '1.0.6',
@@ -856,9 +870,11 @@ describe('config-migrator', () => {
 
       expect(result.migrated).toBe(true);
       const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      // placeholder telegram should be removed by repair step
+      // placeholder telegram and mismatched env should be removed
       expect(updated.agents[0].telegram).toBeUndefined();
+      expect(updated.agents[0].env).toBeUndefined();
       expect(result.removedFields).toContain('agents[0].telegram');
+      expect(result.removedFields).toContain('agents[0].env');
       // non-credential fields merged normally
       expect(updated.agents[0].signatureEmoji).toBe('');
     });

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -10,6 +10,8 @@ import {
   loadCleanTemplate,
   stripIgnoredPaths,
   pruneAgentPaths,
+  repairInjectedAgentFields,
+  AGENT_CREDENTIAL_FIELDS,
 } from '../../src/config/migrator';
 
 describe('config-migrator', () => {
@@ -729,6 +731,46 @@ describe('config-migrator', () => {
       expect(written.gateway.port).toBe(3000); // existing value preserved
     });
 
+    it('does not inject credential fields from template into API-only agents (regression #136)', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '1.0.5',
+        agents: [
+          { id: 'getpod', description: 'API-only agent' },
+          { id: 'feedback-me', description: 'API-only agent' },
+        ],
+      });
+      const templatePath = writeJson('template.json', {
+        _migration: { ignorePaths: ['gateway.api'] },
+        configVersion: '1.0.6',
+        agents: [
+          {
+            id: 'alfred',
+            env: '~/.claude-gateway/agents/alfred/.env',
+            telegram: { botToken: '${ALFRED_BOT_TOKEN}' },
+            signatureEmoji: '🤖',
+          },
+        ],
+      });
+
+      const result = migrateConfig(configPath, templatePath, '1.0.6');
+
+      expect(result.migrated).toBe(true);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+      // credential fields must NOT leak into API-only agents
+      expect(updated.agents[0].telegram).toBeUndefined();
+      expect(updated.agents[0].env).toBeUndefined();
+      expect(updated.agents[0].id).toBe('getpod');
+
+      expect(updated.agents[1].telegram).toBeUndefined();
+      expect(updated.agents[1].env).toBeUndefined();
+      expect(updated.agents[1].id).toBe('feedback-me');
+
+      // non-credential fields should still be merged
+      expect(updated.agents[0].signatureEmoji).toBe('🤖');
+      expect(updated.agents[1].signatureEmoji).toBe('🤖');
+    });
+
     it('does not migrate when versions match', () => {
       const config = { configVersion: '1.1.0', gateway: { port: 3000 }, agents: [] };
       const template = {
@@ -762,6 +804,75 @@ describe('config-migrator', () => {
       expect(fs.existsSync(`${configPath}.bak`)).toBe(true);
       const bak = JSON.parse(fs.readFileSync(`${configPath}.bak`, 'utf-8'));
       expect(bak.configVersion).toBe('1.0.0'); // backup has original
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // repairInjectedAgentFields
+  // ---------------------------------------------------------------------------
+  describe('repairInjectedAgentFields', () => {
+    it('removes telegram block when botToken is a ${} placeholder', () => {
+      const agents: Array<Record<string, unknown>> = [
+        { id: 'getpod', telegram: { botToken: '${ALFRED_BOT_TOKEN}' } },
+        { id: 'feedback', telegram: { botToken: '${OTHER_TOKEN}' } },
+      ];
+      const removed = repairInjectedAgentFields(agents);
+      expect(agents[0].telegram).toBeUndefined();
+      expect(agents[1].telegram).toBeUndefined();
+      expect(removed).toContain('agents[0].telegram');
+      expect(removed).toContain('agents[1].telegram');
+    });
+
+    it('preserves telegram when botToken is a real resolved value', () => {
+      const agents: Array<Record<string, unknown>> = [
+        { id: 'alfred', telegram: { botToken: '123456789:AAHfiq...' } },
+      ];
+      const removed = repairInjectedAgentFields(agents);
+      expect(agents[0].telegram).toBeDefined();
+      expect(removed).toHaveLength(0);
+    });
+
+    it('is a no-op when agents have no telegram', () => {
+      const agents: Array<Record<string, unknown>> = [
+        { id: 'api-only', description: 'no telegram' },
+      ];
+      const removed = repairInjectedAgentFields(agents);
+      expect(removed).toHaveLength(0);
+    });
+
+    it('repairs configs broken by the 1.2.26 bug during next migration', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '1.0.6',
+        agents: [
+          { id: 'getpod', telegram: { botToken: '${ALFRED_BOT_TOKEN}' }, env: '~/.claude-gateway/agents/alfred/.env' },
+        ],
+      });
+      const templatePath = writeJson('template.json', {
+        configVersion: '1.0.7',
+        agents: [{ id: 'alfred', telegram: { botToken: '${ALFRED_BOT_TOKEN}' }, signatureEmoji: '' }],
+      });
+
+      const result = migrateConfig(configPath, templatePath, '1.0.7');
+
+      expect(result.migrated).toBe(true);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      // placeholder telegram should be removed by repair step
+      expect(updated.agents[0].telegram).toBeUndefined();
+      expect(result.removedFields).toContain('agents[0].telegram');
+      // non-credential fields merged normally
+      expect(updated.agents[0].signatureEmoji).toBe('');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // AGENT_CREDENTIAL_FIELDS — ensure all known instance-specific fields covered
+  // ---------------------------------------------------------------------------
+  describe('AGENT_CREDENTIAL_FIELDS', () => {
+    it('contains all instance-specific fields', () => {
+      const expected = ['env', 'telegram', 'discord', 'workspace', 'avatar', 'id', 'name', 'description'];
+      for (const field of expected) {
+        expect(AGENT_CREDENTIAL_FIELDS.has(field)).toBe(true);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #136 — config migration crashloop on GetPod pods after update to v1.2.26.

- \`mergeAgentArrays()\` now builds a per-agent \`ignorePaths\` set that always excludes instance-specific fields: \`env\`, \`telegram\`, \`discord\`, \`workspace\`, \`avatar\`, \`id\`, \`name\`, \`description\` — regardless of what the template contains
- \`repairInjectedAgentFields()\` strips channel blocks with \`\${VAR}\` placeholder botTokens and \`env\` paths referencing a different agent's directory — auto-repairs configs already corrupted by the bug
- \`config.template.json\` bumped to 1.0.7 so existing broken deployments are repaired on next gateway restart
- \`loadConfig\` includes a helpful hint in the \`ConfigValidationError\` when a \`.bak\` file exists

## Root cause

\`mergeAgentArrays()\` used the first template agent (\`alfred\`) as the schema source and deep-merged all its fields — including \`env\` and \`telegram.botToken\` — into every user agent. The template's \`ignorePaths\` only covered \`gateway.api\`, leaving agent-level credentials unguarded.

## Test plan

- [x] Migration test: user agent with no \`telegram\`/\`env\` + template agent that has both → after migration, user agent still has neither
- [x] Startup test: config from the bug scenario (agents with injected \`\${ALFRED_BOT_TOKEN}\`) — repair migration removes the placeholder block; \`env\` pointing to alfred's path is also removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)