### PR TITLE
fix(sockets): recreate socket directory if not writable by current process

### DIFF
--- a/src/apps/socket-server.ts
+++ b/src/apps/socket-server.ts
@@ -58,8 +58,19 @@ export class SocketServer {
     }
 
     return new Promise((resolve, reject) => {
-      // Ensure parent directory exists (socket lives inside a per-app subdirectory)
-      try { fs.mkdirSync(path.dirname(socketPath), { recursive: true }); } catch { /* exists */ }
+      // Ensure parent directory exists and is writable by the current process.
+      // If it exists but is owned by root (from a previous sudo run), remove and recreate it
+      // so the gateway process (running as ubuntu) can create the socket inside.
+      const sockDir = path.dirname(socketPath);
+      try {
+        const stat = fs.statSync(sockDir, { throwIfNoEntry: false });
+        if (stat) {
+          try { fs.accessSync(sockDir, fs.constants.W_OK); } catch {
+            fs.rmSync(sockDir, { recursive: true, force: true });
+          }
+        }
+        fs.mkdirSync(sockDir, { recursive: true });
+      } catch { /* best-effort */ }
       // Clean up any stale socket or leftover directory before binding
       if (fs.existsSync(socketPath)) {
         try { fs.rmSync(socketPath, { recursive: true, force: true }); } catch { /* already gone */ }

--- a/src/apps/socket-server.ts
+++ b/src/apps/socket-server.ts
@@ -109,12 +109,13 @@ export class SocketServer {
     server.close();
     this.servers.delete(socketPath);
     try {
-      fs.rmSync(socketPath, { recursive: true, force: true });
-      // Clean up the parent socket directory if empty (created per-app at install time)
-      const parentDir = path.dirname(socketPath);
-      try { fs.rmdirSync(parentDir); } catch { /* non-empty or already gone — OK */ }
+      fs.unlinkSync(socketPath);
+      // Do NOT remove the parent directory — it is a Docker bind-mount source.
+      // Deleting it causes Docker to recreate it as root:root on next container start,
+      // which prevents the gateway from creating a new socket inside it after restart.
+      // The directory is removed only on app uninstall (installer.ts teardown).
     } catch {
-      // Already removed
+      // Already removed or never existed
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -375,26 +375,36 @@ async function restoreSockets(registry: AppsRegistry, socketServer: SocketServer
       try { fs.unlinkSync(sockPath); } catch { /* stale or absent */ }
       // Ensure socket directory is writable by the current process.
       // If owned by root (from a prior sudo run), remove and recreate it.
+      // rmSync is wrapped: EPERM on rmSync must not skip the remaining sockets.
       const sockDir = path.dirname(sockPath);
-      const dirStat = fs.statSync(sockDir, { throwIfNoEntry: false });
-      if (dirStat) {
-        try { fs.accessSync(sockDir, fs.constants.W_OK); } catch {
-          fs.rmSync(sockDir, { recursive: true, force: true });
+      try {
+        const dirStat = fs.statSync(sockDir, { throwIfNoEntry: false });
+        if (dirStat) {
+          try { fs.accessSync(sockDir, fs.constants.W_OK); } catch {
+            fs.rmSync(sockDir, { recursive: true, force: true });
+          }
         }
+        fs.mkdirSync(sockDir, { recursive: true });
+      } catch (err) {
+        console.warn(`[gateway] Failed to prepare socket dir ${sockDir}: ${(err as Error).message} — skipping ${app.name}/${svcName}`);
+        continue;
       }
-      fs.mkdirSync(sockDir, { recursive: true });
 
-      socketServer.start(sockPath, {
-        appName: app.name,
-        serviceName: svcName,
-        appDir: app.installPath,
-        scripts: Object.fromEntries(
-          Object.entries(svc.gateway_api.scripts ?? {}).map(([name, s]: [string, AppYamlScript]) => [
-            name,
-            { path: s.path, timeoutMs: parseTimeoutMs(s.timeout), args: s.args },
-          ]),
-        ),
-      });
+      try {
+        await socketServer.start(sockPath, {
+          appName: app.name,
+          serviceName: svcName,
+          appDir: app.installPath,
+          scripts: Object.fromEntries(
+            Object.entries(svc.gateway_api.scripts ?? {}).map(([name, s]: [string, AppYamlScript]) => [
+              name,
+              { path: s.path, timeoutMs: parseTimeoutMs(s.timeout), args: s.args },
+            ]),
+          ),
+        });
+      } catch (err) {
+        console.warn(`[gateway] Failed to restore socket for ${app.name}/${svcName}: ${(err as Error).message} — skipping`);
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,7 +373,16 @@ async function restoreSockets(registry: AppsRegistry, socketServer: SocketServer
       if (!svc?.gateway_api) continue;
 
       try { fs.unlinkSync(sockPath); } catch { /* stale or absent */ }
-      fs.mkdirSync(path.dirname(sockPath), { recursive: true });
+      // Ensure socket directory is writable by the current process.
+      // If owned by root (from a prior sudo run), remove and recreate it.
+      const sockDir = path.dirname(sockPath);
+      const dirStat = fs.statSync(sockDir, { throwIfNoEntry: false });
+      if (dirStat) {
+        try { fs.accessSync(sockDir, fs.constants.W_OK); } catch {
+          fs.rmSync(sockDir, { recursive: true, force: true });
+        }
+      }
+      fs.mkdirSync(sockDir, { recursive: true });
 
       socketServer.start(sockPath, {
         appName: app.name,


### PR DESCRIPTION
## Problem

Crash loop when the socket directory (`.claude-gateway/sockets/<app>-<svc>/`) is owned by `root:root` from a previous `sudo` run or an old systemd configuration without `User=ubuntu`.

**Root cause chain (from #140):**
1. `SocketServer.stop()` deleted the per-app socket directory on every gateway shutdown
2. Docker recreated it as `root:root` on next boot (daemon runs as root, dir was missing)
3. `socketServer.start()` in `restoreSockets()` was called without `await`/`.catch()` — EACCES from a root-owned dir caused an **unhandled rejection** that killed the entire gateway process
4. systemd restarted it → crashloop, nginx 502

## Fixes (addresses Fix 1, 2, 3 from #140)

### Fix 1 — `await` + per-socket error isolation in `restoreSockets()`
`socketServer.start()` is now awaited with per-socket try/catch. A single broken socket logs a warning and is skipped; all other sockets continue to restore. One app's failure no longer kills the entire gateway.

### Fix 2 — `SocketServer.stop()` keeps the bind-mount source directory
`stop()` now removes only the `.sock` file, not the parent directory. The parent dir is a Docker bind-mount source — deleting it is what invited Docker to recreate it as `root:root`. Directory removal remains only in the installer teardown path (app uninstall).

### Fix 3 — Self-heal wrong-owner socket directory
Before creating the socket, check `W_OK` access on the dir. If not writable (e.g. survived as `root:root` through another path), remove and recreate it. Defense-in-depth for any edge case that leaves the dir in a bad ownership state.

Additional: `rmSync` in the dir-heal block is now wrapped in try/catch so an unexpected error skips only that socket, not the rest of the restore loop.

## Test plan

- [ ] Gateway starts normally when socket directory already exists and is ubuntu-owned
- [ ] Single broken socket dir (root:root) logs warning and is skipped — other agents unaffected
- [ ] Gateway does NOT delete socket directory on shutdown (`stop()`) — dir persists across restarts
- [ ] Build passes: `npm run build`

Partially addresses #140 (Fix 1, 2, 3 of 4 — Fix 4 receiver orphan detection is a separate follow-up)