### PR TITLE
fix(runner): emit tool_use events from PTY-mode assistant messages in stream

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1666,11 +1666,15 @@ export class AgentRunner extends EventEmitter {
         // Partial assistant message (from --include-partial-messages)
         // Contains cumulative text; compute delta and emit as text_delta
         if (obj['type'] === 'assistant') {
-          const msg = obj['message'] as { content?: Array<{ type: string; text?: string }> } | undefined;
+          const msg = obj['message'] as { content?: Array<{ type: string; text?: string; name?: string; id?: string; input?: unknown }> } | undefined;
           if (Array.isArray(msg?.content)) {
             let fullText = '';
             for (const block of msg!.content) {
               if (block.type === 'text' && block.text) fullText += block.text;
+              // PTY mode (headless=false) emits tool_use blocks inside assistant messages
+              if (block.type === 'tool_use' && block.name && block.id) {
+                if (!clientGone) callbacks.onChunk({ type: 'tool_use', name: block.name, id: block.id, input: block.input as Record<string, unknown> | undefined });
+              }
             }
             if (fullText.length > lastPartialText.length) {
               const delta = fullText.slice(lastPartialText.length);
@@ -2089,11 +2093,15 @@ export class AgentRunner extends EventEmitter {
       try {
         const obj = JSON.parse(line) as Record<string, unknown>;
         if (obj['type'] === 'assistant') {
-          const msg = obj['message'] as { content?: Array<{ type: string; text?: string }> } | undefined;
+          const msg = obj['message'] as { content?: Array<{ type: string; text?: string; name?: string; id?: string; input?: unknown }> } | undefined;
           if (Array.isArray(msg?.content)) {
             let fullText = '';
             for (const block of msg!.content) {
               if (block.type === 'text' && block.text) fullText += block.text;
+              // PTY mode (headless=false) emits tool_use blocks inside assistant messages
+              if (block.type === 'tool_use' && block.name && block.id) {
+                if (!clientGone) callbacks.onChunk({ type: 'tool_use', name: block.name, id: block.id, input: block.input as Record<string, unknown> | undefined });
+              }
             }
             if (fullText.length > lastPartialText.length) {
               const delta = fullText.slice(lastPartialText.length);

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -1361,6 +1361,102 @@ describe('AgentRunner — sendApiMessageStream', () => {
       .join('');
     expect(allDeltaText).toBe('Hello world');
   }, 15000);
+
+  // T-TOOL-USE-PTY: PTY mode (headless=false) emits tool_use blocks inside assistant messages
+  it('T-TOOL-USE-PTY: emits tool_use events from PTY-mode assistant message', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const chunks: StreamEvent[] = [];
+    const donePromise = new Promise<string>((resolve) => {
+      runner.sendApiMessageStream(
+        'stream-tool-use-pty',
+        'test-chat',
+        'open google',
+        {
+          onChunk: (event) => chunks.push(event),
+          onDone: (text) => resolve(text),
+          onError: () => {},
+        },
+        { timeoutMs: 5000 },
+      );
+    });
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const session = getSessions(runner).get('stream-tool-use-pty')!;
+    expect(session).toBeDefined();
+
+    // Simulate PTY-mode assistant message with tool_use block (from emitter.ts emitAssistant)
+    session.emit('output', JSON.stringify({
+      type: 'assistant',
+      session_id: 'stream-tool-use-pty',
+      stop_reason: 'tool_use',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_abc123', name: 'Bash', input: { command: 'ls' } },
+        ],
+      },
+    }));
+    session.emit('output', JSON.stringify({ type: 'result', result: '' }));
+
+    await donePromise;
+
+    const toolUseChunks = chunks.filter(c => c.type === 'tool_use');
+    expect(toolUseChunks).toHaveLength(1);
+    const toolEvent = toolUseChunks[0] as { type: 'tool_use'; name: string; id: string; input?: Record<string, unknown> };
+    expect(toolEvent.name).toBe('Bash');
+    expect(toolEvent.id).toBe('tu_abc123');
+    expect(toolEvent.input).toEqual({ command: 'ls' });
+  }, 15000);
+
+  // T-TOOL-USE-PTY-MIXED: PTY mode assistant message with both text and tool_use blocks
+  it('T-TOOL-USE-PTY-MIXED: emits both text_delta and tool_use from mixed assistant message', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const chunks: StreamEvent[] = [];
+    const donePromise = new Promise<string>((resolve) => {
+      runner.sendApiMessageStream(
+        'stream-tool-use-mixed',
+        'test-chat',
+        'hello with tool',
+        {
+          onChunk: (event) => chunks.push(event),
+          onDone: (text) => resolve(text),
+          onError: () => {},
+        },
+        { timeoutMs: 5000 },
+      );
+    });
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const session = getSessions(runner).get('stream-tool-use-mixed')!;
+
+    // Simulate assistant message with both text and tool_use
+    session.emit('output', JSON.stringify({
+      type: 'assistant',
+      stop_reason: 'tool_use',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Opening now.' },
+          { type: 'tool_use', id: 'tu_xyz', name: 'Skill', input: { skill: 'browser' } },
+        ],
+      },
+    }));
+    session.emit('output', JSON.stringify({ type: 'result', result: 'Opening now.' }));
+
+    await donePromise;
+
+    expect(chunks.some(c => c.type === 'text_delta')).toBe(true);
+    expect(chunks.some(c => c.type === 'tool_use')).toBe(true);
+    const toolEvent = chunks.find(c => c.type === 'tool_use') as { type: 'tool_use'; name: string; id: string } | undefined;
+    expect(toolEvent?.name).toBe('Skill');
+    expect(toolEvent?.id).toBe('tu_xyz');
+  }, 15000);
 });
 
 // ── Typing persistence tests ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When `headless=false`, `claude-pty-shell` emits `type: "assistant"` events with `tool_use` blocks inside `message.content`
- The `onOutput` handlers in `sendApiMessageStream` and `sendMessageToSession` only extracted `text` blocks — tool_use events were never forwarded to `onChunk`
- `headless=true` was unaffected because it uses `stream_event/content_block_*` events handled by `_applyStreamEvent()`

**Fix**: extract and emit `tool_use` blocks when processing `assistant` messages in both streaming handlers (`sendApiMessageStream` and `sendMessageToSession`)

## Root cause

```
PTY mode output:  { type: "assistant", message: { content: [{ type: "tool_use", name: "...", id: "...", input: {...} }, ...] } }
                                                              ^^^ was silently ignored ^^^
```

## Test plan

- [ ] Set `gateway.headless = false` in config
- [ ] Send a message via chat API that triggers a tool call (e.g. "open google")
- [ ] Verify SSE stream includes `{ type: "tool_use", name: "...", id: "...", input: {...} }` events
- [ ] Verify `headless = true` behavior is unchanged
- [ ] Verify Telegram is unaffected (it was never broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)