### PR TITLE
[Fix] Avatar GET returns 404 after extension change due to stale in-memory agentConfigs

### DIFF
--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1938,8 +1938,8 @@ export function createApiRouter(
     }
 
     // Update in-memory map immediately — same reason as PUT handler above.
-    const deleteCfg = agentConfigs.get(agentId);
-    if (deleteCfg) delete deleteCfg.avatar;
+    const cfg = agentConfigs.get(agentId);
+    if (cfg) delete cfg.avatar;
 
     res.status(204).send();
   });

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1899,6 +1899,11 @@ export function createApiRouter(
       return;
     }
 
+    // Update in-memory map immediately — don't wait for the file watcher so the
+    // GET handler can serve the new file before the next config reload fires.
+    const cfg = agentConfigs.get(agentId);
+    if (cfg) cfg.avatar = newFilename;
+
     res.json({ avatarUrl: `/api/v1/agents/${agentId}/avatar` });
   });
 
@@ -1931,6 +1936,10 @@ export function createApiRouter(
       res.status(500).json({ error: `Failed to update config: ${(err as Error).message}` });
       return;
     }
+
+    // Update in-memory map immediately — same reason as PUT handler above.
+    const deleteCfg = agentConfigs.get(agentId);
+    if (deleteCfg) delete deleteCfg.avatar;
 
     res.status(204).send();
   });

--- a/tests/unit/api-avatar-wizard.test.ts
+++ b/tests/unit/api-avatar-wizard.test.ts
@@ -390,6 +390,64 @@ describe('GET /api/v1/agents/:agentId/avatar', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Regression: stale agentConfigs after extension change (PUT jpeg → PUT png → GET)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('avatar extension change regression', () => {
+  it('GET returns 200 immediately after PUT with different extension (no stale 404)', async () => {
+    const { app, tmpDir, agentDir, agentConfigs } = buildCtx({ avatar: 'avatar.jpeg' });
+    try {
+      // Seed the old jpeg file on disk (as if uploaded previously)
+      fs.writeFileSync(path.join(agentDir, 'avatar.jpeg'), makeJpegBuffer(200));
+
+      // PUT a PNG — this should delete avatar.jpeg, write avatar.png, and update agentConfigs in-memory
+      const putRes = await supertest.default(app)
+        .put(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${WRITE_KEY}`)
+        .set('Content-Type', 'image/png')
+        .send(makePngBuffer(200));
+      expect(putRes.status).toBe(200);
+
+      // In-memory map must reflect the new filename immediately (before any file watcher fires)
+      expect(agentConfigs.get(AGENT_ID)?.avatar).toBe('avatar.png');
+
+      // GET immediately after — must NOT return 404 "Avatar file not found"
+      const getRes = await supertest.default(app)
+        .get(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${READ_KEY}`);
+      expect(getRes.status).toBe(200);
+      expect(getRes.headers['content-type']).toMatch(/image\/png/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('GET returns 404 after DELETE — agentConfigs.avatar removed immediately', async () => {
+    const { app, tmpDir, agentDir, agentConfigs } = buildCtx({ avatar: 'avatar.png' });
+    try {
+      fs.writeFileSync(path.join(agentDir, 'avatar.png'), makePngBuffer(200));
+
+      const delRes = await supertest.default(app)
+        .delete(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${WRITE_KEY}`);
+      expect(delRes.status).toBe(204);
+
+      // In-memory map must have avatar removed immediately
+      expect(agentConfigs.get(AGENT_ID)?.avatar).toBeUndefined();
+
+      // GET must return 404 (no avatar set), not 500 or stale file reference
+      const getRes = await supertest.default(app)
+        .get(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${READ_KEY}`);
+      expect(getRes.status).toBe(404);
+      expect(getRes.body.error).toMatch(/no avatar/i);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Wizard State (unit tests for WizardStore)
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

When a user uploads an avatar with a **different file extension** than the existing one (e.g. replacing `avatar.jpeg` with `avatar.png`), the `GET /v1/agents/:agentId/avatar` endpoint returns `{ "error": "Avatar file not found" }` immediately after the upload — even though the file was written and `config.json` was updated successfully.

### Root Cause

The PUT handler correctly:
1. Deletes the old file when the extension changes (`fsp.unlink(oldPath)`)
2. Writes the new file (`fsp.writeFile(...)`)
3. Updates `config.json` via `writeAgentsToConfig`

However, it does **not** update the **in-memory `agentConfigs` map**. That map is only refreshed by the file watcher, which fires asynchronously after the disk write.

When the frontend immediately GETs the avatar after a successful PUT response, the GET handler reads the stale in-memory map:

```
agentConfigs.get("feedback-me").avatar  →  "avatar.jpeg"  ← stale
```

The old file (`avatar.jpeg`) was already deleted → `fs.existsSync(avatarPath)` returns `false` → **404 "Avatar file not found"**.

### Why only on extension change?

If the user uploads the same type (e.g. PNG → PNG), the old file is **not** deleted (same filename). The stale in-memory value still points to a file that exists → no error. The bug only surfaces when the extension changes.

### Observed in Practice

The `feedback-me` agent ships with a default `avatar.jpeg`. When a user first uploads a custom PNG avatar, they hit this exact race condition: the JPEG is deleted, the PNG is written, but `agentConfigs` still references the JPEG → immediate 404.

---

## Fix

After `writeAgentsToConfig` succeeds, synchronously update the in-memory `agentConfigs` map **before** sending the response. This eliminates the race window entirely — subsequent GET requests use the correct filename immediately.

**PUT handler** — set new filename:
```ts
const cfg = agentConfigs.get(agentId);
if (cfg) cfg.avatar = newFilename;
```

**DELETE handler** — remove the avatar field:
```ts
const deleteCfg = agentConfigs.get(agentId);
if (deleteCfg) delete deleteCfg.avatar;
```

The file watcher will still fire and reload the full config as usual — this change just ensures the in-memory state is consistent immediately after a write.

---

## Testing

1. Upload an avatar to any agent (e.g. a JPEG image)
2. Upload a different format (e.g. PNG) to the same agent
3. **Before fix**: `GET /v1/agents/:agentId/avatar` returns `404 Avatar file not found`
4. **After fix**: `GET /v1/agents/:agentId/avatar` returns the new image immediately

Also verified: same-extension re-upload and avatar delete are unaffected.