### PR TITLE
fix(migration): compare against template credentials instead of matching any ${...} pattern

### DIFF
--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -138,32 +138,57 @@ const PLACEHOLDER_RE = /^\$\{[^}]+\}$/;
 const AGENT_ENV_PATH_RE = /[/\\]agents[/\\]([^/\\]+)[/\\]\.env$/;
 
 /**
+ * Collect all botToken placeholder values from template agents so that
+ * repairInjectedAgentFields can distinguish leaked template credentials
+ * from legitimate user credentials (which also use ${VAR} format).
+ */
+function extractTemplateCredentials(templateAgents: Array<Record<string, unknown>>): Set<string> {
+  const creds = new Set<string>();
+  for (const agent of templateAgents) {
+    for (const ch of ['telegram', 'discord'] as const) {
+      const block = agent[ch];
+      if (block && typeof block === 'object' && !Array.isArray(block)) {
+        const bt = String((block as Record<string, unknown>).botToken ?? '');
+        if (PLACEHOLDER_RE.test(bt)) creds.add(bt);
+      }
+    }
+  }
+  return creds;
+}
+
+/**
  * Remove fields from agents that were incorrectly injected by a prior buggy
  * migration (where the template agent's credentials leaked into user agents).
  *
- * - telegram/discord: removed when botToken is an unresolved ${VAR} placeholder
- * - env: removed when the path references a different agent's directory
+ * - telegram/discord: removed only when botToken exactly matches a known template
+ *   credential placeholder (e.g. "${ALFRED_BOT_TOKEN}"). User agents legitimately
+ *   store their own "${AGENT_BOT_TOKEN}" placeholders which must NOT be removed.
+ * - env: removed when the path references a different agent's directory.
  *
  * Returns the list of paths removed.
  */
 export function repairInjectedAgentFields(
   agents: Array<Record<string, unknown>>,
+  templateCredentials: Set<string>,
 ): string[] {
   const removed: string[] = [];
   for (let i = 0; i < agents.length; i++) {
     const agent = agents[i];
 
-    // Remove channel blocks whose botToken is a ${VAR} placeholder
-    for (const channel of ['telegram', 'discord'] as const) {
-      const block = agent[channel];
-      if (
-        block &&
-        typeof block === 'object' &&
-        !Array.isArray(block) &&
-        PLACEHOLDER_RE.test(String((block as Record<string, unknown>).botToken ?? ''))
-      ) {
-        delete agent[channel];
-        removed.push(`agents[${i}].${channel}`);
+    // Remove channel blocks whose botToken exactly matches a template credential —
+    // meaning it was leaked from the template agent into this user agent.
+    if (templateCredentials.size > 0) {
+      for (const channel of ['telegram', 'discord'] as const) {
+        const block = agent[channel];
+        if (
+          block &&
+          typeof block === 'object' &&
+          !Array.isArray(block) &&
+          templateCredentials.has(String((block as Record<string, unknown>).botToken ?? ''))
+        ) {
+          delete agent[channel];
+          removed.push(`agents[${i}].${channel}`);
+        }
       }
     }
 
@@ -344,7 +369,15 @@ export function detectMigration(
 
   // Repair credential fields that were incorrectly injected by earlier buggy migrations
   if (Array.isArray(configClone.agents)) {
-    removed.push(...repairInjectedAgentFields(configClone.agents as Array<Record<string, unknown>>));
+    const templateCreds = extractTemplateCredentials(
+      (template.agents as Array<Record<string, unknown>>) ?? [],
+    );
+    removed.push(
+      ...repairInjectedAgentFields(
+        configClone.agents as Array<Record<string, unknown>>,
+        templateCreds,
+      ),
+    );
   }
 
   // configVersion will always be updated
@@ -405,7 +438,15 @@ export function applyMigration(
 
   // Repair credential fields that were incorrectly injected by earlier buggy migrations
   if (Array.isArray(config.agents)) {
-    removed.push(...repairInjectedAgentFields(config.agents as Array<Record<string, unknown>>));
+    const templateCreds = extractTemplateCredentials(
+      (template.agents as Array<Record<string, unknown>>) ?? [],
+    );
+    removed.push(
+      ...repairInjectedAgentFields(
+        config.agents as Array<Record<string, unknown>>,
+        templateCreds,
+      ),
+    );
   }
 
   // Update configVersion

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -141,6 +141,10 @@ const AGENT_ENV_PATH_RE = /[/\\]agents[/\\]([^/\\]+)[/\\]\.env$/;
  * Collect all botToken placeholder values from template agents so that
  * repairInjectedAgentFields can distinguish leaked template credentials
  * from legitimate user credentials (which also use ${VAR} format).
+ *
+ * Iterates all agents in the template array (typically only index 0 exists).
+ * PLACEHOLDER_RE is intentional here — template configs always ship with
+ * unresolved ${VAR} references, never resolved tokens.
  */
 function extractTemplateCredentials(templateAgents: Array<Record<string, unknown>>): Set<string> {
   const creds = new Set<string>();

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -811,23 +811,26 @@ describe('config-migrator', () => {
   // repairInjectedAgentFields
   // ---------------------------------------------------------------------------
   describe('repairInjectedAgentFields', () => {
-    it('removes telegram block when botToken is a ${} placeholder', () => {
+    it('removes telegram block only when botToken exactly matches a template credential', () => {
+      const templateCreds = new Set(['${ALFRED_BOT_TOKEN}']);
       const agents: Array<Record<string, unknown>> = [
+        // leaked from template — should be removed
         { id: 'getpod', telegram: { botToken: '${ALFRED_BOT_TOKEN}' } },
-        { id: 'feedback', telegram: { botToken: '${OTHER_TOKEN}' } },
+        // user's own placeholder — must NOT be removed
+        { id: 'feedback', telegram: { botToken: '${FEEDBACK_BOT_TOKEN}' } },
       ];
-      const removed = repairInjectedAgentFields(agents);
+      const removed = repairInjectedAgentFields(agents, templateCreds);
       expect(agents[0].telegram).toBeUndefined();
-      expect(agents[1].telegram).toBeUndefined();
+      expect(agents[1].telegram).toBeDefined();
       expect(removed).toContain('agents[0].telegram');
-      expect(removed).toContain('agents[1].telegram');
+      expect(removed).not.toContain('agents[1].telegram');
     });
 
     it('preserves telegram when botToken is a real resolved value', () => {
       const agents: Array<Record<string, unknown>> = [
         { id: 'alfred', telegram: { botToken: '123456789:AAHfiq...' } },
       ];
-      const removed = repairInjectedAgentFields(agents);
+      const removed = repairInjectedAgentFields(agents, new Set());
       expect(agents[0].telegram).toBeDefined();
       expect(removed).toHaveLength(0);
     });
@@ -836,7 +839,17 @@ describe('config-migrator', () => {
       const agents: Array<Record<string, unknown>> = [
         { id: 'api-only', description: 'no telegram' },
       ];
-      const removed = repairInjectedAgentFields(agents);
+      const removed = repairInjectedAgentFields(agents, new Set());
+      expect(removed).toHaveLength(0);
+    });
+
+    it('is a no-op for telegram when templateCredentials is empty', () => {
+      // Even if botToken is a placeholder, empty templateCreds = no leaked values to detect
+      const agents: Array<Record<string, unknown>> = [
+        { id: 'getpod', telegram: { botToken: '${GETPOD_BOT_TOKEN}' } },
+      ];
+      const removed = repairInjectedAgentFields(agents, new Set());
+      expect(agents[0].telegram).toBeDefined();
       expect(removed).toHaveLength(0);
     });
 
@@ -845,7 +858,7 @@ describe('config-migrator', () => {
         { id: 'getpod', env: '~/.claude-gateway/agents/alfred/.env' },
         { id: 'alfred', env: '~/.claude-gateway/agents/alfred/.env' },
       ];
-      const removed = repairInjectedAgentFields(agents);
+      const removed = repairInjectedAgentFields(agents, new Set());
       // getpod's env references alfred — should be removed
       expect(agents[0].env).toBeUndefined();
       expect(removed).toContain('agents[0].env');


### PR DESCRIPTION
## Problem

`repairInjectedAgentFields` in v1.2.27 introduced a regression: it removed `telegram`/`discord`/`env` fields from **all** agents whose `botToken` matched the `${VAR}` regex — including real user configs that legitimately use env-var placeholders (e.g. `${ALFRED_BOT_TOKEN}`).

This caused a silent data loss on migration: every agent that stored their bot token as an env-var reference had their channel config wiped.

## Root Cause

The repair function used a generic regex `/^\$\{[^}]+\}$/` to detect "injected placeholder" values. But real user configs use the **same format** for env-var substitution — there's no way to distinguish them by pattern alone.

## Fix

Extract the actual credential values from the **template agent** (index 0) and only remove fields whose tokens match those exact strings. This is precise: only tokens that are literally the same as what the template injected are removed.

```ts
// Before (too broad — matches any ${VAR})
const PLACEHOLDER_RE = /^\$\{[^}]+\}$/;
if (PLACEHOLDER_RE.test(botToken)) { remove }

// After (precise — only removes template's own credentials)
const templateCreds = extractTemplateCredentials(agents);
if (templateCreds.has(botToken)) { remove }
```

## Test Plan

- [x] `repairInjectedAgentFields` — agents with real `${ENV_VAR}` tokens are NOT removed
- [x] `repairInjectedAgentFields` — agents injected with the template's exact bot token ARE removed
- [x] `repairInjectedAgentFields` — `env` paths matching template are removed
- [x] Full migration test: 53 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)