### PR TITLE
fix(runner): model switch restarts process correctly — fixes #152

### DIFF
--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1182,14 +1182,8 @@ bot.on('callback_query:data', async ctx => {
       })
       const result = (await res.json()) as { success?: boolean; error?: string; restarted?: boolean }
       if (result.success) {
-        if (result.restarted === false) {
-          // No active session — model changed, no restart needed
-          await ctx.answerCallbackQuery({ text: `Model changed to ${newModel}` }).catch(() => {})
-          await ctx.editMessageText(`\u2705 Model changed to ${newModel}`).catch(() => {})
-        } else {
-          await ctx.answerCallbackQuery({ text: `Switching to ${newModel}...` }).catch(() => {})
-          await ctx.editMessageText(`\u23f3 Switching to ${newModel}...`).catch(() => {})
-        }
+        await ctx.answerCallbackQuery({ text: `Model changed to ${newModel}` }).catch(() => {})
+        await ctx.editMessageText(`\u2705 Model changed to ${newModel}`).catch(() => {})
       } else {
         await ctx.answerCallbackQuery({ text: result.error ?? 'Failed' }).catch(() => {})
       }

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1182,7 +1182,7 @@ bot.on('callback_query:data', async ctx => {
       })
       const result = (await res.json()) as { success?: boolean; error?: string; restarted?: boolean }
       if (result.success) {
-        await ctx.answerCallbackQuery({ text: `Model changed to ${newModel}` }).catch(() => {})
+        await ctx.answerCallbackQuery({ text: `✅ Model changed to ${newModel}` }).catch(() => {})
         await ctx.editMessageText(`\u2705 Model changed to ${newModel}`).catch(() => {})
       } else {
         await ctx.answerCallbackQuery({ text: result.error ?? 'Failed' }).catch(() => {})

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -372,36 +372,15 @@ export class AgentRunner extends EventEmitter {
         return;
       }
 
-      // Graceful restart ALL channel sessions via signal files so they pick up the new agent-level model.
-      // Signal file approach: chokidar watcher in SessionProcess detects the file, reads the notify
-      // payload, finishes in-flight work, then restarts — ensuring no mid-response interruption.
-      const chatId = body.chat_id ?? '';
       let restarted = false;
+      const restartPromises: Promise<void>[] = [];
       for (const [key, session] of this.sessions) {
-        // Only restart channel sessions (not API sessions which use per-session model)
         if (session.source !== 'api') {
           restarted = true;
-          const channel = this.channelSourceMap.get(key) ?? 'telegram';
-          const stateDir = channel === 'discord' ? '.discord-state' : '.telegram-state';
-          const signalPayload = JSON.stringify({
-            notify: { chat_id: chatId, text: `✅ Model changed to ${newModel}` },
-          });
-          const signalPath = path.join(
-            this.agentConfig.workspace,
-            stateDir,
-            `restart-${key}`,
-          );
-          try {
-            fs.mkdirSync(path.dirname(signalPath), { recursive: true });
-            fs.writeFileSync(signalPath, signalPayload);
-          } catch (err) {
-            this.logger.error('Failed to write restart signal for set_model', {
-              sessionKey: key,
-              error: (err as Error).message,
-            });
-          }
+          restartPromises.push(this.restartProcess(key));
         }
       }
+      await Promise.all(restartPromises);
 
       respond({ success: true, model: newModel, restarted });
       return;
@@ -411,29 +390,11 @@ export class AgentRunner extends EventEmitter {
       const chatId = body.chat_id ?? '';
       const session = this.sessions.get(chatId);
       if (!session) {
-        // No active session — nothing to restart, but not an error
         respond({ success: true, restarted: false });
         return;
       }
 
-      // Write restart signal with notify payload
-      const signalPayload = JSON.stringify({
-        notify: { chat_id: chatId, text: 'Session restarted — back online!' },
-      });
-      const signalPath = path.join(
-        this.agentConfig.workspace,
-        '.telegram-state',
-        `restart-${chatId}`,
-      );
-      try {
-        fs.mkdirSync(path.dirname(signalPath), { recursive: true });
-        fs.writeFileSync(signalPath, signalPayload);
-      } catch (err) {
-        this.logger.error('Failed to write restart signal', { error: (err as Error).message });
-        respond({ success: false, error: 'Failed to write restart signal' });
-        return;
-      }
-
+      await this.restartProcess(chatId);
       respond({ success: true, restarted: true });
       return;
     }

--- a/tests/unit/command-endpoint.test.ts
+++ b/tests/unit/command-endpoint.test.ts
@@ -246,9 +246,9 @@ describe('AgentRunner /command endpoint', () => {
   });
 
   // --------------------------------------------------------------------------
-  // U-CMD-04: set_model updates agent-level model and stops session process
+  // U-CMD-04: set_model updates agent-level model and restarts session process
   // --------------------------------------------------------------------------
-  it('U-CMD-04: set_model with active session updates agent model and writes restart signal', async () => {
+  it('U-CMD-04: set_model with active session updates agent model and restarts process', async () => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
     await runner.start();
     const port = getCallbackPort(runner);
@@ -269,15 +269,9 @@ describe('AgentRunner /command endpoint', () => {
     expect(data.success).toBe(true);
     expect(data.model).toBe('claude-sonnet-4-6');
 
-    // Session stays in the map — signal file triggers graceful restart via chokidar.
-    // The session is NOT removed immediately (unlike the old direct stop approach).
-    expect(sessions.has('chat123')).toBe(true);
-
-    // Verify a restart signal file was written
-    const signalPath = path.join(agentConfig.workspace, '.telegram-state', 'restart-chat123');
-    expect(fs.existsSync(signalPath)).toBe(true);
-    const signalContent = JSON.parse(fs.readFileSync(signalPath, 'utf-8'));
-    expect(signalContent.notify.text).toContain('claude-sonnet-4-6');
+    // Session is removed from map — restartProcess() stops + deletes it.
+    // It will be lazily re-spawned on the next incoming message with the new model.
+    expect(sessions.has('chat123')).toBe(false);
 
     // Verify get_model returns the agent-level model
     const { data: getResult } = await sendCommand(port, { command: 'get_model', chat_id: 'chat123' });
@@ -316,9 +310,9 @@ describe('AgentRunner /command endpoint', () => {
   });
 
   // --------------------------------------------------------------------------
-  // U-CMD-06: restart with active session writes signal and returns success
+  // U-CMD-06: restart with active session stops process and returns success
   // --------------------------------------------------------------------------
-  it('U-CMD-06: restart with active session writes signal file with notify payload', async () => {
+  it('U-CMD-06: restart with active session stops process and returns success', async () => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
     await runner.start();
     const port = getCallbackPort(runner);
@@ -327,10 +321,8 @@ describe('AgentRunner /command endpoint', () => {
     await sendChannelPost(port, 'chat123', 'hello');
     await new Promise(r => setTimeout(r, 100));
 
-    // Temporarily prevent chokidar from consuming the signal immediately
-    // by checking what the handler writes
-    const stateDir = path.join(agentConfig.workspace, '.telegram-state');
-    const signalPath = path.join(stateDir, 'restart-chat123');
+    const sessions = getSessions(runner);
+    expect(sessions.has('chat123')).toBe(true);
 
     const { data } = await sendCommand(port, {
       command: 'restart',
@@ -338,9 +330,10 @@ describe('AgentRunner /command endpoint', () => {
     });
 
     expect(data.success).toBe(true);
+    expect(data.restarted).toBe(true);
 
-    // The signal file may have been consumed by chokidar already, but the command succeeded.
-    // We verify the response is correct.
+    // Session removed from map — will re-spawn on next message
+    expect(sessions.has('chat123')).toBe(false);
   });
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause**: `set_model` wrote `restart-{chatId}` but `SessionProcess` watched `restart-{sessionId}` (UUID). For channel sessions `chatId !== sessionId`, so the signal file was orphaned and the process never restarted.
- **Fix**: Replace signal-file approach with `restartProcess()` (stop + delete from map). Process re-spawns with fresh model on next incoming message. Same method already used by `/clear`, `delete_session`, `new_session`, etc.
- **Also fixed**: `restart` command had the same signal-file mismatch bug.
- **Net**: -46 lines of broken signal-file logic replaced with 2 `restartProcess()` calls.

Closes #152

## Test plan

- [x] U-CMD-04: `set_model` with active session restarts process (session removed from map)
- [x] U-CMD-06: `restart` with active session stops process (session removed from map)
- [x] All 9 command-endpoint tests pass
- [ ] Manual: `/models` → pick different model → verify process restarts with new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)