### PR TITLE
fix(avatar): replace max-age=3600 with no-cache + ETag (issue #139 layer 2)

### DIFF
--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1966,22 +1966,33 @@ export function createApiRouter(
       res.status(400).json({ error: 'Invalid avatar path' });
       return;
     }
-    if (!fs.existsSync(avatarPath)) { res.status(404).json({ error: 'Avatar file not found' }); return; }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(avatarPath);
+    } catch {
+      res.status(404).json({ error: 'Avatar file not found' });
+      return;
+    }
 
     const ext = path.extname(avatarPath).slice(1).toLowerCase();
     const mimeMap: Record<string, string> = { jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', gif: 'image/gif', webp: 'image/webp' };
     const contentType = mimeMap[ext] ?? 'application/octet-stream';
 
-    const stat = fs.statSync(avatarPath);
-    const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
+    // Weak ETag — mtime+size cannot guarantee byte-identical content so strong ETag is inappropriate.
+    const etag = `W/"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
 
     // no-cache forces revalidation on every request; ETag allows 304 when file is unchanged.
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('ETag', etag);
+    res.setHeader('Last-Modified', new Date(stat.mtimeMs).toUTCString());
     res.setHeader('Content-Type', contentType);
     res.setHeader('X-Content-Type-Options', 'nosniff');
 
-    if (req.headers['if-none-match'] === etag) {
+    // If-None-Match may be a comma-separated list of ETags; check each token.
+    const ifNoneMatch = req.headers['if-none-match'];
+    const matched = ifNoneMatch && ifNoneMatch.split(',').map(t => t.trim()).includes(etag);
+    if (matched) {
       res.status(304).end();
       return;
     }

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1972,9 +1972,19 @@ export function createApiRouter(
     const mimeMap: Record<string, string> = { jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', gif: 'image/gif', webp: 'image/webp' };
     const contentType = mimeMap[ext] ?? 'application/octet-stream';
 
-    res.setHeader('Cache-Control', 'private, max-age=3600');
+    const stat = fs.statSync(avatarPath);
+    const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
+
+    // no-cache forces revalidation on every request; ETag allows 304 when file is unchanged.
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('ETag', etag);
     res.setHeader('Content-Type', contentType);
     res.setHeader('X-Content-Type-Options', 'nosniff');
+
+    if (req.headers['if-none-match'] === etag) {
+      res.status(304).end();
+      return;
+    }
     res.sendFile(avatarPath);
   });
 

--- a/tests/unit/api-avatar-wizard.test.ts
+++ b/tests/unit/api-avatar-wizard.test.ts
@@ -370,7 +370,48 @@ describe('GET /api/v1/agents/:agentId/avatar', () => {
         .set('Authorization', `Bearer ${READ_KEY}`);
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toMatch(/image\/png/);
-      expect(res.headers['cache-control']).toMatch(/max-age=3600/);
+      expect(res.headers['cache-control']).toBe('no-cache');
+      expect(res.headers['etag']).toBeDefined();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 304 when ETag matches (If-None-Match)', async () => {
+    const { app, tmpDir, agentDir } = buildCtx({ avatar: 'avatar.png' });
+    try {
+      const buf = makePngBuffer(200);
+      fs.writeFileSync(path.join(agentDir, 'avatar.png'), buf);
+
+      // First request — get the ETag
+      const first = await supertest.default(app)
+        .get(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${READ_KEY}`);
+      expect(first.status).toBe(200);
+      const etag = first.headers['etag'];
+      expect(etag).toBeDefined();
+
+      // Second request with matching If-None-Match — must return 304
+      const second = await supertest.default(app)
+        .get(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${READ_KEY}`)
+        .set('If-None-Match', etag);
+      expect(second.status).toBe(304);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 200 with new content when ETag does not match (file changed)', async () => {
+    const { app, tmpDir, agentDir } = buildCtx({ avatar: 'avatar.png' });
+    try {
+      fs.writeFileSync(path.join(agentDir, 'avatar.png'), makePngBuffer(200));
+
+      const res = await supertest.default(app)
+        .get(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${READ_KEY}`)
+        .set('If-None-Match', '"stale-etag"');
+      expect(res.status).toBe(200);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/unit/api-avatar-wizard.test.ts
+++ b/tests/unit/api-avatar-wizard.test.ts
@@ -371,7 +371,8 @@ describe('GET /api/v1/agents/:agentId/avatar', () => {
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toMatch(/image\/png/);
       expect(res.headers['cache-control']).toBe('no-cache');
-      expect(res.headers['etag']).toBeDefined();
+      expect(res.headers['etag']).toMatch(/^W\//);
+      expect(res.headers['last-modified']).toBeDefined();
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -410,8 +411,30 @@ describe('GET /api/v1/agents/:agentId/avatar', () => {
       const res = await supertest.default(app)
         .get(`/api/v1/agents/${AGENT_ID}/avatar`)
         .set('Authorization', `Bearer ${READ_KEY}`)
-        .set('If-None-Match', '"stale-etag"');
+        .set('If-None-Match', 'W/"stale-etag"');
       expect(res.status).toBe(200);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 304 when ETag appears in comma-separated If-None-Match list', async () => {
+    const { app, tmpDir, agentDir } = buildCtx({ avatar: 'avatar.png' });
+    try {
+      fs.writeFileSync(path.join(agentDir, 'avatar.png'), makePngBuffer(200));
+
+      const first = await supertest.default(app)
+        .get(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${READ_KEY}`);
+      expect(first.status).toBe(200);
+      const etag = first.headers['etag'];
+
+      // Browser may send multiple ETags — current ETag is one of them
+      const second = await supertest.default(app)
+        .get(`/api/v1/agents/${AGENT_ID}/avatar`)
+        .set('Authorization', `Bearer ${READ_KEY}`)
+        .set('If-None-Match', `W/"other-etag", ${etag}`);
+      expect(second.status).toBe(304);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Fixes layer 2 of issue #139 — browsers cached avatar images for up to 1 hour after an upload due to `Cache-Control: private, max-age=3600`
- Replaces with `Cache-Control: no-cache` + `ETag` derived from file `mtime` + `size`
- Browser now revalidates on every request; if file is unchanged → 304 Not Modified (no re-download)
- No client-side changes required

## Test plan

- [x] `returns image with correct headers` — updated to assert `no-cache` and `ETag` present
- [x] `returns 304 when ETag matches (If-None-Match)` — new regression test
- [x] `returns 200 with new content when ETag does not match` — stale ETag path
- [x] All 52 avatar tests pass

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)