### PR TITLE
fix(gateway): add crash cleanup handlers to prevent zombie bun receiver processes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -708,8 +708,10 @@ async function main(): Promise<void> {
 
   configWatcher.start();
 
-  // Graceful shutdown
+  // Graceful shutdown — idempotent: safe to call from multiple signal/error sources.
   const shutdown = async (signal: string) => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
     console.log(`[gateway] Received ${signal}, shutting down...`);
 
     for (const scheduler of schedulers) {
@@ -727,14 +729,41 @@ async function main(): Promise<void> {
     }
 
     console.log('[gateway] Shutdown complete.');
-    process.exit(0);
   };
 
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
-  process.on('SIGINT', () => shutdown('SIGINT'));
+  // Expose shutdown to the module-level crash handlers registered below.
+  registeredShutdown = shutdown;
+
+  process.on('SIGTERM', () => shutdown('SIGTERM').then(() => process.exit(0)));
+  process.on('SIGINT', () => shutdown('SIGINT').then(() => process.exit(0)));
 }
 
+// Module-level flag and shutdown reference so crash handlers can clean up child
+// processes even when the error occurs outside main()'s try/catch scope.
+let isShuttingDown = false;
+let registeredShutdown: ((signal: string) => Promise<void>) | null = null;
+
+async function emergencyShutdown(label: string, detail: unknown): Promise<void> {
+  console.error(`[gateway] ${label}:`, detail);
+  if (registeredShutdown && !isShuttingDown) {
+    try {
+      await registeredShutdown(label);
+    } catch (e) {
+      console.error('[gateway] Error during emergency shutdown:', e);
+    }
+  }
+}
+
+// Without these handlers, any unhandled rejection or uncaught exception crashes
+// the process immediately via main().catch() — bypassing shutdown() and leaving
+// child receiver processes (bun) alive as zombies that accumulate across restarts.
+process.on('unhandledRejection', (reason) => {
+  emergencyShutdown('unhandledRejection', reason).finally(() => process.exit(1));
+});
+process.on('uncaughtException', (err) => {
+  emergencyShutdown('uncaughtException', err).finally(() => process.exit(1));
+});
+
 main().catch((err) => {
-  console.error('[gateway] Fatal error:', err);
-  process.exit(1);
+  emergencyShutdown('Fatal error in main()', err).finally(() => process.exit(1));
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -409,6 +409,11 @@ async function restoreSockets(registry: AppsRegistry, socketServer: SocketServer
   }
 }
 
+// Module-level flag and shutdown reference so crash handlers can clean up child
+// processes even when the error occurs outside main()'s try/catch scope.
+let isShuttingDown = false;
+let registeredShutdown: ((signal: string) => Promise<void>) | null = null;
+
 async function main(): Promise<void> {
   // Load agent .env files before config interpolation so ${TOKEN} vars resolve
   const gatewayAgentsDir = path.join(path.dirname(CONFIG_PATH), 'agents');
@@ -738,11 +743,6 @@ async function main(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT').then(() => process.exit(0)));
 }
 
-// Module-level flag and shutdown reference so crash handlers can clean up child
-// processes even when the error occurs outside main()'s try/catch scope.
-let isShuttingDown = false;
-let registeredShutdown: ((signal: string) => Promise<void>) | null = null;
-
 async function emergencyShutdown(label: string, detail: unknown): Promise<void> {
   console.error(`[gateway] ${label}:`, detail);
   if (registeredShutdown && !isShuttingDown) {
@@ -758,9 +758,13 @@ async function emergencyShutdown(label: string, detail: unknown): Promise<void> 
 // the process immediately via main().catch() — bypassing shutdown() and leaving
 // child receiver processes (bun) alive as zombies that accumulate across restarts.
 process.on('unhandledRejection', (reason) => {
+  // If a clean SIGTERM shutdown is already in progress, don't interrupt it with
+  // a crash exit — let the in-progress shutdown finish and exit 0.
+  if (isShuttingDown) return;
   emergencyShutdown('unhandledRejection', reason).finally(() => process.exit(1));
 });
 process.on('uncaughtException', (err) => {
+  if (isShuttingDown) return;
   emergencyShutdown('uncaughtException', err).finally(() => process.exit(1));
 });
 


### PR DESCRIPTION
## Problem

When the gateway crashes (unhandled rejection or uncaught exception), `main().catch()` called `process.exit(1)` immediately — bypassing `shutdown()` entirely. This left child `bun receiver-server.ts` processes alive as zombies.

In the root:root socket crash loop (issue #140, fixed by #142), the gateway restarted ~38 times over 90 minutes. Each restart spawned new receiver processes without killing the old ones, accumulating **13 zombie bun processes** that exhausted system resources (CPU, inotify watchers).

## Fix

- Register `unhandledRejection` and `uncaughtException` handlers at module level that call `shutdown()` before `process.exit(1)`
- Make `shutdown()` idempotent via `isShuttingDown` guard — prevents double-cleanup if a signal and a crash event fire concurrently
- Wire `registeredShutdown` reference from inside `main()` once all AgentRunners are initialized — crash handlers call this to stop all receiver child processes

## What this does NOT change

- Normal SIGTERM/SIGINT path is unchanged
- Receiver restart logic (`TelegramReceiver.scheduleRestart`) is unchanged
- If a crash happens before `main()` finishes init, handlers log and exit (nothing to clean up yet)

## Immediate workaround for existing zombies
```bash
ps aux | grep "receiver-server" | grep -v grep | awk '{print $2}' | xargs kill
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)