### PR TITLE
fix(packages): use SIGTERM instead of process.exit on gateway update

### DIFF
--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -173,7 +173,7 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
         warning: isManaged ? 'service will restart' : 'process will stop — restart manually',
       });
 
-      setTimeout(() => process.exit(0), 500);
+      setTimeout(() => process.kill(process.pid, 'SIGTERM'), 500);
     } else {
       res.json({ package: packageName, from, to, updated: true, warning: null });
     }

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -45,20 +45,20 @@ function makeApp(withAuth = true) {
   return app;
 }
 
-// Keep track of the exit spy
-let exitSpy: jest.SpyInstance;
+// Keep track of the kill spy
+let killSpy: jest.SpyInstance;
 
 beforeEach(() => {
   _resetCache();
   jest.clearAllMocks();
-  // Prevent process.exit from actually exiting during tests
-  exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-  // Suppress timer-based exit: fast-forward timers
+  // Prevent process.kill from actually sending signals during tests
+  killSpy = jest.spyOn(process, 'kill').mockImplementation(() => true);
+  // Suppress timer-based kill: fast-forward timers
   jest.useFakeTimers();
 });
 
 afterEach(() => {
-  exitSpy.mockRestore();
+  killSpy.mockRestore();
   jest.useRealTimers();
 });
 
@@ -252,9 +252,9 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
     if (savedPm2Home !== undefined) process.env.PM2_HOME = savedPm2Home;
     if (savedPmId !== undefined) process.env.pm_id = savedPmId;
 
-    // process.exit(0) should be scheduled
+    // process.kill(pid, 'SIGTERM') should be scheduled
     jest.runAllTimers();
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
   });
 
   it('T11: claude-gateway updated — systemd managed warning', async () => {
@@ -346,7 +346,7 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
     });
 
     jest.runAllTimers();
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
   });
 
   it('T15: 403 when non-admin key attempts update', async () => {

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -280,6 +280,9 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
     expect(res.status).toBe(200);
     expect(res.body.warning).toBe('service will restart');
 
+    jest.runAllTimers();
+    expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
+
     if (savedInvocationId !== undefined) process.env.INVOCATION_ID = savedInvocationId;
     else delete process.env.INVOCATION_ID;
   });


### PR DESCRIPTION
## Root Cause

`packages.ts` called `process.exit(0)` after installing a new version. `process.exit()` **bypasses all registered signal handlers** — so the shutdown handler added in #144 (which kills bun receiver processes) was never called. Result: every `claude-gateway-package-update` left 11+ zombie receiver processes alive, causing 100% CPU.

## Fix

Replace `process.exit(0)` with `process.kill(process.pid, 'SIGTERM')`, which triggers the SIGTERM handler that was already registered in `src/index.ts` to clean up receivers before exit.

## Changes

- `src/api/packages.ts`: `process.exit(0)` → `process.kill(process.pid, 'SIGTERM')`
- `tests/unit/packages-router.test.ts`: update spy from `process.exit` to `process.kill`

## Test plan

- [x] 15/15 packages-router tests pass
- [x] Build passes (`tsc` no errors)
- [x] After merge + publish: `claude-gateway-package-update` should no longer leave zombie receivers

Fixes #145 (CPU 100% after package update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)