### PR TITLE
fix(packages): recover from ENOTEMPTY, add concurrency lock, raise timeout

### DIFF
--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -28,18 +28,18 @@ interface CacheEntry {
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 let versionCache: CacheEntry | null = null;
-let updatingPackage: string | null = null;
+let isUpdating = false;
 
 export function _resetCache(): void {
   versionCache = null;
 }
 
 export function _resetLock(): void {
-  updatingPackage = null;
+  isUpdating = false;
 }
 
-export function _setLock(pkg: string): void {
-  updatingPackage = pkg;
+export function _setLock(): void {
+  isUpdating = true;
 }
 
 function getNpmListVersion(packageName: string): string | null {
@@ -98,16 +98,16 @@ function cleanStaleNpmTempDirs(npmRoot: string, packageName: string): void {
   const scopeDir = join(npmRoot, scope);
   let entries: string[];
   try {
-    entries = readdirSync(scopeDir) as string[];
+    entries = readdirSync(scopeDir, { withFileTypes: false }) as string[];
   } catch {
     return;
   }
 
   const prefix = `.${basename}-`;
   for (const entry of entries) {
-    if ((entry as string).startsWith(prefix)) {
+    if (entry.startsWith(prefix)) {
       try {
-        rmSync(join(scopeDir, entry as string), { recursive: true, force: true });
+        rmSync(join(scopeDir, entry), { recursive: true, force: true });
       } catch {
         // best-effort: ignore errors on individual temp dir removal
       }
@@ -199,12 +199,12 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
     }
 
     // Reject if another update is already in progress
-    if (updatingPackage !== null) {
+    if (isUpdating) {
       res.status(409).json({ error: 'update already in progress' });
       return;
     }
 
-    updatingPackage = name;
+    isUpdating = true;
     try {
       // Resolve npm global root for temp dir cleanup
       let npmRoot = '';
@@ -273,7 +273,7 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
         res.json({ package: packageName, from, to, updated: true, warning: null });
       }
     } finally {
-      updatingPackage = null;
+      isUpdating = false;
     }
   });
 

--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { execSync } from 'child_process';
+import { readdirSync, rmSync } from 'fs';
+import { join } from 'path';
 import { ApiKey } from '../types';
 import { createApiAuthMiddleware, isAdmin } from './auth';
 
@@ -26,9 +28,18 @@ interface CacheEntry {
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 let versionCache: CacheEntry | null = null;
+let updatingPackage: string | null = null;
 
 export function _resetCache(): void {
   versionCache = null;
+}
+
+export function _resetLock(): void {
+  updatingPackage = null;
+}
+
+export function _setLock(pkg: string): void {
+  updatingPackage = pkg;
 }
 
 function getNpmListVersion(packageName: string): string | null {
@@ -69,6 +80,50 @@ async function fetchAllPackageVersions(): Promise<PackageInfo[]> {
       };
     }),
   );
+}
+
+function getNpmGlobalRoot(): string {
+  return execSync('npm root -g', {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 10_000,
+  }).trim();
+}
+
+function cleanStaleNpmTempDirs(npmRoot: string, packageName: string): void {
+  const match = packageName.match(/^(@[^/]+)\/(.+)$/);
+  if (!match) return;
+  const [, scope, basename] = match;
+
+  const scopeDir = join(npmRoot, scope);
+  let entries: string[];
+  try {
+    entries = readdirSync(scopeDir) as string[];
+  } catch {
+    return;
+  }
+
+  const prefix = `.${basename}-`;
+  for (const entry of entries) {
+    if ((entry as string).startsWith(prefix)) {
+      try {
+        rmSync(join(scopeDir, entry as string), { recursive: true, force: true });
+      } catch {
+        // best-effort: ignore errors on individual temp dir removal
+      }
+    }
+  }
+}
+
+function removePackageDir(npmRoot: string, packageName: string): void {
+  const match = packageName.match(/^(@[^/]+)\/(.+)$/);
+  if (!match) return;
+  const [, scope, basename] = match;
+  try {
+    rmSync(join(npmRoot, scope, basename), { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
 }
 
 export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
@@ -143,39 +198,82 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
       return;
     }
 
-    // Run npm install
-    try {
-      execSync(`npm install -g ${packageName}@latest`, {
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 120_000,
-      });
-    } catch (err) {
-      const stderr = (err as { stderr?: Buffer }).stderr?.toString() ?? 'install failed';
-      res.status(500).json({ error: stderr });
+    // Reject if another update is already in progress
+    if (updatingPackage !== null) {
+      res.status(409).json({ error: 'update already in progress' });
       return;
     }
 
-    // Invalidate version cache after successful install
-    versionCache = null;
+    updatingPackage = name;
+    try {
+      // Resolve npm global root for temp dir cleanup
+      let npmRoot = '';
+      try {
+        npmRoot = getNpmGlobalRoot();
+      } catch {
+        // non-fatal: skip pre-clean if npm root unavailable
+      }
 
-    const to = getNpmListVersion(packageName);
+      // Pre-clean any stale npm temp dirs left by previous interrupted installs
+      if (npmRoot) {
+        cleanStaleNpmTempDirs(npmRoot, packageName);
+      }
 
-    if (name === 'claude-gateway') {
-      const isSystemd = !!process.env.INVOCATION_ID;
-      const isPm2 = !!process.env.PM2_HOME || process.env.pm_id !== undefined;
-      const isManaged = isSystemd || isPm2;
+      let installErr: unknown = null;
+      try {
+        execSync(`npm install -g ${packageName}@latest`, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 300_000,
+        });
+      } catch (err) {
+        const stderr = (err as { stderr?: Buffer }).stderr?.toString() ?? '';
+        if (npmRoot && (stderr.includes('ENOTEMPTY') || stderr.includes('ENOTDIR'))) {
+          // Remove stale temp dirs and the partially-installed package dir, then retry once
+          cleanStaleNpmTempDirs(npmRoot, packageName);
+          removePackageDir(npmRoot, packageName);
+          try {
+            execSync(`npm install -g ${packageName}@latest`, {
+              stdio: ['pipe', 'pipe', 'pipe'],
+              timeout: 300_000,
+            });
+          } catch (retryErr) {
+            installErr = retryErr;
+          }
+        } else {
+          installErr = err;
+        }
+      }
 
-      res.json({
-        package: packageName,
-        from,
-        to,
-        updated: true,
-        warning: isManaged ? 'service will restart' : 'process will stop — restart manually',
-      });
+      if (installErr !== null) {
+        const stderr = (installErr as { stderr?: Buffer }).stderr?.toString() ?? 'install failed';
+        res.status(500).json({ error: stderr });
+        return;
+      }
 
-      setTimeout(() => process.kill(process.pid, 'SIGTERM'), 500);
-    } else {
-      res.json({ package: packageName, from, to, updated: true, warning: null });
+      // Invalidate version cache after successful install
+      versionCache = null;
+
+      const to = getNpmListVersion(packageName);
+
+      if (name === 'claude-gateway') {
+        const isSystemd = !!process.env.INVOCATION_ID;
+        const isPm2 = !!process.env.PM2_HOME || process.env.pm_id !== undefined;
+        const isManaged = isSystemd || isPm2;
+
+        res.json({
+          package: packageName,
+          from,
+          to,
+          updated: true,
+          warning: isManaged ? 'service will restart' : 'process will stop — restart manually',
+        });
+
+        setTimeout(() => process.kill(process.pid, 'SIGTERM'), 500);
+      } else {
+        res.json({ package: packageName, from, to, updated: true, warning: null });
+      }
+    } finally {
+      updatingPackage = null;
     }
   });
 

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -376,24 +376,6 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
 
 const NPM_ROOT = '/fake/npm/root';
 
-function mockExecSyncWithNpmRoot(npmListResponses: Record<string, string>, installResult?: 'ok' | Error) {
-  let listCallCount = 0;
-  mockExecSync.mockImplementation((cmd: unknown) => {
-    const cmdStr = cmd as string;
-    if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
-    if (cmdStr.includes('npm list')) {
-      const pkg = Object.keys(npmListResponses)[listCallCount % Object.keys(npmListResponses).length];
-      listCallCount++;
-      return npmListResponses[pkg] ?? '{}';
-    }
-    if (cmdStr.includes('npm install')) {
-      if (installResult instanceof Error) throw installResult;
-      return '';
-    }
-    return '{}';
-  });
-}
-
 describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
   it('T16: stale npm temp dir exists → pre-clean removes it, update succeeds', async () => {
     delete process.env.INVOCATION_ID;
@@ -489,7 +471,7 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
     mockReaddirSync.mockReturnValue([] as unknown as ReturnType<typeof readdirSync>);
 
     // Simulate another update already in progress
-    _setLock('claude-code');
+    _setLock();
 
     const res = await request(makeApp())
       .post('/api/v1/packages/claude-code/update')
@@ -497,6 +479,40 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
 
     expect(res.status).toBe(409);
     expect(res.body.error).toBe('update already in progress');
+  });
+
+  it('T18b: lock released after successful update — next request is not 409', async () => {
+    delete process.env.INVOCATION_ID;
+    delete process.env.PM2_HOME;
+    delete process.env.pm_id;
+
+    let listCount = 0;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
+      if (cmdStr.includes('npm list')) {
+        listCount++;
+        const version = listCount <= 2 ? '1.0.5' : '1.1.0';
+        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version } } });
+      }
+      return '';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+    mockReaddirSync.mockReturnValue([] as unknown as ReturnType<typeof readdirSync>);
+
+    const app = makeApp();
+
+    const res1 = await request(app)
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+    expect(res1.status).toBe(200);
+
+    // Reset fetch version so second request also sees an update available
+    listCount = 0;
+    const res2 = await request(app)
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+    expect(res2.status).not.toBe(409);
   });
 
   it('T19: non-ENOTEMPTY install failure → 500, no retry attempted', async () => {

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -16,17 +16,26 @@
  * T13: POST /api/v1/packages/claude-gateway/update — registry unavailable → 503
  * T14: POST /api/v1/packages/claude-code/update — success, warning: null
  * T15: POST /api/v1/packages/claude-gateway/update — 403 when non-admin key
+ * T16: stale npm temp dir exists → pre-clean removes it, update succeeds
+ * T17: ENOTEMPTY on first install → temp + package dirs removed, retry succeeds
+ * T18: concurrent update request → 409 while first is in flight
+ * T19: non-ENOTEMPTY install failure → 500, no retry
  */
 
 import express from 'express';
 import request from 'supertest';
 import { ApiKey } from '../../src/types';
 
-// Must mock child_process before importing the module under test
+// Must mock child_process and fs before importing the module under test
 jest.mock('child_process', () => ({ execSync: jest.fn() }));
+jest.mock('fs', () => ({ readdirSync: jest.fn(), rmSync: jest.fn() }));
 
 import { execSync } from 'child_process';
-import { createPackagesRouter, _resetCache } from '../../src/api/packages';
+import { readdirSync, rmSync } from 'fs';
+import { createPackagesRouter, _resetCache, _resetLock, _setLock } from '../../src/api/packages';
+
+const mockReaddirSync = readdirSync as jest.MockedFunction<typeof readdirSync>;
+const mockRmSync = rmSync as jest.MockedFunction<typeof rmSync>;
 
 const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
 
@@ -50,6 +59,7 @@ let killSpy: jest.SpyInstance;
 
 beforeEach(() => {
   _resetCache();
+  _resetLock();
   jest.clearAllMocks();
   // Prevent process.kill from actually sending signals during tests
   killSpy = jest.spyOn(process, 'kill').mockImplementation(() => true);
@@ -359,5 +369,161 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('admin API key required');
+  });
+});
+
+// ─── T16-T19: ENOTEMPTY recovery & concurrency lock ─────────────────────────
+
+const NPM_ROOT = '/fake/npm/root';
+
+function mockExecSyncWithNpmRoot(npmListResponses: Record<string, string>, installResult?: 'ok' | Error) {
+  let listCallCount = 0;
+  mockExecSync.mockImplementation((cmd: unknown) => {
+    const cmdStr = cmd as string;
+    if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
+    if (cmdStr.includes('npm list')) {
+      const pkg = Object.keys(npmListResponses)[listCallCount % Object.keys(npmListResponses).length];
+      listCallCount++;
+      return npmListResponses[pkg] ?? '{}';
+    }
+    if (cmdStr.includes('npm install')) {
+      if (installResult instanceof Error) throw installResult;
+      return '';
+    }
+    return '{}';
+  });
+}
+
+describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
+  it('T16: stale npm temp dir exists → pre-clean removes it, update succeeds', async () => {
+    delete process.env.INVOCATION_ID;
+    delete process.env.PM2_HOME;
+    delete process.env.pm_id;
+
+    let listCount = 0;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
+      if (cmdStr.includes('npm list')) {
+        listCount++;
+        const version = listCount === 1 ? '1.0.5' : '1.1.0';
+        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version } } });
+      }
+      // npm install — succeed
+      return '';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+
+    // Simulate stale temp dir alongside the real package dir
+    mockReaddirSync.mockReturnValue(['claude-code', '.claude-code-O5kzWOwo'] as unknown as ReturnType<typeof readdirSync>);
+    mockRmSync.mockImplementation(() => undefined);
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.updated).toBe(true);
+
+    // rmSync called for the stale temp entry only (not the real package dir in pre-clean)
+    const rmCalls = mockRmSync.mock.calls.map((c) => c[0] as string);
+    expect(rmCalls.some((p) => p.includes('.claude-code-O5kzWOwo'))).toBe(true);
+    expect(rmCalls.every((p) => !p.endsWith('/claude-code'))).toBe(true);
+  });
+
+  it('T17: ENOTEMPTY on first install → temp + package dirs removed, retry succeeds', async () => {
+    let installAttempt = 0;
+    let listCount = 0;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
+      if (cmdStr.includes('npm list')) {
+        listCount++;
+        const version = listCount === 1 ? '1.0.5' : '1.1.0';
+        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version } } });
+      }
+      if (cmdStr.includes('npm install')) {
+        installAttempt++;
+        if (installAttempt === 1) {
+          const err = Object.assign(new Error('ENOTEMPTY'), {
+            stderr: Buffer.from(
+              'npm error code ENOTEMPTY\nnpm error syscall rename\nnpm error path /fake/npm/root/@anthropic-ai/claude-code',
+            ),
+          });
+          throw err;
+        }
+        // Retry succeeds
+        return '';
+      }
+      return '{}';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+
+    mockReaddirSync.mockReturnValue(['.claude-code-O5kzWOwo'] as unknown as ReturnType<typeof readdirSync>);
+    mockRmSync.mockImplementation(() => undefined);
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.updated).toBe(true);
+    expect(installAttempt).toBe(2);
+
+    // Stale temp dir and package dir both removed before retry
+    const rmCalls = mockRmSync.mock.calls.map((c) => c[0] as string);
+    expect(rmCalls.some((p) => p.includes('.claude-code-O5kzWOwo'))).toBe(true);
+    expect(rmCalls.some((p) => p.endsWith('/claude-code'))).toBe(true);
+  });
+
+  it('T18: concurrent update request → 409 while first is in flight', async () => {
+    // Set up mocks so request reaches the lock check (from !== latest required)
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm list'))
+        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version: '1.0.5' } } });
+      if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
+      return '';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+    mockReaddirSync.mockReturnValue([] as unknown as ReturnType<typeof readdirSync>);
+
+    // Simulate another update already in progress
+    _setLock('claude-code');
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('update already in progress');
+  });
+
+  it('T19: non-ENOTEMPTY install failure → 500, no retry attempted', async () => {
+    let installAttempt = 0;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
+      if (cmdStr.includes('npm list')) {
+        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version: '1.0.5' } } });
+      }
+      if (cmdStr.includes('npm install')) {
+        installAttempt++;
+        throw Object.assign(new Error('npm ERR! 404 Not Found'), {
+          stderr: Buffer.from('npm ERR! 404 Not Found — @anthropic-ai/claude-code@9.9.9'),
+        });
+      }
+      return '{}';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+    mockReaddirSync.mockReturnValue([] as unknown as ReturnType<typeof readdirSync>);
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain('npm ERR!');
+    expect(installAttempt).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #146

## Summary

- **Pre-clean stale npm temp dirs** — before each install, resolve `npm root -g` and remove any `.<basename>-*` entries left by previous interrupted installs (`.claude-code-XXXX`, etc.)
- **Retry once on ENOTEMPTY/ENOTDIR** — if `npm install -g` fails with either error in stderr, wipe the stale temp dirs + the partial package dir, then retry once; a second failure still surfaces a 500
- **In-flight concurrency lock** — module-level `updatingPackage` flag; any concurrent `POST .../update` while one is running returns `409 { error: "update already in progress" }`; cleared in `finally` so even failures release the lock
- **Raise timeout 120 s → 300 s** — the interrupted timeout was the primary cause of the corrupt state; 300 s covers cold-cache installs of `@anthropic-ai/claude-code` on slow links

## Test plan

- [x] T16: stale `.claude-code-*` temp dir present → pre-clean removes it, update succeeds
- [x] T17: first install throws ENOTEMPTY → stale dirs + package dir removed, retry succeeds, `npm install` called exactly twice
- [x] T18: `_setLock()` pre-set → concurrent request returns 409
- [x] T19: non-ENOTEMPTY error → 500 with stderr, no retry (install called once)
- [x] All 19 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)