### PR TITLE
feat(pty): real-time PTY stream viewer, menu bridge (TG+Discord), session dashboard

### DIFF
--- a/API.md
+++ b/API.md
@@ -166,6 +166,43 @@ The `sessionId` is the gateway session UUID. Find it from the process list:
 curl -s http://localhost:10850/processes | grep -o 'sessions/[^/]*' | head -1
 ```
 
+#### Live screen stream (WebSocket)
+
+For a real-time mirror of the PTY (instead of a one-shot snapshot), connect to the
+PTY stream WebSocket. Streams are **per session**, so a `session` is always required —
+each session of an agent is an isolated stream.
+
+| Endpoint | Auth | Description |
+|----------|------|-------------|
+| `POST` | `/api/v1/pty-stream-ticket` | Key | Exchange an API key for a one-time, 30s-TTL ticket bound to a specific `{ agentId, sessionId }` |
+| `WS` | `/api/v1/agents/:agentId/pty-stream` | Ticket *or* Key | Subscribe to the live PTY stream for one session |
+
+**Auth path 1 — ephemeral ticket (used by the browser viewer):**
+
+```bash
+# 1. Mint a ticket (the ticket is bound to this sessionId)
+curl -s -X POST http://localhost:10850/api/v1/pty-stream-ticket \
+  -H "X-Api-Key: <key>" -H "Content-Type: application/json" \
+  -d '{"agentId":"<agentId>","sessionId":"<sessionId>"}'
+# → { "ticket": "<hex>", "expiresAt": "..." }
+
+# 2. Connect (no API key on the URL — the ticket carries the session binding)
+#    ws://localhost:10850/api/v1/agents/<agentId>/pty-stream?ticket=<hex>
+```
+
+**Auth path 2 — header auth (programmatic clients):** pass the API key as a header
+(`X-Api-Key` or `Authorization: Bearer`) **and** the session as a query param:
+
+```
+ws://localhost:10850/api/v1/agents/<agentId>/pty-stream?session=<sessionId>
+```
+
+> **Required:** the header-auth path returns `400 Bad Request` if `?session=` is
+> omitted (streams are per session — there is no agent-wide stream). The ticket path
+> does not need `?session=` because the ticket is already bound to one session.
+
+Closes with code `4404` if the session is not running in PTY mode.
+
 **Auth levels:** `Key` = any valid API key, `Write` = key with write access to the agent, `Admin` = key with `agents: "*"`.
 
 ---

--- a/API.md
+++ b/API.md
@@ -127,6 +127,45 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 | `POST` | `/api/v1/agents/:agentId/media` | Key | Upload a media file (image/* or PDF) — returns `mediaPath` |
 | `GET` | `/api/v1/agents/:agentId/media/*` | Key | Serve a media file by path |
 
+### PTY Shell API
+
+Available only for agents running in wrap-shell (PTY) mode (`gateway.headless: false`).
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/v1/sessions/:sessionId/screen` | Key | Read the current visible screen as plain text — ANSI stripped, trailing blanks removed |
+
+**Response:**
+
+```json
+{
+  "text": "plain text content of the screen\ncursor is here",
+  "cursorRow": 12,
+  "cursorCol": 4,
+  "cols": 200,
+  "rows": 50
+}
+```
+
+- `text` — visible screen rows joined by `\n`, trailing blank lines stripped. Suitable for agent consumption (detect menus, prompts, hang states).
+- `cursorRow` / `cursorCol` — zero-based cursor position in the terminal grid.
+- `cols` / `rows` — terminal dimensions (matches server PTY size).
+
+Returns `404` if the session does not exist or is not running in wrap-shell mode.
+
+**Example:**
+
+```bash
+curl -s http://localhost:10850/api/v1/sessions/<sessionId>/screen \
+  -H "X-Api-Key: <key>"
+```
+
+The `sessionId` is the gateway session UUID. Find it from the process list:
+
+```bash
+curl -s http://localhost:10850/processes | grep -o 'sessions/[^/]*' | head -1
+```
+
 **Auth levels:** `Key` = any valid API key, `Write` = key with write access to the agent, `Admin` = key with `agents: "*"`.
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ help: ## Show this help message
 start: ## Build and start the gateway
 	npm run build && npm start
 
+start-dev: ## Dev mode — tsc --watch + hot-reload /dashboard on save (no gateway restart needed)
+	npm run build
+	@trap 'kill 0' EXIT; ./node_modules/.bin/tsc --watch & DEV_MODE=1 node --no-warnings=ExperimentalWarning --env-file-if-exists=.env dist/index.js
+
 stop: ## Stop claude-gateway (node dist/index.js) and all spawned children
 	@echo "Stopping claude-gateway..."
 	-@pkill -f "[n]ode dist/index\.js" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 - **App Store** — install, update, and host Docker-compose apps on the gateway; apps get a reverse proxy at `/app/:name/:portName/*`, optional Unix socket bridge for host scripts, and optional AI agent injection
 - **Self-update API** — check for newer versions of `claude-gateway` and `claude-code` and trigger an update via a single API call; no SSH or shell access needed
 - **Session persistence** — conversation history saved and restored across restarts
-- **PTY backend** — optional interactive pseudo-terminal backend (`gateway.headless: false`) for tools that require a real TTY; uses `TranscriptTailer` for reliable output instead of ANSI parsing; app-agents always stay headless
+- **PTY shell (wrap-shell mode)** — optional interactive pseudo-terminal backend (`gateway.headless: false`) for tools that require a real TTY; includes a live browser viewer (xterm.js) and a `/api/v1/sessions/:sessionId/screen` endpoint that returns the visible screen as plain text — agents can poll it to detect hang states, menus, or unexpected output without parsing ANSI escape codes; app-agents always stay headless
 
 ---
 

--- a/mcp/tools/discord/module.ts
+++ b/mcp/tools/discord/module.ts
@@ -16,9 +16,10 @@ import type {
   McpToolResult,
   ToolVisibility,
   InboundMessageHandler,
+  InboundMessage,
   ChannelId,
 } from '../../types';
-import { sendMessage } from './outbound';
+import { sendMessage, buildChoiceComponents } from './outbound';
 import { loadAccess, saveAccess, gate } from './access';
 import { maybeCreateThread } from './threading';
 import { createMessageHandler } from './inbound';
@@ -260,6 +261,61 @@ export class DiscordModule implements ChannelModule {
       }
     });
 
+    // Interactive-menu button clicks: custom_id `choice:N`. A click is routed
+    // exactly like the user typing "N" (same InboundMessage → handler), so the
+    // session's pending-menu handler injects the selection into the PTY.
+    // Security mirrors the message path: the access gate must return 'deliver'.
+    this.client.on('interactionCreate', async (interaction: any) => {
+      try {
+        if (!interaction.isButton?.()) return;
+        const m = /^choice:(\d+)$/.exec(interaction.customId ?? '');
+        if (!m) return;
+
+        const isDM = !interaction.guildId;
+        const isThread = interaction.channel?.isThread?.() ?? false;
+        const context: DiscordMessageContext = {
+          guildId: interaction.guildId ?? null,
+          channelId: interaction.channelId,
+          threadId: isThread ? interaction.channelId : null,
+          userId: interaction.user.id,
+          username: interaction.user.username,
+          messageId: interaction.message?.id ?? '',
+          isDM,
+          isThread,
+        };
+        const access = loadAccessFn();
+        const result = gate(access, context, saveAccessFn, () => randomBytes(3).toString('hex'));
+        if (result.action !== 'deliver') {
+          await interaction.reply({ content: 'Not authorized.', ephemeral: true }).catch(() => {});
+          return;
+        }
+
+        // Disable the buttons (acknowledges the click + prevents double-selection).
+        await interaction.update({ components: [] }).catch(() => {});
+
+        const channelId = interaction.channelId;
+        const typingFileDir = path.join(this.stateDir, 'typing');
+        try {
+          fs.mkdirSync(typingFileDir, { recursive: true });
+          fs.writeFileSync(path.join(typingFileDir, channelId), '');
+        } catch {}
+
+        const inbound: InboundMessage = {
+          channel: 'discord',
+          accountId: interaction.client.user?.id ?? 'discord',
+          senderId: interaction.user.id,
+          chatId: channelId,
+          chatType: isDM ? 'direct' : 'group',
+          text: m[1],
+          messageId: interaction.message?.id ?? '',
+          ts: Date.now(),
+        };
+        await handler(inbound);
+      } catch (err) {
+        process.stderr.write(`discord: interaction handler error: ${err}\n`);
+      }
+    });
+
     const approvedDir = path.join(this.stateDir, 'approved');
     const approvedInterval = setInterval(() => { void this.checkApprovals(approvedDir); }, 5000);
     approvedInterval.unref();
@@ -288,6 +344,24 @@ export class DiscordModule implements ChannelModule {
     try { files = fs.readdirSync(typingDir); } catch { return; }
 
     for (const file of files) {
+      // Interactive menu: render the question with Secondary buttons. Each click
+      // routes back as a normal "N" message (see the interactionCreate handler).
+      if (file.endsWith('.menu')) {
+        const filePath = path.join(typingDir, file);
+        const channelId = file.slice(0, -'.menu'.length);
+        try {
+          const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8').trim()) as {
+            text: string;
+            options: Array<{ label: string }>;
+          };
+          fs.rmSync(filePath, { force: true });
+          if (parsed.text && Array.isArray(parsed.options) && parsed.options.length) {
+            const channel = await this.client.channels.fetch(channelId);
+            await sendMessage(channel, parsed.text, { components: buildChoiceComponents(parsed.options) });
+          }
+        } catch { /* non-fatal — result text carries the numbered list as fallback */ }
+        continue;
+      }
       if (!file.endsWith('.forward')) continue;
       const filePath = path.join(typingDir, file);
       const channelId = file.slice(0, -'.forward'.length);

--- a/mcp/tools/discord/module.ts
+++ b/mcp/tools/discord/module.ts
@@ -265,7 +265,20 @@ export class DiscordModule implements ChannelModule {
     // exactly like the user typing "N" (same InboundMessage → handler), so the
     // session's pending-menu handler injects the selection into the PTY.
     // Security mirrors the message path: the access gate must return 'deliver'.
-    this.client.on('interactionCreate', async (interaction: any) => {
+    // discord.js client is typed as `any` (dynamic import) so we narrow locally.
+    interface ButtonInteraction {
+      isButton?: () => boolean;
+      customId?: string;
+      guildId?: string | null;
+      channelId: string;
+      channel?: { isThread?: () => boolean };
+      user: { id: string; username: string };
+      message?: { id: string };
+      client: { user?: { id: string } };
+      reply(opts: { content: string; ephemeral: boolean }): Promise<unknown>;
+      update(opts: { components: unknown[] }): Promise<unknown>;
+    }
+    this.client.on('interactionCreate', async (interaction: ButtonInteraction) => {
       try {
         if (!interaction.isButton?.()) return;
         const m = /^choice:(\d+)$/.exec(interaction.customId ?? '');

--- a/mcp/tools/discord/outbound.ts
+++ b/mcp/tools/discord/outbound.ts
@@ -82,7 +82,7 @@ export function buildChoiceComponents(options: Array<{ label: string }>): unknow
       return {
         type: 2, // Button
         style: 2, // Secondary
-        label: `${n}. ${options[i + j].label}`.slice(0, 80),
+        label: `${n}. ${o.label}`.slice(0, 80),
         custom_id: `choice:${n}`,
       };
     });

--- a/mcp/tools/discord/outbound.ts
+++ b/mcp/tools/discord/outbound.ts
@@ -17,9 +17,22 @@ export async function sendMessage(
     replyTo?: string;
     files?: string[];
     useEmbed?: boolean;
+    components?: unknown[];
   } = {},
 ): Promise<SentMessage[]> {
   const sent: SentMessage[] = [];
+
+  // Interactive menu: send the text with button rows attached to the first message.
+  if (options.components && options.components.length) {
+    const chunks = chunkText(text, MAX_MESSAGE_LENGTH);
+    for (let i = 0; i < chunks.length; i++) {
+      const last = i === chunks.length - 1;
+      const sendOpts: Parameters<SendableChannel['send']>[0] = { content: chunks[i] };
+      if (last) sendOpts.components = options.components;
+      sent.push(await channel.send(sendOpts));
+    }
+    return sent;
+  }
 
   if (text.length > MAX_MESSAGE_LENGTH && options.useEmbed) {
     const embedText = text.slice(0, MAX_EMBED_DESCRIPTION);
@@ -53,6 +66,29 @@ export async function sendMessage(
   }
 
   return sent;
+}
+
+/**
+ * Build Discord action-row components for an interactive menu. Each option
+ * becomes a Secondary button labelled "N. label" whose custom_id is `choice:N`
+ * (≤5 buttons per row, ≤5 rows). Uses raw component JSON to keep this module
+ * free of a discord.js import (matching the rest of the file).
+ */
+export function buildChoiceComponents(options: Array<{ label: string }>): unknown[] {
+  const rows: unknown[] = [];
+  for (let i = 0; i < options.length && rows.length < 5; i += 5) {
+    const buttons = options.slice(i, i + 5).map((o, j) => {
+      const n = i + j + 1;
+      return {
+        type: 2, // Button
+        style: 2, // Secondary
+        label: `${n}. ${options[i + j].label}`.slice(0, 80),
+        custom_id: `choice:${n}`,
+      };
+    });
+    rows.push({ type: 1, components: buttons }); // ActionRow
+  }
+  return rows;
 }
 
 export function chunkText(text: string, limit: number): string[] {

--- a/mcp/tools/discord/types.ts
+++ b/mcp/tools/discord/types.ts
@@ -65,6 +65,8 @@ export type SendOptions = {
   embeds?: EmbedData[];
   files?: FileAttachment[];
   reply?: { messageReference: string };
+  /** Raw Discord message components (action rows of buttons), passed through to channel.send. */
+  components?: unknown[];
 };
 
 export type SentMessage = { id: string };

--- a/mcp/tools/telegram/menu-parser.ts
+++ b/mcp/tools/telegram/menu-parser.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure parsing logic for .menu files written by AgentRunner.writeMenuForward.
+ * Kept in a separate module so tests can import it without pulling in the full
+ * bot runtime (receiver-server.ts imports grammy + all its dependencies).
+ */
+
+export type InlineKeyboardButton = { text: string; callback_data: string };
+
+export type MenuMessage = {
+  text: string;
+  inline_keyboard: Array<Array<InlineKeyboardButton>>;
+};
+
+/**
+ * Parse raw .menu file content into a Telegram sendMessage payload.
+ * Returns null if the content is malformed or missing required fields.
+ */
+export function parseMenuFileContent(raw: string): MenuMessage | null {
+  let parsed: { text?: unknown; options?: unknown };
+  try {
+    parsed = JSON.parse(raw) as { text?: unknown; options?: unknown };
+  } catch {
+    return null;
+  }
+  const text = typeof parsed.text === 'string' ? parsed.text : '';
+  const options = Array.isArray(parsed.options)
+    ? (parsed.options as Array<{ label?: unknown }>)
+        .map(o => (typeof o?.label === 'string' ? o.label : ''))
+        .filter((l): l is string => l.length > 0)
+    : [];
+  if (!text || options.length === 0) return null;
+  const inline_keyboard = options.map((label, i) => [{
+    text: `${i + 1}. ${label}`.slice(0, 60),
+    callback_data: `choice:${i + 1}`,
+  }]);
+  return { text, inline_keyboard };
+}

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1157,6 +1157,45 @@ bot.command('clear', async ctx => {
 bot.on('callback_query:data', async ctx => {
   const data = ctx.callbackQuery.data
 
+  // Handle interactive-menu choice: choice:<N>. A tap is routed back exactly like
+  // the user typing "N" — same content + meta as the text path — so the session's
+  // pending-menu handler injects the selection into the PTY. Security mirrors the
+  // text path: the tapper must be in allowFrom.
+  const choiceMatch = /^choice:(\d+)$/.exec(data)
+  if (choiceMatch) {
+    const access = loadAccess()
+    if (!access.allowFrom.includes(String(ctx.from.id))) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    const chat_id = String(ctx.callbackQuery.message?.chat.id ?? ctx.from.id)
+    const choice = choiceMatch[1]
+    // Remove the keyboard immediately to prevent double-selection.
+    await ctx.editMessageReplyMarkup({ reply_markup: undefined }).catch(() => {})
+    await ctx.answerCallbackQuery({ text: `✓ ${choice}` }).catch(() => {})
+    const callbackUrl = process.env.CLAUDE_CHANNEL_CALLBACK
+    if (callbackUrl) {
+      const channelParams = {
+        content: choice,
+        meta: {
+          chat_id,
+          user: ctx.from.username ?? String(ctx.from.id),
+          user_id: String(ctx.from.id),
+          ts: new Date().toISOString(),
+        },
+      }
+      fetch(callbackUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(channelParams),
+      }).catch(err => {
+        process.stderr.write(`telegram channel: choice callback POST failed: ${err}\n`)
+      })
+      if (RECEIVER_MODE) typingManager.start(chat_id)
+    }
+    return
+  }
+
   // Handle model selection callback: model:<model_id>
   const modelMatch = /^model:(.+)$/.exec(data)
   if (modelMatch) {
@@ -1632,6 +1671,57 @@ if (RECEIVER_MODE) {
   }
   process.on('SIGTERM', shutdown)
   process.on('SIGINT', shutdown)
+
+  // Interactive-menu delivery. The AgentRunner drops a `<chatId>.menu` file in
+  // TYPING_DIR whenever the PTY session blocks on an interactive select menu
+  // (AskUserQuestion / plan approval). We render it as inline buttons here.
+  //
+  // This MUST be independent of the typing-indicator lifecycle: a menu can be
+  // emitted after typing has already been torn down (e.g. the agent called the
+  // reply tool earlier in the same turn, or the turn ended), and the old
+  // stop()-coupled drain would early-return on a missing typing state, leaving
+  // the .menu file orphaned and the user staring at a silent chat. A standalone
+  // poller — mirroring the Discord side — guarantees every menu reaches the chat.
+  function drainMenuFiles(): void {
+    let files: string[]
+    try {
+      files = readdirSync(TYPING_DIR)
+    } catch {
+      return
+    }
+    for (const name of files) {
+      if (!name.endsWith('.menu')) continue
+      const chatId = name.slice(0, -'.menu'.length)
+      const menuPath = join(TYPING_DIR, name)
+      let parsed: { text?: unknown; options?: unknown }
+      try {
+        parsed = JSON.parse(readFileSync(menuPath, 'utf8').trim()) as { text?: unknown; options?: unknown }
+      } catch {
+        // Malformed or mid-write (the runner writes atomically, so this is rare) —
+        // drop it so the poller doesn't spin on the same bad file forever.
+        rmSync(menuPath, { force: true })
+        continue
+      }
+      // Remove BEFORE sending: a slow or failing send must not let the next tick
+      // re-deliver the same menu (which would stack duplicate button messages).
+      rmSync(menuPath, { force: true })
+      const text = typeof parsed.text === 'string' ? parsed.text : ''
+      const options = Array.isArray(parsed.options)
+        ? (parsed.options as Array<{ label?: unknown }>)
+            .map(o => (typeof o?.label === 'string' ? o.label : ''))
+            .filter((l): l is string => l.length > 0)
+        : []
+      if (!text || options.length === 0) continue
+      const inline_keyboard = options.map((label, i) => [{
+        text: `${i + 1}. ${label}`.slice(0, 60),
+        callback_data: `choice:${i + 1}`,
+      }])
+      void bot.api.sendMessage(chatId, text, { reply_markup: { inline_keyboard } }).catch(err => {
+        process.stderr.write(`telegram channel (receiver): failed to send menu to ${chatId}: ${err}\n`)
+      })
+    }
+  }
+  setInterval(drainMenuFiles, 1000).unref()
 
   void (async () => {
     for (let attempt = 1; ; attempt++) {

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -690,6 +690,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
 const SEND_ONLY = process.env.TELEGRAM_SEND_ONLY === 'true'
 const RECEIVER_MODE = process.env.TELEGRAM_RECEIVER_MODE === 'true'
 
+import { parseMenuFileContent } from './menu-parser'
+
 const BOT_COMMANDS = [
   { command: 'session', description: 'Show current session info' },
   { command: 'sessions', description: 'Manage conversation sessions' },
@@ -1693,9 +1695,9 @@ if (RECEIVER_MODE) {
       if (!name.endsWith('.menu')) continue
       const chatId = name.slice(0, -'.menu'.length)
       const menuPath = join(TYPING_DIR, name)
-      let parsed: { text?: unknown; options?: unknown }
+      let raw: string
       try {
-        parsed = JSON.parse(readFileSync(menuPath, 'utf8').trim()) as { text?: unknown; options?: unknown }
+        raw = readFileSync(menuPath, 'utf8').trim()
       } catch {
         // Malformed or mid-write (the runner writes atomically, so this is rare) —
         // drop it so the poller doesn't spin on the same bad file forever.
@@ -1705,18 +1707,9 @@ if (RECEIVER_MODE) {
       // Remove BEFORE sending: a slow or failing send must not let the next tick
       // re-deliver the same menu (which would stack duplicate button messages).
       rmSync(menuPath, { force: true })
-      const text = typeof parsed.text === 'string' ? parsed.text : ''
-      const options = Array.isArray(parsed.options)
-        ? (parsed.options as Array<{ label?: unknown }>)
-            .map(o => (typeof o?.label === 'string' ? o.label : ''))
-            .filter((l): l is string => l.length > 0)
-        : []
-      if (!text || options.length === 0) continue
-      const inline_keyboard = options.map((label, i) => [{
-        text: `${i + 1}. ${label}`.slice(0, 60),
-        callback_data: `choice:${i + 1}`,
-      }])
-      void bot.api.sendMessage(chatId, text, { reply_markup: { inline_keyboard } }).catch(err => {
+      const msg = parseMenuFileContent(raw)
+      if (!msg) continue
+      void bot.api.sendMessage(chatId, msg.text, { reply_markup: { inline_keyboard: msg.inline_keyboard } }).catch(err => {
         process.stderr.write(`telegram channel (receiver): failed to send menu to ${chatId}: ${err}\n`)
       })
     }

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -96,7 +96,7 @@ export interface WorkingState {
 
 export interface BotApi {
   sendChatAction(chatId: string, action: 'typing'): Promise<unknown>
-  sendMessage(chatId: string, text: string, opts?: { parse_mode?: 'MarkdownV2' | 'HTML' | 'Markdown' }): Promise<{ message_id: number }>
+  sendMessage(chatId: string, text: string, opts?: { parse_mode?: 'MarkdownV2' | 'HTML' | 'Markdown'; reply_markup?: unknown }): Promise<{ message_id: number }>
   editMessageText(chatId: string, msgId: number, text: string): Promise<unknown>
   deleteMessage(chatId: string, msgId: number): Promise<unknown>
   setMessageReaction(chatId: string, msgId: number, emoji: string): Promise<unknown>
@@ -212,6 +212,12 @@ export function createWorkingStateManager(
       } catch {}
       fsApi.rmSync(forwardPath, { force: true })
     }
+    // NOTE: interactive-menu (.menu) delivery is handled by an independent poller
+    // in receiver-server.ts (drainMenuFiles), NOT here. A menu can be emitted
+    // after the typing state has already been torn down (reply tool called earlier
+    // in the turn, or the turn ended), in which case this stop() never runs for it
+    // and the .menu file would be orphaned. The standalone poller has no such
+    // coupling, so it reliably delivers every menu. Do not re-add a drain here.
     fsApi.rmSync(repliedPath, { force: true })
     // Read signal file timestamp before deleting — process.ts overwrites it with a newer
     // timestamp when a queued turn is injected; if newer than this turn's startedAt it means

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.3.4",
       "hasInstallScript": true,
       "dependencies": {
-        "@types/ws": "^8.18.1",
         "@xterm/headless": "^6.0.0",
         "chokidar": "^3.5.0",
         "cron-parser": "^5.5.0",
@@ -32,6 +31,7 @@
         "@types/node-cron": "^3.0.0",
         "@types/supertest": "^7.2.0",
         "@types/tmp": "^0.2.0",
+        "@types/ws": "^8.18.1",
         "jest": "^29.0.0",
         "supertest": "^7.2.2",
         "tmp": "^0.2.0",
@@ -1273,6 +1273,7 @@
       "version": "22.19.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
       "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1374,6 +1375,7 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5282,6 +5284,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.3.4",
       "hasInstallScript": true,
       "dependencies": {
+        "@types/ws": "^8.18.1",
         "@xterm/headless": "^6.0.0",
         "chokidar": "^3.5.0",
         "cron-parser": "^5.5.0",
@@ -17,7 +18,8 @@
         "lru-cache": "^10.0.0",
         "node-cron": "^3.0.0",
         "node-pty": "^1.1.0",
-        "p-queue": "^6.6.2"
+        "p-queue": "^6.6.2",
+        "ws": "^8.21.0"
       },
       "bin": {
         "claude-gateway": "dist/index.js"
@@ -1271,7 +1273,6 @@
       "version": "22.19.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
       "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1368,6 +1369,15 @@
       "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -5272,7 +5282,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -5434,6 +5443,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@types/ws": "^8.18.1",
     "@xterm/headless": "^6.0.0",
     "chokidar": "^3.5.0",
     "cron-parser": "^5.5.0",
@@ -53,6 +52,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.0",
+    "@types/ws": "^8.18.1",
     "@types/jest": "^29.0.0",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.19.18",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@types/ws": "^8.18.1",
     "@xterm/headless": "^6.0.0",
     "chokidar": "^3.5.0",
     "cron-parser": "^5.5.0",
@@ -47,7 +48,8 @@
     "lru-cache": "^10.0.0",
     "node-cron": "^3.0.0",
     "node-pty": "^1.1.0",
-    "p-queue": "^6.6.2"
+    "p-queue": "^6.6.2",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.0",

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -699,6 +699,9 @@ export class AgentRunner extends EventEmitter {
       // Auto-forward result text to channel if agent didn't call reply tool.
       let replyCalled = false;
       let replyToolUseId: string | null = null; // track id to detect failed tool calls
+      // Set when an interactive-menu prompt was rendered to the channel this turn,
+      // so the result's plain-text auto-forward is skipped (no duplicate message).
+      let menuSentThisTurn = false;
       let typingDoneTimer: ReturnType<typeof setTimeout> | null = null;
       const TYPING_DONE_DELAY_MS = 3000;
       const replyToolName = source === 'discord' ? 'mcp__gateway__discord_reply' : 'mcp__gateway__telegram_reply';
@@ -750,6 +753,31 @@ export class AgentRunner extends EventEmitter {
               }
             }
           }
+          // Interactive select menu blocking the PTY: render it as channel-native
+          // UI (inline buttons). This output handler only runs for Telegram/Discord
+          // sessions; API uses a separate path and falls back to the result text's
+          // numbered list (no buttons), as intended.
+          if (obj['type'] === 'system' && obj['subtype'] === 'menu_prompt') {
+            const promptText = typeof obj['prompt'] === 'string' ? obj['prompt'] : '';
+            const rawOptions = Array.isArray(obj['options']) ? obj['options'] as Array<{ label?: unknown }> : [];
+            const options = rawOptions
+              .map((o) => ({ label: typeof o?.label === 'string' ? o.label : '' }))
+              .filter((o) => o.label);
+            if (promptText && options.length) {
+              this.writeMenuForward(mapKey, promptText, options);
+              menuSentThisTurn = true;
+              // Persist the question to chat history so it's visible in the transcript.
+              const channelSrc = this.channelSourceMap.get(mapKey) ?? 'telegram';
+              this.historyDb.insertMessage({
+                chatId: `${channelSrc}-${mapKey}`,
+                sessionId: actualSessionId,
+                source: channelSrc as HistorySource,
+                role: 'assistant',
+                content: promptText,
+                ts: Date.now(),
+              });
+            }
+          }
           if (obj['type'] === 'result') {
             proc.setProcessing(false);
             // Telegram: accumulate image size via stat of local file (FIFO, one per turn)
@@ -781,7 +809,9 @@ export class AgentRunner extends EventEmitter {
             // so the raw API error must not reach the user's chat or the history DB.
             const isThinkingCorruption =
               obj['is_error'] === true && SessionProcess.isThinkingCorruptionError(resultText);
-            if (resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption) {
+            // Skip when a menu was rendered to buttons this turn — the result
+            // text is the same numbered list and would duplicate the menu message.
+            if (resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption && !menuSentThisTurn) {
               const text = resultText.trim();
               const channelSrcForResult = this.channelSourceMap.get(mapKey) ?? 'telegram';
               // Persist assistant reply to permanent history DB
@@ -802,6 +832,7 @@ export class AgentRunner extends EventEmitter {
             }
             replyCalled = false; // reset for next turn
             replyToolUseId = null;
+            menuSentThisTurn = false;
             // Delay typing done — agent may continue with more work
             typingDoneTimer = setTimeout(() => {
               this.writeTypingDone(mapKey);
@@ -1221,6 +1252,27 @@ export class AgentRunner extends EventEmitter {
     }
   }
 
+  /**
+   * Signal the channel receiver to render an interactive menu as native UI
+   * (inline buttons on Telegram/Discord). The receiver maps each option to a
+   * `choice:N` callback whose tap arrives back as a normal "N" message — the
+   * same as the user typing the number.
+   */
+  private writeMenuForward(chatId: string, text: string, options: Array<{ label: string }>): void {
+    const typingDir = this.getTypingDir(chatId);
+    try {
+      fs.mkdirSync(typingDir, { recursive: true });
+      // Write atomically (tmp + rename): the receiver polls this directory every
+      // second, so a non-atomic write could be read mid-flush as truncated JSON.
+      const finalPath = path.join(typingDir, `${chatId}.menu`);
+      const tmpPath = `${finalPath}.tmp`;
+      fs.writeFileSync(tmpPath, JSON.stringify({ text, options }));
+      fs.renameSync(tmpPath, finalPath);
+    } catch {
+      // Non-fatal — the result text still carries the numbered list as a fallback.
+    }
+  }
+
   private startIdleCleaner(): void {
     this.idleCleanerTimer = setInterval(async () => {
       for (const [id, proc] of this.sessions) {
@@ -1355,15 +1407,32 @@ export class AgentRunner extends EventEmitter {
     return this.receiver?.isRunning() ?? false;
   }
 
-  getSessionsSummary(): Array<{ chatId: string; sessionId: string; source: string; mode: string; model: string; isRunning: boolean; spawnedAt: number; uptimeSec: number }> {
+  getSessionsSummary(): Array<{ chatId: string; sessionId: string; source: string; mode: string; model: string; isRunning: boolean; spawnedAt: number; uptimeSec: number; tokens: number }> {
     const now = Date.now();
-    return this.sessionHistory.map((e) => {
-      const isRunning = this.sessions.has(e.chatId);
+    // A single logical session can appear multiple times in the ring buffer: a
+    // restart / model-switch / error-recovery respawn pushes a fresh entry with
+    // the SAME sessionId but a new spawnedAt. History is newest-first (unshift),
+    // so the first occurrence of a (source, sessionId, chatId) is the current
+    // incarnation — collapse to it so the dashboard shows one row per session
+    // instead of duplicating it.
+    const seen = new Set<string>();
+    const out: Array<{ chatId: string; sessionId: string; source: string; mode: string; model: string; isRunning: boolean; spawnedAt: number; uptimeSec: number; tokens: number }> = [];
+    for (const e of this.sessionHistory) {
+      const dedupKey = `${e.source}:${e.sessionId}:${e.chatId}`;
+      if (seen.has(dedupKey)) continue;
+      seen.add(dedupKey);
+      const proc = this.sessions.get(e.chatId);
+      // Running only when the live process IS this incarnation: a stale entry
+      // from before a respawn must not borrow the new process's running state.
+      const isRunning = !!proc && proc.spawnedAt === e.spawnedAt;
       // For API sessions the ring-buffer chatId equals the sessionId (the map key);
       // surface the real caller chatId instead when we have it.
       const chatId = e.source === 'api' ? (this.apiChatIds.get(e.sessionId) ?? e.chatId) : e.chatId;
-      return { ...e, chatId, isRunning, uptimeSec: Math.floor((now - e.spawnedAt) / 1000) };
-    });
+      // Live context-window token usage from the running process (0 when stopped).
+      const tokens = isRunning ? (proc?.totalTokens ?? 0) : 0;
+      out.push({ ...e, chatId, isRunning, uptimeSec: Math.floor((now - e.spawnedAt) / 1000), tokens });
+    }
+    return out;
   }
 
   /**

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -122,6 +122,9 @@ export class AgentRunner extends EventEmitter {
   // Buffers attachment file paths registered via api_reply tool for the current API session turn.
   private readonly pendingApiAttachments = new Map<string, string[]>();
 
+  // Session history ring-buffer (last 10 spawned, newest first)
+  private readonly sessionHistory: Array<{ chatId: string; sessionId: string; source: string; spawnedAt: number }> = [];
+
   // Skill registry for detecting /skill-name commands in user messages
   private skillRegistry: SkillRegistry = { skills: new Map() };
 
@@ -851,6 +854,8 @@ export class AgentRunner extends EventEmitter {
     }
 
     this.sessions.set(mapKey, proc);
+    this.sessionHistory.unshift({ chatId: mapKey, sessionId: proc.sessionId, source: proc.source, spawnedAt: proc.spawnedAt });
+    if (this.sessionHistory.length > 10) this.sessionHistory.length = 10;
     if (source === 'telegram' || source === 'discord') {
       this.channelSourceMap.set(mapKey, source);
     }
@@ -1343,6 +1348,14 @@ export class AgentRunner extends EventEmitter {
 
   isRunning(): boolean {
     return this.receiver?.isRunning() ?? false;
+  }
+
+  getSessionsSummary(): Array<{ chatId: string; sessionId: string; source: string; isRunning: boolean; spawnedAt: number; uptimeSec: number }> {
+    const now = Date.now();
+    return this.sessionHistory.map((e) => {
+      const isRunning = this.sessions.has(e.chatId);
+      return { ...e, isRunning, uptimeSec: Math.floor((now - e.spawnedAt) / 1000) };
+    });
   }
 
   /**

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -123,7 +123,7 @@ export class AgentRunner extends EventEmitter {
   private readonly pendingApiAttachments = new Map<string, string[]>();
 
   // Session history ring-buffer (last 10 spawned, newest first)
-  private readonly sessionHistory: Array<{ chatId: string; sessionId: string; source: string; mode: string; spawnedAt: number }> = [];
+  private readonly sessionHistory: Array<{ chatId: string; sessionId: string; source: string; mode: string; model: string; spawnedAt: number }> = [];
 
   // For API sessions the map key is the sessionId, so the real caller chatId
   // (e.g. the app/agent identifier) is not captured at spawn. Record it here
@@ -859,7 +859,7 @@ export class AgentRunner extends EventEmitter {
     }
 
     this.sessions.set(mapKey, proc);
-    this.sessionHistory.unshift({ chatId: mapKey, sessionId: proc.sessionId, source: proc.source, mode: proc.backend, spawnedAt: proc.spawnedAt });
+    this.sessionHistory.unshift({ chatId: mapKey, sessionId: proc.sessionId, source: proc.source, mode: proc.backend, model: proc.model, spawnedAt: proc.spawnedAt });
     if (this.sessionHistory.length > 10) this.sessionHistory.length = 10;
     if (source === 'telegram' || source === 'discord') {
       this.channelSourceMap.set(mapKey, source);
@@ -1355,7 +1355,7 @@ export class AgentRunner extends EventEmitter {
     return this.receiver?.isRunning() ?? false;
   }
 
-  getSessionsSummary(): Array<{ chatId: string; sessionId: string; source: string; mode: string; isRunning: boolean; spawnedAt: number; uptimeSec: number }> {
+  getSessionsSummary(): Array<{ chatId: string; sessionId: string; source: string; mode: string; model: string; isRunning: boolean; spawnedAt: number; uptimeSec: number }> {
     const now = Date.now();
     return this.sessionHistory.map((e) => {
       const isRunning = this.sessions.has(e.chatId);

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -123,7 +123,12 @@ export class AgentRunner extends EventEmitter {
   private readonly pendingApiAttachments = new Map<string, string[]>();
 
   // Session history ring-buffer (last 10 spawned, newest first)
-  private readonly sessionHistory: Array<{ chatId: string; sessionId: string; source: string; spawnedAt: number }> = [];
+  private readonly sessionHistory: Array<{ chatId: string; sessionId: string; source: string; mode: string; spawnedAt: number }> = [];
+
+  // For API sessions the map key is the sessionId, so the real caller chatId
+  // (e.g. the app/agent identifier) is not captured at spawn. Record it here
+  // keyed by sessionId so the dashboard can show the actual chat id.
+  private readonly apiChatIds = new Map<string, string>();
 
   // Skill registry for detecting /skill-name commands in user messages
   private skillRegistry: SkillRegistry = { skills: new Map() };
@@ -854,7 +859,7 @@ export class AgentRunner extends EventEmitter {
     }
 
     this.sessions.set(mapKey, proc);
-    this.sessionHistory.unshift({ chatId: mapKey, sessionId: proc.sessionId, source: proc.source, spawnedAt: proc.spawnedAt });
+    this.sessionHistory.unshift({ chatId: mapKey, sessionId: proc.sessionId, source: proc.source, mode: proc.backend, spawnedAt: proc.spawnedAt });
     if (this.sessionHistory.length > 10) this.sessionHistory.length = 10;
     if (source === 'telegram' || source === 'discord') {
       this.channelSourceMap.set(mapKey, source);
@@ -1350,11 +1355,14 @@ export class AgentRunner extends EventEmitter {
     return this.receiver?.isRunning() ?? false;
   }
 
-  getSessionsSummary(): Array<{ chatId: string; sessionId: string; source: string; isRunning: boolean; spawnedAt: number; uptimeSec: number }> {
+  getSessionsSummary(): Array<{ chatId: string; sessionId: string; source: string; mode: string; isRunning: boolean; spawnedAt: number; uptimeSec: number }> {
     const now = Date.now();
     return this.sessionHistory.map((e) => {
       const isRunning = this.sessions.has(e.chatId);
-      return { ...e, isRunning, uptimeSec: Math.floor((now - e.spawnedAt) / 1000) };
+      // For API sessions the ring-buffer chatId equals the sessionId (the map key);
+      // surface the real caller chatId instead when we have it.
+      const chatId = e.source === 'api' ? (this.apiChatIds.get(e.sessionId) ?? e.chatId) : e.chatId;
+      return { ...e, chatId, isRunning, uptimeSec: Math.floor((now - e.spawnedAt) / 1000) };
     });
   }
 
@@ -1387,6 +1395,7 @@ export class AgentRunner extends EventEmitter {
 
     // Use model from request body if provided, otherwise use agent default
     const session = await this.getOrSpawnSession(sessionId, 'api', undefined, opts.model);
+    this.apiChatIds.set(sessionId, chatId);
 
     // Promote UI-uploaded files from staging to permanent per-session storage
     const finalMediaFiles = opts.mediaFiles?.length
@@ -1590,6 +1599,7 @@ export class AgentRunner extends EventEmitter {
 
     // Use model from request body if provided, otherwise use agent default
     const session = await this.getOrSpawnSession(sessionId, 'api', undefined, opts.model);
+    this.apiChatIds.set(sessionId, chatId);
 
     // Promote UI-uploaded files from staging to permanent per-session storage
     const finalMediaFilesStream = opts.mediaFiles?.length

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1905,6 +1905,8 @@ export class AgentRunner extends EventEmitter {
   }
 
   private cleanupApiSessionMediaDir(sessionId: string, source: string): void {
+    // Always evict the chat-id mapping — safe no-op for non-api sessions.
+    this.apiChatIds.delete(sessionId);
     if (source !== 'api') return;
     const mediaDir = path.join(this.agentsBaseDir, this.agentConfig.id, 'media', `api-${sessionId}`);
     try {

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import * as http from 'node:http';
+import { execSync } from 'child_process';
 import { Server } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { AgentRunner } from '../agent/runner';
@@ -298,6 +299,24 @@ export class GatewayRouter {
       res.send(generateDashboardHtml());
     });
 
+    // Process tree endpoint — returns raw ps data for dashboard
+    this.app.get('/processes', (_req: Request, res: Response) => {
+      try {
+        const out = execSync(
+          "ps -eo pid,ppid,stat,args --no-headers 2>/dev/null | grep -E 'claude|bun.*gateway|bun.*mcp|bun.*receiver|node.*dist/' | grep -v grep | grep -v vscode",
+          { encoding: 'utf8', timeout: 5000 }
+        );
+        const processes = out.trim().split('\n').filter(Boolean).map((line) => {
+          const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+          if (!m) return null;
+          return { pid: parseInt(m[1]), ppid: parseInt(m[2]), stat: m[3], args: m[4].trim() };
+        }).filter(Boolean);
+        res.json({ processes });
+      } catch {
+        res.json({ processes: [] });
+      }
+    });
+
     // Status endpoint — per-agent stats + heartbeat history
     this.app.get('/status', (_req: Request, res: Response) => {
       const uptimeMs = Date.now() - this.startedAt.getTime();
@@ -339,6 +358,7 @@ export class GatewayRouter {
           messagesReceived: this.messagesReceived.get(id) ?? 0,
           messagesSent: this.messagesSent.get(id) ?? 0,
           lastActivityAt: lastActivity ? lastActivity.toISOString() : null,
+          hasPtyStream: ptyStreamRegistry.hasSockets(id),
           heartbeat: {
             tasks: taskNames,
             lastResults,

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -363,9 +363,15 @@ export class GatewayRouter {
         const lastActivity = this.lastActivityAt.get(id);
         const sessions = runner.getSessionsSummary();
 
+        // An agent with a channel receiver configured (telegram/discord) has a
+        // meaningful running/stopped state. API-only agents have no receiver — they
+        // are always available as long as the gateway has them loaded.
+        const hasChannel = !!(agentConfig?.telegram?.botToken || agentConfig?.discord?.botToken);
+
         return {
           id,
           isRunning: runner.isRunning(),
+          hasChannel,
           messagesReceived: this.messagesReceived.get(id) ?? 0,
           messagesSent: this.messagesSent.get(id) ?? 0,
           lastActivityAt: lastActivity ? lastActivity.toISOString() : null,

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -1,6 +1,8 @@
 import express, { Request, Response } from 'express';
 import * as http from 'node:http';
 import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import { Server } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { AgentRunner } from '../agent/runner';
@@ -21,6 +23,18 @@ import { createAppsRouter } from './apps-router';
 import { ComposePort } from '../apps/compose-generator';
 
 const APP_NAME_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
+
+function getGatewayVersion(): string {
+  try {
+    const pkgPath = path.join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+const GATEWAY_VERSION = getGatewayVersion();
 
 // ─── Proxy types ──────────────────────────────────────────────────────────────
 
@@ -293,8 +307,8 @@ export class GatewayRouter {
       res.json({ status: 'ok', agents: [...this.agents.keys()] });
     });
 
-    // Web UI dashboard
-    this.app.get('/ui', (_req: Request, res: Response) => {
+    // Web dashboard
+    this.app.get('/dashboard', (_req: Request, res: Response) => {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.send(generateDashboardHtml());
     });
@@ -346,11 +360,7 @@ export class GatewayRouter {
         }).filter(Boolean);
 
         const lastActivity = this.lastActivityAt.get(id);
-        const sessions = (this.recentSessions.get(id) ?? []).slice(0, 5).map((s) => ({
-          chatId: s.chatId,
-          messageCount: s.messageCount,
-          lastActivity: s.lastActivity.toISOString(),
-        }));
+        const sessions = runner.getSessionsSummary();
 
         return {
           id,
@@ -371,6 +381,7 @@ export class GatewayRouter {
         agents: agentsStatus,
         uptime: Math.floor(uptimeMs / 1000),
         startedAt: this.startedAt.toISOString(),
+        version: GATEWAY_VERSION,
       });
     });
   }

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -406,7 +406,7 @@ export class GatewayRouter {
 
       this.server.on('upgrade', (req: http.IncomingMessage, socket, head) => {
         const url = req.url ?? '';
-        const match = url.match(/^\/api\/v1\/agents\/([^/?]+)\/pty-stream(?:\?.*)?$/);
+        const match = url.match(/\/api\/v1\/agents\/([^/?]+)\/pty-stream(?:\?.*)?$/);
         if (!match) {
           socket.destroy();
           return;

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -309,8 +309,9 @@ export class GatewayRouter {
 
     // Web dashboard
     this.app.get('/dashboard', (_req: Request, res: Response) => {
+      const firstKey = (this.gatewayConfig?.gateway?.api?.keys ?? [])[0]?.key ?? '';
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      res.send(generateDashboardHtml());
+      res.send(generateDashboardHtml(firstKey));
     });
 
     // Process tree endpoint — returns raw ps data for dashboard
@@ -411,10 +412,13 @@ export class GatewayRouter {
           return;
         }
 
-        // Auth: Bearer token or X-Api-Key header
+        // Auth: Bearer token, X-Api-Key header, or ?key= query param (for browser WS)
         const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
         const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
-        const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
+        const queryKey = new URL(url, 'http://localhost').searchParams.get('key') ?? '';
+        const token = authHeader.startsWith('Bearer ')
+          ? authHeader.slice(7).trim()
+          : xApiKey.trim() || queryKey.trim();
         if (!token || !apiKeys.some((k) => k.key === token)) {
           socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
           socket.destroy();

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -105,8 +105,8 @@ export class GatewayRouter {
   private processesCache: { data: unknown[]; ts: number } | null = null;
   private static readonly PROCESSES_CACHE_TTL_MS = 3_000;
 
-  /** Short-lived WS auth tickets: ticket → { agentId, expiresAt }. One-time use. */
-  private readonly ptyStreamTickets = new Map<string, { agentId: string; expiresAt: number }>();
+  /** Short-lived WS auth tickets: ticket → { agentId, sessionId, expiresAt }. One-time use. */
+  private readonly ptyStreamTickets = new Map<string, { agentId: string; sessionId: string; expiresAt: number }>();
   private ticketPruner: ReturnType<typeof setInterval> | null = null;
 
   /** Short-lived dashboard session tokens (10 min TTL). Issued at /dashboard serve time
@@ -222,14 +222,25 @@ export class GatewayRouter {
         res.status(401).json({ error: 'Unauthorized' });
         return;
       }
-      const agentId = (req.body as { agentId?: string })?.agentId ?? '';
+      const body = (req.body as { agentId?: string; sessionId?: string }) ?? {};
+      const agentId = body.agentId ?? '';
+      const sessionId = body.sessionId ?? '';
       if (!agentId || !this.agents.has(agentId)) {
         res.status(404).json({ error: 'Agent not found' });
         return;
       }
+      // Bind the ticket to a specific session. Validate the session actually
+      // belongs to this agent so a ticket can't be minted for an arbitrary
+      // stream key. hasSockets() at WS time is the final gate on liveness.
+      const sessionExists = (this.agents.get(agentId)?.getSessionsSummary() ?? [])
+        .some((s) => s.sessionId === sessionId);
+      if (!sessionId || !sessionExists) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
       const ticket = crypto.randomBytes(16).toString('hex');
       const expiresAt = Date.now() + 30_000;
-      this.ptyStreamTickets.set(ticket, { agentId, expiresAt });
+      this.ptyStreamTickets.set(ticket, { agentId, sessionId, expiresAt });
       res.json({ ticket, expiresAt: new Date(expiresAt).toISOString() });
     });
 
@@ -414,6 +425,43 @@ export class GatewayRouter {
       );
     });
 
+    // PTY screen snapshot — plain text, ANSI stripped. For agents that need to
+    // observe what is currently displayed in the PTY shell to detect hangs, menu
+    // states, or unexpected output without parsing escape codes.
+    // Auth: X-Api-Key or Authorization: Bearer header (API keys only — no dashboard token,
+    // as this endpoint is intended for programmatic/agent access, not the browser).
+    this.app.get('/api/v1/sessions/:sessionId/screen', (req: Request, res: Response) => {
+      const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
+      const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
+      const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
+      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
+      if (!token || !apiKeys.some((k) => k.key === token)) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const sessionId = req.params['sessionId'] ?? '';
+      if (!sessionId) {
+        res.status(400).json({ error: 'sessionId is required' });
+        return;
+      }
+
+      if (!ptyStreamRegistry.hasSockets(sessionId)) {
+        res.status(404).json({ error: 'Session not found or not running in PTY mode' });
+        return;
+      }
+
+      ptyStreamRegistry.screenText(sessionId).then((snapshot) => {
+        if (!snapshot) {
+          res.status(404).json({ error: 'No screen data available for this session' });
+          return;
+        }
+        res.json(snapshot);
+      }).catch(() => {
+        res.status(500).json({ error: 'Failed to read screen state' });
+      });
+    });
+
     // Status endpoint — per-agent stats + heartbeat history
     this.app.get('/status', (_req: Request, res: Response) => {
       const uptimeMs = Date.now() - this.startedAt.getTime();
@@ -443,7 +491,12 @@ export class GatewayRouter {
         }).filter(Boolean);
 
         const lastActivity = this.lastActivityAt.get(id);
-        const sessions = runner.getSessionsSummary();
+        // PTY streams are keyed per session, so liveness is per session too.
+        const sessions = runner.getSessionsSummary().map((s) => ({
+          ...s,
+          hasPtyStream: ptyStreamRegistry.hasSockets(s.sessionId),
+        }));
+        const hasPtyStream = sessions.some((s) => s.hasPtyStream);
 
         // An agent with a channel receiver configured (telegram/discord) has a
         // meaningful running/stopped state. API-only agents have no receiver — they
@@ -457,7 +510,7 @@ export class GatewayRouter {
           messagesReceived: this.messagesReceived.get(id) ?? 0,
           messagesSent: this.messagesSent.get(id) ?? 0,
           lastActivityAt: lastActivity ? lastActivity.toISOString() : null,
-          hasPtyStream: ptyStreamRegistry.hasSockets(id),
+          hasPtyStream,
           heartbeat: {
             tasks: taskNames,
             lastResults,
@@ -527,19 +580,21 @@ export class GatewayRouter {
           }
           this.ptyStreamTickets.delete(ticketParam); // one-time use
           const agentId = entry.agentId;
+          const sessionId = entry.sessionId;
           if (!this.agents.has(agentId)) {
             socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
             socket.destroy();
             return;
           }
           this.wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-            if (!ptyStreamRegistry.hasSockets(agentId)) {
-              ws.close(4404, 'agent not running in PTY mode');
+            // Subscribe by sessionId — each session is its own isolated stream.
+            if (!ptyStreamRegistry.hasSockets(sessionId)) {
+              ws.close(4404, 'session not running in PTY mode');
               return;
             }
-            ptyStreamRegistry.subscribe(agentId, ws);
-            ws.on('close', () => ptyStreamRegistry.unsubscribe(agentId, ws));
-            ws.on('error', () => ptyStreamRegistry.unsubscribe(agentId, ws));
+            ptyStreamRegistry.subscribe(sessionId, ws);
+            ws.on('close', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
+            ws.on('error', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
           });
           return;
         }
@@ -562,15 +617,22 @@ export class GatewayRouter {
           socket.destroy();
           return;
         }
+        // Streams are per-session; programmatic clients pass ?session=<sessionId>.
+        const sessionId = params.get('session') ?? '';
+        if (!sessionId) {
+          socket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
+          socket.destroy();
+          return;
+        }
 
         this.wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-          if (!ptyStreamRegistry.hasSockets(agentId)) {
-            ws.close(4404, 'agent not running in PTY mode');
+          if (!ptyStreamRegistry.hasSockets(sessionId)) {
+            ws.close(4404, 'session not running in PTY mode');
             return;
           }
-          ptyStreamRegistry.subscribe(agentId, ws);
-          ws.on('close', () => ptyStreamRegistry.unsubscribe(agentId, ws));
-          ws.on('error', () => ptyStreamRegistry.unsubscribe(agentId, ws));
+          ptyStreamRegistry.subscribe(sessionId, ws);
+          ws.on('close', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
+          ws.on('error', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
         });
       });
     });

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -83,6 +83,7 @@ export class GatewayRouter {
   private readonly configs: Map<string, AgentConfig>;
   private readonly app: express.Application;
   private server: Server | null = null;
+  private wss: WebSocketServer | null = null;
 
   /** Per-agent message counters (output lines from subprocess) */
   private readonly messagesReceived: Map<string, number> = new Map();
@@ -368,7 +369,8 @@ export class GatewayRouter {
         }
       });
 
-      const wss = new WebSocketServer({ noServer: true });
+      this.wss = new WebSocketServer({ noServer: true });
+      const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
 
       this.server.on('upgrade', (req: http.IncomingMessage, socket, head) => {
         const url = req.url ?? '';
@@ -377,13 +379,30 @@ export class GatewayRouter {
           socket.destroy();
           return;
         }
+
+        // Auth: Bearer token or X-Api-Key header
+        const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
+        const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
+        const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
+        if (!token || !apiKeys.some((k) => k.key === token)) {
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+
         const agentId = decodeURIComponent(match[1]!);
         if (!this.agents.has(agentId)) {
           socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
           socket.destroy();
           return;
         }
-        wss.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+
+        this.wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+          // If agent is not in PTY mode, no data will arrive — tell the client immediately
+          if (!ptyStreamRegistry.hasSockets(agentId)) {
+            ws.close(4404, 'agent not running in PTY mode');
+            return;
+          }
           ptyStreamRegistry.subscribe(agentId, ws);
           ws.on('close', () => ptyStreamRegistry.unsubscribe(agentId, ws));
           ws.on('error', () => ptyStreamRegistry.unsubscribe(agentId, ws));
@@ -427,6 +446,7 @@ export class GatewayRouter {
   }
 
   async stop(): Promise<void> {
+    this.wss?.close();
     return new Promise((resolve, reject) => {
       if (!this.server) {
         resolve();

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -109,6 +109,10 @@ export class GatewayRouter {
   private readonly ptyStreamTickets = new Map<string, { agentId: string; expiresAt: number }>();
   private ticketPruner: ReturnType<typeof setInterval> | null = null;
 
+  /** Short-lived dashboard session tokens (10 min TTL). Issued at /dashboard serve time
+   *  so the raw API key is never embedded in the HTML page source. */
+  private readonly dashboardTokens = new Map<string, number>(); // token → expiresAt
+
   /** Per-agent message counters (output lines from subprocess) */
   private readonly messagesReceived: Map<string, number> = new Map();
   private readonly messagesSent: Map<string, number> = new Map();
@@ -185,7 +189,49 @@ export class GatewayRouter {
   }
 
   private setupRoutes(): void {
+    if (process.env.DEV_MODE) {
+      process.stderr.write('[gateway] DEV_MODE=1 active — module cache busted on every /dashboard request. Never enable in production.\n');
+    }
     this.app.use(express.json());
+
+    // Ephemeral WS ticket — exchange a short-lived token for PTY stream access.
+    // MUST be registered before the apiRouter middleware so it handles its own auth
+    // (dashboard token or API key) without the apiRouter's auth gate intercepting first.
+    // The ticket is one-time-use with a 30s TTL so neither the API key nor the
+    // dashboard token appears in WS URLs (server access logs / browser history).
+    // Accepts two credential types:
+    //   • X-Api-Key / Bearer — full API key (programmatic clients)
+    //   • X-Dash-Token       — dashboard session token (browser, 10 min, issued at /dashboard)
+    this.app.post('/api/v1/pty-stream-ticket', (req: Request, res: Response) => {
+      const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
+      const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
+      const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
+      const xDashToken = (req.headers['x-dash-token'] as string | undefined) ?? '';
+      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
+
+      // Validate: API key OR a live dashboard token.
+      const now = Date.now();
+      const dashExpiry = xDashToken ? (this.dashboardTokens.get(xDashToken) ?? 0) : 0;
+      const dashValid = dashExpiry > now;
+      if (dashValid) {
+        // Dashboard tokens are one-time-use: revoke immediately after auth so a
+        // leaked page source can't be replayed (each /dashboard visit gets a fresh one).
+        this.dashboardTokens.delete(xDashToken);
+      }
+      if (!dashValid && (!token || !apiKeys.some((k) => k.key === token))) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const agentId = (req.body as { agentId?: string })?.agentId ?? '';
+      if (!agentId || !this.agents.has(agentId)) {
+        res.status(404).json({ error: 'Agent not found' });
+        return;
+      }
+      const ticket = crypto.randomBytes(16).toString('hex');
+      const expiresAt = Date.now() + 30_000;
+      this.ptyStreamTickets.set(ticket, { agentId, expiresAt });
+      res.json({ ticket, expiresAt: new Date(expiresAt).toISOString() });
+    });
 
     // Mount API router after body parser so req.body is populated
     if (this.gatewayConfig?.gateway?.api?.keys?.length) {
@@ -318,7 +364,11 @@ export class GatewayRouter {
 
     // Web dashboard
     this.app.get('/dashboard', (_req: Request, res: Response) => {
-      const firstKey = (this.gatewayConfig?.gateway?.api?.keys ?? [])[0]?.key ?? '';
+      // Issue a short-lived dashboard token (10 min) instead of embedding the raw
+      // API key in the HTML. A view-source leak exposes only a token that can
+      // exclusively obtain PTY stream tickets — not make arbitrary API calls.
+      const dashToken = crypto.randomBytes(16).toString('hex');
+      this.dashboardTokens.set(dashToken, Date.now() + 10 * 60 * 1000);
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       if (process.env.DEV_MODE) {
         // Hot-reload: bust module cache so each browser refresh picks up the latest compiled web-ui.js
@@ -326,9 +376,9 @@ export class GatewayRouter {
         delete require.cache[webUiPath];
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { generateDashboardHtml: fresh } = require('../ui/web-ui') as typeof import('../ui/web-ui');
-        res.send(fresh(firstKey));
+        res.send(fresh(dashToken));
       } else {
-        res.send(generateDashboardHtml(firstKey));
+        res.send(generateDashboardHtml(dashToken));
       }
     });
 
@@ -343,7 +393,8 @@ export class GatewayRouter {
       exec(
         "ps -eo pid,ppid,stat,%cpu,%mem,rss,args --no-headers 2>/dev/null | grep -E 'claude|bun.*gateway|bun.*mcp|bun.*receiver|node.*dist/' | grep -v grep | grep -v vscode",
         { encoding: 'utf8', timeout: 5000 },
-        (_err, stdout) => {
+        (err, stdout) => {
+          if (err) process.stderr.write(`[processes] ps error: ${err.message}\n`);
           const processes = (stdout ?? '').trim().split('\n').filter(Boolean).map((line) => {
             const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(.+)$/);
             if (!m) return null;
@@ -361,29 +412,6 @@ export class GatewayRouter {
           res.json({ processes });
         },
       );
-    });
-
-    // Ephemeral WS ticket — exchange a short-lived token for PTY stream access.
-    // The ticket is one-time-use with a 30s TTL so the API key never appears in WS URLs
-    // (which would expose it in server access logs and browser history).
-    this.app.post('/api/v1/pty-stream-ticket', (req: Request, res: Response) => {
-      const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
-      const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
-      const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
-      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
-      if (!token || !apiKeys.some((k) => k.key === token)) {
-        res.status(401).json({ error: 'Unauthorized' });
-        return;
-      }
-      const agentId = (req.body as { agentId?: string })?.agentId ?? '';
-      if (!agentId || !this.agents.has(agentId)) {
-        res.status(404).json({ error: 'Agent not found' });
-        return;
-      }
-      const ticket = crypto.randomBytes(16).toString('hex');
-      const expiresAt = Date.now() + 30_000;
-      this.ptyStreamTickets.set(ticket, { agentId, expiresAt });
-      res.json({ ticket, expiresAt: new Date(expiresAt).toISOString() });
     });
 
     // Status endpoint — per-agent stats + heartbeat history
@@ -464,11 +492,14 @@ export class GatewayRouter {
       this.wss = new WebSocketServer({ noServer: true });
       const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
 
-      // Prune expired tickets every 60s.
+      // Prune expired tickets and dashboard tokens every 60s.
       this.ticketPruner = setInterval(() => {
         const now = Date.now();
         for (const [k, v] of this.ptyStreamTickets) {
           if (v.expiresAt < now) this.ptyStreamTickets.delete(k);
+        }
+        for (const [k, exp] of this.dashboardTokens) {
+          if (exp < now) this.dashboardTokens.delete(k);
         }
       }, 60_000);
       this.ticketPruner.unref();

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -311,20 +311,38 @@ export class GatewayRouter {
     this.app.get('/dashboard', (_req: Request, res: Response) => {
       const firstKey = (this.gatewayConfig?.gateway?.api?.keys ?? [])[0]?.key ?? '';
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      res.send(generateDashboardHtml(firstKey));
+      if (process.env.DEV_MODE) {
+        // Hot-reload: bust module cache so each browser refresh picks up the latest compiled web-ui.js
+        const webUiPath = require.resolve('../ui/web-ui');
+        delete require.cache[webUiPath];
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { generateDashboardHtml: fresh } = require('../ui/web-ui') as typeof import('../ui/web-ui');
+        res.send(fresh(firstKey));
+      } else {
+        res.send(generateDashboardHtml(firstKey));
+      }
     });
 
     // Process tree endpoint — returns raw ps data for dashboard
     this.app.get('/processes', (_req: Request, res: Response) => {
       try {
         const out = execSync(
-          "ps -eo pid,ppid,stat,args --no-headers 2>/dev/null | grep -E 'claude|bun.*gateway|bun.*mcp|bun.*receiver|node.*dist/' | grep -v grep | grep -v vscode",
+          "ps -eo pid,ppid,stat,%cpu,%mem,rss,args --no-headers 2>/dev/null | grep -E 'claude|bun.*gateway|bun.*mcp|bun.*receiver|node.*dist/' | grep -v grep | grep -v vscode",
           { encoding: 'utf8', timeout: 5000 }
         );
         const processes = out.trim().split('\n').filter(Boolean).map((line) => {
-          const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+          // pid ppid stat %cpu %mem rss args...
+          const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(.+)$/);
           if (!m) return null;
-          return { pid: parseInt(m[1]), ppid: parseInt(m[2]), stat: m[3], args: m[4].trim() };
+          return {
+            pid: parseInt(m[1]),
+            ppid: parseInt(m[2]),
+            stat: m[3],
+            cpu: parseFloat(m[4]),
+            mem: parseFloat(m[5]),
+            rssKb: parseInt(m[6]),
+            args: m[7].trim(),
+          };
         }).filter(Boolean);
         res.json({ processes });
       } catch {

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -1,8 +1,10 @@
 import express, { Request, Response } from 'express';
 import * as http from 'node:http';
 import { Server } from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
 import { AgentRunner } from '../agent/runner';
 import { AgentConfig, AgentStats, ApiKey, GatewayConfig, HeartbeatResult } from '../types';
+import { ptyStreamRegistry } from '../shell/pty-stream-registry';
 import { CronScheduler } from '../cron/scheduler';
 import { CronManager } from '../cron/manager';
 import { generateDashboardHtml } from '../ui/web-ui';
@@ -364,6 +366,28 @@ export class GatewayRouter {
         } else {
           reject(err);
         }
+      });
+
+      const wss = new WebSocketServer({ noServer: true });
+
+      this.server.on('upgrade', (req: http.IncomingMessage, socket, head) => {
+        const url = req.url ?? '';
+        const match = url.match(/^\/api\/v1\/agents\/([^/?]+)\/pty-stream(?:\?.*)?$/);
+        if (!match) {
+          socket.destroy();
+          return;
+        }
+        const agentId = decodeURIComponent(match[1]!);
+        if (!this.agents.has(agentId)) {
+          socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+        wss.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+          ptyStreamRegistry.subscribe(agentId, ws);
+          ws.on('close', () => ptyStreamRegistry.unsubscribe(agentId, ws));
+          ws.on('error', () => ptyStreamRegistry.unsubscribe(agentId, ws));
+        });
       });
     });
   }

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express';
 import * as http from 'node:http';
-import { execSync } from 'child_process';
+import { exec } from 'child_process';
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Server } from 'http';
@@ -99,6 +100,14 @@ export class GatewayRouter {
   private readonly app: express.Application;
   private server: Server | null = null;
   private wss: WebSocketServer | null = null;
+
+  /** Cached /processes result (3s TTL, avoids blocking execSync on every poll). */
+  private processesCache: { data: unknown[]; ts: number } | null = null;
+  private static readonly PROCESSES_CACHE_TTL_MS = 3_000;
+
+  /** Short-lived WS auth tickets: ticket → { agentId, expiresAt }. One-time use. */
+  private readonly ptyStreamTickets = new Map<string, { agentId: string; expiresAt: number }>();
+  private ticketPruner: ReturnType<typeof setInterval> | null = null;
 
   /** Per-agent message counters (output lines from subprocess) */
   private readonly messagesReceived: Map<string, number> = new Map();
@@ -323,31 +332,58 @@ export class GatewayRouter {
       }
     });
 
-    // Process tree endpoint — returns raw ps data for dashboard
+    // Process tree endpoint — returns raw ps data for dashboard.
+    // Async exec + 3s cache: avoids blocking the event loop on every dashboard poll.
     this.app.get('/processes', (_req: Request, res: Response) => {
-      try {
-        const out = execSync(
-          "ps -eo pid,ppid,stat,%cpu,%mem,rss,args --no-headers 2>/dev/null | grep -E 'claude|bun.*gateway|bun.*mcp|bun.*receiver|node.*dist/' | grep -v grep | grep -v vscode",
-          { encoding: 'utf8', timeout: 5000 }
-        );
-        const processes = out.trim().split('\n').filter(Boolean).map((line) => {
-          // pid ppid stat %cpu %mem rss args...
-          const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(.+)$/);
-          if (!m) return null;
-          return {
-            pid: parseInt(m[1]),
-            ppid: parseInt(m[2]),
-            stat: m[3],
-            cpu: parseFloat(m[4]),
-            mem: parseFloat(m[5]),
-            rssKb: parseInt(m[6]),
-            args: m[7].trim(),
-          };
-        }).filter(Boolean);
-        res.json({ processes });
-      } catch {
-        res.json({ processes: [] });
+      const now = Date.now();
+      if (this.processesCache && now - this.processesCache.ts < GatewayRouter.PROCESSES_CACHE_TTL_MS) {
+        res.json({ processes: this.processesCache.data });
+        return;
       }
+      exec(
+        "ps -eo pid,ppid,stat,%cpu,%mem,rss,args --no-headers 2>/dev/null | grep -E 'claude|bun.*gateway|bun.*mcp|bun.*receiver|node.*dist/' | grep -v grep | grep -v vscode",
+        { encoding: 'utf8', timeout: 5000 },
+        (_err, stdout) => {
+          const processes = (stdout ?? '').trim().split('\n').filter(Boolean).map((line) => {
+            const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(.+)$/);
+            if (!m) return null;
+            return {
+              pid: parseInt(m[1]),
+              ppid: parseInt(m[2]),
+              stat: m[3],
+              cpu: parseFloat(m[4]),
+              mem: parseFloat(m[5]),
+              rssKb: parseInt(m[6]),
+              args: m[7].trim(),
+            };
+          }).filter(Boolean);
+          this.processesCache = { data: processes, ts: Date.now() };
+          res.json({ processes });
+        },
+      );
+    });
+
+    // Ephemeral WS ticket — exchange a short-lived token for PTY stream access.
+    // The ticket is one-time-use with a 30s TTL so the API key never appears in WS URLs
+    // (which would expose it in server access logs and browser history).
+    this.app.post('/api/v1/pty-stream-ticket', (req: Request, res: Response) => {
+      const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
+      const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
+      const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
+      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
+      if (!token || !apiKeys.some((k) => k.key === token)) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const agentId = (req.body as { agentId?: string })?.agentId ?? '';
+      if (!agentId || !this.agents.has(agentId)) {
+        res.status(404).json({ error: 'Agent not found' });
+        return;
+      }
+      const ticket = crypto.randomBytes(16).toString('hex');
+      const expiresAt = Date.now() + 30_000;
+      this.ptyStreamTickets.set(ticket, { agentId, expiresAt });
+      res.json({ ticket, expiresAt: new Date(expiresAt).toISOString() });
     });
 
     // Status endpoint — per-agent stats + heartbeat history
@@ -428,6 +464,15 @@ export class GatewayRouter {
       this.wss = new WebSocketServer({ noServer: true });
       const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
 
+      // Prune expired tickets every 60s.
+      this.ticketPruner = setInterval(() => {
+        const now = Date.now();
+        for (const [k, v] of this.ptyStreamTickets) {
+          if (v.expiresAt < now) this.ptyStreamTickets.delete(k);
+        }
+      }, 60_000);
+      this.ticketPruner.unref();
+
       this.server.on('upgrade', (req: http.IncomingMessage, socket, head) => {
         const url = req.url ?? '';
         const match = url.match(/\/api\/v1\/agents\/([^/?]+)\/pty-stream(?:\?.*)?$/);
@@ -436,13 +481,44 @@ export class GatewayRouter {
           return;
         }
 
-        // Auth: Bearer token, X-Api-Key header, or ?key= query param (for browser WS)
+        const params = new URL(url, 'http://localhost').searchParams;
+
+        // Auth path 1: ephemeral ticket (?ticket=<hex>) — one-time-use, 30s TTL.
+        // The dashboard obtains a ticket via POST /api/v1/pty-stream-ticket before
+        // opening the WebSocket so the API key never appears in the WS URL.
+        const ticketParam = params.get('ticket') ?? '';
+        if (ticketParam) {
+          const entry = this.ptyStreamTickets.get(ticketParam);
+          if (!entry || entry.expiresAt < Date.now()) {
+            socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+            socket.destroy();
+            return;
+          }
+          this.ptyStreamTickets.delete(ticketParam); // one-time use
+          const agentId = entry.agentId;
+          if (!this.agents.has(agentId)) {
+            socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+            socket.destroy();
+            return;
+          }
+          this.wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+            if (!ptyStreamRegistry.hasSockets(agentId)) {
+              ws.close(4404, 'agent not running in PTY mode');
+              return;
+            }
+            ptyStreamRegistry.subscribe(agentId, ws);
+            ws.on('close', () => ptyStreamRegistry.unsubscribe(agentId, ws));
+            ws.on('error', () => ptyStreamRegistry.unsubscribe(agentId, ws));
+          });
+          return;
+        }
+
+        // Auth path 2: Bearer token or X-Api-Key header (for non-browser clients).
         const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
         const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
-        const queryKey = new URL(url, 'http://localhost').searchParams.get('key') ?? '';
         const token = authHeader.startsWith('Bearer ')
           ? authHeader.slice(7).trim()
-          : xApiKey.trim() || queryKey.trim();
+          : xApiKey.trim();
         if (!token || !apiKeys.some((k) => k.key === token)) {
           socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
           socket.destroy();
@@ -457,7 +533,6 @@ export class GatewayRouter {
         }
 
         this.wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-          // If agent is not in PTY mode, no data will arrive — tell the client immediately
           if (!ptyStreamRegistry.hasSockets(agentId)) {
             ws.close(4404, 'agent not running in PTY mode');
             return;
@@ -505,6 +580,7 @@ export class GatewayRouter {
   }
 
   async stop(): Promise<void> {
+    if (this.ticketPruner) clearInterval(this.ticketPruner);
     this.wss?.close();
     return new Promise((resolve, reject) => {
       if (!this.server) {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -7,6 +7,7 @@ import chokidar from 'chokidar';
 import { AgentConfig, GatewayConfig } from '../types';
 import { SessionStore } from './store';
 import { createLogger } from '../logger';
+import { ptyStreamRegistry } from '../shell/pty-stream-registry';
 import {
   CODING_TOOLS,
   TOOL_LABELS,
@@ -419,6 +420,12 @@ export class SessionProcess extends EventEmitter {
         ]
       : allArgs;
 
+    let ptyStreamSocketPath: string | null = null;
+    if (usePtyShell) {
+      ptyStreamSocketPath = ptyStreamRegistry.socketPath(this.agentConfig.id, this.sessionId);
+      ptyStreamRegistry.listen(this.agentConfig.id, ptyStreamSocketPath);
+    }
+
     const proc = spawn(spawnBin, spawnArgs, {
       env: {
         ...process.env,
@@ -427,6 +434,7 @@ export class SessionProcess extends EventEmitter {
         GATEWAY_RESTART_SIGNAL_PATH: this.restartSignalPath,
         ...(ptyRealBin ? { CLAUDE_REAL_BIN: ptyRealBin } : {}),
         ...(ptyHeartbeatPath ? { PTY_SHELL_HEARTBEAT_PATH: ptyHeartbeatPath } : {}),
+        ...(ptyStreamSocketPath ? { PTY_SHELL_STREAM_SOCKET: ptyStreamSocketPath } : {}),
       },
       cwd: this.agentConfig.workspace,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -624,6 +632,7 @@ export class SessionProcess extends EventEmitter {
         signal,
         sessionId: this.sessionId,
       });
+      if (ptyStreamSocketPath) ptyStreamRegistry.close(ptyStreamSocketPath);
       this.process = null;
       if (!this.stopping) this.scheduleRestart();
     });

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -440,8 +440,10 @@ export class SessionProcess extends EventEmitter {
 
     let ptyStreamSocketPath: string | null = null;
     if (usePtyShell) {
-      ptyStreamSocketPath = ptyStreamRegistry.socketPath(this.agentConfig.id, this.sessionId);
-      ptyStreamRegistry.listen(this.agentConfig.id, ptyStreamSocketPath);
+      // Key the stream by sessionId, not agentId: one agent may run several
+      // concurrent sessions, each needing its own isolated PTY mirror.
+      ptyStreamSocketPath = ptyStreamRegistry.socketPath(this.sessionId);
+      ptyStreamRegistry.listen(this.sessionId, ptyStreamSocketPath);
     }
 
     const proc = spawn(spawnBin, spawnArgs, {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -49,6 +49,10 @@ export class SessionProcess extends EventEmitter {
   private readonly configPath: string;
   private readonly restartSignalPath: string;
   queryMode = false;
+  // Latest context-window token usage (input context + output) for the most
+  // recent turn. Surfaced read-only for the status dashboard. Best-effort —
+  // reset to 0 until the first tokenUsage event fires.
+  private lastTotalTokens = 0;
   private thinkingRecoveryCount = 0;
   private _queryResolve?: (text: string) => void;
   private _queryBuffer = '';
@@ -101,6 +105,11 @@ export class SessionProcess extends EventEmitter {
   /** Public accessor for the model this session currently resolves to (for status/UI). */
   get model(): string {
     return this.readFreshModel();
+  }
+
+  /** Latest context-window token usage for this session (for status/UI). */
+  get totalTokens(): number {
+    return this.lastTotalTokens;
   }
 
   private readFreshModel(): string {
@@ -620,6 +629,7 @@ export class SessionProcess extends EventEmitter {
               const outputTokens = usage?.output_tokens ?? 0;
               const totalTokens = lastMessageStartContext + outputTokens;
               if (lastMessageStartContext > 0) {
+                this.lastTotalTokens = totalTokens;
                 this.emit('tokenUsage', { inputTokens: lastMessageStartContext, outputTokens, totalTokens });
               }
               lastMessageStartContext = 0;

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -30,6 +30,7 @@ export class SessionProcess extends EventEmitter {
   readonly source: 'telegram' | 'discord' | 'api';
   private readonly sessionChannel: 'telegram' | 'discord';
   lastActivityAt = Date.now(); // accessible by AgentRunner for eviction sort
+  readonly spawnedAt = Date.now();
   modelOverride?: string; // per-session model override (set by runner from SessionMeta)
   spawnContext: { loadedAtSpawn: number; archivedCount: number; messageCountAtSpawn: number } | null = null;
   private process: ChildProcess | null = null;

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -98,6 +98,11 @@ export class SessionProcess extends EventEmitter {
       : this.sessionStore.appendMessage(this.agentConfig.id, this.sessionId, msg);
   }
 
+  /** Public accessor for the model this session currently resolves to (for status/UI). */
+  get model(): string {
+    return this.readFreshModel();
+  }
+
   private readFreshModel(): string {
     // Per-session model override takes priority
     if (this.modelOverride) return this.modelOverride;

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -31,6 +31,8 @@ export class SessionProcess extends EventEmitter {
   private readonly sessionChannel: 'telegram' | 'discord';
   lastActivityAt = Date.now(); // accessible by AgentRunner for eviction sort
   readonly spawnedAt = Date.now();
+  /** Backend used to run the subprocess. Set during start(); 'headless' until then. */
+  backend: 'pty-shell' | 'headless' = 'headless';
   modelOverride?: string; // per-session model override (set by runner from SessionMeta)
   spawnContext: { loadedAtSpawn: number; archivedCount: number; messageCountAtSpawn: number } | null = null;
   private process: ChildProcess | null = null;
@@ -371,6 +373,7 @@ export class SessionProcess extends EventEmitter {
     // App-agents always stay headless: the wrapper (node-pty) lives on the
     // host and cannot wrap a binary inside a docker-exec container.
     const usePtyShell = this.gatewayConfig.gateway.headless === false && !isAppAgent;
+    this.backend = usePtyShell ? 'pty-shell' : 'headless';
     let ptyRealBin: string | null = null;
     // Pre-calculate heartbeat path so we can pass it to the PTY shell before spawn.
     // API sessions are excluded: the stalled detector is receiver-side (Telegram/Discord)

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -19,6 +19,7 @@ import { PtyHost } from './pty-host';
 import { TranscriptTailer, AssistantRecord, UsageInfo } from './tailer';
 import { ProtocolEmitter } from './emitter';
 import { preTrustWorkspace, checkAuthStatus } from './trust';
+import { decideMenuCancel } from './menu-cancel';
 
 const POLL_MS = 200;
 const STARTUP_QUIET_MS = 600;
@@ -88,6 +89,16 @@ class Driver {
   // Set when an interactive menu has been bridged to chat and we're awaiting the
   // user's choice. While set, the next stdin message is treated as a selection.
   private pendingMenu: { options: MenuOption[] } | null = null;
+  // Set after ESC-cancelling a bridged menu in response to a free-text reply.
+  // The queued text is held until the TUI settles back to an idle prompt (driven
+  // by tick()), so the paste doesn't race Claude's cancellation redraw.
+  private menuCancel: { since: number; lastEscAt: number; escs: number } | null = null;
+  // Set after a /stop (SIGINT → ESC) interrupted the active turn. An interrupted
+  // turn writes no turn_duration record, so tick() ends it once the TUI is back to
+  // an idle prompt — otherwise a message queued right after /stop would hang behind
+  // a turn that never ends (until the watchdog). Reuses the menu-cancel settle
+  // decision (menuVisible is always false here, so it never re-sends ESC).
+  private interrupting: { since: number; lastEscAt: number; escs: number } | null = null;
   private lastDialogActionAt = 0;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   private host!: PtyHost;
@@ -219,6 +230,13 @@ class Driver {
       if (this.turn) {
         logWarn('SIGINT → sending ESC to interrupt current turn');
         this.host.writeRaw('\x1b');
+        // Arm interrupt-settle so tick() ends the (now interrupted) turn once the
+        // TUI returns to an idle prompt, then drains anything queued after /stop.
+        // No-op if already armed (repeated SIGINTs during the same interrupt).
+        if (!this.interrupting) {
+          const t = Date.now();
+          this.interrupting = { since: t, lastEscAt: t, escs: 1 };
+        }
       }
     });
     process.on('SIGTERM', () => {
@@ -252,6 +270,10 @@ class Driver {
     const turn = this.turn;
     if (!turn) return;
     this.turn = null;
+    // Clear any armed interrupt-settle — the turn is ending now regardless of how
+    // (interrupt path, normal turn_duration, or error), so a stale flag must not
+    // linger and block the next trySubmit().
+    this.interrupting = null;
     this.tailer.flush(); // drain any records written in the last poll window
     const text = turn.texts.join('');
     this.emitter.emitResult({
@@ -268,7 +290,10 @@ class Driver {
   // ---- turn submission -----------------------------------------------------
 
   private trySubmit(): void {
-    if (!this.ready || this.turn || this.queue.length === 0 || this.exiting) return;
+    // While menuCancel is armed, submission is deferred to tick() until the TUI
+    // settles after an ESC menu-cancel — don't let an event-driven trySubmit
+    // (e.g. a second incoming message) paste into the cancellation transition.
+    if (!this.ready || this.turn || this.queue.length === 0 || this.exiting || this.menuCancel || this.interrupting) return;
     const text = this.queue.shift() as string;
     this.beginTurn();
     void this.typeAndSubmit(text);
@@ -337,6 +362,56 @@ class Driver {
       if (now - this.startedAt > STARTUP_TIMEOUT_MS) {
         logError(`claude TUI did not become ready within startup timeout; screen:\n${this.screen.text()}`);
         this.shutdown(1);
+      }
+      return;
+    }
+
+    // Waiting for the TUI to settle after ESC-cancelling a bridged menu (the user
+    // typed a free-text reply instead of a number). Submit the queued prompt only
+    // once the menu is gone and the prompt is idle — otherwise the paste races
+    // Claude's cancellation redraw and never lands (→ watchdog hang).
+    if (this.menuCancel) {
+      const action = decideMenuCancel(this.menuCancel, {
+        now,
+        menuVisible: this.screen.detectMenu() !== null,
+        hasPrompt: this.screen.hasPrompt(),
+        isBusy: this.screen.isBusy(),
+        quietMs: this.screen.quietMs(),
+      });
+      if (action === 'submit') {
+        logDebug('menu cancelled and TUI settled — submitting queued prompt');
+        this.menuCancel = null;
+        this.trySubmit();
+      } else if (action === 'resend-esc') {
+        this.menuCancel.escs++;
+        this.menuCancel.lastEscAt = now;
+        logWarn(`menu still on screen after cancel — re-sending ESC (${this.menuCancel.escs}/3)`);
+        this.host.writeRaw('\x1b');
+      }
+      return;
+    }
+
+    // Settling after a /stop interrupt (SIGINT → ESC). The interrupted turn is
+    // still active (Claude writes no turn_duration for an interrupted turn), so
+    // end it as soon as the TUI is back to a quiet idle prompt — finishTurn()
+    // emits the result (clearing the gateway's in-flight state) and trySubmit()
+    // drains anything the user queued after /stop. Without this, a turn interrupted
+    // before any assistant output never meets the fallback below and the next
+    // message hangs behind it until the watchdog. menuVisible is false here, so the
+    // shared decision never returns 'resend-esc' — only 'wait' or (settle/timeout)
+    // 'submit'.
+    if (this.interrupting) {
+      const action = decideMenuCancel(this.interrupting, {
+        now,
+        menuVisible: false,
+        hasPrompt: this.screen.hasPrompt(),
+        isBusy: this.screen.isBusy(),
+        quietMs: this.screen.quietMs(),
+      });
+      if (action === 'submit') {
+        logDebug('interrupt settled — ending interrupted turn');
+        this.interrupting = null;
+        this.finishTurn(false);
       }
       return;
     }
@@ -457,11 +532,18 @@ class Driver {
       // Not a valid choice — cancel the menu and treat the text as a new prompt
       // so the user can break out by typing an instruction instead of a number.
       // Re-queue the ORIGINAL envelope so Claude still sees the full channel context.
+      //
+      // ESC makes Claude resume (it processes the menu cancellation), so the TUI
+      // is briefly busy/redrawing. Submitting the text immediately races that
+      // transition and the prompt never lands → 30-min watchdog hang. Instead we
+      // arm menuCancel and let tick() submit once the TUI is back to an idle
+      // prompt. trySubmit() is gated on !menuCancel so nothing fires early.
       logWarn(`menu reply "${choiceText.slice(0, 40)}" is not a valid choice — cancelling menu`);
       this.host.writeRaw('\x1b');
       this.pendingMenu = null;
       this.queue.push(text);
-      this.trySubmit();
+      const now = Date.now();
+      this.menuCancel = { since: now, lastEscAt: now, escs: 1 };
       return;
     }
     logDebug(`menu selection: ${n}`);

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -121,7 +121,7 @@ class Driver {
       onData: (d) => {
         this.screen.write(d);
         if (this.streamSocket?.writable) {
-          try { this.streamSocket.write(d); } catch { /* socket closed */ }
+          try { this.streamSocket.write(d, 'latin1'); } catch { /* socket closed */ }
         }
       },
       onExit: (code) => this.onChildExit(code),

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -121,7 +121,13 @@ class Driver {
       onData: (d) => {
         this.screen.write(d);
         if (this.streamSocket?.writable) {
-          try { this.streamSocket.write(d, 'latin1'); } catch { /* socket closed */ }
+          // node-pty emits UTF-8-decoded strings, so re-encode as UTF-8 to keep
+          // multi-byte glyphs (box-drawing ─│╭╮, the braille spinner, emoji)
+          // intact. Writing as latin1 would truncate every code point > 0xFF to
+          // a single byte — those land in the 0x00-0x1F control range and
+          // scramble the viewer's cursor positioning. The client decodes the
+          // stream with TextDecoder('utf-8'), so this is the matching encoding.
+          try { this.streamSocket.write(d, 'utf8'); } catch { /* socket closed */ }
         }
       },
       onExit: (code) => this.onChildExit(code),

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -14,7 +14,7 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as readline from 'readline';
 import { translateArgs, sanitizeUserText } from './args';
-import { ScreenModel } from './screen';
+import { ScreenModel, MenuOption, parseMenuChoice, formatMenuPrompt, extractChannelContent } from './screen';
 import { PtyHost } from './pty-host';
 import { TranscriptTailer, AssistantRecord, UsageInfo } from './tailer';
 import { ProtocolEmitter } from './emitter';
@@ -30,6 +30,15 @@ const SUBMIT_RETRY_AFTER_MS = 4000;
 const MAX_ENTER_RETRIES = 2;
 const FALLBACK_IDLE_QUIET_MS = 2000;
 const DIALOG_ACTION_COOLDOWN_MS = 2000;
+// An interactive select menu must be stable (no PTY output) this long before we
+// bridge it to chat — avoids racing a menu that's still rendering.
+const MENU_STABLE_QUIET_MS = 700;
+// After injecting the digit for a menu choice, wait this long, then send Enter
+// only if the menu is still on screen (some TUIs confirm on the digit alone).
+const MENU_SELECT_ENTER_DELAY_MS = 250;
+// Set PTY_SHELL_SKIP_MENU_BRIDGE=1 to disable bridging interactive menus to chat
+// (falls back to leaving the menu on the PTY — use if a TUI update breaks the matcher).
+const SKIP_MENU_BRIDGE = process.env.PTY_SHELL_SKIP_MENU_BRIDGE === '1';
 const STARTUP_TIMEOUT_MS = 120_000;
 const WATCHDOG_MS = process.env.PTY_SHELL_WATCHDOG_MS
   ? Number(process.env.PTY_SHELL_WATCHDOG_MS) || (30 * 60 * 1000)
@@ -76,6 +85,9 @@ class Driver {
   private startedAt = Date.now();
   private queue: string[] = [];
   private turn: ActiveTurn | null = null;
+  // Set when an interactive menu has been bridged to chat and we're awaiting the
+  // user's choice. While set, the next stdin message is treated as a selection.
+  private pendingMenu: { options: MenuOption[] } | null = null;
   private lastDialogActionAt = 0;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   private host!: PtyHost;
@@ -181,6 +193,12 @@ class Driver {
         });
         return;
       }
+      // A menu is awaiting a choice — interpret this message as the selection
+      // (a typed number or a button tap, which both arrive as plain text).
+      if (this.pendingMenu) {
+        this.handleMenuReply(sanitized);
+        return;
+      }
       this.queue.push(sanitized);
       this.trySubmit();
     });
@@ -248,6 +266,12 @@ class Driver {
   private trySubmit(): void {
     if (!this.ready || this.turn || this.queue.length === 0 || this.exiting) return;
     const text = this.queue.shift() as string;
+    this.beginTurn();
+    void this.typeAndSubmit(text);
+  }
+
+  /** Initialize a fresh active turn (shared by normal submit and menu selection). */
+  private beginTurn(): void {
     const now = Date.now();
     this.turn = {
       startedAt: now,
@@ -261,7 +285,6 @@ class Driver {
       dialogEscapes: 0,
       recordsAtStart: this.tailer.seenRecords,
     };
-    void this.typeAndSubmit(text);
   }
 
   private async typeAndSubmit(text: string): Promise<void> {
@@ -330,9 +353,13 @@ class Driver {
       return;
     }
 
-    // Not busy. Possible: still rendering, swallowed Enter, dialog, or done
+    // Not busy. Possible: still rendering, swallowed Enter, dialog, menu, or done
     // (turn_duration normally ends the turn before we get here).
     this.maybeHandleDialog();
+
+    // Blocked on an interactive select menu → bridge it to chat and end the turn
+    // so the session goes idle (no watchdog kill) until the user picks an option.
+    if (this.maybeBridgeMenu(turn)) return;
 
     if (!turn.sawBusy
         && now - turn.submittedAt > SUBMIT_RETRY_AFTER_MS
@@ -383,6 +410,72 @@ class Driver {
       logWarn('accepting Bypass Permissions dialog (per built-in --dangerously-skip-permissions)');
       this.host.writeRaw('2');
     }
+  }
+
+  // ---- interactive menu bridging ------------------------------------------
+
+  /**
+   * If the TUI is blocked on an interactive select menu, emit it to the gateway
+   * (rendered as chat buttons / numbered text) and end the turn so the session
+   * goes idle while we await the user's choice. Returns true if it bridged.
+   *
+   * Never auto-selects — a destructive option must be a human decision. The
+   * bypass-permissions dialog also shows the menu footer, so it's excluded here
+   * and left to maybeHandleDialog()'s auto-accept.
+   */
+  private maybeBridgeMenu(turn: ActiveTurn): boolean {
+    if (SKIP_MENU_BRIDGE || this.pendingMenu) return false;
+    if (this.screen.quietMs() < MENU_STABLE_QUIET_MS) return false;
+    if (this.screen.detectDialog() === 'bypass-permissions') return false;
+    const options = this.screen.detectMenu();
+    if (!options) return false;
+
+    const prompt = formatMenuPrompt(options);
+    logWarn(`interactive menu detected (${options.length} options) — bridging to chat`);
+    this.emitter.emitMenuPrompt({ sessionId: this.args.sessionId, prompt, options });
+    // Carry the numbered list as the turn's result text too: this is the API
+    // fallback (no buttons) and what gets persisted to chat history.
+    turn.texts.push((turn.texts.length ? '\n\n' : '') + prompt);
+    this.pendingMenu = { options };
+    this.finishTurn(false);
+    return true;
+  }
+
+  /** Route a user's menu reply (typed number or button tap) to a selection. */
+  private handleMenuReply(text: string): void {
+    const menu = this.pendingMenu;
+    if (!menu) return;
+    // Channel turns arrive wrapped in a <channel …>…</channel> envelope, so the
+    // bare "1" is buried inside it — unwrap before parsing the selection.
+    const choiceText = extractChannelContent(text);
+    const n = parseMenuChoice(choiceText, menu.options.length);
+    if (n === null) {
+      // Not a valid choice — cancel the menu and treat the text as a new prompt
+      // so the user can break out by typing an instruction instead of a number.
+      // Re-queue the ORIGINAL envelope so Claude still sees the full channel context.
+      logWarn(`menu reply "${choiceText.slice(0, 40)}" is not a valid choice — cancelling menu`);
+      this.host.writeRaw('\x1b');
+      this.pendingMenu = null;
+      this.queue.push(text);
+      this.trySubmit();
+      return;
+    }
+    logDebug(`menu selection: ${n}`);
+    this.pendingMenu = null;
+    this.beginTurn();
+    void this.selectMenuOption(n);
+  }
+
+  /**
+   * Inject the keystrokes that select option `n`. Sends the digit, then Enter
+   * only if the menu is still on screen — self-correcting whether the TUI
+   * confirms on the digit alone or requires Enter.
+   */
+  private async selectMenuOption(n: number): Promise<void> {
+    this.host.writeRaw(String(n));
+    await new Promise((r) => setTimeout(r, MENU_SELECT_ENTER_DELAY_MS));
+    if (this.screen.detectMenu()) this.host.writeRaw('\r');
+    if (this.turn) this.turn.submittedAt = Date.now();
   }
 
   // ---- lifecycle ------------------------------------------------------------

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -122,7 +122,11 @@ class Driver {
     const streamSocketPath = process.env.PTY_SHELL_STREAM_SOCKET;
     if (streamSocketPath) {
       const sock = net.createConnection(streamSocketPath);
-      sock.on('error', () => { /* registry may not be listening yet or already closed */ });
+      sock.on('error', (err) => {
+        // Non-fatal: the registry socket may not be ready yet or was already closed.
+        // Log so timing issues are diagnosable without a restart.
+        logWarn(`stream socket error (${streamSocketPath}): ${err.message}`);
+      });
       this.streamSocket = sock;
     }
 

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -11,6 +11,7 @@
  * the PTY screen is used only for busy/idle/dialog liveness signals.
  */
 import * as fs from 'fs';
+import * as net from 'net';
 import * as readline from 'readline';
 import { translateArgs, sanitizeUserText } from './args';
 import { ScreenModel } from './screen';
@@ -79,6 +80,7 @@ class Driver {
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   private host!: PtyHost;
   private tailer!: TranscriptTailer;
+  private streamSocket: net.Socket | null = null;
 
   private readonly screen = new ScreenModel();
   private readonly emitter = new ProtocolEmitter();
@@ -105,11 +107,23 @@ class Driver {
     const [realBin, ...realBinArgs] = this.realBinParts;
     logDebug(`session=${this.args.sessionId} bin=${this.realBinParts.join(' ')} args=${this.args.claudeArgs.join(' ')}`);
 
+    const streamSocketPath = process.env.PTY_SHELL_STREAM_SOCKET;
+    if (streamSocketPath) {
+      const sock = net.createConnection(streamSocketPath);
+      sock.on('error', () => { /* registry may not be listening yet or already closed */ });
+      this.streamSocket = sock;
+    }
+
     this.host = new PtyHost(realBin, [...realBinArgs, ...this.args.claudeArgs], {
       cols: this.screen.cols,
       rows: this.screen.rows,
       cwd: process.cwd(),
-      onData: (d) => this.screen.write(d),
+      onData: (d) => {
+        this.screen.write(d);
+        if (this.streamSocket?.writable) {
+          try { this.streamSocket.write(d); } catch { /* socket closed */ }
+        }
+      },
       onExit: (code) => this.onChildExit(code),
     });
 
@@ -384,6 +398,7 @@ class Driver {
     this.exiting = true;
     if (this.tickTimer) clearInterval(this.tickTimer);
     this.tailer.stop();
+    if (this.streamSocket) { try { this.streamSocket.destroy(); } catch { /* ignore */ } }
     this.host.kill();
     // PtyHost.onExit will exit(child code); this is the safety net.
     setTimeout(() => process.exit(code), 1500).unref();

--- a/src/shell/emitter.ts
+++ b/src/shell/emitter.ts
@@ -1,4 +1,5 @@
 import type { AssistantRecord, UsageInfo } from './tailer';
+import type { MenuOption } from './screen';
 
 /**
  * Synthesizes the stream-json events the gateway's SessionProcess stdout
@@ -71,6 +72,23 @@ export class ProtocolEmitter {
       .filter((b) => b.type === 'text')
       .map((b) => String((b as { text?: unknown }).text ?? ''))
       .join('');
+  }
+
+  /**
+   * Signal that the TUI is blocked on an interactive select menu. The gateway
+   * (runner.ts) renders this as channel-native UI — inline buttons on
+   * Telegram/Discord — while the turn's result text carries the same numbered
+   * list as a fallback (and for API, which has no buttons). callback_data /
+   * custom_id only ever carry the 1-based choice index.
+   */
+  emitMenuPrompt(opts: { sessionId: string; prompt: string; options: MenuOption[] }): void {
+    this.writeLine({
+      type: 'system',
+      subtype: 'menu_prompt',
+      session_id: opts.sessionId,
+      prompt: opts.prompt,
+      options: opts.options,
+    });
   }
 
   emitResult(opts: {

--- a/src/shell/menu-cancel.ts
+++ b/src/shell/menu-cancel.ts
@@ -1,0 +1,85 @@
+/**
+ * Decision logic for submitting a queued prompt after ESC-cancelling a bridged
+ * interactive menu.
+ *
+ * When the user replies to a bridged menu with free text instead of a number,
+ * the wrapper sends ESC to dismiss the menu and then wants to submit the text as
+ * a fresh prompt. But ESC makes Claude resume (it processes the cancellation),
+ * so the TUI is briefly busy/redrawing. Submitting into that transition races —
+ * the paste lands in a non-prompt state, the Enter is swallowed, and the turn
+ * never starts (→ 30-min watchdog hang). So submission is deferred until the TUI
+ * settles back to an idle prompt.
+ *
+ * This module is the pure decision: given the current observations, return the
+ * action the caller should take. Kept free of node-pty / screen imports so it is
+ * cheap to unit-test in isolation.
+ */
+
+// Minimum delay after the ESC before we allow a submit. Gives Claude time to
+// start any cancellation response so `isBusy` can catch it (and block us).
+export const MENU_CANCEL_MIN_WAIT_MS = 800;
+// The PTY must be quiet at least this long, once back at an idle prompt.
+export const MENU_CANCEL_SETTLE_QUIET_MS = 600;
+// If the menu lingers (ESC swallowed), re-send ESC no more often than this.
+export const MENU_CANCEL_ESC_RETRY_MS = 1500;
+// Cap on ESC re-sends before we stop retrying.
+export const MENU_CANCEL_MAX_ESC = 3;
+// Hard fallback: submit anyway after this long so a stuck TUI never hangs.
+export const MENU_CANCEL_TIMEOUT_MS = 15_000;
+
+export type MenuCancelAction = 'wait' | 'resend-esc' | 'submit';
+
+export interface MenuCancelState {
+  /** Timestamp (ms) of the first ESC that started this cancel. */
+  since: number;
+  /** Timestamp (ms) of the most recent ESC sent. */
+  lastEscAt: number;
+  /** How many ESCs have been sent so far (starts at 1). */
+  escs: number;
+}
+
+export interface MenuCancelObs {
+  now: number;
+  /** Is an interactive select menu still on screen? */
+  menuVisible: boolean;
+  /** Is the normal input prompt box present? */
+  hasPrompt: boolean;
+  /** Is the TUI busy (spinner / processing)? */
+  isBusy: boolean;
+  /** Milliseconds since the last PTY output. */
+  quietMs: number;
+}
+
+/**
+ * Decide what to do while waiting for the TUI to settle after a menu-cancel.
+ *
+ * - `submit`    — the queued prompt is safe to type now (or the hard timeout hit).
+ * - `resend-esc` — the menu is still up; ESC was likely swallowed, send it again.
+ * - `wait`      — keep waiting; nothing to do this tick.
+ */
+export function decideMenuCancel(state: MenuCancelState, obs: MenuCancelObs): MenuCancelAction {
+  const { since, lastEscAt, escs } = state;
+  const { now, menuVisible, hasPrompt, isBusy, quietMs } = obs;
+
+  // Hard timeout: never hang — submit regardless of screen state. The turn's
+  // own Enter-retry logic is the last line of defence for a swallowed submit.
+  if (now - since > MENU_CANCEL_TIMEOUT_MS) return 'submit';
+
+  // Settled back to an idle prompt → safe to submit the queued text.
+  if (!menuVisible
+      && hasPrompt
+      && !isBusy
+      && now - since >= MENU_CANCEL_MIN_WAIT_MS
+      && quietMs >= MENU_CANCEL_SETTLE_QUIET_MS) {
+    return 'submit';
+  }
+
+  // Menu still lingering → ESC may have been swallowed; re-send periodically.
+  if (menuVisible
+      && now - lastEscAt > MENU_CANCEL_ESC_RETRY_MS
+      && escs < MENU_CANCEL_MAX_ESC) {
+    return 'resend-esc';
+  }
+
+  return 'wait';
+}

--- a/src/shell/pty-serialize.ts
+++ b/src/shell/pty-serialize.ts
@@ -1,0 +1,120 @@
+import type { Terminal } from '@xterm/headless';
+import type { IBufferCell } from '@xterm/headless';
+
+/**
+ * Serialize a headless terminal's CURRENT visible screen into a self-contained
+ * sequence of escape codes that, written into a fresh xterm, reproduces the same
+ * screen exactly.
+ *
+ * Why this exists: the PTY stream registry used to replay the last N KB of RAW
+ * bytes on every (re)connect. An alt-screen TUI (Claude Code runs in the
+ * alternate buffer) cannot be reconstructed from a truncated byte tail — the
+ * visible screen is the *cumulative* result of every byte since session start.
+ * Once output exceeds the ring-buffer cap (which happens fast during an active
+ * turn), the front is trimmed mid-sequence: the alt-screen-enter, scroll-region
+ * setup, cursor moves, and even multi-byte UTF-8 codepoints get cut in half, so
+ * xterm desyncs and renders a blank or garbled screen (notably the infrequently
+ * repainted bottom status/cost bar). Serializing the live screen grid instead
+ * guarantees the viewer always receives one complete, coherent frame regardless
+ * of how much history has scrolled past.
+ *
+ * The output is a Unicode string (cell chars are decoded) — callers MUST encode
+ * it as UTF-8 on the wire, not latin1.
+ */
+export function serializeScreen(term: Terminal): string {
+  const buf = term.buffer.active;
+  const cols = term.cols;
+  const rows = term.rows;
+
+  let out = '\x1b[0m';
+  // Match the server's buffer mode so a later '?1049l' (session exit) behaves
+  // correctly on the client; alt-screen also clears its own scrollback.
+  if (buf.type === 'alternate') out += '\x1b[?1049h';
+  out += '\x1b[2J';
+
+  let cell: IBufferCell | undefined;
+  for (let y = 0; y < rows; y++) {
+    const line = buf.getLine(buf.viewportY + y);
+    out += `\x1b[${y + 1};1H`;
+    if (!line) continue;
+
+    // Find the last column that paints something visible. The screen was already
+    // cleared by '\x1b[2J', so trailing blanks need not be emitted — this keeps
+    // null cells null (faithful reconstruction) and shrinks the frame a lot.
+    let last = -1;
+    for (let x = cols - 1; x >= 0; x--) {
+      cell = line.getCell(x, cell);
+      if (cell && isVisible(cell)) { last = x; break; }
+    }
+    if (last < 0) continue;
+
+    let curSgr = '';
+    for (let x = 0; x <= last; x++) {
+      cell = line.getCell(x, cell);
+      if (!cell) {
+        out += ' ';
+        continue;
+      }
+      // Width 0 = the spacer cell that follows a wide (CJK/emoji) glyph; the
+      // glyph itself already emitted its full width, so skip the spacer.
+      if (cell.getWidth() === 0) continue;
+
+      const sgr = sgrFor(cell);
+      if (sgr !== curSgr) {
+        // Reset first so attributes never leak from the previous cell.
+        out += '\x1b[0m' + sgr;
+        curSgr = sgr;
+      }
+      const chars = cell.getChars();
+      out += chars === '' ? ' ' : chars;
+    }
+    out += '\x1b[0m';
+  }
+
+  // Restore the cursor to where the live screen has it (1-based, viewport-relative).
+  out += `\x1b[${buf.cursorY + 1};${buf.cursorX + 1}H`;
+  return out;
+}
+
+/**
+ * Whether a cell paints anything the eye can see. A space with default colors is
+ * invisible (so it can be trimmed from a cleared screen), but a space with a
+ * background color, or under inverse video (which swaps fg/bg), is visible.
+ */
+function isVisible(cell: IBufferCell): boolean {
+  const ch = cell.getChars();
+  if (ch !== '' && ch !== ' ') return true;
+  if (!cell.isBgDefault()) return true;
+  if (cell.isInverse()) return true;
+  return false;
+}
+
+/** Build the SGR (Select Graphic Rendition) escape for a single cell's attributes. */
+function sgrFor(cell: IBufferCell): string {
+  const codes: number[] = [];
+  if (cell.isBold()) codes.push(1);
+  if (cell.isDim()) codes.push(2);
+  if (cell.isItalic()) codes.push(3);
+  if (cell.isUnderline()) codes.push(4);
+  if (cell.isBlink()) codes.push(5);
+  if (cell.isInverse()) codes.push(7);
+  if (cell.isInvisible()) codes.push(8);
+  if (cell.isStrikethrough()) codes.push(9);
+  if (cell.isOverline()) codes.push(53);
+
+  if (cell.isFgRGB()) {
+    const c = cell.getFgColor();
+    codes.push(38, 2, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff);
+  } else if (cell.isFgPalette()) {
+    codes.push(38, 5, cell.getFgColor());
+  }
+
+  if (cell.isBgRGB()) {
+    const c = cell.getBgColor();
+    codes.push(48, 2, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff);
+  } else if (cell.isBgPalette()) {
+    codes.push(48, 5, cell.getBgColor());
+  }
+
+  return codes.length ? `\x1b[${codes.join(';')}m` : '';
+}

--- a/src/shell/pty-stream-registry.ts
+++ b/src/shell/pty-stream-registry.ts
@@ -17,7 +17,9 @@ class PtyStreamRegistry {
     try { fs.unlinkSync(socketPath); } catch { /* stale or absent */ }
 
     const server = net.createServer((conn) => {
-      conn.on('data', (chunk) => this.broadcast(agentId, chunk.toString()));
+      // Use latin1 to preserve raw byte sequences from the PTY without UTF-8 re-encoding
+      conn.setEncoding('latin1');
+      conn.on('data', (chunk: string) => this.broadcast(agentId, chunk));
       conn.on('error', () => { /* child exited */ });
     });
 
@@ -34,13 +36,24 @@ class PtyStreamRegistry {
     try { fs.unlinkSync(socketPath); } catch { /* already gone */ }
   }
 
+  /** Returns true if at least one active PTY socket server is registered for this agent. */
+  hasSockets(agentId: string): boolean {
+    for (const key of this.servers.keys()) {
+      if (key.includes(`gw-pty-${agentId}-`)) return true;
+    }
+    return false;
+  }
+
   subscribe(agentId: string, ws: WebSocket): void {
     if (!this.clients.has(agentId)) this.clients.set(agentId, new Set());
     this.clients.get(agentId)!.add(ws);
   }
 
   unsubscribe(agentId: string, ws: WebSocket): void {
-    this.clients.get(agentId)?.delete(ws);
+    const set = this.clients.get(agentId);
+    if (!set) return;
+    set.delete(ws);
+    if (!set.size) this.clients.delete(agentId);
   }
 
   broadcast(agentId: string, data: string): void {
@@ -48,7 +61,8 @@ class PtyStreamRegistry {
     if (!set?.size) return;
     for (const ws of set) {
       if (ws.readyState === WebSocket.OPEN) {
-        try { ws.send(data); } catch { /* client gone */ }
+        // Send as binary to preserve latin1 bytes faithfully; xterm.js accepts both
+        try { ws.send(Buffer.from(data, 'latin1')); } catch { /* client gone */ }
       }
     }
   }

--- a/src/shell/pty-stream-registry.ts
+++ b/src/shell/pty-stream-registry.ts
@@ -1,0 +1,57 @@
+import * as net from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { WebSocket } from 'ws';
+
+class PtyStreamRegistry {
+  private readonly clients = new Map<string, Set<WebSocket>>();
+  private readonly servers = new Map<string, net.Server>();
+
+  socketPath(agentId: string, sessionKey: string): string {
+    const safe = sessionKey.replace(/[^a-z0-9_-]/gi, '').slice(0, 32);
+    return path.join(os.tmpdir(), `gw-pty-${agentId}-${safe}.sock`);
+  }
+
+  listen(agentId: string, socketPath: string): void {
+    try { fs.unlinkSync(socketPath); } catch { /* stale or absent */ }
+
+    const server = net.createServer((conn) => {
+      conn.on('data', (chunk) => this.broadcast(agentId, chunk.toString()));
+      conn.on('error', () => { /* child exited */ });
+    });
+
+    server.on('error', () => { /* ignore — another process may have grabbed the path */ });
+    server.listen(socketPath);
+    this.servers.set(socketPath, server);
+  }
+
+  close(socketPath: string): void {
+    const server = this.servers.get(socketPath);
+    if (!server) return;
+    server.close();
+    this.servers.delete(socketPath);
+    try { fs.unlinkSync(socketPath); } catch { /* already gone */ }
+  }
+
+  subscribe(agentId: string, ws: WebSocket): void {
+    if (!this.clients.has(agentId)) this.clients.set(agentId, new Set());
+    this.clients.get(agentId)!.add(ws);
+  }
+
+  unsubscribe(agentId: string, ws: WebSocket): void {
+    this.clients.get(agentId)?.delete(ws);
+  }
+
+  broadcast(agentId: string, data: string): void {
+    const set = this.clients.get(agentId);
+    if (!set?.size) return;
+    for (const ws of set) {
+      if (ws.readyState === WebSocket.OPEN) {
+        try { ws.send(data); } catch { /* client gone */ }
+      }
+    }
+  }
+}
+
+export const ptyStreamRegistry = new PtyStreamRegistry();

--- a/src/shell/pty-stream-registry.ts
+++ b/src/shell/pty-stream-registry.ts
@@ -4,46 +4,60 @@ import * as os from 'os';
 import * as path from 'path';
 import { WebSocket } from 'ws';
 import { Terminal } from '@xterm/headless';
+import type { IBufferCell } from '@xterm/headless';
 import { serializeScreen } from './pty-serialize';
 
 /** Server PTY geometry — the headless mirror must match so the screen reconstructs faithfully. */
 const PTY_COLS = 200;
 const PTY_ROWS = 50;
 
+/**
+ * Tracks live PTY output streams so the dashboard can mirror a running shell.
+ *
+ * Everything is keyed by `streamKey` — the per-session id, NOT the agent id. A
+ * single agent can run several concurrent sessions (e.g. a Telegram session and
+ * an API/cron session), each its own PTY with its own screen. Keying by agent
+ * id would merge them: both sessions would feed one shared mirror (interleaved,
+ * unreadable output) and the viewer could not target a specific session. Keying
+ * by session id keeps each stream isolated.
+ */
 export class PtyStreamRegistry {
   private readonly clients = new Map<string, Set<WebSocket>>();
   private readonly servers = new Map<string, net.Server>();
-  private readonly agentSockets = new Map<string, Set<string>>();
+  private readonly streamSockets = new Map<string, Set<string>>();
   /**
-   * Headless terminal mirror per agent. Fed every PTY byte so it always holds
-   * the agent's current screen grid; on subscribe we serialize this into one
+   * Headless terminal mirror per stream. Fed every PTY byte so it always holds
+   * the session's current screen grid; on subscribe we serialize this into one
    * complete frame instead of replaying a (lossy, truncatable) raw-byte tail.
    */
   private readonly screens = new Map<string, Terminal>();
 
-  socketPath(agentId: string, sessionKey: string): string {
-    const safe = sessionKey.replace(/[^a-z0-9_-]/gi, '').slice(0, 32);
+  /** Per-session unix socket path. Derived from the session id so each session gets its own stream. */
+  socketPath(streamKey: string): string {
+    // 48 chars comfortably fits a full UUID without truncation — two sessions
+    // must never collide onto the same socket (that would cross-wire output).
+    const safe = streamKey.replace(/[^a-z0-9_-]/gi, '').slice(0, 48);
     return path.join(os.tmpdir(), `gw-pty-${safe}.sock`);
   }
 
-  listen(agentId: string, socketPath: string): void {
+  listen(streamKey: string, socketPath: string): void {
     try { fs.unlinkSync(socketPath); } catch { /* stale or absent */ }
 
     const server = net.createServer((conn) => {
       // Use latin1 to preserve raw byte sequences from the PTY without UTF-8 re-encoding
       conn.setEncoding('latin1');
-      conn.on('data', (chunk: string) => this.broadcast(agentId, chunk));
+      conn.on('data', (chunk: string) => this.broadcast(streamKey, chunk));
       conn.on('error', () => { /* child exited */ });
     });
 
     server.on('error', () => { /* ignore — another process may have grabbed the path */ });
     server.listen(socketPath);
     this.servers.set(socketPath, server);
-    if (!this.agentSockets.has(agentId)) this.agentSockets.set(agentId, new Set());
-    // First socket for this agent → a fresh session is starting, so reset the
+    if (!this.streamSockets.has(streamKey)) this.streamSockets.set(streamKey, new Set());
+    // First socket for this stream → a fresh session is starting, so reset the
     // screen mirror to show output from this session's start, not a prior one.
-    if (this.agentSockets.get(agentId)!.size === 0) this.resetScreen(agentId);
-    this.agentSockets.get(agentId)!.add(socketPath);
+    if (this.streamSockets.get(streamKey)!.size === 0) this.resetScreen(streamKey);
+    this.streamSockets.get(streamKey)!.add(socketPath);
   }
 
   close(socketPath: string): void {
@@ -52,29 +66,94 @@ export class PtyStreamRegistry {
     server.close();
     this.servers.delete(socketPath);
     try { fs.unlinkSync(socketPath); } catch { /* already gone */ }
-    for (const [agentId, paths] of this.agentSockets) {
+    for (const [streamKey, paths] of this.streamSockets) {
       paths.delete(socketPath);
       if (!paths.size) {
-        this.agentSockets.delete(agentId);
-        this.disposeScreen(agentId);
+        this.streamSockets.delete(streamKey);
+        this.disposeScreen(streamKey);
       }
     }
   }
 
-  /** Returns true if at least one active PTY socket server is registered for this agent. */
-  hasSockets(agentId: string): boolean {
-    return (this.agentSockets.get(agentId)?.size ?? 0) > 0;
+  /** Returns true if at least one active PTY socket server is registered for this stream/session. */
+  hasSockets(streamKey: string): boolean {
+    return (this.streamSockets.get(streamKey)?.size ?? 0) > 0;
   }
 
-  subscribe(agentId: string, ws: WebSocket): void {
-    if (!this.clients.has(agentId)) this.clients.set(agentId, new Set());
+  /**
+   * Return the current visible screen as plain text — ANSI escape codes stripped,
+   * trailing blank lines removed. Each screen row becomes one line in the output.
+   * Returns null if no headless mirror exists for the given stream key (session
+   * not running in PTY mode, or not yet started).
+   *
+   * Intended for agents that need to observe what is currently displayed in the
+   * PTY shell (e.g. to detect hang states, unexpected prompts, or tool output)
+   * without having to parse ANSI/VT100 sequences.
+   *
+   * Async: flushes the terminal's write queue (same as subscribe does for the
+   * serialized frame) so the snapshot reflects every byte received so far.
+   */
+  async screenText(streamKey: string): Promise<{ text: string; cursorRow: number; cursorCol: number; cols: number; rows: number } | null> {
+    const term = this.screens.get(streamKey);
+    if (!term) return null;
+
+    // Flush write queue so the buffer reflects all bytes received so far.
+    await new Promise<void>((resolve) => term.write('', resolve));
+
+    const buf = term.buffer.active;
+    const cols = term.cols;
+    const rows = term.rows;
+    const lines: string[] = [];
+    let cell: IBufferCell | undefined;
+
+    for (let y = 0; y < rows; y++) {
+      const line = buf.getLine(buf.viewportY + y);
+      if (!line) { lines.push(''); continue; }
+
+      // Collect characters up to the last non-blank cell on this row.
+      let rowStr = '';
+      let lastNonBlank = -1;
+      // First pass: find last non-blank column.
+      for (let x = cols - 1; x >= 0; x--) {
+        cell = line.getCell(x, cell);
+        if (cell) {
+          const ch = cell.getChars();
+          if (ch !== '' && ch !== ' ') { lastNonBlank = x; break; }
+        }
+      }
+      if (lastNonBlank < 0) { lines.push(''); continue; }
+      // Second pass: build the string up to lastNonBlank.
+      for (let x = 0; x <= lastNonBlank; x++) {
+        cell = line.getCell(x, cell);
+        if (!cell) { rowStr += ' '; continue; }
+        if (cell.getWidth() === 0) continue; // spacer for wide glyph
+        const ch = cell.getChars();
+        rowStr += ch === '' ? ' ' : ch;
+      }
+      lines.push(rowStr);
+    }
+
+    // Strip trailing blank lines so the agent sees a compact snapshot.
+    while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+
+    return {
+      text: lines.join('\n'),
+      cursorRow: buf.cursorY,
+      cursorCol: buf.cursorX,
+      cols,
+      rows,
+    };
+  }
+
+  subscribe(streamKey: string, ws: WebSocket): void {
+    if (!this.clients.has(streamKey)) this.clients.set(streamKey, new Set());
     // Register the client BEFORE sending the frame so no live byte produced in
     // the meantime is dropped (a gap there is exactly the old replay bug). The
     // frame is a full repaint, so any byte that races ahead of it is harmlessly
     // re-applied by Claude's next redraw.
-    this.clients.get(agentId)!.add(ws);
+    this.clients.get(streamKey)!.add(ws);
 
-    const term = this.screens.get(agentId);
+    const term = this.screens.get(streamKey);
     if (!term || ws.readyState !== WebSocket.OPEN) return;
     // Flush the terminal's write queue first so the serialized frame reflects
     // every byte received so far, then send one complete screen snapshot.
@@ -87,16 +166,16 @@ export class PtyStreamRegistry {
     });
   }
 
-  unsubscribe(agentId: string, ws: WebSocket): void {
-    const set = this.clients.get(agentId);
+  unsubscribe(streamKey: string, ws: WebSocket): void {
+    const set = this.clients.get(streamKey);
     if (!set) return;
     set.delete(ws);
-    if (!set.size) this.clients.delete(agentId);
+    if (!set.size) this.clients.delete(streamKey);
   }
 
-  broadcast(agentId: string, data: string): void {
-    this.feedScreen(agentId, data);
-    const set = this.clients.get(agentId);
+  broadcast(streamKey: string, data: string): void {
+    this.feedScreen(streamKey, data);
+    const set = this.clients.get(streamKey);
     if (!set?.size) return;
     for (const ws of set) {
       if (ws.readyState === WebSocket.OPEN) {
@@ -106,11 +185,11 @@ export class PtyStreamRegistry {
     }
   }
 
-  /** Feed raw PTY bytes into the agent's headless mirror, creating it on first use. */
-  private feedScreen(agentId: string, data: string): void {
+  /** Feed raw PTY bytes into the stream's headless mirror, creating it on first use. */
+  private feedScreen(streamKey: string, data: string): void {
     if (!data) return;
-    let term = this.screens.get(agentId);
-    if (!term) { term = this.createTerm(); this.screens.set(agentId, term); }
+    let term = this.screens.get(streamKey);
+    if (!term) { term = this.createTerm(); this.screens.set(streamKey, term); }
     // `data` is a latin1-decoded byte string (the socket reads with
     // setEncoding('latin1')). Reconstruct the raw bytes and hand xterm a
     // Uint8Array, NOT a string: xterm.write(string) treats each code unit as a
@@ -121,15 +200,15 @@ export class PtyStreamRegistry {
   }
 
   /** Start a clean mirror for a fresh session, disposing any prior one. */
-  private resetScreen(agentId: string): void {
-    this.disposeScreen(agentId);
-    this.screens.set(agentId, this.createTerm());
+  private resetScreen(streamKey: string): void {
+    this.disposeScreen(streamKey);
+    this.screens.set(streamKey, this.createTerm());
   }
 
-  private disposeScreen(agentId: string): void {
-    const term = this.screens.get(agentId);
+  private disposeScreen(streamKey: string): void {
+    const term = this.screens.get(streamKey);
     if (term) { try { term.dispose(); } catch { /* already disposed */ } }
-    this.screens.delete(agentId);
+    this.screens.delete(streamKey);
   }
 
   private createTerm(): Terminal {

--- a/src/shell/pty-stream-registry.ts
+++ b/src/shell/pty-stream-registry.ts
@@ -3,16 +3,23 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { WebSocket } from 'ws';
+import { Terminal } from '@xterm/headless';
+import { serializeScreen } from './pty-serialize';
 
-/** Max bytes of recent PTY output retained per agent for scrollback replay. */
-const SCROLLBACK_MAX_BYTES = 256 * 1024;
+/** Server PTY geometry — the headless mirror must match so the screen reconstructs faithfully. */
+const PTY_COLS = 200;
+const PTY_ROWS = 50;
 
 export class PtyStreamRegistry {
   private readonly clients = new Map<string, Set<WebSocket>>();
   private readonly servers = new Map<string, net.Server>();
   private readonly agentSockets = new Map<string, Set<string>>();
-  /** Rolling buffer of recent PTY bytes per agent (latin1), for replay on subscribe. */
-  private readonly scrollback = new Map<string, { chunks: string[]; bytes: number }>();
+  /**
+   * Headless terminal mirror per agent. Fed every PTY byte so it always holds
+   * the agent's current screen grid; on subscribe we serialize this into one
+   * complete frame instead of replaying a (lossy, truncatable) raw-byte tail.
+   */
+  private readonly screens = new Map<string, Terminal>();
 
   socketPath(agentId: string, sessionKey: string): string {
     const safe = sessionKey.replace(/[^a-z0-9_-]/gi, '').slice(0, 32);
@@ -34,8 +41,8 @@ export class PtyStreamRegistry {
     this.servers.set(socketPath, server);
     if (!this.agentSockets.has(agentId)) this.agentSockets.set(agentId, new Set());
     // First socket for this agent → a fresh session is starting, so reset the
-    // scrollback so replay shows output from this session's start, not a prior one.
-    if (this.agentSockets.get(agentId)!.size === 0) this.scrollback.delete(agentId);
+    // screen mirror to show output from this session's start, not a prior one.
+    if (this.agentSockets.get(agentId)!.size === 0) this.resetScreen(agentId);
     this.agentSockets.get(agentId)!.add(socketPath);
   }
 
@@ -47,7 +54,10 @@ export class PtyStreamRegistry {
     try { fs.unlinkSync(socketPath); } catch { /* already gone */ }
     for (const [agentId, paths] of this.agentSockets) {
       paths.delete(socketPath);
-      if (!paths.size) this.agentSockets.delete(agentId);
+      if (!paths.size) {
+        this.agentSockets.delete(agentId);
+        this.disposeScreen(agentId);
+      }
     }
   }
 
@@ -58,13 +68,23 @@ export class PtyStreamRegistry {
 
   subscribe(agentId: string, ws: WebSocket): void {
     if (!this.clients.has(agentId)) this.clients.set(agentId, new Set());
+    // Register the client BEFORE sending the frame so no live byte produced in
+    // the meantime is dropped (a gap there is exactly the old replay bug). The
+    // frame is a full repaint, so any byte that races ahead of it is harmlessly
+    // re-applied by Claude's next redraw.
     this.clients.get(agentId)!.add(ws);
-    // Replay buffered scrollback so the viewer sees output from session start,
-    // not just bytes that arrive after connecting.
-    const buf = this.scrollback.get(agentId);
-    if (buf && buf.chunks.length && ws.readyState === WebSocket.OPEN) {
-      try { ws.send(Buffer.from(buf.chunks.join(''), 'latin1')); } catch { /* client gone */ }
-    }
+
+    const term = this.screens.get(agentId);
+    if (!term || ws.readyState !== WebSocket.OPEN) return;
+    // Flush the terminal's write queue first so the serialized frame reflects
+    // every byte received so far, then send one complete screen snapshot.
+    term.write('', () => {
+      if (ws.readyState !== WebSocket.OPEN) return;
+      try {
+        // UTF-8 (not latin1): serialized cell chars are decoded Unicode.
+        ws.send(Buffer.from(serializeScreen(term), 'utf8'));
+      } catch { /* client gone */ }
+    });
   }
 
   unsubscribe(agentId: string, ws: WebSocket): void {
@@ -75,7 +95,7 @@ export class PtyStreamRegistry {
   }
 
   broadcast(agentId: string, data: string): void {
-    this.appendScrollback(agentId, data);
+    this.feedScreen(agentId, data);
     const set = this.clients.get(agentId);
     if (!set?.size) return;
     for (const ws of set) {
@@ -86,16 +106,36 @@ export class PtyStreamRegistry {
     }
   }
 
-  /** Append data to the agent's rolling scrollback, trimming oldest bytes past the cap. */
-  private appendScrollback(agentId: string, data: string): void {
+  /** Feed raw PTY bytes into the agent's headless mirror, creating it on first use. */
+  private feedScreen(agentId: string, data: string): void {
     if (!data) return;
-    let buf = this.scrollback.get(agentId);
-    if (!buf) { buf = { chunks: [], bytes: 0 }; this.scrollback.set(agentId, buf); }
-    buf.chunks.push(data);
-    buf.bytes += data.length;
-    while (buf.bytes > SCROLLBACK_MAX_BYTES && buf.chunks.length > 1) {
-      buf.bytes -= buf.chunks.shift()!.length;
-    }
+    let term = this.screens.get(agentId);
+    if (!term) { term = this.createTerm(); this.screens.set(agentId, term); }
+    // `data` is a latin1-decoded byte string (the socket reads with
+    // setEncoding('latin1')). Reconstruct the raw bytes and hand xterm a
+    // Uint8Array, NOT a string: xterm.write(string) treats each code unit as a
+    // final codepoint and does NOT UTF-8-decode, so multi-byte glyphs (Thai,
+    // emoji) would be stored as individual latin1 chars and serialize back as
+    // mojibake. xterm.write(Uint8Array) runs them through its UTF-8 decoder.
+    term.write(Buffer.from(data, 'latin1'));
+  }
+
+  /** Start a clean mirror for a fresh session, disposing any prior one. */
+  private resetScreen(agentId: string): void {
+    this.disposeScreen(agentId);
+    this.screens.set(agentId, this.createTerm());
+  }
+
+  private disposeScreen(agentId: string): void {
+    const term = this.screens.get(agentId);
+    if (term) { try { term.dispose(); } catch { /* already disposed */ } }
+    this.screens.delete(agentId);
+  }
+
+  private createTerm(): Terminal {
+    // scrollback: 0 — we only ever serialize the visible screen (the alt-screen
+    // TUI has no scrollback by design), so retaining none bounds memory.
+    return new Terminal({ cols: PTY_COLS, rows: PTY_ROWS, scrollback: 0, allowProposedApi: true });
   }
 }
 

--- a/src/shell/pty-stream-registry.ts
+++ b/src/shell/pty-stream-registry.ts
@@ -4,10 +4,15 @@ import * as os from 'os';
 import * as path from 'path';
 import { WebSocket } from 'ws';
 
+/** Max bytes of recent PTY output retained per agent for scrollback replay. */
+const SCROLLBACK_MAX_BYTES = 256 * 1024;
+
 export class PtyStreamRegistry {
   private readonly clients = new Map<string, Set<WebSocket>>();
   private readonly servers = new Map<string, net.Server>();
   private readonly agentSockets = new Map<string, Set<string>>();
+  /** Rolling buffer of recent PTY bytes per agent (latin1), for replay on subscribe. */
+  private readonly scrollback = new Map<string, { chunks: string[]; bytes: number }>();
 
   socketPath(agentId: string, sessionKey: string): string {
     const safe = sessionKey.replace(/[^a-z0-9_-]/gi, '').slice(0, 32);
@@ -28,6 +33,9 @@ export class PtyStreamRegistry {
     server.listen(socketPath);
     this.servers.set(socketPath, server);
     if (!this.agentSockets.has(agentId)) this.agentSockets.set(agentId, new Set());
+    // First socket for this agent → a fresh session is starting, so reset the
+    // scrollback so replay shows output from this session's start, not a prior one.
+    if (this.agentSockets.get(agentId)!.size === 0) this.scrollback.delete(agentId);
     this.agentSockets.get(agentId)!.add(socketPath);
   }
 
@@ -51,6 +59,12 @@ export class PtyStreamRegistry {
   subscribe(agentId: string, ws: WebSocket): void {
     if (!this.clients.has(agentId)) this.clients.set(agentId, new Set());
     this.clients.get(agentId)!.add(ws);
+    // Replay buffered scrollback so the viewer sees output from session start,
+    // not just bytes that arrive after connecting.
+    const buf = this.scrollback.get(agentId);
+    if (buf && buf.chunks.length && ws.readyState === WebSocket.OPEN) {
+      try { ws.send(Buffer.from(buf.chunks.join(''), 'latin1')); } catch { /* client gone */ }
+    }
   }
 
   unsubscribe(agentId: string, ws: WebSocket): void {
@@ -61,6 +75,7 @@ export class PtyStreamRegistry {
   }
 
   broadcast(agentId: string, data: string): void {
+    this.appendScrollback(agentId, data);
     const set = this.clients.get(agentId);
     if (!set?.size) return;
     for (const ws of set) {
@@ -68,6 +83,18 @@ export class PtyStreamRegistry {
         // Send as binary to preserve latin1 bytes faithfully; xterm.js accepts both
         try { ws.send(Buffer.from(data, 'latin1')); } catch { /* client gone */ }
       }
+    }
+  }
+
+  /** Append data to the agent's rolling scrollback, trimming oldest bytes past the cap. */
+  private appendScrollback(agentId: string, data: string): void {
+    if (!data) return;
+    let buf = this.scrollback.get(agentId);
+    if (!buf) { buf = { chunks: [], bytes: 0 }; this.scrollback.set(agentId, buf); }
+    buf.chunks.push(data);
+    buf.bytes += data.length;
+    while (buf.bytes > SCROLLBACK_MAX_BYTES && buf.chunks.length > 1) {
+      buf.bytes -= buf.chunks.shift()!.length;
     }
   }
 }

--- a/src/shell/pty-stream-registry.ts
+++ b/src/shell/pty-stream-registry.ts
@@ -4,13 +4,14 @@ import * as os from 'os';
 import * as path from 'path';
 import { WebSocket } from 'ws';
 
-class PtyStreamRegistry {
+export class PtyStreamRegistry {
   private readonly clients = new Map<string, Set<WebSocket>>();
   private readonly servers = new Map<string, net.Server>();
+  private readonly agentSockets = new Map<string, Set<string>>();
 
   socketPath(agentId: string, sessionKey: string): string {
     const safe = sessionKey.replace(/[^a-z0-9_-]/gi, '').slice(0, 32);
-    return path.join(os.tmpdir(), `gw-pty-${agentId}-${safe}.sock`);
+    return path.join(os.tmpdir(), `gw-pty-${safe}.sock`);
   }
 
   listen(agentId: string, socketPath: string): void {
@@ -26,6 +27,8 @@ class PtyStreamRegistry {
     server.on('error', () => { /* ignore — another process may have grabbed the path */ });
     server.listen(socketPath);
     this.servers.set(socketPath, server);
+    if (!this.agentSockets.has(agentId)) this.agentSockets.set(agentId, new Set());
+    this.agentSockets.get(agentId)!.add(socketPath);
   }
 
   close(socketPath: string): void {
@@ -34,14 +37,15 @@ class PtyStreamRegistry {
     server.close();
     this.servers.delete(socketPath);
     try { fs.unlinkSync(socketPath); } catch { /* already gone */ }
+    for (const [agentId, paths] of this.agentSockets) {
+      paths.delete(socketPath);
+      if (!paths.size) this.agentSockets.delete(agentId);
+    }
   }
 
   /** Returns true if at least one active PTY socket server is registered for this agent. */
   hasSockets(agentId: string): boolean {
-    for (const key of this.servers.keys()) {
-      if (key.includes(`gw-pty-${agentId}-`)) return true;
-    }
-    return false;
+    return (this.agentSockets.get(agentId)?.size ?? 0) > 0;
   }
 
   subscribe(agentId: string, ws: WebSocket): void {

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -2,6 +2,14 @@ import { Terminal } from '@xterm/headless';
 
 export type DialogKind = 'bypass-permissions';
 
+/** One selectable row in an interactive TUI menu (AskUserQuestion / plan approval). */
+export interface MenuOption {
+  /** 1-based number as shown in the TUI. */
+  index: number;
+  /** Human-readable label (first line only; sub-descriptions are ignored). */
+  label: string;
+}
+
 /** The TUI renders spaces as U+00A0 (non-breaking) — normalize before matching. */
 function normalize(text: string): string {
   return text.replace(/ /g, ' ');
@@ -19,6 +27,47 @@ function normalize(text: string): string {
 export const TUI_BUSY_MARKER = 'esc to interrupt';
 export const TUI_PROMPT_RE = /^❯ /m;
 export const TUI_BYPASS_PERMS = ['Bypass Permissions mode', 'Yes, I accept'] as const;
+
+/**
+ * Interactive select-menu footer markers (e.g. AskUserQuestion). The footer reads
+ * "Enter to select · ↑/↓ to navigate · Esc to cancel"; we match on the two stable
+ * fragments so spacing/middle-dot variations across TUI versions don't break it.
+ */
+export const TUI_MENU_FOOTER = ['to navigate', 'to cancel'] as const;
+/** A numbered option row, with an optional leading ❯/> highlight marker. */
+export const TUI_MENU_OPTION_RE = /^\s*[❯>]?\s*(\d+)\.\s+(.+?)\s*$/;
+
+/**
+ * Parse a user's menu reply (typed number or a button's choice payload) into a
+ * 1-based option index. Returns null for anything that isn't a leading integer
+ * within [1, count] — never trust chat input to be a valid selection.
+ */
+export function parseMenuChoice(text: string, count: number): number | null {
+  const m = /^\s*(\d+)/.exec(text);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isInteger(n) && n >= 1 && n <= count ? n : null;
+}
+
+/**
+ * Channel turns reach the wrapper wrapped in a <channel …>…</channel> envelope
+ * (see AgentRunner.buildChannelXml) — even a one-character menu reply like "1"
+ * arrives as `<channel source="telegram" …>1</channel>`. To interpret a menu
+ * selection we need the user's actual text, not the envelope, so pull out the
+ * inner content and drop any nested <replied> block. Returns the input
+ * unchanged when it is not a channel envelope (e.g. a raw API/typed reply).
+ */
+export function extractChannelContent(text: string): string {
+  const m = /<channel\b[^>]*>([\s\S]*)<\/channel>/.exec(text);
+  if (!m) return text;
+  return m[1].replace(/<replied\b[^>]*>[\s\S]*?<\/replied>/g, '').trim();
+}
+
+/** Build the chat-facing menu prompt (also the API/number fallback text). */
+export function formatMenuPrompt(options: MenuOption[]): string {
+  const lines = options.map((o, i) => `${i + 1}. ${o.label}`).join('\n');
+  return `🔢 Choose an option — tap a button below, or reply with the number:\n\n${lines}`;
+}
 
 /**
  * Virtual terminal fed with raw PTY bytes. Used ONLY for liveness signals
@@ -79,5 +128,51 @@ export class ScreenModel {
       return 'bypass-permissions';
     }
     return null;
+  }
+
+  /**
+   * Detect an interactive select menu blocking on keyboard input (e.g. the
+   * AskUserQuestion / plan-approval prompt) and parse its numbered options.
+   * Returns the options in display order, or null when no menu is on screen.
+   *
+   * Requires the select-menu footer AND at least two numbered rows — ordinary
+   * numbered lists in assistant output never carry the footer, so this won't
+   * false-positive on them. The bypass-permissions dialog also matches the
+   * footer; callers must check detectDialog() first and let it auto-accept.
+   */
+  detectMenu(): MenuOption[] | null {
+    const text = this.text();
+    if (!TUI_MENU_FOOTER.every((s) => text.includes(s))) return null;
+    // Scan only the region ABOVE the footer — the live menu's options always
+    // sit between the question and the "to navigate · to cancel" footer.
+    const lines = text.split('\n');
+    const footerIdx = lines.findIndex((l) => TUI_MENU_FOOTER.some((s) => l.includes(s)));
+    const region = footerIdx >= 0 ? lines.slice(0, footerIdx) : lines;
+
+    const matches: MenuOption[] = [];
+    for (const line of region) {
+      const m = TUI_MENU_OPTION_RE.exec(line);
+      if (m) matches.push({ index: Number(m[1]), label: m[2].trim() });
+    }
+    if (matches.length < 2) return null;
+
+    // Scrollback above the menu can contain stale numbered lines (e.g. a prior
+    // chat message rendered as "1. … 2. …"). The real select menu always numbers
+    // its options 1..N in order, so take the LAST run that starts at "1." and
+    // increments by one — that is the live menu nearest the footer, not history.
+    // This run's position is what selectMenuOption() types into the TUI, so it
+    // MUST mirror the on-screen numbering exactly.
+    let start = -1;
+    for (let i = 0; i < matches.length; i++) {
+      if (matches[i].index === 1) start = i;
+    }
+    if (start === -1) return null;
+    const run: MenuOption[] = [];
+    let expected = 1;
+    for (let i = start; i < matches.length && matches[i].index === expected; i++) {
+      run.push(matches[i]);
+      expected++;
+    }
+    return run.length >= 2 ? run : null;
   }
 }

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -121,7 +121,7 @@ export function generateDashboardHtml(): string {
   </style>
 </head>
 <body>
-  <h1>Claude Gateway <span id="refresh-indicator">refreshing...</span></h1>
+  <h1>Claude Gateway <span id="gateway-version" style="font-size:0.75rem;color:#718096;"></span> <span id="refresh-indicator">refreshing...</span></h1>
   <div class="meta">
     Uptime: <span id="uptime">—</span> &nbsp;|&nbsp;
     Started: <span id="started-at">—</span> &nbsp;|&nbsp;
@@ -168,18 +168,20 @@ export function generateDashboardHtml(): string {
     </tbody>
   </table>
 
-  <h2>Recent Sessions (last 5 per agent)</h2>
+  <h2>Sessions (last 10 per agent)</h2>
   <table id="sessions-table">
     <thead>
       <tr>
         <th>Agent</th>
         <th>Chat ID</th>
-        <th>Messages</th>
-        <th>Last Activity</th>
+        <th>Source</th>
+        <th>Status</th>
+        <th>Uptime</th>
+        <th>Spawned</th>
       </tr>
     </thead>
     <tbody id="sessions-tbody">
-      <tr><td colspan="4" class="ts">Loading...</td></tr>
+      <tr><td colspan="6" class="ts">Loading...</td></tr>
     </tbody>
   </table>
 
@@ -224,7 +226,9 @@ export function generateDashboardHtml(): string {
     // Compute base path from current URL (handles reverse proxy sub-paths)
     function basePath() {
       const p = window.location.pathname;
-      return p.endsWith('/ui') ? p.slice(0, -3) : (p.endsWith('/ui/') ? p.slice(0, -4) : p.replace(/\\/$/, ''));
+      if (p.endsWith('/dashboard')) return p.slice(0, -10);
+      if (p.endsWith('/dashboard/')) return p.slice(0, -11);
+      return p.replace(/\\/$/, '');
     }
 
     function apiUrl(path) {
@@ -301,6 +305,7 @@ export function generateDashboardHtml(): string {
         document.getElementById('started-at').textContent = data.startedAt
           ? new Date(data.startedAt).toLocaleString() : '—';
         document.getElementById('last-updated').textContent = new Date().toLocaleTimeString();
+        if (data.version) document.getElementById('gateway-version').textContent = 'v' + data.version;
         document.getElementById('error-msg').style.display = 'none';
 
         // Agents table (with Live button for PTY agents)
@@ -340,18 +345,23 @@ export function generateDashboardHtml(): string {
         // Sessions table
         const sessRows = [];
         (data.agents || []).forEach(function(a) {
-          const sessions = (a.sessions || []).slice(0, 5);
-          sessions.forEach(function(s) {
+          (a.sessions || []).forEach(function(s) {
+            const statusBadge = s.isRunning
+              ? '<span class="badge badge-green">running</span>'
+              : '<span class="badge badge-gray">stopped</span>';
+            const uptime = s.isRunning ? fmtUptime(s.uptimeSec || 0) : '<span class="ts">—</span>';
             sessRows.push('<tr>' +
               '<td>' + a.id + '</td>' +
-              '<td>' + s.chatId + '</td>' +
-              '<td>' + (s.messageCount || 0) + '</td>' +
-              '<td>' + fmtTs(s.lastActivity) + '</td>' +
+              '<td class="ts">' + s.chatId + '</td>' +
+              '<td>' + (s.source || '—') + '</td>' +
+              '<td>' + statusBadge + '</td>' +
+              '<td>' + uptime + '</td>' +
+              '<td>' + fmtTs(s.spawnedAt ? new Date(s.spawnedAt).toISOString() : null) + '</td>' +
               '</tr>');
           });
         });
         document.getElementById('sessions-tbody').innerHTML =
-          sessRows.length ? sessRows.join('') : '<tr><td colspan="4" class="ts">No sessions yet</td></tr>';
+          sessRows.length ? sessRows.join('') : '<tr><td colspan="6" class="ts">No sessions yet</td></tr>';
 
         document.getElementById('refresh-indicator').textContent = 'auto-refresh 5s';
       } catch(e) {
@@ -387,13 +397,17 @@ export function generateDashboardHtml(): string {
         const a = p.args;
         if (a.includes('node') && a.includes('dist/index')) return 'orchestrator';
         if (a.includes('claude-pty-shell')) return 'pty';
-        if (a.includes('claude') && a.includes('--session-id')) {
-          const parent = pidMap[p.ppid];
-          return (parent && cat(parent) === 'pty') ? 'claude-pty' : 'claude-headless';
-        }
         if (a.includes('bun') && a.includes('mcp/server')) return 'mcp';
         if (a.includes('bun') && a.includes('telegram') && a.includes('receiver')) return 'telegram';
         if (a.includes('bun') && a.includes('discord') && a.includes('receiver')) return 'discord';
+        // Match both PTY (--session-id) and headless (--print) claude processes
+        if (a.includes('--mcp-config') && (a.includes('--session-id') || a.includes('--print'))) {
+          if (a.includes('--session-id')) {
+            const parent = pidMap[p.ppid];
+            return (parent && cat(parent) === 'pty') ? 'claude-pty' : 'claude-headless';
+          }
+          return 'claude-headless';
+        }
         return 'other';
       }
 

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -128,65 +128,59 @@ export function generateDashboardHtml(): string {
     Last updated: <span id="last-updated">—</span>
   </div>
 
-  <h2>Agents</h2>
-  <table id="agents-table">
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Status</th>
-        <th>Received</th>
-        <th>Sent</th>
-        <th>Last Activity</th>
-        <th>Live</th>
-      </tr>
-    </thead>
-    <tbody id="agents-tbody">
-      <tr><td colspan="6" class="ts">Loading...</td></tr>
-    </tbody>
-  </table>
-
-  <div class="pty-viewer" id="pty-viewer">
-    <div class="pty-viewer-header">
-      <span>PTY Live &mdash; <span class="agent-label" id="pty-agent-label"></span></span>
-      <button class="pty-close" id="pty-close-btn" title="Close">✕</button>
+  <div style="display:grid;grid-template-columns:1fr 1.5fr;gap:24px;align-items:start;">
+    <!-- Left column: Processes -->
+    <div>
+      <h2>Processes</h2>
+      <div class="proc-tree" id="proc-tree">Loading...</div>
     </div>
-    <div id="pty-terminal"></div>
+
+    <!-- Right column: Agents + Sessions -->
+    <div>
+      <h2>Agents</h2>
+      <table id="agents-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Status</th>
+            <th>Received</th>
+            <th>Sent</th>
+            <th>Last Activity</th>
+            <th>Live</th>
+          </tr>
+        </thead>
+        <tbody id="agents-tbody">
+          <tr><td colspan="6" class="ts">Loading...</td></tr>
+        </tbody>
+      </table>
+
+      <div class="pty-viewer" id="pty-viewer">
+        <div class="pty-viewer-header">
+          <span>PTY Live &mdash; <span class="agent-label" id="pty-agent-label"></span></span>
+          <button class="pty-close" id="pty-close-btn" title="Close">✕</button>
+        </div>
+        <div id="pty-terminal"></div>
+      </div>
+
+      <h2>Sessions</h2>
+      <table id="sessions-table">
+        <thead>
+          <tr>
+            <th>Agent</th>
+            <th>Chat ID</th>
+            <th>Session ID</th>
+            <th>Source</th>
+            <th>Status</th>
+            <th>Uptime</th>
+            <th>Spawned</th>
+          </tr>
+        </thead>
+        <tbody id="sessions-tbody">
+          <tr><td colspan="7" class="ts">Loading...</td></tr>
+        </tbody>
+      </table>
+    </div>
   </div>
-
-  <h2>Heartbeat Tasks</h2>
-  <table id="heartbeat-table">
-    <thead>
-      <tr>
-        <th>Agent</th>
-        <th>Task</th>
-        <th>Last Run</th>
-        <th>Result</th>
-      </tr>
-    </thead>
-    <tbody id="heartbeat-tbody">
-      <tr><td colspan="4" class="ts">Loading...</td></tr>
-    </tbody>
-  </table>
-
-  <h2>Sessions (last 10 per agent)</h2>
-  <table id="sessions-table">
-    <thead>
-      <tr>
-        <th>Agent</th>
-        <th>Chat ID</th>
-        <th>Source</th>
-        <th>Status</th>
-        <th>Uptime</th>
-        <th>Spawned</th>
-      </tr>
-    </thead>
-    <tbody id="sessions-tbody">
-      <tr><td colspan="6" class="ts">Loading...</td></tr>
-    </tbody>
-  </table>
-
-  <h2>Processes</h2>
-  <div class="proc-tree" id="proc-tree">Loading...</div>
 
   <div id="error-msg" class="error" style="display:none;"></div>
 
@@ -215,12 +209,6 @@ export function generateDashboardHtml(): string {
       return running
         ? '<span class="badge badge-green">running</span>'
         : '<span class="badge badge-red">stopped</span>';
-    }
-
-    function resultBadge(suppressed, rateLimited) {
-      if (rateLimited) return '<span class="badge badge-gray">rate-limited</span>';
-      if (suppressed) return '<span class="badge badge-gray">suppressed</span>';
-      return '<span class="badge badge-green">sent</span>';
     }
 
     // Compute base path from current URL (handles reverse proxy sub-paths)
@@ -325,23 +313,6 @@ export function generateDashboardHtml(): string {
         document.getElementById('agents-tbody').innerHTML =
           agentRows.length ? agentRows.join('') : '<tr><td colspan="6" class="ts">No agents</td></tr>';
 
-        // Heartbeat table
-        const hbRows = [];
-        (data.agents || []).forEach(function(a) {
-          const lastResults = (a.heartbeat && a.heartbeat.lastResults) || [];
-          lastResults.forEach(function(r) {
-            if (!r) return;
-            hbRows.push('<tr>' +
-              '<td>' + a.id + '</td>' +
-              '<td>' + r.taskName + '</td>' +
-              '<td>' + fmtTs(r.ts) + '</td>' +
-              '<td>' + resultBadge(r.suppressed, r.rateLimited) + '</td>' +
-              '</tr>');
-          });
-        });
-        document.getElementById('heartbeat-tbody').innerHTML =
-          hbRows.length ? hbRows.join('') : '<tr><td colspan="4" class="ts">No heartbeat data yet</td></tr>';
-
         // Sessions table
         const sessRows = [];
         (data.agents || []).forEach(function(a) {
@@ -350,9 +321,11 @@ export function generateDashboardHtml(): string {
               ? '<span class="badge badge-green">running</span>'
               : '<span class="badge badge-gray">stopped</span>';
             const uptime = s.isRunning ? fmtUptime(s.uptimeSec || 0) : '<span class="ts">—</span>';
+            const shortSessId = s.sessionId ? s.sessionId.slice(0, 8) + '…' : '<span class="ts">—</span>';
             sessRows.push('<tr>' +
               '<td>' + a.id + '</td>' +
               '<td class="ts">' + s.chatId + '</td>' +
+              '<td class="ts">' + shortSessId + '</td>' +
               '<td>' + (s.source || '—') + '</td>' +
               '<td>' + statusBadge + '</td>' +
               '<td>' + uptime + '</td>' +
@@ -361,7 +334,7 @@ export function generateDashboardHtml(): string {
           });
         });
         document.getElementById('sessions-tbody').innerHTML =
-          sessRows.length ? sessRows.join('') : '<tr><td colspan="6" class="ts">No sessions yet</td></tr>';
+          sessRows.length ? sessRows.join('') : '<tr><td colspan="7" class="ts">No sessions yet</td></tr>';
 
         document.getElementById('refresh-indicator').textContent = 'auto-refresh 5s';
       } catch(e) {

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -78,15 +78,15 @@ export function generateDashboardHtml(apiKey = ''): string {
     #refresh-indicator { float: right; font-size: 0.75rem; color: #4a5568; }
     .error { color: #fc8181; font-size: 0.85rem; margin-top: 8px; }
     .btn-stream {
-      background: #1a365d;
-      color: #63b3ed;
-      border: 1px solid #2b6cb0;
+      background: #44337a;
+      color: #d6bcfa;
+      border: 1px solid #6b46c1;
       border-radius: 4px;
       padding: 2px 8px;
       font-size: 0.75rem;
       cursor: pointer;
     }
-    .btn-stream:hover { background: #2b6cb0; color: #ebf8ff; }
+    .btn-stream:hover { background: #6b46c1; color: #faf5ff; }
     .pty-viewer {
       display: none;
       margin-top: 24px;
@@ -105,7 +105,7 @@ export function generateDashboardHtml(apiKey = ''): string {
     }
     .pty-viewer-header .agent-label { color: #63b3ed; font-weight: 600; }
     .pty-viewer-header .session-label { color: #718096; font-family: monospace; font-size: 0.78rem; }
-    .pty-close {
+    .pty-close, .pty-refresh {
       background: none;
       border: none;
       color: #718096;
@@ -114,6 +114,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       padding: 0 4px;
     }
     .pty-close:hover { color: #fc8181; }
+    .pty-refresh:hover { color: #68d391; }
     /* Fixed-size terminal viewport — the server PTY runs at 200x50, so the
        viewer must NOT resize to the panel (that mismatch is what garbles the
        output). We render at the native size and pan horizontally if the 200-col
@@ -125,7 +126,6 @@ export function generateDashboardHtml(apiKey = ''): string {
       background: #0d1117;
       overflow-x: auto;
       overflow-y: hidden;
-      max-height: 70vh;
       border-radius: 6px;
     }
     /* No scrollback in alt-screen mode → suppress xterm's vertical scrollbar. */
@@ -231,7 +231,10 @@ export function generateDashboardHtml(apiKey = ''): string {
   <div class="pty-viewer" id="pty-viewer">
     <div class="pty-viewer-header">
       <span>Shell Monitor &mdash; <span class="agent-label" id="pty-agent-label"></span><span class="session-label" id="pty-session-label"></span></span>
-      <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
+      <span>
+        <button class="pty-refresh" id="pty-refresh-btn" title="Refresh display">&#x21BA;</button>
+        <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
+      </span>
     </div>
     <div id="pty-terminal"></div>
   </div>
@@ -314,6 +317,7 @@ export function generateDashboardHtml(apiKey = ''): string {
     let term = null;
     let ptyWs = null;
     let currentPtyAgent = null;
+    let currentPtySession = null;
     // Streaming UTF-8 decoder. The PTY stream carries raw UTF-8 bytes (box-drawing
     // chars, spinner braille, emoji). Decoding them as latin1 mangles every
     // multi-byte char into noise — decode as UTF-8 with {stream:true} so sequences
@@ -334,6 +338,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       closePtyViewer();
 
       currentPtyAgent = agentId;
+      currentPtySession = sessionId;
       document.getElementById('pty-agent-label').textContent = agentId;
       // Append the session id after the agent name, e.g. "claude-founder · 3c01897c…".
       document.getElementById('pty-session-label').textContent = sessionId ? ' \\u00b7 ' + sessionId : '';
@@ -389,10 +394,23 @@ export function generateDashboardHtml(apiKey = ''): string {
     function closePtyViewer() {
       if (ptyWs) { ptyWs.close(); ptyWs = null; }
       currentPtyAgent = null;
+      currentPtySession = null;
       document.getElementById('pty-viewer').style.display = 'none';
     }
 
+    function refreshPtyViewer() {
+      if (!currentPtyAgent) return;
+      const agentId = currentPtyAgent;
+      const sessionId = currentPtySession;
+      // Close existing WS and reset terminal to a clean state, then reconnect.
+      if (ptyWs) { ptyWs.close(); ptyWs = null; }
+      currentPtyAgent = null; // bypass the early-return guard in openPtyViewer
+      if (term) term.reset();
+      openPtyViewer(agentId, sessionId);
+    }
+
     document.getElementById('pty-close-btn').addEventListener('click', closePtyViewer);
+    document.getElementById('pty-refresh-btn').addEventListener('click', refreshPtyViewer);
 
     // Event delegation for Live buttons (avoids inline onclick + HTML injection)
     document.getElementById('sessions-tbody').addEventListener('click', function(e) {
@@ -493,7 +511,7 @@ export function generateDashboardHtml(apiKey = ''): string {
               ? '<span class="session-id">' + escHtml(String(s.chatId)) + '</span>'
               : '<span class="ts">&mdash;</span>';
             const liveBtn = (a.hasPtyStream && s.isRunning && s.mode === 'pty-shell')
-              ? '<button class="btn-stream" data-agent-id="' + escHtml(a.id) + '" data-session-id="' + escHtml(s.sessionId || '') + '">▶ Live</button>'
+              ? '<button class="btn-stream" data-agent-id="' + escHtml(a.id) + '" data-session-id="' + escHtml(s.sessionId || '') + '">💻 View</button>'
               : '<span class="ts">&mdash;</span>';
             rows.push(
               '<tr class="session-row">' +

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -2,14 +2,14 @@
  * Generates a self-contained HTML dashboard page for the gateway status UI.
  * No external dependencies except xterm.js CDN for PTY viewer.
  */
-export function generateDashboardHtml(apiKey = ''): string {
-  const safeKey = apiKey.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+export function generateDashboardHtml(dashToken = ''): string {
+  const safeToken = dashToken.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="api-key" content="${safeKey}">
+  <meta name="dash-token" content="${safeToken}">
   <title>Claude Gateway</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css"/>
   <style>
@@ -92,7 +92,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       margin-top: 24px;
       border: 1px solid #2d3748;
       border-radius: 6px;
-      overflow: hidden;
+      overflow-x: hidden;
     }
     .pty-viewer-header {
       background: #1a202c;
@@ -200,8 +200,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       .meta { font-size: 0.78rem; }
       #refresh-indicator { float: none; display: block; margin-top: 4px; }
       .proc-tree { font-size: 0.72rem; padding: 10px 12px; }
-      /* On phones the PTY mirror can use the full viewport width and fit. */
-      #pty-terminal { max-height: 60vh; }
+      /* On phones allow horizontal pan only — no vertical clipping. */
     }
   </style>
 </head>
@@ -268,8 +267,9 @@ export function generateDashboardHtml(apiKey = ''): string {
 
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
   <script>
-    // Read API key from meta tag (safe — no inline JS string injection)
-    const DASHBOARD_API_KEY = document.querySelector('meta[name="api-key"]') ? document.querySelector('meta[name="api-key"]').getAttribute('content') : '';
+    // Read short-lived dashboard token from meta tag (10 min, server-issued at page load).
+    // The raw API key is never embedded in HTML — only this scoped, expiring token is.
+    const DASHBOARD_API_KEY = document.querySelector('meta[name="dash-token"]') ? document.querySelector('meta[name="dash-token"]').getAttribute('content') : '';
 
     // Must match the server PTY size (src/shell/screen.ts ScreenModel defaults).
     const PTY_COLS = 200;
@@ -316,7 +316,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       }
       const r = await fetch(apiUrl('/api/v1/pty-stream-ticket'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Api-Key': DASHBOARD_API_KEY },
+        headers: { 'Content-Type': 'application/json', 'X-Dash-Token': DASHBOARD_API_KEY },
         body: JSON.stringify({ agentId }),
       });
       const { ticket } = await r.json();
@@ -378,6 +378,16 @@ export function generateDashboardHtml(apiKey = ''): string {
           convertEol: false,
         });
         term.open(document.getElementById('pty-terminal'));
+        // After open(), xterm has measured cell height. Pin the container height
+        // so all PTY_ROWS are always visible — prevents the alt-screen bottom rows
+        // (cost bar, status line) from being clipped by parent overflow or viewport.
+        requestAnimationFrame(function() {
+          const screen = document.querySelector('#pty-terminal .xterm-screen');
+          if (screen) {
+            const h = screen.offsetHeight;
+            if (h > 0) document.getElementById('pty-terminal').style.minHeight = h + 'px';
+          }
+        });
       } else {
         term.reset();
       }

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -1,6 +1,6 @@
 /**
  * Generates a self-contained HTML dashboard page for the gateway status UI.
- * No external dependencies — all CSS and JS is inline.
+ * No external dependencies except xterm.js CDN for PTY viewer.
  */
 export function generateDashboardHtml(): string {
   return `<!DOCTYPE html>
@@ -9,6 +9,7 @@ export function generateDashboardHtml(): string {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Claude Gateway Status</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css"/>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -53,6 +54,7 @@ export function generateDashboardHtml(): string {
     .badge-green { background: #22543d; color: #68d391; }
     .badge-red { background: #742a2a; color: #fc8181; }
     .badge-gray { background: #2d3748; color: #a0aec0; }
+    .badge-blue { background: #1a365d; color: #63b3ed; }
     .ts { color: #718096; font-size: 0.8rem; }
     #refresh-indicator {
       float: right;
@@ -60,6 +62,62 @@ export function generateDashboardHtml(): string {
       color: #4a5568;
     }
     .error { color: #fc8181; font-size: 0.85rem; margin-top: 8px; }
+    .btn-stream {
+      background: #1a365d;
+      color: #63b3ed;
+      border: 1px solid #2b6cb0;
+      border-radius: 4px;
+      padding: 2px 8px;
+      font-size: 0.75rem;
+      cursor: pointer;
+    }
+    .btn-stream:hover { background: #2b6cb0; color: #ebf8ff; }
+    .pty-viewer {
+      display: none;
+      margin-bottom: 24px;
+      border: 1px solid #2d3748;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .pty-viewer-header {
+      background: #1a202c;
+      padding: 8px 12px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      color: #a0aec0;
+    }
+    .pty-viewer-header .agent-label { color: #63b3ed; font-weight: 600; }
+    .pty-close {
+      background: none;
+      border: none;
+      color: #718096;
+      cursor: pointer;
+      font-size: 1rem;
+      padding: 0 4px;
+    }
+    .pty-close:hover { color: #fc8181; }
+    #pty-terminal { padding: 8px; background: #0d1117; }
+    .proc-tree {
+      font-family: monospace;
+      font-size: 0.82rem;
+      background: #0d1117;
+      border: 1px solid #2d3748;
+      border-radius: 6px;
+      padding: 12px 16px;
+      white-space: pre;
+      color: #a0aec0;
+      margin-bottom: 24px;
+      overflow-x: auto;
+    }
+    .proc-tree .proc-orchestrator { color: #63b3ed; }
+    .proc-tree .proc-pty { color: #68d391; }
+    .proc-tree .proc-claude { color: #f6e05e; }
+    .proc-tree .proc-mcp { color: #b794f4; }
+    .proc-tree .proc-receiver { color: #76e4f7; }
+    .proc-tree .proc-orphan { color: #fc8181; }
+    .proc-tree .proc-label { color: #718096; }
   </style>
 </head>
 <body>
@@ -79,12 +137,21 @@ export function generateDashboardHtml(): string {
         <th>Received</th>
         <th>Sent</th>
         <th>Last Activity</th>
+        <th>Live</th>
       </tr>
     </thead>
     <tbody id="agents-tbody">
-      <tr><td colspan="5" class="ts">Loading...</td></tr>
+      <tr><td colspan="6" class="ts">Loading...</td></tr>
     </tbody>
   </table>
+
+  <div class="pty-viewer" id="pty-viewer">
+    <div class="pty-viewer-header">
+      <span>PTY Live &mdash; <span class="agent-label" id="pty-agent-label"></span></span>
+      <button class="pty-close" id="pty-close-btn" title="Close">✕</button>
+    </div>
+    <div id="pty-terminal"></div>
+  </div>
 
   <h2>Heartbeat Tasks</h2>
   <table id="heartbeat-table">
@@ -116,9 +183,15 @@ export function generateDashboardHtml(): string {
     </tbody>
   </table>
 
+  <h2>Processes</h2>
+  <div class="proc-tree" id="proc-tree">Loading...</div>
+
   <div id="error-msg" class="error" style="display:none;"></div>
 
+  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
   <script>
+    // ── Helpers ──────────────────────────────────────────────────────────────
     function fmtUptime(seconds) {
       const h = Math.floor(seconds / 3600);
       const m = Math.floor((seconds % 3600) / 60);
@@ -148,10 +221,79 @@ export function generateDashboardHtml(): string {
       return '<span class="badge badge-green">sent</span>';
     }
 
+    // Compute base path from current URL (handles reverse proxy sub-paths)
+    function basePath() {
+      const p = window.location.pathname;
+      return p.endsWith('/ui') ? p.slice(0, -2) : (p.endsWith('/ui/') ? p.slice(0, -3) : p.replace(/\\/$/, ''));
+    }
+
+    function apiUrl(path) {
+      return basePath() + path;
+    }
+
+    function wsUrl(path) {
+      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      return proto + '//' + window.location.host + basePath() + path;
+    }
+
+    // ── PTY Viewer ───────────────────────────────────────────────────────────
+    let term = null;
+    let fitAddon = null;
+    let ptyWs = null;
+    let currentPtyAgent = null;
+
+    function openPtyViewer(agentId) {
+      if (currentPtyAgent === agentId && ptyWs && ptyWs.readyState === WebSocket.OPEN) return;
+      closePtyViewer();
+
+      currentPtyAgent = agentId;
+      document.getElementById('pty-agent-label').textContent = agentId;
+      document.getElementById('pty-viewer').style.display = 'block';
+
+      if (!term) {
+        term = new Terminal({
+          theme: { background: '#0d1117', foreground: '#e2e8f0', cursor: '#63b3ed' },
+          fontSize: 13,
+          fontFamily: 'Menlo, Monaco, Consolas, monospace',
+          convertEol: true,
+          scrollback: 2000,
+        });
+        fitAddon = new FitAddon.FitAddon();
+        term.loadAddon(fitAddon);
+        term.open(document.getElementById('pty-terminal'));
+        fitAddon.fit();
+      } else {
+        term.clear();
+      }
+
+      const url = wsUrl('/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream');
+      ptyWs = new WebSocket(url);
+      ptyWs.binaryType = 'arraybuffer';
+
+      ptyWs.onopen = function() { term.writeln('\\r\\x1b[32m[connected to ' + agentId + ']\\x1b[0m'); };
+      ptyWs.onmessage = function(ev) {
+        const data = ev.data instanceof ArrayBuffer
+          ? new TextDecoder().decode(ev.data)
+          : ev.data;
+        term.write(data);
+      };
+      ptyWs.onclose = function() { if (term) term.writeln('\\r\\x1b[33m[disconnected]\\x1b[0m'); };
+      ptyWs.onerror = function() { if (term) term.writeln('\\r\\x1b[31m[connection error]\\x1b[0m'); };
+    }
+
+    function closePtyViewer() {
+      if (ptyWs) { ptyWs.close(); ptyWs = null; }
+      currentPtyAgent = null;
+      document.getElementById('pty-viewer').style.display = 'none';
+    }
+
+    document.getElementById('pty-close-btn').addEventListener('click', closePtyViewer);
+
+    // ── Status Refresh ────────────────────────────────────────────────────────
     async function refresh() {
       document.getElementById('refresh-indicator').textContent = 'refreshing...';
       try {
-        const res = await fetch('/status');
+        const res = await fetch(apiUrl('/status'));
         if (!res.ok) throw new Error('HTTP ' + res.status);
         const data = await res.json();
 
@@ -161,18 +303,22 @@ export function generateDashboardHtml(): string {
         document.getElementById('last-updated').textContent = new Date().toLocaleTimeString();
         document.getElementById('error-msg').style.display = 'none';
 
-        // Agents table
+        // Agents table (with Live button for PTY agents)
         const agentRows = (data.agents || []).map(function(a) {
+          const liveBtn = a.hasPtyStream
+            ? '<button class="btn-stream" onclick="openPtyViewer(' + JSON.stringify(a.id) + ')">▶ Live</button>'
+            : '<span class="ts">—</span>';
           return '<tr>' +
             '<td>' + a.id + '</td>' +
             '<td>' + badge(a.isRunning) + '</td>' +
             '<td>' + (a.messagesReceived || 0) + '</td>' +
             '<td>' + (a.messagesSent || 0) + '</td>' +
             '<td>' + fmtTs(a.lastActivityAt) + '</td>' +
+            '<td>' + liveBtn + '</td>' +
             '</tr>';
         });
         document.getElementById('agents-tbody').innerHTML =
-          agentRows.length ? agentRows.join('') : '<tr><td colspan="5" class="ts">No agents</td></tr>';
+          agentRows.length ? agentRows.join('') : '<tr><td colspan="6" class="ts">No agents</td></tr>';
 
         // Heartbeat table
         const hbRows = [];
@@ -215,8 +361,128 @@ export function generateDashboardHtml(): string {
       }
     }
 
+    // ── Process Tree ─────────────────────────────────────────────────────────
+    async function refreshProcesses() {
+      try {
+        const res = await fetch(apiUrl('/processes'));
+        if (!res.ok) return;
+        const data = await res.json();
+        renderProcessTree(data.processes || []);
+      } catch(e) {
+        document.getElementById('proc-tree').textContent = 'Error: ' + e.message;
+      }
+    }
+
+    function renderProcessTree(procs) {
+      if (!procs.length) {
+        document.getElementById('proc-tree').textContent = '— no gateway processes found —';
+        return;
+      }
+
+      const pidMap = {};
+      procs.forEach(function(p) { pidMap[p.pid] = p; });
+
+      // Categorize
+      function cat(p) {
+        const a = p.args;
+        if (a.includes('node') && a.includes('dist/index')) return 'orchestrator';
+        if (a.includes('claude-pty-shell')) return 'pty';
+        if (a.includes('claude') && a.includes('--session-id')) {
+          const parent = pidMap[p.ppid];
+          return (parent && cat(parent) === 'pty') ? 'claude-pty' : 'claude-headless';
+        }
+        if (a.includes('bun') && a.includes('mcp/server')) return 'mcp';
+        if (a.includes('bun') && a.includes('telegram') && a.includes('receiver')) return 'telegram';
+        if (a.includes('bun') && a.includes('discord') && a.includes('receiver')) return 'discord';
+        return 'other';
+      }
+
+      function short(args, maxLen) {
+        return args.length > maxLen ? args.slice(0, maxLen) + '…' : args;
+      }
+
+      function sessionId(args) {
+        const m = args.match(/--session-id\\s+(\\S+)/);
+        return m ? m[1].slice(0, 8) + '…' : '?';
+      }
+
+      function agentName(args) {
+        const m = args.match(/agents\\/([^/]+)\\/workspace/);
+        return m ? m[1] : '?';
+      }
+
+      const lines = [];
+      const orchestrator = procs.find(function(p) { return cat(p) === 'orchestrator'; });
+      const ptys = procs.filter(function(p) { return cat(p) === 'pty'; });
+      const headless = procs.filter(function(p) { return cat(p) === 'claude-headless'; });
+      const telegramReceivers = procs.filter(function(p) { return cat(p) === 'telegram'; });
+      const discordReceivers = procs.filter(function(p) { return cat(p) === 'discord'; });
+      const mcpServers = procs.filter(function(p) { return cat(p) === 'mcp'; });
+
+      // Find orphans: gateway-like procs whose ppid is not in our proc set
+      const gatewayPids = new Set(procs.map(function(p) { return p.pid; }));
+      const orphans = procs.filter(function(p) {
+        const c = cat(p);
+        return (c === 'claude-pty' || c === 'claude-headless' || c === 'pty' || c === 'mcp')
+          && !gatewayPids.has(p.ppid)
+          && p.pid !== (orchestrator && orchestrator.pid);
+      });
+
+      if (orchestrator) {
+        lines.push('<span class="proc-orchestrator">Orchestrator</span>');
+        lines.push('  PID ' + orchestrator.pid + '  <span class="proc-orchestrator">' + short(orchestrator.args, 40) + '</span>');
+        lines.push('');
+      }
+
+      const sessionCount = ptys.length + headless.length;
+      lines.push('<span class="proc-label">Sessions (' + sessionCount + ' total)</span>');
+
+      ptys.forEach(function(pty) {
+        const agent = agentName(pty.args);
+        lines.push('  PID ' + pty.pid + '  <span class="proc-pty">claude-pty-shell.js</span>  [agent=' + agent + ']  ← PTY wrapper');
+        const claudeChild = procs.find(function(p) { return p.ppid === pty.pid && cat(p) === 'claude-pty'; });
+        if (claudeChild) {
+          lines.push('    └─ PID ' + claudeChild.pid + '  <span class="proc-claude">claude --session-id ' + sessionId(claudeChild.args) + '</span>');
+          const mcp = mcpServers.find(function(p) { return p.ppid === claudeChild.pid; });
+          if (mcp) {
+            lines.push('         └─ PID ' + mcp.pid + '  <span class="proc-mcp">bun mcp/server.ts</span>');
+          }
+        }
+      });
+
+      headless.forEach(function(cl) {
+        lines.push('  PID ' + cl.pid + '  <span class="proc-claude">claude --print</span>  [headless]');
+        const mcp = mcpServers.find(function(p) { return p.ppid === cl.pid; });
+        if (mcp) {
+          lines.push('    └─ PID ' + mcp.pid + '  <span class="proc-mcp">bun mcp/server.ts</span>');
+        }
+      });
+
+      if (sessionCount === 0) lines.push('  <span class="ts">— none —</span>');
+      lines.push('');
+
+      lines.push('<span class="proc-label">Receivers &amp; Services</span>');
+      if (telegramReceivers.length) lines.push('  Telegram pollers  ×' + telegramReceivers.length + '  <span class="proc-receiver">(bun)</span>');
+      if (discordReceivers.length) lines.push('  Discord pollers   ×' + discordReceivers.length + '  <span class="proc-receiver">(bun)</span>');
+      if (!telegramReceivers.length && !discordReceivers.length) lines.push('  <span class="ts">— none —</span>');
+      lines.push('');
+
+      lines.push('<span class="proc-label">Orphans</span>');
+      if (orphans.length) {
+        orphans.forEach(function(p) {
+          lines.push('  PID ' + p.pid + '  <span class="proc-orphan">' + short(p.args, 60) + '</span>  (ppid=' + p.ppid + ')');
+        });
+      } else {
+        lines.push('  <span class="ts">— none —  ✅</span>');
+      }
+
+      document.getElementById('proc-tree').innerHTML = lines.join('\\n');
+    }
+
     refresh();
+    refreshProcesses();
     setInterval(refresh, 5000);
+    setInterval(refreshProcesses, 10000);
   </script>
 </body>
 </html>`;

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -105,7 +105,7 @@ export function generateDashboardHtml(dashToken = ''): string {
     }
     .pty-viewer-header .agent-label { color: #63b3ed; font-weight: 600; }
     .pty-viewer-header .session-label { color: #718096; font-family: monospace; font-size: 0.78rem; }
-    .pty-close, .pty-refresh {
+    .pty-close {
       background: none;
       border: none;
       color: #718096;
@@ -114,7 +114,6 @@ export function generateDashboardHtml(dashToken = ''): string {
       padding: 0 4px;
     }
     .pty-close:hover { color: #fc8181; }
-    .pty-refresh:hover { color: #68d391; }
     /* Fixed-size terminal viewport — the server PTY runs at 200x50, so the
        viewer must NOT resize to the panel (that mismatch is what garbles the
        output). We render at the native size and pan horizontally if the 200-col
@@ -229,9 +228,8 @@ export function generateDashboardHtml(dashToken = ''): string {
        in view when streaming. -->
   <div class="pty-viewer" id="pty-viewer">
     <div class="pty-viewer-header">
-      <span>Shell Monitor &mdash; <span class="agent-label" id="pty-agent-label"></span><span class="session-label" id="pty-session-label"></span></span>
+      <span>Shell Process Viewer &mdash; <span class="agent-label" id="pty-agent-label"></span><span class="session-label" id="pty-session-label"></span></span>
       <span>
-        <button class="pty-refresh" id="pty-refresh-btn" title="Refresh display">&#x21BA;</button>
         <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
       </span>
     </div>
@@ -419,19 +417,7 @@ export function generateDashboardHtml(dashToken = ''): string {
       document.getElementById('pty-viewer').style.display = 'none';
     }
 
-    async function refreshPtyViewer() {
-      if (!currentPtyAgent) return;
-      const agentId = currentPtyAgent;
-      const sessionId = currentPtySession;
-      // Close existing WS and reset terminal to a clean state, then reconnect.
-      if (ptyWs) { ptyWs.close(); ptyWs = null; }
-      currentPtyAgent = null; // bypass the early-return guard in openPtyViewer
-      if (term) term.reset();
-      await openPtyViewer(agentId, sessionId);
-    }
-
     document.getElementById('pty-close-btn').addEventListener('click', closePtyViewer);
-    document.getElementById('pty-refresh-btn').addEventListener('click', () => void refreshPtyViewer());
 
     // Event delegation for Live buttons (avoids inline onclick + HTML injection)
     document.getElementById('sessions-tbody').addEventListener('click', function(e) {
@@ -448,7 +434,7 @@ export function generateDashboardHtml(dashToken = ''): string {
     }
 
     function modeBadge(mode) {
-      if (mode === 'pty-shell') return '<span class="badge badge-blue">pty-shell</span>';
+      if (mode === 'pty-shell') return '<span class="badge badge-blue">wrap-shell</span>';
       if (mode === 'headless') return '<span class="badge badge-purple">headless</span>';
       return '<span class="ts">' + escHtml(mode || '?') + '</span>';
     }
@@ -666,7 +652,7 @@ export function generateDashboardHtml(dashToken = ''): string {
 
       ptys.forEach(function(pty) {
         const agent = agentName(pty.args);
-        lines.push('  PID ' + pty.pid + '  <span class="proc-pty">pty-shell</span>  [' + agent + ']');
+        lines.push('  PID ' + pty.pid + '  <span class="proc-pty">wrap-shell</span>  [' + agent + ']');
         const claudeChild = procs.find(function(p) { return p.ppid === pty.pid && cat(p) === 'claude-pty'; });
         if (claudeChild) {
           lines.push('  \\u2514\\u2500 PID ' + claudeChild.pid + '  <span class="proc-claude">claude ' + sessionId(claudeChild.args) + '</span>');

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -43,7 +43,24 @@ export function generateDashboardHtml(apiKey = ''): string {
       padding: 8px 12px;
       border-bottom: 1px solid #1a202c;
     }
-    tr:hover td { background: #1a202c; }
+    tr.agent-row td {
+      background: #131720;
+      font-weight: 600;
+      color: #90cdf4;
+    }
+    tr.agent-row:hover td { background: #1a202c; }
+    tr.session-row td {
+      padding-left: 28px;
+      background: #0f1117;
+      color: #cbd5e0;
+      font-size: 0.82rem;
+    }
+    tr.session-row:hover td { background: #1a202c; }
+    tr.session-row td:first-child::before {
+      content: '└─ ';
+      color: #4a5568;
+      font-family: monospace;
+    }
     .badge {
       display: inline-block;
       padding: 2px 8px;
@@ -108,7 +125,6 @@ export function generateDashboardHtml(apiKey = ''): string {
       padding: 12px 16px;
       white-space: pre;
       color: #a0aec0;
-      margin-bottom: 24px;
       overflow-x: auto;
     }
     .proc-tree .proc-orchestrator { color: #63b3ed; }
@@ -118,6 +134,12 @@ export function generateDashboardHtml(apiKey = ''): string {
     .proc-tree .proc-receiver { color: #76e4f7; }
     .proc-tree .proc-orphan { color: #fc8181; }
     .proc-tree .proc-label { color: #718096; }
+    .session-id {
+      font-family: monospace;
+      font-size: 0.75rem;
+      color: #a0aec0;
+      word-break: break-all;
+    }
   </style>
 </head>
 <body>
@@ -128,29 +150,27 @@ export function generateDashboardHtml(apiKey = ''): string {
     Last updated: <span id="last-updated">—</span>
   </div>
 
-  <div style="display:grid;grid-template-columns:1fr 1.5fr;gap:24px;align-items:start;">
-    <!-- Left column: Processes -->
-    <div>
-      <h2>Processes</h2>
-      <div class="proc-tree" id="proc-tree">Loading...</div>
-    </div>
+  <!-- 80% / 20% layout — Agents+Sessions left, Processes right -->
+  <div style="display:grid;grid-template-columns:4fr 1fr;gap:24px;align-items:start;">
 
-    <!-- Right column: Agents + Sessions -->
+    <!-- Left column: Agents + Sessions (combined) -->
     <div>
-      <h2>Agents</h2>
+      <h2>Agents &amp; Sessions</h2>
       <table id="agents-table">
         <thead>
           <tr>
-            <th>ID</th>
+            <th>Agent / Session ID</th>
+            <th>Chat ID</th>
+            <th>Source</th>
             <th>Status</th>
-            <th>Received</th>
-            <th>Sent</th>
-            <th>Last Activity</th>
+            <th>Recv / Sent</th>
+            <th>Uptime</th>
+            <th>Last Activity / Spawned</th>
             <th>Live</th>
           </tr>
         </thead>
         <tbody id="agents-tbody">
-          <tr><td colspan="6" class="ts">Loading...</td></tr>
+          <tr><td colspan="8" class="ts">Loading...</td></tr>
         </tbody>
       </table>
 
@@ -161,24 +181,12 @@ export function generateDashboardHtml(apiKey = ''): string {
         </div>
         <div id="pty-terminal"></div>
       </div>
+    </div>
 
-      <h2>Sessions</h2>
-      <table id="sessions-table">
-        <thead>
-          <tr>
-            <th>Agent</th>
-            <th>Chat ID</th>
-            <th>Session ID</th>
-            <th>Source</th>
-            <th>Status</th>
-            <th>Uptime</th>
-            <th>Spawned</th>
-          </tr>
-        </thead>
-        <tbody id="sessions-tbody">
-          <tr><td colspan="7" class="ts">Loading...</td></tr>
-        </tbody>
-      </table>
+    <!-- Right column: Processes -->
+    <div>
+      <h2>Processes</h2>
+      <div class="proc-tree" id="proc-tree">Loading...</div>
     </div>
   </div>
 
@@ -299,45 +307,61 @@ export function generateDashboardHtml(apiKey = ''): string {
         if (data.version) document.getElementById('gateway-version').textContent = 'v' + data.version;
         document.getElementById('error-msg').style.display = 'none';
 
-        // Agents table (with Live button for PTY agents)
-        const agentRows = (data.agents || []).map(function(a) {
-          const liveBtn = a.hasPtyStream
-            ? '<button class="btn-stream" onclick="openPtyViewer(' + JSON.stringify(a.id) + ')">▶ Live</button>'
-            : '<span class="ts">—</span>';
-          return '<tr>' +
-            '<td>' + a.id + '</td>' +
-            '<td>' + badge(a.isRunning) + '</td>' +
-            '<td>' + (a.messagesReceived || 0) + '</td>' +
-            '<td>' + (a.messagesSent || 0) + '</td>' +
-            '<td>' + fmtTs(a.lastActivityAt) + '</td>' +
-            '<td>' + liveBtn + '</td>' +
-            '</tr>';
-        });
-        document.getElementById('agents-tbody').innerHTML =
-          agentRows.length ? agentRows.join('') : '<tr><td colspan="6" class="ts">No agents</td></tr>';
-
-        // Sessions table
-        const sessRows = [];
+        // Combined Agents + Sessions table
+        const rows = [];
         (data.agents || []).forEach(function(a) {
-          (a.sessions || []).forEach(function(s) {
-            const statusBadge = s.isRunning
-              ? '<span class="badge badge-green">running</span>'
-              : '<span class="badge badge-gray">stopped</span>';
-            const uptime = s.isRunning ? fmtUptime(s.uptimeSec || 0) : '<span class="ts">—</span>';
-            const shortSessId = s.sessionId ? s.sessionId.slice(0, 8) + '…' : '<span class="ts">—</span>';
-            sessRows.push('<tr>' +
-              '<td>' + a.id + '</td>' +
-              '<td class="ts">' + s.chatId + '</td>' +
-              '<td class="ts">' + shortSessId + '</td>' +
-              '<td>' + (s.source || '—') + '</td>' +
-              '<td>' + statusBadge + '</td>' +
-              '<td>' + uptime + '</td>' +
-              '<td>' + fmtTs(s.spawnedAt ? new Date(s.spawnedAt).toISOString() : null) + '</td>' +
-              '</tr>');
-          });
+          // Agent header row
+          rows.push(
+            '<tr class="agent-row">' +
+            '<td>' + a.id + '</td>' +
+            '<td class="ts">—</td>' +
+            '<td class="ts">—</td>' +
+            '<td>' + badge(a.isRunning) + '</td>' +
+            '<td>' + (a.messagesReceived || 0) + ' / ' + (a.messagesSent || 0) + '</td>' +
+            '<td class="ts">—</td>' +
+            '<td>' + fmtTs(a.lastActivityAt) + '</td>' +
+            '<td class="ts">—</td>' +
+            '</tr>'
+          );
+
+          // Session sub-rows
+          const sessions = a.sessions || [];
+          if (sessions.length === 0) {
+            rows.push(
+              '<tr class="session-row">' +
+              '<td colspan="8" class="ts" style="padding-left:28px;">no sessions</td>' +
+              '</tr>'
+            );
+          } else {
+            sessions.forEach(function(s) {
+              const statusBadge = s.isRunning
+                ? '<span class="badge badge-green">running</span>'
+                : '<span class="badge badge-gray">stopped</span>';
+              const uptime = s.isRunning ? fmtUptime(s.uptimeSec || 0) : '<span class="ts">—</span>';
+              const sessIdFull = s.sessionId
+                ? '<span class="session-id">' + s.sessionId + '</span>'
+                : '<span class="ts">—</span>';
+              const liveBtn = (a.hasPtyStream && s.isRunning)
+                ? '<button class="btn-stream" onclick="openPtyViewer(' + JSON.stringify(a.id) + ')">▶ Live</button>'
+                : '<span class="ts">—</span>';
+              rows.push(
+                '<tr class="session-row">' +
+                '<td>' + sessIdFull + '</td>' +
+                '<td class="ts">' + (s.chatId || '—') + '</td>' +
+                '<td>' + (s.source || '—') + '</td>' +
+                '<td>' + statusBadge + '</td>' +
+                '<td class="ts">—</td>' +
+                '<td>' + uptime + '</td>' +
+                '<td>' + fmtTs(s.spawnedAt ? new Date(s.spawnedAt).toISOString() : null) + '</td>' +
+                '<td>' + liveBtn + '</td>' +
+                '</tr>'
+              );
+            });
+          }
         });
-        document.getElementById('sessions-tbody').innerHTML =
-          sessRows.length ? sessRows.join('') : '<tr><td colspan="7" class="ts">No sessions yet</td></tr>';
+
+        document.getElementById('agents-tbody').innerHTML =
+          rows.length ? rows.join('') : '<tr><td colspan="8" class="ts">No agents</td></tr>';
 
         document.getElementById('refresh-indicator').textContent = 'auto-refresh 5s';
       } catch(e) {
@@ -368,7 +392,6 @@ export function generateDashboardHtml(apiKey = ''): string {
       const pidMap = {};
       procs.forEach(function(p) { pidMap[p.pid] = p; });
 
-      // Categorize
       function cat(p) {
         const a = p.args;
         if (a.includes('node') && a.includes('dist/index')) return 'orchestrator';
@@ -376,7 +399,6 @@ export function generateDashboardHtml(apiKey = ''): string {
         if (a.includes('bun') && a.includes('mcp/server')) return 'mcp';
         if (a.includes('bun') && a.includes('telegram') && a.includes('receiver')) return 'telegram';
         if (a.includes('bun') && a.includes('discord') && a.includes('receiver')) return 'discord';
-        // Match both PTY (--session-id) and headless (--print) claude processes
         if (a.includes('--mcp-config') && (a.includes('--session-id') || a.includes('--print'))) {
           if (a.includes('--session-id')) {
             const parent = pidMap[p.ppid];
@@ -409,7 +431,6 @@ export function generateDashboardHtml(apiKey = ''): string {
       const discordReceivers = procs.filter(function(p) { return cat(p) === 'discord'; });
       const mcpServers = procs.filter(function(p) { return cat(p) === 'mcp'; });
 
-      // Find orphans: gateway-like procs whose ppid is not in our proc set
       const gatewayPids = new Set(procs.map(function(p) { return p.pid; }));
       const orphans = procs.filter(function(p) {
         const c = cat(p);
@@ -425,45 +446,45 @@ export function generateDashboardHtml(apiKey = ''): string {
       }
 
       const sessionCount = ptys.length + headless.length;
-      lines.push('<span class="proc-label">Sessions (' + sessionCount + ' total)</span>');
+      lines.push('<span class="proc-label">Sessions (' + sessionCount + ')</span>');
 
       ptys.forEach(function(pty) {
         const agent = agentName(pty.args);
-        lines.push('  PID ' + pty.pid + '  <span class="proc-pty">claude-pty-shell.js</span>  [agent=' + agent + ']  ← PTY wrapper');
+        lines.push('  PID ' + pty.pid + '  <span class="proc-pty">pty-shell</span>  [' + agent + ']');
         const claudeChild = procs.find(function(p) { return p.ppid === pty.pid && cat(p) === 'claude-pty'; });
         if (claudeChild) {
-          lines.push('    └─ PID ' + claudeChild.pid + '  <span class="proc-claude">claude --session-id ' + sessionId(claudeChild.args) + '</span>');
+          lines.push('  └─ PID ' + claudeChild.pid + '  <span class="proc-claude">claude ' + sessionId(claudeChild.args) + '</span>');
           const mcp = mcpServers.find(function(p) { return p.ppid === claudeChild.pid; });
           if (mcp) {
-            lines.push('         └─ PID ' + mcp.pid + '  <span class="proc-mcp">bun mcp/server.ts</span>');
+            lines.push('     └─ PID ' + mcp.pid + '  <span class="proc-mcp">mcp</span>');
           }
         }
       });
 
       headless.forEach(function(cl) {
-        lines.push('  PID ' + cl.pid + '  <span class="proc-claude">claude --print</span>  [headless]');
+        lines.push('  PID ' + cl.pid + '  <span class="proc-claude">claude --print</span>');
         const mcp = mcpServers.find(function(p) { return p.ppid === cl.pid; });
         if (mcp) {
-          lines.push('    └─ PID ' + mcp.pid + '  <span class="proc-mcp">bun mcp/server.ts</span>');
+          lines.push('  └─ PID ' + mcp.pid + '  <span class="proc-mcp">mcp</span>');
         }
       });
 
       if (sessionCount === 0) lines.push('  <span class="ts">— none —</span>');
       lines.push('');
 
-      lines.push('<span class="proc-label">Receivers &amp; Services</span>');
-      if (telegramReceivers.length) lines.push('  Telegram pollers  ×' + telegramReceivers.length + '  <span class="proc-receiver">(bun)</span>');
-      if (discordReceivers.length) lines.push('  Discord pollers   ×' + discordReceivers.length + '  <span class="proc-receiver">(bun)</span>');
+      lines.push('<span class="proc-label">Receivers</span>');
+      if (telegramReceivers.length) lines.push('  TG ×' + telegramReceivers.length);
+      if (discordReceivers.length) lines.push('  DC ×' + discordReceivers.length);
       if (!telegramReceivers.length && !discordReceivers.length) lines.push('  <span class="ts">— none —</span>');
       lines.push('');
 
       lines.push('<span class="proc-label">Orphans</span>');
       if (orphans.length) {
         orphans.forEach(function(p) {
-          lines.push('  PID ' + p.pid + '  <span class="proc-orphan">' + short(p.args, 60) + '</span>  (ppid=' + p.ppid + ')');
+          lines.push('  ⚠ PID ' + p.pid + '  <span class="proc-orphan">' + short(p.args, 30) + '</span>');
         });
       } else {
-        lines.push('  <span class="ts">— none —  ✅</span>');
+        lines.push('  <span class="ts">none ✅</span>');
       }
 
       document.getElementById('proc-tree').innerHTML = lines.join('\\n');

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -20,7 +20,16 @@ export function generateDashboardHtml(apiKey = ''): string {
       color: #e2e8f0;
       padding: 24px;
     }
-    h1 { color: #63b3ed; font-size: 1.5rem; margin-bottom: 8px; }
+    h1 { font-size: 1.5rem; margin-bottom: 8px; }
+    .rainbow {
+      background: linear-gradient(90deg, #ff0080, #ff8c00, #ffe600, #00d26a, #00b4ff, #a855f7, #ff0080);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      animation: rainbow-shift 3s linear infinite;
+    }
+    @keyframes rainbow-shift { to { background-position: 200% center; } }
     .meta { color: #718096; font-size: 0.85rem; margin-bottom: 16px; }
     .meta span { color: #a0aec0; }
     h2 { color: #90cdf4; font-size: 1.1rem; margin: 20px 0 10px; }
@@ -59,6 +68,12 @@ export function generateDashboardHtml(apiKey = ''): string {
     .badge-gray { background: #2d3748; color: #a0aec0; }
     .badge-blue { background: #1a365d; color: #63b3ed; }
     .badge-purple { background: #44337a; color: #b794f4; }
+    /* Per-model badge colors — each model family gets a distinct hue. */
+    .badge-opus { background: #5a3a1a; color: #f6ad55; }
+    .badge-sonnet { background: #1a4a52; color: #4fd1c5; }
+    .badge-haiku { background: #22543d; color: #68d391; }
+    .badge-fable { background: #553052; color: #f687b3; }
+    .badge-model { background: #2d3748; color: #cbd5e0; }
     .ts { color: #718096; font-size: 0.8rem; }
     #refresh-indicator { float: right; font-size: 0.75rem; color: #4a5568; }
     .error { color: #fc8181; font-size: 0.85rem; margin-top: 8px; }
@@ -89,6 +104,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       color: #a0aec0;
     }
     .pty-viewer-header .agent-label { color: #63b3ed; font-weight: 600; }
+    .pty-viewer-header .session-label { color: #718096; font-family: monospace; font-size: 0.78rem; }
     .pty-close {
       background: none;
       border: none;
@@ -100,14 +116,20 @@ export function generateDashboardHtml(apiKey = ''): string {
     .pty-close:hover { color: #fc8181; }
     /* Fixed-size terminal viewport — the server PTY runs at 200x50, so the
        viewer must NOT resize to the panel (that mismatch is what garbles the
-       output). We render at the native size and scroll if it overflows. */
+       output). We render at the native size and pan horizontally if the 200-col
+       width overflows the panel. The Claude TUI uses the alternate screen buffer
+       (\x1b[?1049h), which has no scrollback by design — so there is nothing to
+       scroll vertically and we hide the (non-functional) vertical scrollbar. */
     #pty-terminal {
       padding: 8px;
       background: #0d1117;
-      overflow: auto;
+      overflow-x: auto;
+      overflow-y: hidden;
       max-height: 70vh;
       border-radius: 6px;
     }
+    /* No scrollback in alt-screen mode → suppress xterm's vertical scrollbar. */
+    #pty-terminal .xterm-viewport { overflow-y: hidden !important; }
     .proc-tree {
       font-family: monospace;
       font-size: 0.82rem;
@@ -126,6 +148,7 @@ export function generateDashboardHtml(apiKey = ''): string {
     .proc-tree .proc-receiver { color: #76e4f7; }
     .proc-tree .proc-orphan { color: #fc8181; }
     .proc-tree .proc-label { color: #718096; }
+    .proc-tree .proc-summary { color: #f6e05e; font-weight: 600; }
     .session-id {
       font-family: monospace;
       font-size: 0.75rem;
@@ -152,18 +175,46 @@ export function generateDashboardHtml(apiKey = ''): string {
     .agent-badge .agent-name { color: #90cdf4; font-weight: 600; }
     .agent-badge .dot-green { color: #68d391; }
     .agent-badge .dot-red { color: #fc8181; }
+
+    /* Top row: Processes 70% | Agents 30%. Collapses to a single column on
+       narrow screens (see media query below). */
+    .top-grid {
+      display: grid;
+      grid-template-columns: 7fr 3fr;
+      gap: 24px;
+      align-items: start;
+    }
+    /* The Sessions table has 10 columns — too wide for phones. Wrap it so it
+       scrolls horizontally instead of breaking the layout. */
+    .table-wrap { width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .table-wrap table { min-width: 820px; }
+
+    /* ── Responsive breakpoints ──────────────────────────────────────────── */
+    @media (max-width: 900px) {
+      .top-grid { grid-template-columns: 1fr; gap: 16px; }
+    }
+    @media (max-width: 640px) {
+      body { padding: 14px; }
+      h1 { font-size: 1.2rem; }
+      h2 { font-size: 1rem; }
+      .meta { font-size: 0.78rem; }
+      #refresh-indicator { float: none; display: block; margin-top: 4px; }
+      .proc-tree { font-size: 0.72rem; padding: 10px 12px; }
+      /* On phones the PTY mirror can use the full viewport width and fit. */
+      #pty-terminal { max-height: 60vh; }
+    }
   </style>
 </head>
 <body>
-  <h1>Claude Gateway <span id="gateway-version" style="font-size:0.75rem;color:#718096;"></span> <span id="refresh-indicator">refreshing...</span></h1>
+  <h1><span class="rainbow">Claude Gateway</span> <span id="gateway-version" style="font-size:0.75rem;color:#718096;"></span> <span id="refresh-indicator">refreshing...</span></h1>
   <div class="meta">
     Uptime: <span id="uptime">&mdash;</span> &nbsp;|&nbsp;
     Started: <span id="started-at">&mdash;</span> &nbsp;|&nbsp;
     Last updated: <span id="last-updated">&mdash;</span>
   </div>
 
-  <!-- Row: Processes 70% | Agent badges 30% -->
-  <div style="display:grid;grid-template-columns:7fr 3fr;gap:24px;align-items:start;">
+  <!-- Row: Processes 70% | Agent badges 30% (collapses on narrow screens) -->
+  <div class="top-grid">
     <div>
       <h2>Processes</h2>
       <div class="proc-tree" id="proc-tree">Loading...</div>
@@ -174,35 +225,40 @@ export function generateDashboardHtml(apiKey = ''): string {
     </div>
   </div>
 
-  <!-- Sessions — full width (session-centric, flat list) -->
-  <h2>Sessions</h2>
-  <table id="sessions-table">
-    <thead>
-      <tr>
-        <th>Agent</th>
-        <th>Session ID</th>
-        <th>Chat ID</th>
-        <th>Source</th>
-        <th>Mode</th>
-        <th>Model</th>
-        <th>Status</th>
-        <th>Uptime</th>
-        <th>Spawned</th>
-        <th>Live</th>
-      </tr>
-    </thead>
-    <tbody id="sessions-tbody">
-      <tr><td colspan="10" class="ts">Loading...</td></tr>
-    </tbody>
-  </table>
-
-  <!-- PTY viewer — full width so the native 200-col terminal has room -->
+  <!-- PTY viewer — full width so the native 200-col terminal has room.
+       Placed above the Sessions table so the live mirror is the first thing
+       in view when streaming. -->
   <div class="pty-viewer" id="pty-viewer">
     <div class="pty-viewer-header">
-      <span>PTY Live &mdash; <span class="agent-label" id="pty-agent-label"></span></span>
+      <span>Shell Monitor &mdash; <span class="agent-label" id="pty-agent-label"></span><span class="session-label" id="pty-session-label"></span></span>
       <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
     </div>
     <div id="pty-terminal"></div>
+  </div>
+
+  <!-- Sessions — full width (session-centric, flat list) -->
+  <h2>Sessions</h2>
+  <div class="table-wrap">
+    <table id="sessions-table">
+      <thead>
+        <tr>
+          <th>Agent</th>
+          <th>Session ID</th>
+          <th>Chat ID</th>
+          <th>Source</th>
+          <th>Mode</th>
+          <th>Model</th>
+          <th>Tokens</th>
+          <th>Status</th>
+          <th>Uptime</th>
+          <th>Spawned</th>
+          <th>Shell</th>
+        </tr>
+      </thead>
+      <tbody id="sessions-tbody">
+        <tr><td colspan="11" class="ts">Loading...</td></tr>
+      </tbody>
+    </table>
   </div>
 
   <div id="error-msg" class="error" style="display:none;"></div>
@@ -225,11 +281,15 @@ export function generateDashboardHtml(apiKey = ''): string {
       return s + 's';
     }
 
+    // Spawned timestamp, formatted like "6/14/2026, 10:32:31 PM" (en-US, 12h).
     function fmtTs(ts) {
       if (!ts) return '<span class="ts">&mdash;</span>';
       try {
         const d = new Date(ts);
-        return '<span class="ts">' + d.toLocaleTimeString() + ' ' + d.toLocaleDateString() + '</span>';
+        return '<span class="ts">' + d.toLocaleString('en-US', {
+          year: 'numeric', month: 'numeric', day: 'numeric',
+          hour: 'numeric', minute: '2-digit', second: '2-digit', hour12: true
+        }) + '</span>';
       } catch(e) { return ts; }
     }
 
@@ -260,18 +320,29 @@ export function generateDashboardHtml(apiKey = ''): string {
     // split across WebSocket frames are reassembled instead of corrupted.
     let utf8Decoder = null;
 
-    function openPtyViewer(agentId) {
+    // The agent's TUI enables mouse tracking (DECSET 1000/1002/1003/1006...).
+    // While those modes are active, xterm.js forwards wheel/click events to the
+    // app as mouse escapes, which can leave stray report bytes in the view. This
+    // is a view-only mirror (disableStdin) so mouse reporting is useless here —
+    // strip the set/reset sequences to keep the mirror clean.
+    function stripMouseModes(s) {
+      return s.replace(/\\x1b\\[\\?(1000|1001|1002|1003|1004|1005|1006|1015|1016)[hl]/g, '');
+    }
+
+    function openPtyViewer(agentId, sessionId) {
       if (currentPtyAgent === agentId && ptyWs && ptyWs.readyState === WebSocket.OPEN) return;
       closePtyViewer();
 
       currentPtyAgent = agentId;
       document.getElementById('pty-agent-label').textContent = agentId;
+      // Append the session id after the agent name, e.g. "claude-founder · 3c01897c…".
+      document.getElementById('pty-session-label').textContent = sessionId ? ' \\u00b7 ' + sessionId : '';
       document.getElementById('pty-viewer').style.display = 'block';
 
       if (!term) {
         term = new Terminal({
           theme: { background: '#0d1117', foreground: '#e2e8f0', cursor: '#63b3ed' },
-          fontSize: 10,
+          fontSize: 11,
           lineHeight: 1.0,
           letterSpacing: 0,
           fontFamily: '"JetBrains Mono", "Cascadia Code", Menlo, Monaco, Consolas, "Courier New", monospace',
@@ -281,7 +352,10 @@ export function generateDashboardHtml(apiKey = ''): string {
           // size mismatch is what makes the output unreadable.
           cols: PTY_COLS,
           rows: PTY_ROWS,
-          scrollback: 5000,
+          // Alt-screen TUI has no scrollback (the live mirror only shows the
+          // current screen), so don't retain any — this also removes the
+          // non-functional vertical scrollbar.
+          scrollback: 0,
           // View-only mirror of the agent's TUI.
           disableStdin: true,
           cursorBlink: false,
@@ -304,7 +378,7 @@ export function generateDashboardHtml(apiKey = ''): string {
         const data = ev.data instanceof ArrayBuffer
           ? utf8Decoder.decode(ev.data, { stream: true })
           : ev.data;
-        term.write(data);
+        term.write(stripMouseModes(data));
       };
       ptyWs.onclose = function(ev) {
         if (term) term.writeln('\\r\\n\\x1b[33m[disconnected: ' + (ev.reason || 'closed') + ']\\x1b[0m');
@@ -323,7 +397,7 @@ export function generateDashboardHtml(apiKey = ''): string {
     // Event delegation for Live buttons (avoids inline onclick + HTML injection)
     document.getElementById('sessions-tbody').addEventListener('click', function(e) {
       const btn = e.target.closest('.btn-stream');
-      if (btn) openPtyViewer(btn.getAttribute('data-agent-id'));
+      if (btn) openPtyViewer(btn.getAttribute('data-agent-id'), btn.getAttribute('data-session-id'));
     });
 
     function escHtml(s) {
@@ -340,13 +414,38 @@ export function generateDashboardHtml(apiKey = ''): string {
       return '<span class="ts">' + escHtml(mode || '?') + '</span>';
     }
 
+    // Source badge with a per-channel color: telegram=blue, discord=purple,
+    // api=gray. Unknown sources fall back to gray.
+    function sourceBadge(source) {
+      const s = String(source || '?').toLowerCase();
+      if (s === 'telegram') return '<span class="badge badge-blue">telegram</span>';
+      if (s === 'discord') return '<span class="badge badge-purple">discord</span>';
+      if (s === 'api') return '<span class="badge badge-gray">api</span>';
+      return '<span class="badge badge-gray">' + escHtml(source || '?') + '</span>';
+    }
+
     // Prettify a model id for display: drop the "claude-" prefix and any
     // trailing date stamp, e.g. claude-haiku-4-5-20251001 -> haiku-4-5.
-    // Full id is kept in the tooltip.
+    // Each model family gets a distinct badge color; full id kept in the tooltip.
     function fmtModel(m) {
       if (!m) return '<span class="ts">&mdash;</span>';
-      const label = String(m).replace(/^claude-/, '').replace(/-\\d{8}$/, '');
-      return '<span class="badge badge-gray" title="' + escHtml(m) + '">' + escHtml(label) + '</span>';
+      const id = String(m);
+      const label = id.replace(/^claude-/, '').replace(/-\\d{8}$/, '');
+      let cls = 'badge-model';
+      if (/opus/i.test(id)) cls = 'badge-opus';
+      else if (/sonnet/i.test(id)) cls = 'badge-sonnet';
+      else if (/haiku/i.test(id)) cls = 'badge-haiku';
+      else if (/fable/i.test(id)) cls = 'badge-fable';
+      return '<span class="badge ' + cls + '" title="' + escHtml(id) + '">' + escHtml(label) + '</span>';
+    }
+
+    // Format a context-window token count compactly: 1234 -> "1.2k", 45000 -> "45k".
+    // Full value is kept in the tooltip. 0/unknown renders as a dash.
+    function fmtTokens(n) {
+      const v = Number(n) || 0;
+      if (v <= 0) return '<span class="ts">&mdash;</span>';
+      const label = v >= 1000 ? (v / 1000).toFixed(v >= 10000 ? 0 : 1) + 'k' : String(v);
+      return '<span title="' + v.toLocaleString() + ' tokens">' + label + '</span>';
     }
 
     // ── Status Refresh ────────────────────────────────────────────────────────
@@ -394,16 +493,17 @@ export function generateDashboardHtml(apiKey = ''): string {
               ? '<span class="session-id">' + escHtml(String(s.chatId)) + '</span>'
               : '<span class="ts">&mdash;</span>';
             const liveBtn = (a.hasPtyStream && s.isRunning && s.mode === 'pty-shell')
-              ? '<button class="btn-stream" data-agent-id="' + escHtml(a.id) + '">▶ Live</button>'
+              ? '<button class="btn-stream" data-agent-id="' + escHtml(a.id) + '" data-session-id="' + escHtml(s.sessionId || '') + '">▶ Live</button>'
               : '<span class="ts">&mdash;</span>';
             rows.push(
               '<tr class="session-row">' +
               '<td><span style="color:#90cdf4;font-weight:600;">' + escHtml(a.id) + '</span></td>' +
               '<td>' + sessId + '</td>' +
               '<td>' + chatCell + '</td>' +
-              '<td><span class="badge badge-gray">' + escHtml(s.source || '?') + '</span></td>' +
+              '<td>' + sourceBadge(s.source) + '</td>' +
               '<td>' + modeBadge(s.mode) + '</td>' +
               '<td>' + fmtModel(s.model) + '</td>' +
+              '<td>' + fmtTokens(s.tokens) + '</td>' +
               '<td>' + statusBadge + '</td>' +
               '<td>' + uptime + '</td>' +
               '<td>' + fmtTs(s.spawnedAt ? new Date(s.spawnedAt).toISOString() : null) + '</td>' +
@@ -414,9 +514,9 @@ export function generateDashboardHtml(apiKey = ''): string {
         });
 
         document.getElementById('sessions-tbody').innerHTML =
-          rows.length ? rows.join('') : '<tr><td colspan="10" class="ts">No active sessions</td></tr>';
+          rows.length ? rows.join('') : '<tr><td colspan="11" class="ts">No active sessions</td></tr>';
 
-        document.getElementById('refresh-indicator').textContent = 'auto-refresh 5s';
+        document.getElementById('refresh-indicator').textContent = 'auto-refresh 3s';
       } catch(e) {
         document.getElementById('error-msg').textContent = 'Error fetching status: ' + e.message;
         document.getElementById('error-msg').style.display = 'block';
@@ -444,6 +544,20 @@ export function generateDashboardHtml(apiKey = ''): string {
 
       const pidMap = {};
       procs.forEach(function(p) { pidMap[p.pid] = p; });
+
+      // Aggregate resource usage across the whole gateway process tree.
+      // %CPU is ps's lifetime average per process (summed → total load share);
+      // RSS is summed and may slightly over-count shared pages, but is a good
+      // proxy for "memory used by the gateway".
+      let totalCpu = 0, totalRssKb = 0;
+      procs.forEach(function(p) {
+        totalCpu += Number(p.cpu) || 0;
+        totalRssKb += Number(p.rssKb) || 0;
+      });
+      const totalMemMb = totalRssKb / 1024;
+      const memStr = totalMemMb >= 1024
+        ? (totalMemMb / 1024).toFixed(2) + ' GB'
+        : totalMemMb.toFixed(0) + ' MB';
 
       function cat(p) {
         const a = p.args;
@@ -478,6 +592,15 @@ export function generateDashboardHtml(apiKey = ''): string {
       }
 
       const lines = [];
+      // First line: total resource usage across the whole gateway tree.
+      lines.push(
+        '<span class="proc-summary">' +
+        '\\u2211 ' + procs.length + ' procs' +
+        '  \\u00b7  CPU ' + totalCpu.toFixed(1) + '%' +
+        '  \\u00b7  MEM ' + memStr +
+        '</span>'
+      );
+      lines.push('');
       const orchestrator = procs.find(function(p) { return cat(p) === 'orchestrator'; });
       const ptys = procs.filter(function(p) { return cat(p) === 'pty'; });
       const headless = procs.filter(function(p) { return cat(p) === 'claude-headless'; });
@@ -528,8 +651,8 @@ export function generateDashboardHtml(apiKey = ''): string {
       lines.push('');
 
       lines.push('<span class="proc-label">Receivers</span>');
-      if (telegramReceivers.length) lines.push('  TG \\u00d7' + telegramReceivers.length);
-      if (discordReceivers.length) lines.push('  DC \\u00d7' + discordReceivers.length);
+      if (telegramReceivers.length) lines.push('  Telegram \\u00d7' + telegramReceivers.length);
+      if (discordReceivers.length) lines.push('  Discord \\u00d7' + discordReceivers.length);
       if (!telegramReceivers.length && !discordReceivers.length) lines.push('  <span class="ts">\\u2014 none \\u2014</span>');
       lines.push('');
 
@@ -547,8 +670,9 @@ export function generateDashboardHtml(apiKey = ''): string {
 
     refresh();
     refreshProcesses();
-    setInterval(refresh, 5000);
-    setInterval(refreshProcesses, 10000);
+    setInterval(refresh, 3000);
+    // Process tree (with CPU/mem) is heavier (spawns ps) — refresh a bit slower.
+    setInterval(refreshProcesses, 6000);
   </script>
 </body>
 </html>`;

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -271,7 +271,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       if (!term) {
         term = new Terminal({
           theme: { background: '#0d1117', foreground: '#e2e8f0', cursor: '#63b3ed' },
-          fontSize: 11,
+          fontSize: 10,
           lineHeight: 1.0,
           letterSpacing: 0,
           fontFamily: '"JetBrains Mono", "Cascadia Code", Menlo, Monaco, Consolas, "Courier New", monospace',

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -224,7 +224,7 @@ export function generateDashboardHtml(): string {
     // Compute base path from current URL (handles reverse proxy sub-paths)
     function basePath() {
       const p = window.location.pathname;
-      return p.endsWith('/ui') ? p.slice(0, -2) : (p.endsWith('/ui/') ? p.slice(0, -3) : p.replace(/\\/$/, ''));
+      return p.endsWith('/ui') ? p.slice(0, -3) : (p.endsWith('/ui/') ? p.slice(0, -4) : p.replace(/\\/$/, ''));
     }
 
     function apiUrl(path) {

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -11,7 +11,8 @@ export function generateDashboardHtml(dashToken = ''): string {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="dash-token" content="${safeToken}">
   <title>Claude Gateway</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/css/xterm.min.css"
+    integrity="sha384-eDYu/eBZQNhtqTaA7Wl3XighXKxm/9VYF+Chh3hQS+UUlKQIJ14hK2imKu4n99aR" crossorigin="anonymous"/>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -105,7 +106,7 @@ export function generateDashboardHtml(dashToken = ''): string {
     }
     .pty-viewer-header .agent-label { color: #63b3ed; font-weight: 600; }
     .pty-viewer-header .session-label { color: #718096; font-family: monospace; font-size: 0.78rem; }
-    .pty-close {
+    .pty-close, .pty-refresh {
       background: none;
       border: none;
       color: #718096;
@@ -114,6 +115,7 @@ export function generateDashboardHtml(dashToken = ''): string {
       padding: 0 4px;
     }
     .pty-close:hover { color: #fc8181; }
+    .pty-refresh:hover { color: #63b3ed; }
     /* Fixed-size terminal viewport — the server PTY runs at 200x50, so the
        viewer must NOT resize to the panel (that mismatch is what garbles the
        output). We render at the native size and pan horizontally if the 200-col
@@ -230,6 +232,7 @@ export function generateDashboardHtml(dashToken = ''): string {
     <div class="pty-viewer-header">
       <span>Shell Process Viewer &mdash; <span class="agent-label" id="pty-agent-label"></span><span class="session-label" id="pty-session-label"></span></span>
       <span>
+        <button class="pty-refresh" id="pty-refresh-btn" title="Refresh (reconnect &amp; redraw)">&#x21ba;</button>
         <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
       </span>
     </div>
@@ -263,7 +266,8 @@ export function generateDashboardHtml(dashToken = ''): string {
 
   <div id="error-msg" class="error" style="display:none;"></div>
 
-  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/lib/xterm.min.js"
+    integrity="sha384-pELe6ZHtFxFcuYBq3gMkqvmnNIqUWnAYjBG5gThqQQCjWp8PJ/65MLK4lMIfEK1e" crossorigin="anonymous"></script>
   <script>
     // Read short-lived dashboard token from meta tag (10 min, server-issued at page load).
     // The raw API key is never embedded in HTML — only this scoped, expiring token is.
@@ -305,21 +309,22 @@ export function generateDashboardHtml(dashToken = ''): string {
       return basePath() + path;
     }
 
-    async function wsPtyUrl(agentId) {
+    async function wsPtyUrl(agentId, sessionId) {
       // Exchange the API key for a short-lived ticket so the key never appears in
       // the WS URL (which would expose it in server logs and browser history).
+      // Streams are per-session, so the session id is always part of the request.
+      const base = basePath() + '/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream';
+      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       if (!DASHBOARD_API_KEY) {
-        const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        return proto + '//' + window.location.host + basePath() + '/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream';
+        return proto + '//' + window.location.host + base + '?session=' + encodeURIComponent(sessionId);
       }
       const r = await fetch(apiUrl('/api/v1/pty-stream-ticket'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Dash-Token': DASHBOARD_API_KEY },
-        body: JSON.stringify({ agentId }),
+        body: JSON.stringify({ agentId, sessionId }),
       });
       const { ticket } = await r.json();
-      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      return proto + '//' + window.location.host + basePath() + '/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream?ticket=' + ticket;
+      return proto + '//' + window.location.host + base + '?ticket=' + ticket;
     }
 
     // ── PTY Viewer ───────────────────────────────────────────────────────────
@@ -343,7 +348,10 @@ export function generateDashboardHtml(dashToken = ''): string {
     }
 
     async function openPtyViewer(agentId, sessionId) {
-      if (currentPtyAgent === agentId && ptyWs && ptyWs.readyState === WebSocket.OPEN) return;
+      // Compare the SESSION, not the agent: one agent can have several sessions,
+      // each its own stream. Guarding on agent alone made switching between two
+      // sessions of the same agent a no-op (the viewer never reconnected).
+      if (currentPtySession === sessionId && ptyWs && ptyWs.readyState === WebSocket.OPEN) return;
       closePtyViewer();
 
       currentPtyAgent = agentId;
@@ -394,7 +402,7 @@ export function generateDashboardHtml(dashToken = ''): string {
       // viewing can't corrupt the first character of this stream.
       utf8Decoder = new TextDecoder('utf-8');
 
-      const url = await wsPtyUrl(agentId);
+      const url = await wsPtyUrl(agentId, sessionId);
       ptyWs = new WebSocket(url);
       ptyWs.binaryType = 'arraybuffer';
 
@@ -417,7 +425,19 @@ export function generateDashboardHtml(dashToken = ''): string {
       document.getElementById('pty-viewer').style.display = 'none';
     }
 
+    // Refresh: force a clean reconnect of the CURRENT session. The server replays
+    // a freshly-serialized screen frame on subscribe, so this redraws from a clean
+    // xterm state — a manual escape hatch if the live stream ever drifts.
+    async function refreshPtyViewer() {
+      const agentId = currentPtyAgent;
+      const sessionId = currentPtySession;
+      if (!agentId) return;
+      closePtyViewer();
+      await openPtyViewer(agentId, sessionId);
+    }
+
     document.getElementById('pty-close-btn').addEventListener('click', closePtyViewer);
+    document.getElementById('pty-refresh-btn').addEventListener('click', function() { void refreshPtyViewer(); });
 
     // Event delegation for Live buttons (avoids inline onclick + HTML injection)
     document.getElementById('sessions-tbody').addEventListener('click', function(e) {
@@ -517,7 +537,7 @@ export function generateDashboardHtml(dashToken = ''): string {
             const chatCell = s.chatId
               ? '<span class="session-id">' + escHtml(String(s.chatId)) + '</span>'
               : '<span class="ts">&mdash;</span>';
-            const liveBtn = (a.hasPtyStream && s.isRunning && s.mode === 'pty-shell')
+            const liveBtn = (s.hasPtyStream && s.isRunning && s.mode === 'pty-shell')
               ? '<button class="btn-stream" data-agent-id="' + escHtml(a.id) + '" data-session-id="' + escHtml(s.sessionId || '') + '">💻 View</button>'
               : '<span class="ts">&mdash;</span>';
             rows.push(

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -307,10 +307,21 @@ export function generateDashboardHtml(apiKey = ''): string {
       return basePath() + path;
     }
 
-    function wsUrl(path) {
+    async function wsPtyUrl(agentId) {
+      // Exchange the API key for a short-lived ticket so the key never appears in
+      // the WS URL (which would expose it in server logs and browser history).
+      if (!DASHBOARD_API_KEY) {
+        const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        return proto + '//' + window.location.host + basePath() + '/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream';
+      }
+      const r = await fetch(apiUrl('/api/v1/pty-stream-ticket'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Api-Key': DASHBOARD_API_KEY },
+        body: JSON.stringify({ agentId }),
+      });
+      const { ticket } = await r.json();
       const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const base = proto + '//' + window.location.host + basePath() + path;
-      return DASHBOARD_API_KEY ? base + (base.includes('?') ? '&' : '?') + 'key=' + encodeURIComponent(DASHBOARD_API_KEY) : base;
+      return proto + '//' + window.location.host + basePath() + '/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream?ticket=' + ticket;
     }
 
     // ── PTY Viewer ───────────────────────────────────────────────────────────
@@ -333,7 +344,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       return s.replace(/\\x1b\\[\\?(1000|1001|1002|1003|1004|1005|1006|1015|1016)[hl]/g, '');
     }
 
-    function openPtyViewer(agentId, sessionId) {
+    async function openPtyViewer(agentId, sessionId) {
       if (currentPtyAgent === agentId && ptyWs && ptyWs.readyState === WebSocket.OPEN) return;
       closePtyViewer();
 
@@ -375,7 +386,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       // viewing can't corrupt the first character of this stream.
       utf8Decoder = new TextDecoder('utf-8');
 
-      const url = wsUrl('/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream');
+      const url = await wsPtyUrl(agentId);
       ptyWs = new WebSocket(url);
       ptyWs.binaryType = 'arraybuffer';
 
@@ -398,7 +409,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       document.getElementById('pty-viewer').style.display = 'none';
     }
 
-    function refreshPtyViewer() {
+    async function refreshPtyViewer() {
       if (!currentPtyAgent) return;
       const agentId = currentPtyAgent;
       const sessionId = currentPtySession;
@@ -406,16 +417,16 @@ export function generateDashboardHtml(apiKey = ''): string {
       if (ptyWs) { ptyWs.close(); ptyWs = null; }
       currentPtyAgent = null; // bypass the early-return guard in openPtyViewer
       if (term) term.reset();
-      openPtyViewer(agentId, sessionId);
+      await openPtyViewer(agentId, sessionId);
     }
 
     document.getElementById('pty-close-btn').addEventListener('click', closePtyViewer);
-    document.getElementById('pty-refresh-btn').addEventListener('click', refreshPtyViewer);
+    document.getElementById('pty-refresh-btn').addEventListener('click', () => void refreshPtyViewer());
 
     // Event delegation for Live buttons (avoids inline onclick + HTML injection)
     document.getElementById('sessions-tbody').addEventListener('click', function(e) {
       const btn = e.target.closest('.btn-stream');
-      if (btn) openPtyViewer(btn.getAttribute('data-agent-id'), btn.getAttribute('data-session-id'));
+      if (btn) void openPtyViewer(btn.getAttribute('data-agent-id'), btn.getAttribute('data-session-id'));
     });
 
     function escHtml(s) {

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -101,7 +101,13 @@ export function generateDashboardHtml(apiKey = ''): string {
     /* Fixed-size terminal viewport — the server PTY runs at 200x50, so the
        viewer must NOT resize to the panel (that mismatch is what garbles the
        output). We render at the native size and scroll if it overflows. */
-    #pty-terminal { padding: 8px; background: #0d1117; overflow: auto; }
+    #pty-terminal {
+      padding: 8px;
+      background: #0d1117;
+      overflow: auto;
+      max-height: 70vh;
+      border-radius: 6px;
+    }
     .proc-tree {
       font-family: monospace;
       font-size: 0.82rem;
@@ -265,9 +271,12 @@ export function generateDashboardHtml(apiKey = ''): string {
       if (!term) {
         term = new Terminal({
           theme: { background: '#0d1117', foreground: '#e2e8f0', cursor: '#63b3ed' },
-          fontSize: 13,
-          lineHeight: 1.1,
-          fontFamily: 'Menlo, Monaco, Consolas, monospace',
+          fontSize: 11,
+          lineHeight: 1.0,
+          letterSpacing: 0,
+          fontFamily: '"JetBrains Mono", "Cascadia Code", Menlo, Monaco, Consolas, "Courier New", monospace',
+          fontWeight: 400,
+          fontWeightBold: 600,
           // Fixed dimensions matching the server PTY — do NOT auto-fit, the
           // size mismatch is what makes the output unreadable.
           cols: PTY_COLS,

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -3,12 +3,14 @@
  * No external dependencies except xterm.js CDN for PTY viewer.
  */
 export function generateDashboardHtml(apiKey = ''): string {
+  const safeKey = apiKey.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Claude Gateway Status</title>
+  <meta name="api-key" content="${safeKey}">
+  <title>Claude Gateway</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css"/>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -19,7 +21,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       padding: 24px;
     }
     h1 { color: #63b3ed; font-size: 1.5rem; margin-bottom: 8px; }
-    .meta { color: #718096; font-size: 0.85rem; margin-bottom: 24px; }
+    .meta { color: #718096; font-size: 0.85rem; margin-bottom: 16px; }
     .meta span { color: #a0aec0; }
     h2 { color: #90cdf4; font-size: 1.1rem; margin: 20px 0 10px; }
     table {
@@ -43,24 +45,8 @@ export function generateDashboardHtml(apiKey = ''): string {
       padding: 8px 12px;
       border-bottom: 1px solid #1a202c;
     }
-    tr.agent-row td {
-      background: #131720;
-      font-weight: 600;
-      color: #90cdf4;
-    }
-    tr.agent-row:hover td { background: #1a202c; }
-    tr.session-row td {
-      padding-left: 28px;
-      background: #0f1117;
-      color: #cbd5e0;
-      font-size: 0.82rem;
-    }
+    tr.session-row td { background: #0f1117; color: #cbd5e0; font-size: 0.82rem; }
     tr.session-row:hover td { background: #1a202c; }
-    tr.session-row td:first-child::before {
-      content: '└─ ';
-      color: #4a5568;
-      font-family: monospace;
-    }
     .badge {
       display: inline-block;
       padding: 2px 8px;
@@ -71,13 +57,8 @@ export function generateDashboardHtml(apiKey = ''): string {
     .badge-green { background: #22543d; color: #68d391; }
     .badge-red { background: #742a2a; color: #fc8181; }
     .badge-gray { background: #2d3748; color: #a0aec0; }
-    .badge-blue { background: #1a365d; color: #63b3ed; }
     .ts { color: #718096; font-size: 0.8rem; }
-    #refresh-indicator {
-      float: right;
-      font-size: 0.75rem;
-      color: #4a5568;
-    }
+    #refresh-indicator { float: right; font-size: 0.75rem; color: #4a5568; }
     .error { color: #fc8181; font-size: 0.85rem; margin-top: 8px; }
     .btn-stream {
       background: #1a365d;
@@ -140,36 +121,59 @@ export function generateDashboardHtml(apiKey = ''): string {
       color: #a0aec0;
       word-break: break-all;
     }
+    /* Agent status badges bar */
+    .agents-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 20px;
+    }
+    .agent-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: #1a202c;
+      border: 1px solid #2d3748;
+      border-radius: 6px;
+      padding: 4px 12px;
+      font-size: 0.8rem;
+    }
+    .agent-badge .agent-name { color: #90cdf4; font-weight: 600; }
+    .agent-badge .dot-green { color: #68d391; }
+    .agent-badge .dot-red { color: #fc8181; }
   </style>
 </head>
 <body>
   <h1>Claude Gateway <span id="gateway-version" style="font-size:0.75rem;color:#718096;"></span> <span id="refresh-indicator">refreshing...</span></h1>
   <div class="meta">
-    Uptime: <span id="uptime">—</span> &nbsp;|&nbsp;
-    Started: <span id="started-at">—</span> &nbsp;|&nbsp;
-    Last updated: <span id="last-updated">—</span>
+    Uptime: <span id="uptime">&mdash;</span> &nbsp;|&nbsp;
+    Started: <span id="started-at">&mdash;</span> &nbsp;|&nbsp;
+    Last updated: <span id="last-updated">&mdash;</span>
   </div>
 
-  <!-- 80% / 20% layout — Agents+Sessions left, Processes right -->
-  <div style="display:grid;grid-template-columns:4fr 1fr;gap:24px;align-items:start;">
+  <!-- Agent status badges -->
+  <div class="agents-bar" id="agents-bar"></div>
 
-    <!-- Left column: Agents + Sessions (combined) -->
+  <!-- 70% / 30% layout — Sessions left, Processes right -->
+  <div style="display:grid;grid-template-columns:7fr 3fr;gap:24px;align-items:start;">
+
+    <!-- Left column: Sessions table -->
     <div>
-      <h2>Agents &amp; Sessions</h2>
-      <table id="agents-table">
+      <h2>Sessions</h2>
+      <table id="sessions-table">
         <thead>
           <tr>
-            <th>Agent / Session ID</th>
+            <th>Agent</th>
+            <th>Session ID</th>
             <th>Chat ID</th>
             <th>Source</th>
             <th>Status</th>
-            <th>Recv / Sent</th>
             <th>Uptime</th>
-            <th>Last Activity / Spawned</th>
+            <th>Spawned</th>
             <th>Live</th>
           </tr>
         </thead>
-        <tbody id="agents-tbody">
+        <tbody id="sessions-tbody">
           <tr><td colspan="8" class="ts">Loading...</td></tr>
         </tbody>
       </table>
@@ -177,7 +181,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       <div class="pty-viewer" id="pty-viewer">
         <div class="pty-viewer-header">
           <span>PTY Live &mdash; <span class="agent-label" id="pty-agent-label"></span></span>
-          <button class="pty-close" id="pty-close-btn" title="Close">✕</button>
+          <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
         </div>
         <div id="pty-terminal"></div>
       </div>
@@ -195,7 +199,9 @@ export function generateDashboardHtml(apiKey = ''): string {
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
   <script>
-    // ── Helpers ──────────────────────────────────────────────────────────────
+    // Read API key from meta tag (safe — no inline JS string injection)
+    const DASHBOARD_API_KEY = document.querySelector('meta[name="api-key"]') ? document.querySelector('meta[name="api-key"]').getAttribute('content') : '';
+
     function fmtUptime(seconds) {
       const h = Math.floor(seconds / 3600);
       const m = Math.floor((seconds % 3600) / 60);
@@ -206,32 +212,23 @@ export function generateDashboardHtml(apiKey = ''): string {
     }
 
     function fmtTs(ts) {
-      if (!ts) return '<span class="ts">—</span>';
+      if (!ts) return '<span class="ts">&mdash;</span>';
       try {
         const d = new Date(ts);
         return '<span class="ts">' + d.toLocaleTimeString() + ' ' + d.toLocaleDateString() + '</span>';
       } catch(e) { return ts; }
     }
 
-    function badge(running) {
-      return running
-        ? '<span class="badge badge-green">running</span>'
-        : '<span class="badge badge-red">stopped</span>';
-    }
-
-    // Compute base path from current URL (handles reverse proxy sub-paths)
     function basePath() {
       const p = window.location.pathname;
       if (p.endsWith('/dashboard')) return p.slice(0, -10);
       if (p.endsWith('/dashboard/')) return p.slice(0, -11);
-      return p.replace(/\\/$/, '');
+      return p.replace(/\/$/, '');
     }
 
     function apiUrl(path) {
       return basePath() + path;
     }
-
-    const DASHBOARD_API_KEY = ${JSON.stringify(apiKey)};
 
     function wsUrl(path) {
       const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -275,12 +272,12 @@ export function generateDashboardHtml(apiKey = ''): string {
 
       ptyWs.onopen = function() { term.writeln('\\r\\x1b[32m[connected to ' + agentId + ']\\x1b[0m'); };
       ptyWs.onmessage = function(ev) {
-        const data = ev.data instanceof ArrayBuffer
-          ? new TextDecoder().decode(ev.data)
-          : ev.data;
+        const data = ev.data instanceof ArrayBuffer ? new TextDecoder().decode(ev.data) : ev.data;
         term.write(data);
       };
-      ptyWs.onclose = function() { if (term) term.writeln('\\r\\x1b[33m[disconnected]\\x1b[0m'); };
+      ptyWs.onclose = function(ev) {
+        if (term) term.writeln('\\r\\x1b[33m[disconnected: ' + (ev.reason || 'closed') + ']\\x1b[0m');
+      };
       ptyWs.onerror = function() { if (term) term.writeln('\\r\\x1b[31m[connection error]\\x1b[0m'); };
     }
 
@@ -292,6 +289,12 @@ export function generateDashboardHtml(apiKey = ''): string {
 
     document.getElementById('pty-close-btn').addEventListener('click', closePtyViewer);
 
+    // Event delegation for Live buttons (avoids inline onclick + HTML injection)
+    document.getElementById('sessions-tbody').addEventListener('click', function(e) {
+      const btn = e.target.closest('.btn-stream');
+      if (btn) openPtyViewer(btn.getAttribute('data-agent-id'));
+    });
+
     // ── Status Refresh ────────────────────────────────────────────────────────
     async function refresh() {
       document.getElementById('refresh-indicator').textContent = 'refreshing...';
@@ -302,34 +305,27 @@ export function generateDashboardHtml(apiKey = ''): string {
 
         document.getElementById('uptime').textContent = fmtUptime(data.uptime || 0);
         document.getElementById('started-at').textContent = data.startedAt
-          ? new Date(data.startedAt).toLocaleString() : '—';
+          ? new Date(data.startedAt).toLocaleString() : '&mdash;';
         document.getElementById('last-updated').textContent = new Date().toLocaleTimeString();
         if (data.version) document.getElementById('gateway-version').textContent = 'v' + data.version;
         document.getElementById('error-msg').style.display = 'none';
 
-        // Combined Agents + Sessions table
+        // Agent badges bar
+        const badges = (data.agents || []).map(function(a) {
+          const dot = a.isRunning ? '<span class="dot-green">&#x25CF;</span>' : '<span class="dot-red">&#x25CF;</span>';
+          return '<span class="agent-badge">' + dot + ' <span class="agent-name">' + escHtml(a.id) + '</span></span>';
+        });
+        document.getElementById('agents-bar').innerHTML = badges.join('') || '<span class="ts">No agents</span>';
+
+        // Sessions table — flat list with agent column
         const rows = [];
         (data.agents || []).forEach(function(a) {
-          // Agent header row
-          rows.push(
-            '<tr class="agent-row">' +
-            '<td>' + a.id + '</td>' +
-            '<td class="ts">—</td>' +
-            '<td class="ts">—</td>' +
-            '<td>' + badge(a.isRunning) + '</td>' +
-            '<td>' + (a.messagesReceived || 0) + ' / ' + (a.messagesSent || 0) + '</td>' +
-            '<td class="ts">—</td>' +
-            '<td>' + fmtTs(a.lastActivityAt) + '</td>' +
-            '<td class="ts">—</td>' +
-            '</tr>'
-          );
-
-          // Session sub-rows
           const sessions = a.sessions || [];
           if (sessions.length === 0) {
             rows.push(
               '<tr class="session-row">' +
-              '<td colspan="8" class="ts" style="padding-left:28px;">no sessions</td>' +
+              '<td><span class="ts">' + escHtml(a.id) + '</span></td>' +
+              '<td colspan="7" class="ts">no sessions</td>' +
               '</tr>'
             );
           } else {
@@ -337,20 +333,20 @@ export function generateDashboardHtml(apiKey = ''): string {
               const statusBadge = s.isRunning
                 ? '<span class="badge badge-green">running</span>'
                 : '<span class="badge badge-gray">stopped</span>';
-              const uptime = s.isRunning ? fmtUptime(s.uptimeSec || 0) : '<span class="ts">—</span>';
-              const sessIdFull = s.sessionId
-                ? '<span class="session-id">' + s.sessionId + '</span>'
-                : '<span class="ts">—</span>';
+              const uptime = s.isRunning ? fmtUptime(s.uptimeSec || 0) : '<span class="ts">&mdash;</span>';
+              const sessId = s.sessionId
+                ? '<span class="session-id">' + escHtml(s.sessionId) + '</span>'
+                : '<span class="ts">&mdash;</span>';
               const liveBtn = (a.hasPtyStream && s.isRunning)
-                ? '<button class="btn-stream" onclick="openPtyViewer(' + JSON.stringify(a.id) + ')">▶ Live</button>'
-                : '<span class="ts">—</span>';
+                ? '<button class="btn-stream" data-agent-id="' + escHtml(a.id) + '">▶ Live</button>'
+                : '<span class="ts">&mdash;</span>';
               rows.push(
                 '<tr class="session-row">' +
-                '<td>' + sessIdFull + '</td>' +
-                '<td class="ts">' + (s.chatId || '—') + '</td>' +
-                '<td>' + (s.source || '—') + '</td>' +
+                '<td><span style="color:#90cdf4;font-weight:600;">' + escHtml(a.id) + '</span></td>' +
+                '<td>' + sessId + '</td>' +
+                '<td class="ts">' + escHtml(String(s.chatId || '&mdash;')) + '</td>' +
+                '<td>' + escHtml(s.source || '&mdash;') + '</td>' +
                 '<td>' + statusBadge + '</td>' +
-                '<td class="ts">—</td>' +
                 '<td>' + uptime + '</td>' +
                 '<td>' + fmtTs(s.spawnedAt ? new Date(s.spawnedAt).toISOString() : null) + '</td>' +
                 '<td>' + liveBtn + '</td>' +
@@ -360,8 +356,8 @@ export function generateDashboardHtml(apiKey = ''): string {
           }
         });
 
-        document.getElementById('agents-tbody').innerHTML =
-          rows.length ? rows.join('') : '<tr><td colspan="8" class="ts">No agents</td></tr>';
+        document.getElementById('sessions-tbody').innerHTML =
+          rows.length ? rows.join('') : '<tr><td colspan="8" class="ts">No sessions</td></tr>';
 
         document.getElementById('refresh-indicator').textContent = 'auto-refresh 5s';
       } catch(e) {
@@ -369,6 +365,14 @@ export function generateDashboardHtml(apiKey = ''): string {
         document.getElementById('error-msg').style.display = 'block';
         document.getElementById('refresh-indicator').textContent = 'error';
       }
+    }
+
+    function escHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
     }
 
     // ── Process Tree ─────────────────────────────────────────────────────────
@@ -410,12 +414,12 @@ export function generateDashboardHtml(apiKey = ''): string {
       }
 
       function short(args, maxLen) {
-        return args.length > maxLen ? args.slice(0, maxLen) + '…' : args;
+        return args.length > maxLen ? args.slice(0, maxLen) + '\\u2026' : args;
       }
 
       function sessionId(args) {
         const m = args.match(/--session-id\\s+(\\S+)/);
-        return m ? m[1].slice(0, 8) + '…' : '?';
+        return m ? m[1].slice(0, 8) + '\\u2026' : '?';
       }
 
       function agentName(args) {
@@ -453,38 +457,39 @@ export function generateDashboardHtml(apiKey = ''): string {
         lines.push('  PID ' + pty.pid + '  <span class="proc-pty">pty-shell</span>  [' + agent + ']');
         const claudeChild = procs.find(function(p) { return p.ppid === pty.pid && cat(p) === 'claude-pty'; });
         if (claudeChild) {
-          lines.push('  └─ PID ' + claudeChild.pid + '  <span class="proc-claude">claude ' + sessionId(claudeChild.args) + '</span>');
+          lines.push('  \\u2514\\u2500 PID ' + claudeChild.pid + '  <span class="proc-claude">claude ' + sessionId(claudeChild.args) + '</span>');
           const mcp = mcpServers.find(function(p) { return p.ppid === claudeChild.pid; });
           if (mcp) {
-            lines.push('     └─ PID ' + mcp.pid + '  <span class="proc-mcp">mcp</span>');
+            lines.push('     \\u2514\\u2500 PID ' + mcp.pid + '  <span class="proc-mcp">mcp</span>');
           }
         }
       });
 
       headless.forEach(function(cl) {
-        lines.push('  PID ' + cl.pid + '  <span class="proc-claude">claude --print</span>');
+        const agent = agentName(cl.args);
+        lines.push('  PID ' + cl.pid + '  <span class="proc-claude">claude --print</span>' + (agent !== '?' ? '  [' + agent + ']' : ''));
         const mcp = mcpServers.find(function(p) { return p.ppid === cl.pid; });
         if (mcp) {
-          lines.push('  └─ PID ' + mcp.pid + '  <span class="proc-mcp">mcp</span>');
+          lines.push('  \\u2514\\u2500 PID ' + mcp.pid + '  <span class="proc-mcp">mcp</span>');
         }
       });
 
-      if (sessionCount === 0) lines.push('  <span class="ts">— none —</span>');
+      if (sessionCount === 0) lines.push('  <span class="ts">\\u2014 none \\u2014</span>');
       lines.push('');
 
       lines.push('<span class="proc-label">Receivers</span>');
-      if (telegramReceivers.length) lines.push('  TG ×' + telegramReceivers.length);
-      if (discordReceivers.length) lines.push('  DC ×' + discordReceivers.length);
-      if (!telegramReceivers.length && !discordReceivers.length) lines.push('  <span class="ts">— none —</span>');
+      if (telegramReceivers.length) lines.push('  TG \\u00d7' + telegramReceivers.length);
+      if (discordReceivers.length) lines.push('  DC \\u00d7' + discordReceivers.length);
+      if (!telegramReceivers.length && !discordReceivers.length) lines.push('  <span class="ts">\\u2014 none \\u2014</span>');
       lines.push('');
 
       lines.push('<span class="proc-label">Orphans</span>');
       if (orphans.length) {
         orphans.forEach(function(p) {
-          lines.push('  ⚠ PID ' + p.pid + '  <span class="proc-orphan">' + short(p.args, 30) + '</span>');
+          lines.push('  \\u26a0 PID ' + p.pid + '  <span class="proc-orphan">' + short(p.args, 30) + '</span>');
         });
       } else {
-        lines.push('  <span class="ts">none ✅</span>');
+        lines.push('  <span class="ts">none \\u2705</span>');
       }
 
       document.getElementById('proc-tree').innerHTML = lines.join('\\n');

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -2,7 +2,7 @@
  * Generates a self-contained HTML dashboard page for the gateway status UI.
  * No external dependencies except xterm.js CDN for PTY viewer.
  */
-export function generateDashboardHtml(): string {
+export function generateDashboardHtml(apiKey = ''): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -223,9 +223,12 @@ export function generateDashboardHtml(): string {
       return basePath() + path;
     }
 
+    const DASHBOARD_API_KEY = ${JSON.stringify(apiKey)};
+
     function wsUrl(path) {
       const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      return proto + '//' + window.location.host + basePath() + path;
+      const base = proto + '//' + window.location.host + basePath() + path;
+      return DASHBOARD_API_KEY ? base + (base.includes('?') ? '&' : '?') + 'key=' + encodeURIComponent(DASHBOARD_API_KEY) : base;
     }
 
     // ── PTY Viewer ───────────────────────────────────────────────────────────

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -57,6 +57,8 @@ export function generateDashboardHtml(apiKey = ''): string {
     .badge-green { background: #22543d; color: #68d391; }
     .badge-red { background: #742a2a; color: #fc8181; }
     .badge-gray { background: #2d3748; color: #a0aec0; }
+    .badge-blue { background: #1a365d; color: #63b3ed; }
+    .badge-purple { background: #44337a; color: #b794f4; }
     .ts { color: #718096; font-size: 0.8rem; }
     #refresh-indicator { float: right; font-size: 0.75rem; color: #4a5568; }
     .error { color: #fc8181; font-size: 0.85rem; margin-top: 8px; }
@@ -72,7 +74,7 @@ export function generateDashboardHtml(apiKey = ''): string {
     .btn-stream:hover { background: #2b6cb0; color: #ebf8ff; }
     .pty-viewer {
       display: none;
-      margin-bottom: 24px;
+      margin-top: 24px;
       border: 1px solid #2d3748;
       border-radius: 6px;
       overflow: hidden;
@@ -96,7 +98,10 @@ export function generateDashboardHtml(apiKey = ''): string {
       padding: 0 4px;
     }
     .pty-close:hover { color: #fc8181; }
-    #pty-terminal { padding: 8px; background: #0d1117; }
+    /* Fixed-size terminal viewport — the server PTY runs at 200x50, so the
+       viewer must NOT resize to the panel (that mismatch is what garbles the
+       output). We render at the native size and scroll if it overflows. */
+    #pty-terminal { padding: 8px; background: #0d1117; overflow: auto; }
     .proc-tree {
       font-family: monospace;
       font-size: 0.82rem;
@@ -151,56 +156,58 @@ export function generateDashboardHtml(apiKey = ''): string {
     Last updated: <span id="last-updated">&mdash;</span>
   </div>
 
-  <!-- Agent status badges -->
-  <div class="agents-bar" id="agents-bar"></div>
-
-  <!-- 70% / 30% layout — Sessions left, Processes right -->
-  <div style="display:grid;grid-template-columns:6fr 4fr;gap:24px;align-items:start;">
-
-    <!-- Left column: Sessions table -->
-    <div>
-      <h2>Sessions</h2>
-      <table id="sessions-table">
-        <thead>
-          <tr>
-            <th>Agent</th>
-            <th>Session ID</th>
-            <th>Chat ID</th>
-            <th>Source</th>
-            <th>Status</th>
-            <th>Uptime</th>
-            <th>Spawned</th>
-            <th>Live</th>
-          </tr>
-        </thead>
-        <tbody id="sessions-tbody">
-          <tr><td colspan="8" class="ts">Loading...</td></tr>
-        </tbody>
-      </table>
-
-      <div class="pty-viewer" id="pty-viewer">
-        <div class="pty-viewer-header">
-          <span>PTY Live &mdash; <span class="agent-label" id="pty-agent-label"></span></span>
-          <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
-        </div>
-        <div id="pty-terminal"></div>
-      </div>
-    </div>
-
-    <!-- Right column: Processes -->
+  <!-- Row: Processes 50% | Agent badges 50% -->
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;align-items:start;">
     <div>
       <h2>Processes</h2>
       <div class="proc-tree" id="proc-tree">Loading...</div>
     </div>
+    <div>
+      <h2>Agents</h2>
+      <div class="agents-bar" id="agents-bar"></div>
+    </div>
+  </div>
+
+  <!-- Sessions — full width (session-centric, flat list) -->
+  <h2>Sessions</h2>
+  <table id="sessions-table">
+    <thead>
+      <tr>
+        <th>Agent</th>
+        <th>Session ID</th>
+        <th>Chat ID</th>
+        <th>Source</th>
+        <th>Mode</th>
+        <th>Status</th>
+        <th>Uptime</th>
+        <th>Spawned</th>
+        <th>Live</th>
+      </tr>
+    </thead>
+    <tbody id="sessions-tbody">
+      <tr><td colspan="9" class="ts">Loading...</td></tr>
+    </tbody>
+  </table>
+
+  <!-- PTY viewer — full width so the native 200-col terminal has room -->
+  <div class="pty-viewer" id="pty-viewer">
+    <div class="pty-viewer-header">
+      <span>PTY Live &mdash; <span class="agent-label" id="pty-agent-label"></span></span>
+      <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
+    </div>
+    <div id="pty-terminal"></div>
   </div>
 
   <div id="error-msg" class="error" style="display:none;"></div>
 
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
   <script>
     // Read API key from meta tag (safe — no inline JS string injection)
     const DASHBOARD_API_KEY = document.querySelector('meta[name="api-key"]') ? document.querySelector('meta[name="api-key"]').getAttribute('content') : '';
+
+    // Must match the server PTY size (src/shell/screen.ts ScreenModel defaults).
+    const PTY_COLS = 200;
+    const PTY_ROWS = 50;
 
     function fmtUptime(seconds) {
       const h = Math.floor(seconds / 3600);
@@ -238,7 +245,6 @@ export function generateDashboardHtml(apiKey = ''): string {
 
     // ── PTY Viewer ───────────────────────────────────────────────────────────
     let term = null;
-    let fitAddon = null;
     let ptyWs = null;
     let currentPtyAgent = null;
 
@@ -253,32 +259,31 @@ export function generateDashboardHtml(apiKey = ''): string {
       if (!term) {
         term = new Terminal({
           theme: { background: '#0d1117', foreground: '#e2e8f0', cursor: '#63b3ed' },
-          fontSize: 13,
+          fontSize: 10,
           fontFamily: 'Menlo, Monaco, Consolas, monospace',
-          convertEol: true,
-          scrollback: 2000,
+          // Fixed dimensions matching the server PTY — do NOT auto-fit, the
+          // size mismatch is what makes the output unreadable.
+          cols: PTY_COLS,
+          rows: PTY_ROWS,
+          scrollback: 5000,
         });
-        fitAddon = new FitAddon.FitAddon();
-        term.loadAddon(fitAddon);
         term.open(document.getElementById('pty-terminal'));
-        fitAddon.fit();
       } else {
-        term.clear();
+        term.reset();
       }
 
       const url = wsUrl('/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream');
       ptyWs = new WebSocket(url);
       ptyWs.binaryType = 'arraybuffer';
 
-      ptyWs.onopen = function() { term.writeln('\\r\\x1b[32m[connected to ' + agentId + ']\\x1b[0m'); };
       ptyWs.onmessage = function(ev) {
-        const data = ev.data instanceof ArrayBuffer ? new TextDecoder().decode(ev.data) : ev.data;
+        const data = ev.data instanceof ArrayBuffer ? new TextDecoder('latin1').decode(ev.data) : ev.data;
         term.write(data);
       };
       ptyWs.onclose = function(ev) {
-        if (term) term.writeln('\\r\\x1b[33m[disconnected: ' + (ev.reason || 'closed') + ']\\x1b[0m');
+        if (term) term.writeln('\\r\\n\\x1b[33m[disconnected: ' + (ev.reason || 'closed') + ']\\x1b[0m');
       };
-      ptyWs.onerror = function() { if (term) term.writeln('\\r\\x1b[31m[connection error]\\x1b[0m'); };
+      ptyWs.onerror = function() { if (term) term.writeln('\\r\\n\\x1b[31m[connection error]\\x1b[0m'); };
     }
 
     function closePtyViewer() {
@@ -295,6 +300,20 @@ export function generateDashboardHtml(apiKey = ''): string {
       if (btn) openPtyViewer(btn.getAttribute('data-agent-id'));
     });
 
+    function escHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    function modeBadge(mode) {
+      if (mode === 'pty-shell') return '<span class="badge badge-blue">pty-shell</span>';
+      if (mode === 'headless') return '<span class="badge badge-purple">headless</span>';
+      return '<span class="ts">' + escHtml(mode || '?') + '</span>';
+    }
+
     // ── Status Refresh ────────────────────────────────────────────────────────
     async function refresh() {
       document.getElementById('refresh-indicator').textContent = 'refreshing...';
@@ -305,59 +324,61 @@ export function generateDashboardHtml(apiKey = ''): string {
 
         document.getElementById('uptime').textContent = fmtUptime(data.uptime || 0);
         document.getElementById('started-at').textContent = data.startedAt
-          ? new Date(data.startedAt).toLocaleString() : '&mdash;';
+          ? new Date(data.startedAt).toLocaleString() : '\\u2014';
         document.getElementById('last-updated').textContent = new Date().toLocaleTimeString();
         if (data.version) document.getElementById('gateway-version').textContent = 'v' + data.version;
         document.getElementById('error-msg').style.display = 'none';
 
-        // Agent badges bar
-        const badges = (data.agents || []).map(function(a) {
-          const dot = a.isRunning ? '<span class="dot-green">&#x25CF;</span>' : '<span class="dot-red">&#x25CF;</span>';
+        const agents = data.agents || [];
+
+        // Agent badges bar.
+        // Green = available. An agent with a channel receiver (telegram/discord)
+        // is green only while its receiver is running; API-only agents have no
+        // receiver, so they are always green as long as the gateway loaded them.
+        // Red = a channel agent whose receiver is down (genuinely stopped).
+        const badges = agents.map(function(a) {
+          const ok = a.hasChannel ? a.isRunning : true;
+          const dot = ok ? '<span class="dot-green">&#x25CF;</span>' : '<span class="dot-red">&#x25CF;</span>';
           return '<span class="agent-badge">' + dot + ' <span class="agent-name">' + escHtml(a.id) + '</span></span>';
         });
         document.getElementById('agents-bar').innerHTML = badges.join('') || '<span class="ts">No agents</span>';
 
-        // Sessions table — flat list with agent column
+        // Sessions table — flat, session-centric. One row per real session across
+        // all agents; agents with no session do not produce a row.
         const rows = [];
-        (data.agents || []).forEach(function(a) {
-          const sessions = a.sessions || [];
-          if (sessions.length === 0) {
+        agents.forEach(function(a) {
+          (a.sessions || []).forEach(function(s) {
+            const statusBadge = s.isRunning
+              ? '<span class="badge badge-green">running</span>'
+              : '<span class="badge badge-gray">stopped</span>';
+            const uptime = s.isRunning ? fmtUptime(s.uptimeSec || 0) : '<span class="ts">&mdash;</span>';
+            const sessId = s.sessionId
+              ? '<span class="session-id">' + escHtml(s.sessionId) + '</span>'
+              : '<span class="ts">&mdash;</span>';
+            const chatCell = s.chatId
+              ? '<span class="session-id">' + escHtml(String(s.chatId)) + '</span>'
+              : '<span class="ts">&mdash;</span>';
+            const liveBtn = (a.hasPtyStream && s.isRunning && s.mode === 'pty-shell')
+              ? '<button class="btn-stream" data-agent-id="' + escHtml(a.id) + '">▶ Live</button>'
+              : '<span class="ts">&mdash;</span>';
             rows.push(
               '<tr class="session-row">' +
-              '<td><span class="ts">' + escHtml(a.id) + '</span></td>' +
-              '<td colspan="7" class="ts">no sessions</td>' +
+              '<td><span style="color:#90cdf4;font-weight:600;">' + escHtml(a.id) + '</span></td>' +
+              '<td>' + sessId + '</td>' +
+              '<td>' + chatCell + '</td>' +
+              '<td><span class="badge badge-gray">' + escHtml(s.source || '?') + '</span></td>' +
+              '<td>' + modeBadge(s.mode) + '</td>' +
+              '<td>' + statusBadge + '</td>' +
+              '<td>' + uptime + '</td>' +
+              '<td>' + fmtTs(s.spawnedAt ? new Date(s.spawnedAt).toISOString() : null) + '</td>' +
+              '<td>' + liveBtn + '</td>' +
               '</tr>'
             );
-          } else {
-            sessions.forEach(function(s) {
-              const statusBadge = s.isRunning
-                ? '<span class="badge badge-green">running</span>'
-                : '<span class="badge badge-gray">stopped</span>';
-              const uptime = s.isRunning ? fmtUptime(s.uptimeSec || 0) : '<span class="ts">&mdash;</span>';
-              const sessId = s.sessionId
-                ? '<span class="session-id">' + escHtml(s.sessionId) + '</span>'
-                : '<span class="ts">&mdash;</span>';
-              const liveBtn = (a.hasPtyStream && s.isRunning)
-                ? '<button class="btn-stream" data-agent-id="' + escHtml(a.id) + '">▶ Live</button>'
-                : '<span class="ts">&mdash;</span>';
-              rows.push(
-                '<tr class="session-row">' +
-                '<td><span style="color:#90cdf4;font-weight:600;">' + escHtml(a.id) + '</span></td>' +
-                '<td>' + sessId + '</td>' +
-                '<td class="ts">' + escHtml(String(s.chatId || '&mdash;')) + '</td>' +
-                '<td>' + escHtml(s.source || '&mdash;') + '</td>' +
-                '<td>' + statusBadge + '</td>' +
-                '<td>' + uptime + '</td>' +
-                '<td>' + fmtTs(s.spawnedAt ? new Date(s.spawnedAt).toISOString() : null) + '</td>' +
-                '<td>' + liveBtn + '</td>' +
-                '</tr>'
-              );
-            });
-          }
+          });
         });
 
         document.getElementById('sessions-tbody').innerHTML =
-          rows.length ? rows.join('') : '<tr><td colspan="8" class="ts">No sessions</td></tr>';
+          rows.length ? rows.join('') : '<tr><td colspan="9" class="ts">No active sessions</td></tr>';
 
         document.getElementById('refresh-indicator').textContent = 'auto-refresh 5s';
       } catch(e) {
@@ -365,14 +386,6 @@ export function generateDashboardHtml(apiKey = ''): string {
         document.getElementById('error-msg').style.display = 'block';
         document.getElementById('refresh-indicator').textContent = 'error';
       }
-    }
-
-    function escHtml(s) {
-      return String(s)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
     }
 
     // ── Process Tree ─────────────────────────────────────────────────────────

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -155,7 +155,7 @@ export function generateDashboardHtml(apiKey = ''): string {
   <div class="agents-bar" id="agents-bar"></div>
 
   <!-- 70% / 30% layout — Sessions left, Processes right -->
-  <div style="display:grid;grid-template-columns:7fr 3fr;gap:24px;align-items:start;">
+  <div style="display:grid;grid-template-columns:6fr 4fr;gap:24px;align-items:start;">
 
     <!-- Left column: Sessions table -->
     <div>
@@ -223,7 +223,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       const p = window.location.pathname;
       if (p.endsWith('/dashboard')) return p.slice(0, -10);
       if (p.endsWith('/dashboard/')) return p.slice(0, -11);
-      return p.replace(/\/$/, '');
+      return p.endsWith('/') ? p.slice(0, -1) : p;
     }
 
     function apiUrl(path) {

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -109,9 +109,9 @@ export function generateDashboardHtml(apiKey = ''): string {
       border: 1px solid #2d3748;
       border-radius: 6px;
       padding: 12px 16px;
-      white-space: pre;
+      white-space: pre-wrap;
+      word-break: break-word;
       color: #a0aec0;
-      overflow-x: auto;
     }
     .proc-tree .proc-orchestrator { color: #63b3ed; }
     .proc-tree .proc-pty { color: #68d391; }
@@ -156,8 +156,8 @@ export function generateDashboardHtml(apiKey = ''): string {
     Last updated: <span id="last-updated">&mdash;</span>
   </div>
 
-  <!-- Row: Processes 50% | Agent badges 50% -->
-  <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;align-items:start;">
+  <!-- Row: Processes 70% | Agent badges 30% -->
+  <div style="display:grid;grid-template-columns:7fr 3fr;gap:24px;align-items:start;">
     <div>
       <h2>Processes</h2>
       <div class="proc-tree" id="proc-tree">Loading...</div>
@@ -178,6 +178,7 @@ export function generateDashboardHtml(apiKey = ''): string {
         <th>Chat ID</th>
         <th>Source</th>
         <th>Mode</th>
+        <th>Model</th>
         <th>Status</th>
         <th>Uptime</th>
         <th>Spawned</th>
@@ -185,7 +186,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       </tr>
     </thead>
     <tbody id="sessions-tbody">
-      <tr><td colspan="9" class="ts">Loading...</td></tr>
+      <tr><td colspan="10" class="ts">Loading...</td></tr>
     </tbody>
   </table>
 
@@ -247,6 +248,11 @@ export function generateDashboardHtml(apiKey = ''): string {
     let term = null;
     let ptyWs = null;
     let currentPtyAgent = null;
+    // Streaming UTF-8 decoder. The PTY stream carries raw UTF-8 bytes (box-drawing
+    // chars, spinner braille, emoji). Decoding them as latin1 mangles every
+    // multi-byte char into noise — decode as UTF-8 with {stream:true} so sequences
+    // split across WebSocket frames are reassembled instead of corrupted.
+    let utf8Decoder = null;
 
     function openPtyViewer(agentId) {
       if (currentPtyAgent === agentId && ptyWs && ptyWs.readyState === WebSocket.OPEN) return;
@@ -259,25 +265,36 @@ export function generateDashboardHtml(apiKey = ''): string {
       if (!term) {
         term = new Terminal({
           theme: { background: '#0d1117', foreground: '#e2e8f0', cursor: '#63b3ed' },
-          fontSize: 10,
+          fontSize: 13,
+          lineHeight: 1.1,
           fontFamily: 'Menlo, Monaco, Consolas, monospace',
           // Fixed dimensions matching the server PTY — do NOT auto-fit, the
           // size mismatch is what makes the output unreadable.
           cols: PTY_COLS,
           rows: PTY_ROWS,
           scrollback: 5000,
+          // View-only mirror of the agent's TUI.
+          disableStdin: true,
+          cursorBlink: false,
+          convertEol: false,
         });
         term.open(document.getElementById('pty-terminal'));
       } else {
         term.reset();
       }
 
+      // Fresh decoder per session so a leftover partial byte from a previous
+      // viewing can't corrupt the first character of this stream.
+      utf8Decoder = new TextDecoder('utf-8');
+
       const url = wsUrl('/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream');
       ptyWs = new WebSocket(url);
       ptyWs.binaryType = 'arraybuffer';
 
       ptyWs.onmessage = function(ev) {
-        const data = ev.data instanceof ArrayBuffer ? new TextDecoder('latin1').decode(ev.data) : ev.data;
+        const data = ev.data instanceof ArrayBuffer
+          ? utf8Decoder.decode(ev.data, { stream: true })
+          : ev.data;
         term.write(data);
       };
       ptyWs.onclose = function(ev) {
@@ -312,6 +329,15 @@ export function generateDashboardHtml(apiKey = ''): string {
       if (mode === 'pty-shell') return '<span class="badge badge-blue">pty-shell</span>';
       if (mode === 'headless') return '<span class="badge badge-purple">headless</span>';
       return '<span class="ts">' + escHtml(mode || '?') + '</span>';
+    }
+
+    // Prettify a model id for display: drop the "claude-" prefix and any
+    // trailing date stamp, e.g. claude-haiku-4-5-20251001 -> haiku-4-5.
+    // Full id is kept in the tooltip.
+    function fmtModel(m) {
+      if (!m) return '<span class="ts">&mdash;</span>';
+      const label = String(m).replace(/^claude-/, '').replace(/-\\d{8}$/, '');
+      return '<span class="badge badge-gray" title="' + escHtml(m) + '">' + escHtml(label) + '</span>';
     }
 
     // ── Status Refresh ────────────────────────────────────────────────────────
@@ -368,6 +394,7 @@ export function generateDashboardHtml(apiKey = ''): string {
               '<td>' + chatCell + '</td>' +
               '<td><span class="badge badge-gray">' + escHtml(s.source || '?') + '</span></td>' +
               '<td>' + modeBadge(s.mode) + '</td>' +
+              '<td>' + fmtModel(s.model) + '</td>' +
               '<td>' + statusBadge + '</td>' +
               '<td>' + uptime + '</td>' +
               '<td>' + fmtTs(s.spawnedAt ? new Date(s.spawnedAt).toISOString() : null) + '</td>' +
@@ -378,7 +405,7 @@ export function generateDashboardHtml(apiKey = ''): string {
         });
 
         document.getElementById('sessions-tbody').innerHTML =
-          rows.length ? rows.join('') : '<tr><td colspan="9" class="ts">No active sessions</td></tr>';
+          rows.length ? rows.join('') : '<tr><td colspan="10" class="ts">No active sessions</td></tr>';
 
         document.getElementById('refresh-indicator').textContent = 'auto-refresh 5s';
       } catch(e) {
@@ -426,13 +453,14 @@ export function generateDashboardHtml(apiKey = ''): string {
         return 'other';
       }
 
-      function short(args, maxLen) {
-        return args.length > maxLen ? args.slice(0, maxLen) + '\\u2026' : args;
+      // Show full command lines (no truncation) — text wraps inside the box.
+      function full(args) {
+        return escHtml(args);
       }
 
       function sessionId(args) {
         const m = args.match(/--session-id\\s+(\\S+)/);
-        return m ? m[1].slice(0, 8) + '\\u2026' : '?';
+        return m ? escHtml(m[1]) : '?';
       }
 
       function agentName(args) {
@@ -458,7 +486,7 @@ export function generateDashboardHtml(apiKey = ''): string {
 
       if (orchestrator) {
         lines.push('<span class="proc-orchestrator">Orchestrator</span>');
-        lines.push('  PID ' + orchestrator.pid + '  <span class="proc-orchestrator">' + short(orchestrator.args, 40) + '</span>');
+        lines.push('  PID ' + orchestrator.pid + '  <span class="proc-orchestrator">' + full(orchestrator.args) + '</span>');
         lines.push('');
       }
 
@@ -499,7 +527,7 @@ export function generateDashboardHtml(apiKey = ''): string {
       lines.push('<span class="proc-label">Orphans</span>');
       if (orphans.length) {
         orphans.forEach(function(p) {
-          lines.push('  \\u26a0 PID ' + p.pid + '  <span class="proc-orphan">' + short(p.args, 30) + '</span>');
+          lines.push('  \\u26a0 PID ' + p.pid + '  <span class="proc-orphan">' + full(p.args) + '</span>');
         });
       } else {
         lines.push('  <span class="ts">none \\u2705</span>');

--- a/tests/integration/character-system.test.ts
+++ b/tests/integration/character-system.test.ts
@@ -174,7 +174,7 @@ describe('Character System Integration', () => {
     await router.start(0);
 
     try {
-      const res = await supertest(router.getApp()).get('/ui');
+      const res = await supertest(router.getApp()).get('/dashboard');
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toMatch(/text\/html/);
       const body = res.text.toLowerCase();

--- a/tests/integration/gateway-e2e.test.ts
+++ b/tests/integration/gateway-e2e.test.ts
@@ -363,6 +363,9 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
       const gatewayCfg = makeGatewayConfig(logDir, [{ key: 'secret-key', agents: '*' }]);
       const runner = new AgentRunner(agentCfg, gatewayCfg);
       await runner.start();
+      // Tickets are bound to a session; stub one live session so the endpoint's
+      // session-belongs-to-agent check passes without spawning a real PTY.
+      jest.spyOn(runner, 'getSessionsSummary').mockReturnValue([{ sessionId: 'sess-x' } as any]);
       const agents = new Map([[agentId, runner]]);
       const configs = new Map([[agentId, agentCfg]]);
       const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
@@ -375,7 +378,7 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
       const res = await supertest(router.getApp())
         .post('/api/v1/pty-stream-ticket')
         .set('X-Api-Key', 'secret-key')
-        .send({ agentId: 'ticket-agent-01' });
+        .send({ agentId: 'ticket-agent-01', sessionId: 'sess-x' });
       expect(res.status).toBe(200);
       expect(typeof res.body.ticket).toBe('string');
       expect(res.body.ticket).toHaveLength(32); // 16 bytes hex
@@ -416,14 +419,14 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
       const first = await supertest(router.getApp())
         .post('/api/v1/pty-stream-ticket')
         .set('X-Dash-Token', dashToken)
-        .send({ agentId: 'ticket-agent-04' });
+        .send({ agentId: 'ticket-agent-04', sessionId: 'sess-x' });
       expect(first.status).toBe(200);
 
       // Second use with the same token: must be rejected (one-time-use).
       const second = await supertest(router.getApp())
         .post('/api/v1/pty-stream-ticket')
         .set('X-Dash-Token', dashToken)
-        .send({ agentId: 'ticket-agent-04' });
+        .send({ agentId: 'ticket-agent-04', sessionId: 'sess-x' });
       expect(second.status).toBe(401);
 
       await router.stop(); await runner.stop();
@@ -434,8 +437,25 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
       const res = await supertest(router.getApp())
         .post('/api/v1/pty-stream-ticket')
         .set('Authorization', 'Bearer secret-key')
-        .send({ agentId: 'ticket-agent-05' });
+        .send({ agentId: 'ticket-agent-05', sessionId: 'sess-x' });
       expect(res.status).toBe(200);
+      await router.stop(); await runner.stop();
+    });
+
+    it('T-06: known agent but missing/unknown sessionId → 404', async () => {
+      const { router, runner } = await makeRouter('ticket-agent-06');
+      // Missing sessionId.
+      const missing = await supertest(router.getApp())
+        .post('/api/v1/pty-stream-ticket')
+        .set('X-Api-Key', 'secret-key')
+        .send({ agentId: 'ticket-agent-06' });
+      expect(missing.status).toBe(404);
+      // Unknown sessionId (not one of the agent's sessions).
+      const unknown = await supertest(router.getApp())
+        .post('/api/v1/pty-stream-ticket')
+        .set('X-Api-Key', 'secret-key')
+        .send({ agentId: 'ticket-agent-06', sessionId: 'not-a-real-session' });
+      expect(unknown.status).toBe(404);
       await router.stop(); await runner.stop();
     });
   });

--- a/tests/integration/gateway-e2e.test.ts
+++ b/tests/integration/gateway-e2e.test.ts
@@ -53,9 +53,9 @@ function makeAgentConfig(
   };
 }
 
-function makeGatewayConfig(logDir: string): GatewayConfig {
+function makeGatewayConfig(logDir: string, apiKeys: import('../../src/types').ApiKey[] = []): GatewayConfig {
   return {
-    gateway: { logDir, timezone: 'UTC' },
+    gateway: { logDir, timezone: 'UTC', ...(apiKeys.length ? { api: { keys: apiKeys } } : {}) },
     agents: [],
   };
 }
@@ -352,6 +352,92 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
     await runner.stop();
 
     expect(runner.isRunning()).toBe(false);
+  });
+
+  // ─── I-E2E-12: Ephemeral PTY ticket endpoint ─────────────────────────────
+  describe('POST /api/v1/pty-stream-ticket', () => {
+    async function makeRouter(agentId: string) {
+      const workspace = createTempWorkspace(`e2e-ticket-${agentId}-`);
+      const logDir = createTempDir(`e2e-ticket-${agentId}-log-`);
+      const agentCfg = makeAgentConfig(agentId, `token-${agentId}`, workspace);
+      const gatewayCfg = makeGatewayConfig(logDir, [{ key: 'secret-key', agents: '*' }]);
+      const runner = new AgentRunner(agentCfg, gatewayCfg);
+      await runner.start();
+      const agents = new Map([[agentId, runner]]);
+      const configs = new Map([[agentId, agentCfg]]);
+      const router = new GatewayRouter(agents, configs, undefined, gatewayCfg);
+      await router.start(0);
+      return { router, runner };
+    }
+
+    it('T-01: valid API key + known agent → 200 with ticket', async () => {
+      const { router, runner } = await makeRouter('ticket-agent-01');
+      const res = await supertest(router.getApp())
+        .post('/api/v1/pty-stream-ticket')
+        .set('X-Api-Key', 'secret-key')
+        .send({ agentId: 'ticket-agent-01' });
+      expect(res.status).toBe(200);
+      expect(typeof res.body.ticket).toBe('string');
+      expect(res.body.ticket).toHaveLength(32); // 16 bytes hex
+      expect(typeof res.body.expiresAt).toBe('string');
+      await router.stop(); await runner.stop();
+    });
+
+    it('T-02: invalid API key → 401', async () => {
+      const { router, runner } = await makeRouter('ticket-agent-02');
+      const res = await supertest(router.getApp())
+        .post('/api/v1/pty-stream-ticket')
+        .set('X-Api-Key', 'wrong-key')
+        .send({ agentId: 'ticket-agent-02' });
+      expect([401, 403]).toContain(res.status); // auth middleware may return 401 or 403
+      await router.stop(); await runner.stop();
+    });
+
+    it('T-03: unknown agent → 404', async () => {
+      const { router, runner } = await makeRouter('ticket-agent-03');
+      const res = await supertest(router.getApp())
+        .post('/api/v1/pty-stream-ticket')
+        .set('X-Api-Key', 'secret-key')
+        .send({ agentId: 'no-such-agent' });
+      expect(res.status).toBe(404);
+      await router.stop(); await runner.stop();
+    });
+
+    it('T-04: dashboard token (from /dashboard) → 200 with ticket, token is one-time-use', async () => {
+      const { router, runner } = await makeRouter('ticket-agent-04');
+      // Fetch the dashboard page — server issues a short-lived dashToken embedded in HTML.
+      const dashRes = await supertest(router.getApp()).get('/dashboard');
+      expect(dashRes.status).toBe(200);
+      const metaMatch = /name="dash-token" content="([0-9a-f]+)"/.exec(dashRes.text);
+      expect(metaMatch).not.toBeNull();
+      const dashToken = metaMatch![1];
+
+      // First use: should succeed.
+      const first = await supertest(router.getApp())
+        .post('/api/v1/pty-stream-ticket')
+        .set('X-Dash-Token', dashToken)
+        .send({ agentId: 'ticket-agent-04' });
+      expect(first.status).toBe(200);
+
+      // Second use with the same token: must be rejected (one-time-use).
+      const second = await supertest(router.getApp())
+        .post('/api/v1/pty-stream-ticket')
+        .set('X-Dash-Token', dashToken)
+        .send({ agentId: 'ticket-agent-04' });
+      expect(second.status).toBe(401);
+
+      await router.stop(); await runner.stop();
+    });
+
+    it('T-05: Bearer Authorization header accepted alongside X-Api-Key', async () => {
+      const { router, runner } = await makeRouter('ticket-agent-05');
+      const res = await supertest(router.getApp())
+        .post('/api/v1/pty-stream-ticket')
+        .set('Authorization', 'Bearer secret-key')
+        .send({ agentId: 'ticket-agent-05' });
+      expect(res.status).toBe(200);
+      await router.stop(); await runner.stop();
+    });
   });
 
   // ─── I-E2E-11: Session store works correctly ──────────────────────────────

--- a/tests/integration/phase-manual.test.ts
+++ b/tests/integration/phase-manual.test.ts
@@ -1680,7 +1680,7 @@ describe('Phase 4: Web UI and status endpoint', () => {
     const configs = new Map<string, AgentConfig>([['p411-agent', agentCfg]]);
     const router = new GatewayRouter(agents, configs);
 
-    const res = await supertest(router.getApp()).get('/ui');
+    const res = await supertest(router.getApp()).get('/dashboard');
 
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/text\/html/);

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -3405,3 +3405,50 @@ describe('AgentRunner — getSessionsSummary dedup', () => {
     expect(rows[0].tokens).toBe(0);
   });
 });
+
+// ── writeMenuForward: atomic .menu file ────────────────────────────────────────
+describe('AgentRunner — writeMenuForward', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-menu-'));
+    const workspace = path.join(tmpDir, 'agents', 'alfred', 'workspace');
+    fs.mkdirSync(workspace, { recursive: true });
+    agentConfig = makeAgentConfig(workspace);
+    gatewayConfig = makeGatewayConfig();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function callWriteMenu(runner: AgentRunner, chatId: string, text: string, options: Array<{ label: string }>): void {
+    (runner as unknown as { writeMenuForward(c: string, t: string, o: Array<{ label: string }>): void })
+      .writeMenuForward(chatId, text, options);
+  }
+
+  it('writes a .menu file with correct JSON content', () => {
+    const runner = new AgentRunner(agentConfig, gatewayConfig);
+    const chatId = '997170033';
+    callWriteMenu(runner, chatId, 'Pick one:', [{ label: 'Alpha' }, { label: 'Beta' }]);
+
+    const typingDir = (runner as unknown as { getTypingDir(c: string): string }).getTypingDir(chatId);
+    const menuPath = path.join(typingDir, `${chatId}.menu`);
+    expect(fs.existsSync(menuPath)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(menuPath, 'utf8'));
+    expect(parsed.text).toBe('Pick one:');
+    expect(parsed.options).toEqual([{ label: 'Alpha' }, { label: 'Beta' }]);
+  });
+
+  it('leaves no .tmp file after successful write (atomic rename)', () => {
+    const runner = new AgentRunner(agentConfig, gatewayConfig);
+    const chatId = '997170033';
+    callWriteMenu(runner, chatId, 'Q', [{ label: 'X' }]);
+
+    const typingDir = (runner as unknown as { getTypingDir(c: string): string }).getTypingDir(chatId);
+    const tmpPath = path.join(typingDir, `${chatId}.menu.tmp`);
+    expect(fs.existsSync(tmpPath)).toBe(false);
+  });
+});

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -3319,3 +3319,89 @@ describe('AgentRunner — API attachment buffer', () => {
     expect(attachments[0].relPath).toBe('api-sess/screen.jpg');
   });
 });
+
+// ── getSessionsSummary: dedup respawned sessions ──────────────────────────────
+describe('AgentRunner — getSessionsSummary dedup', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-summary-'));
+    const workspace = path.join(tmpDir, 'agents', 'alfred', 'workspace');
+    fs.mkdirSync(workspace, { recursive: true });
+    agentConfig = makeAgentConfig(workspace);
+    gatewayConfig = makeGatewayConfig();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  type HistoryEntry = { chatId: string; sessionId: string; source: string; mode: string; model: string; spawnedAt: number };
+  function internals(runner: AgentRunner) {
+    return runner as unknown as {
+      sessionHistory: HistoryEntry[];
+      sessions: Map<string, SessionProcess>;
+      apiChatIds: Map<string, string>;
+    };
+  }
+  function stubProc(spawnedAt: number, totalTokens: number): SessionProcess {
+    return { spawnedAt, totalTokens } as unknown as SessionProcess;
+  }
+  function entry(over: Partial<HistoryEntry>): HistoryEntry {
+    return { chatId: 'getpod', sessionId: 'sess-A', source: 'api', mode: 'pty-shell', model: 'sonnet-4-6', spawnedAt: 0, ...over };
+  }
+
+  it('collapses a respawned session (same sessionId) into one running row', () => {
+    const runner = new AgentRunner(agentConfig, gatewayConfig);
+    const internal = internals(runner);
+    // History is newest-first (unshift): the 10:34 respawn precedes the 10:32 spawn.
+    internal.sessionHistory.push(entry({ spawnedAt: 1_000_034_000 })); // newest = current incarnation
+    internal.sessionHistory.push(entry({ spawnedAt: 1_000_032_000 })); // stale pre-respawn entry
+    internal.sessions.set('getpod', stubProc(1_000_034_000, 47_000));
+
+    const rows = runner.getSessionsSummary();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sessionId).toBe('sess-A');
+    expect(rows[0].isRunning).toBe(true);
+    expect(rows[0].spawnedAt).toBe(1_000_034_000);
+    expect(rows[0].tokens).toBe(47_000);
+  });
+
+  it('a stale pre-respawn entry never borrows the live process running state', () => {
+    const runner = new AgentRunner(agentConfig, gatewayConfig);
+    const internal = internals(runner);
+    // Keep ONLY the stale entry in history; the live proc is a newer incarnation.
+    internal.sessionHistory.push(entry({ spawnedAt: 1_000_032_000 }));
+    internal.sessions.set('getpod', stubProc(1_000_034_000, 47_000)); // different spawnedAt
+
+    const rows = runner.getSessionsSummary();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isRunning).toBe(false); // spawnedAt mismatch → not this incarnation
+    expect(rows[0].tokens).toBe(0); // stopped rows report 0 tokens
+  });
+
+  it('keeps genuinely distinct sessions as separate rows', () => {
+    const runner = new AgentRunner(agentConfig, gatewayConfig);
+    const internal = internals(runner);
+    internal.sessionHistory.push(entry({ chatId: 'chat:1', sessionId: 'sess-A', source: 'telegram', spawnedAt: 2_000 }));
+    internal.sessionHistory.push(entry({ chatId: 'chat:1', sessionId: 'sess-B', source: 'telegram', spawnedAt: 1_000 }));
+
+    const rows = runner.getSessionsSummary();
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map(r => r.sessionId))).toEqual(new Set(['sess-A', 'sess-B']));
+  });
+
+  it('reports a stopped session (no live process) as not running with 0 tokens', () => {
+    const runner = new AgentRunner(agentConfig, gatewayConfig);
+    const internal = internals(runner);
+    internal.sessionHistory.push(entry({ spawnedAt: 1_000_032_000 }));
+    // no proc in sessions map
+
+    const rows = runner.getSessionsSummary();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isRunning).toBe(false);
+    expect(rows[0].tokens).toBe(0);
+  });
+});

--- a/tests/unit/discord-plugin/outbound.test.ts
+++ b/tests/unit/discord-plugin/outbound.test.ts
@@ -1,4 +1,4 @@
-import { sendMessage, chunkText } from '../../../mcp/tools/discord/outbound';
+import { sendMessage, chunkText, buildChoiceComponents } from '../../../mcp/tools/discord/outbound';
 import type { SendableChannel, SentMessage } from '../../../mcp/tools/discord/types';
 
 function makeMockChannel(responses?: Partial<SentMessage>[]): SendableChannel & { calls: any[] } {
@@ -86,5 +86,44 @@ describe('sendMessage', () => {
     if (channel.calls.length > 1) {
       expect(channel.calls[1].reply).toBeUndefined();
     }
+  });
+});
+
+describe('buildChoiceComponents', () => {
+  it('builds one ActionRow for 3 options', () => {
+    const rows = buildChoiceComponents([{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }]);
+    expect(rows).toHaveLength(1);
+    const row = rows[0] as { type: number; components: Array<{ type: number; style: number; label: string; custom_id: string }> };
+    expect(row.type).toBe(1);
+    expect(row.components).toHaveLength(3);
+    expect(row.components[0]).toMatchObject({ type: 2, style: 2, label: '1. Alpha', custom_id: 'choice:1' });
+    expect(row.components[2]).toMatchObject({ custom_id: 'choice:3' });
+  });
+
+  it('splits into multiple ActionRows when >5 options', () => {
+    const opts = Array.from({ length: 7 }, (_, i) => ({ label: `Option ${i + 1}` }));
+    const rows = buildChoiceComponents(opts);
+    expect(rows).toHaveLength(2);
+    const row0 = rows[0] as { components: unknown[] };
+    const row1 = rows[1] as { components: unknown[] };
+    expect(row0.components).toHaveLength(5);
+    expect(row1.components).toHaveLength(2);
+  });
+
+  it('caps label at 80 characters', () => {
+    const longLabel = 'A'.repeat(100);
+    const rows = buildChoiceComponents([{ label: longLabel }]);
+    const row = rows[0] as { components: Array<{ label: string }> };
+    expect(row.components[0].label.length).toBeLessThanOrEqual(80);
+  });
+
+  it('caps at 5 ActionRows (25 options max rendered)', () => {
+    const opts = Array.from({ length: 30 }, (_, i) => ({ label: `Opt ${i + 1}` }));
+    const rows = buildChoiceComponents(opts);
+    expect(rows.length).toBeLessThanOrEqual(5);
+  });
+
+  it('returns empty array for no options', () => {
+    expect(buildChoiceComponents([])).toHaveLength(0);
   });
 });

--- a/tests/unit/pty-serialize.test.ts
+++ b/tests/unit/pty-serialize.test.ts
@@ -118,6 +118,40 @@ describe('serializeScreen', () => {
     expect(frame).toContain('38;2;100;200;50');
   });
 
+  it('preserves trailing spaces that carry a background color (isVisible trim)', async () => {
+    // A status bar is often blank glyphs painted only via background color. These
+    // cells contain a space char but ARE visible, so the serializer must NOT trim
+    // them as empty. Paint 5 blue-bg spaces, then leave the rest of the row default.
+    const a = makeTerm();
+    await write(a, '\x1b[2J\x1b[1;1H\x1b[44m     \x1b[0m');
+    const frame = serializeScreen(a);
+    const b = makeTerm();
+    await write(b, frame);
+
+    // Cells 0..4 must keep the blue (palette 4) background after the round-trip.
+    const lineB = b.buffer.active.getLine(0)!;
+    for (let x = 0; x < 5; x++) {
+      const cell = lineB.getCell(x)!;
+      expect(cell.isBgPalette()).toBe(true);
+      expect(cell.getBgColor()).toBe(4);
+    }
+    // Cell 5 (past the bar) must be a default-background cell.
+    expect(lineB.getCell(5)!.isBgDefault()).toBe(true);
+  });
+
+  it('preserves a trailing inverse-video space region', async () => {
+    // Inverse swaps fg/bg, so even default-color spaces become visible. The bottom
+    // bar in the bug report used \x1b[7m — confirm a trailing inverse run survives.
+    const a = makeTerm();
+    await write(a, '\x1b[2J\x1b[1;1H\x1b[7m   \x1b[0m');
+    const frame = serializeScreen(a);
+    expect(frame).toContain('\x1b[7m'); // inverse SGR must be emitted, not trimmed
+    const b = makeTerm();
+    await write(b, frame);
+    // isInverse() returns the flag bitmask (truthy number), not a literal boolean.
+    expect(b.buffer.active.getLine(0)!.getCell(0)!.isInverse()).toBeTruthy();
+  });
+
   it('restores the cursor position', async () => {
     const a = makeTerm();
     await write(a, '\x1b[2J\x1b[10;25HX');

--- a/tests/unit/pty-serialize.test.ts
+++ b/tests/unit/pty-serialize.test.ts
@@ -1,0 +1,131 @@
+import { Terminal } from '@xterm/headless';
+import { serializeScreen } from '../../src/shell/pty-serialize';
+
+const COLS = 200;
+const ROWS = 50;
+
+/** Write data into a headless terminal and resolve once xterm has parsed it. */
+function write(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, () => resolve()));
+}
+
+function makeTerm(): Terminal {
+  return new Terminal({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true });
+}
+
+/** Visible screen as plain text (one string per row), for state comparison. */
+function screenText(term: Terminal): string[] {
+  const buf = term.buffer.active;
+  const lines: string[] = [];
+  for (let y = 0; y < term.rows; y++) {
+    const line = buf.getLine(buf.viewportY + y);
+    lines.push(line ? line.translateToString(true) : '');
+  }
+  return lines;
+}
+
+/** Feed source bytes, serialize, replay into a fresh term, and return both screens. */
+async function roundTrip(source: string): Promise<{ before: string[]; after: string[]; frame: string }> {
+  const a = makeTerm();
+  await write(a, source);
+  const frame = serializeScreen(a);
+
+  const b = makeTerm();
+  await write(b, frame);
+  return { before: screenText(a), after: screenText(b), frame };
+}
+
+describe('serializeScreen', () => {
+  it('reproduces plain positioned text', async () => {
+    const { before, after } = await roundTrip('\x1b[2J\x1b[H' + 'Hello, world!');
+    expect(after).toEqual(before);
+    expect(after[0]).toContain('Hello, world!');
+  });
+
+  it('reproduces an alt-screen frame with content at the bottom row (the bug case)', async () => {
+    // Enter alt-screen, paint a top line and a bottom status bar — the bottom
+    // bar is exactly what used to vanish on reconnect.
+    const src =
+      '\x1b[?1049h\x1b[2J' +
+      '\x1b[1;1HClaude is working...' +
+      `\x1b[${ROWS};1H` + '\x1b[7m $0.42 · 143k tokens \x1b[0m';
+    const { before, after, frame } = await roundTrip(src);
+    expect(after).toEqual(before);
+    // Bottom row must survive the round-trip.
+    expect(after[ROWS - 1]).toContain('$0.42');
+    expect(after[ROWS - 1]).toContain('143k tokens');
+    // Frame must re-enter alt-screen so the client buffer mode matches.
+    expect(frame).toContain('\x1b[?1049h');
+  });
+
+  it('survives output that far exceeds any byte ring-buffer (root-cause regression)', async () => {
+    // Emit ~1 MB of noisy redraws — well past the old 256 KB cap — then a final
+    // full repaint. Serialization reflects the live grid, not a truncated tail,
+    // so the whole screen (including the bottom bar) must reconstruct intact.
+    let src = '\x1b[?1049h\x1b[2J';
+    for (let i = 0; i < 20000; i++) {
+      src += `\x1b[1;1HStreaming token chunk number ${i} ............................`;
+    }
+    src += '\x1b[1;1H\x1b[2J';
+    src += '\x1b[1;1HFinal first line';
+    src += `\x1b[${ROWS};1H\x1b[7m bottom status bar intact \x1b[0m`;
+    const { before, after } = await roundTrip(src);
+    expect(after).toEqual(before);
+    expect(after[0]).toContain('Final first line');
+    expect(after[ROWS - 1]).toContain('bottom status bar intact');
+  });
+
+  it('preserves multi-byte UTF-8 content (Thai) without mojibake', async () => {
+    const thai = 'แก้ issues จาก code review PR #159';
+    const { before, after } = await roundTrip('\x1b[2J\x1b[1;1H' + thai);
+    expect(after).toEqual(before);
+    expect(after[0]).toContain(thai);
+  });
+
+  it('preserves Thai fed via the socket pipeline (latin1 byte-string → bytes)', async () => {
+    // Reproduce the EXACT production path that broke the live viewer:
+    // the unix socket reads with setEncoding('latin1'), so the registry sees a
+    // byte-string where each UTF-8 byte is one latin1 char. Feeding that string
+    // straight into xterm stores mojibake; feeding the reconstructed bytes
+    // (Uint8Array) makes xterm UTF-8-decode correctly. This test feeds via the
+    // bytes path and asserts no mojibake survives into the serialized frame.
+    const thai = 'แก้ issues จาก code review PR #159';
+    const source = '\x1b[2J\x1b[1;1H' + thai;
+    const latin1ByteString = Buffer.from(source, 'utf8').toString('latin1'); // what the socket hands us
+
+    const a = makeTerm();
+    await new Promise<void>((r) => a.write(Buffer.from(latin1ByteString, 'latin1'), () => r()));
+    const frame = serializeScreen(a);
+
+    const b = makeTerm();
+    await write(b, frame);
+    expect(screenText(b)[0]).toContain(thai);
+    // The mojibake signature (UTF-8 bytes seen as latin1) must NOT appear.
+    expect(frame).not.toContain('à¸');
+  });
+
+  it('reproduces SGR colors and attributes', async () => {
+    const src =
+      '\x1b[2J\x1b[1;1H' +
+      '\x1b[1;31mBOLD RED\x1b[0m ' + // bold + palette red
+      '\x1b[38;2;100;200;050mTRUECOLOR\x1b[0m ' + // RGB fg
+      '\x1b[4;32mUNDER GREEN\x1b[0m'; // underline + green
+    const { before, after, frame } = await roundTrip(src);
+    expect(after).toEqual(before);
+    expect(after[0]).toContain('BOLD RED');
+    expect(after[0]).toContain('TRUECOLOR');
+    // RGB foreground must be serialized in truecolor form.
+    expect(frame).toContain('38;2;100;200;50');
+  });
+
+  it('restores the cursor position', async () => {
+    const a = makeTerm();
+    await write(a, '\x1b[2J\x1b[10;25HX');
+    const frame = serializeScreen(a);
+    const b = makeTerm();
+    await write(b, frame);
+    // Cursor should be back where the source left it (row 10, col 26 after 'X').
+    expect(b.buffer.active.cursorY).toBe(a.buffer.active.cursorY);
+    expect(b.buffer.active.cursorX).toBe(a.buffer.active.cursorX);
+  });
+});

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -4,6 +4,9 @@ import {
   ScreenModel,
   TUI_BUSY_MARKER,
   TUI_BYPASS_PERMS,
+  parseMenuChoice,
+  formatMenuPrompt,
+  extractChannelContent,
 } from '../../src/shell/screen';
 import { preTrustWorkspace, checkAuthStatus } from '../../src/shell/trust';
 import * as os from 'os';
@@ -128,6 +131,130 @@ describe('ScreenModel raw-chunk busy detection', () => {
     screen.write('hello');
     await new Promise((r) => setTimeout(r, 50));
     expect(screen.quietMs()).toBeGreaterThanOrEqual(40);
+  });
+});
+
+// Feed a screen and let xterm's async write buffer flush before reading text().
+async function renderScreen(lines: string[]): Promise<ScreenModel> {
+  const screen = new ScreenModel();
+  screen.write(lines.join('\r\n'));
+  await new Promise((r) => setTimeout(r, 30));
+  return screen;
+}
+
+const MENU_FOOTER = 'Enter to select · ↑/↓ to navigate · Esc to cancel';
+
+describe('ScreenModel detectMenu', () => {
+  it('parses numbered options (with ❯ highlight + a divider) when the footer is present', async () => {
+    const screen = await renderScreen([
+      'Which option do you want?',
+      '',
+      '❯ 1. First choice',
+      '  2. Second choice',
+      '  3. Third choice',
+      '  ─────────────',
+      '  4. Chat about this',
+      '',
+      MENU_FOOTER,
+    ]);
+    const menu = screen.detectMenu();
+    expect(menu).not.toBeNull();
+    expect(menu!.map((o) => o.index)).toEqual([1, 2, 3, 4]);
+    expect(menu![0].label).toBe('First choice');
+    expect(menu![3].label).toBe('Chat about this');
+  });
+
+  it('ignores stale numbered scrollback above the live menu', async () => {
+    // Reproduces the live bug: a prior chat message rendered as "1. … 2. …"
+    // sat in scrollback above an AskUserQuestion menu, so detectMenu swept the
+    // phantom rows in — inflating the option list and shifting every index.
+    const screen = await renderScreen([
+      '1. restart gateway now',
+      '2. restart drops the running session',
+      '',
+      'Which option do you want?',
+      '',
+      '❯ 1. See the buttons',
+      '  2. Type the number',
+      '  3. Nothing showed up',
+      '',
+      MENU_FOOTER,
+    ]);
+    const menu = screen.detectMenu();
+    expect(menu).not.toBeNull();
+    // Only the real 1..3 run nearest the footer — phantom rows excluded.
+    expect(menu!.map((o) => o.index)).toEqual([1, 2, 3]);
+    expect(menu![0].label).toBe('See the buttons');
+    expect(menu!.map((o) => o.label)).not.toContain('restart gateway now');
+  });
+
+  it('returns null without the menu footer', async () => {
+    const screen = await renderScreen([
+      'Here is a numbered list in normal output:',
+      '1. not a menu',
+      '2. still not a menu',
+    ]);
+    expect(screen.detectMenu()).toBeNull();
+  });
+
+  it('returns null with the footer but fewer than two options', async () => {
+    const screen = await renderScreen([
+      'Confirm?',
+      '  1. Only choice',
+      MENU_FOOTER,
+    ]);
+    expect(screen.detectMenu()).toBeNull();
+  });
+});
+
+describe('parseMenuChoice', () => {
+  it('accepts a leading integer within range', () => {
+    expect(parseMenuChoice('1', 4)).toBe(1);
+    expect(parseMenuChoice('2.', 4)).toBe(2);
+    expect(parseMenuChoice('  3 pick this', 4)).toBe(3);
+  });
+
+  it('rejects non-numbers and out-of-range values', () => {
+    expect(parseMenuChoice('abc', 5)).toBeNull();
+    expect(parseMenuChoice('', 5)).toBeNull();
+    expect(parseMenuChoice('0', 5)).toBeNull();
+    expect(parseMenuChoice('9', 5)).toBeNull();
+  });
+});
+
+describe('extractChannelContent', () => {
+  it('unwraps a channel envelope so a menu reply parses as the bare choice', () => {
+    const xml = '<channel source="telegram" chat_id="997170033" message_id="42" user="boss" ts="2026-06-14T00:00:00.000Z">1</channel>';
+    expect(extractChannelContent(xml)).toBe('1');
+    // Regression: the whole reason taps/typed numbers failed — the envelope
+    // starts with "<", so parseMenuChoice on the raw XML returns null.
+    expect(parseMenuChoice(xml, 4)).toBeNull();
+    expect(parseMenuChoice(extractChannelContent(xml), 4)).toBe(1);
+  });
+
+  it('strips a nested <replied> block before the user content', () => {
+    const xml = '<channel source="discord" chat_id="9" message_id="1" user="u" ts="t"><replied message_id="7" user="bot">3. Pick C</replied>2</channel>';
+    expect(extractChannelContent(xml)).toBe('2');
+  });
+
+  it('returns plain text unchanged (raw API / typed reply)', () => {
+    expect(extractChannelContent('2')).toBe('2');
+    expect(extractChannelContent('  3 ')).toBe('  3 ');
+  });
+
+  it('ignores numeric noise in envelope attributes (chat_id, ts)', () => {
+    const xml = '<channel source="telegram" chat_id="997170033" ts="2026-06-14">4</channel>';
+    expect(extractChannelContent(xml)).toBe('4');
+    expect(parseMenuChoice(extractChannelContent(xml), 5)).toBe(4);
+  });
+});
+
+describe('formatMenuPrompt', () => {
+  it('renders a numbered list with the reply instruction', () => {
+    const text = formatMenuPrompt([{ index: 1, label: 'Alpha' }, { index: 2, label: 'Beta' }]);
+    expect(text).toContain('1. Alpha');
+    expect(text).toContain('2. Beta');
+    expect(text.toLowerCase()).toContain('reply with the number');
   });
 });
 

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -9,6 +9,7 @@ import {
   extractChannelContent,
 } from '../../src/shell/screen';
 import { preTrustWorkspace, checkAuthStatus } from '../../src/shell/trust';
+import { decideMenuCancel, MenuCancelState } from '../../src/shell/menu-cancel';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -387,5 +388,154 @@ describe('pty-shell transcript path', () => {
     const uuid = '11111111-2222-3333-4444-555555555555';
     expect(transcriptPath('/tmp/pty-poc', uuid))
       .toBe(`${os.homedir()}/.claude/projects/-tmp-pty-poc/${uuid}.jsonl`);
+  });
+});
+
+describe('pty-shell menu-cancel settle decision', () => {
+  // Models the bug: user types a free-text question while a bridged menu is up.
+  // The wrapper ESCs the menu, then must wait for the TUI to return to an idle
+  // prompt before submitting — submitting into Claude's cancellation redraw is
+  // what caused the 30-min watchdog hang.
+  const T0 = 100_000;
+  const baseState = (): MenuCancelState => ({ since: T0, lastEscAt: T0, escs: 1 });
+
+  it('waits while the TUI is still busy reacting to the ESC cancel', () => {
+    const action = decideMenuCancel(baseState(), {
+      now: T0 + 1000,            // past MIN_WAIT
+      menuVisible: false,        // menu dismissed
+      hasPrompt: false,          // but no idle prompt yet
+      isBusy: true,              // Claude is processing the cancellation
+      quietMs: 50,
+    });
+    expect(action).toBe('wait');
+  });
+
+  it('waits until the minimum delay after ESC has elapsed', () => {
+    const action = decideMenuCancel(baseState(), {
+      now: T0 + 300,             // < MIN_WAIT (800ms)
+      menuVisible: false,
+      hasPrompt: true,
+      isBusy: false,
+      quietMs: 1000,
+    });
+    expect(action).toBe('wait');
+  });
+
+  it('waits until the screen has been quiet long enough', () => {
+    const action = decideMenuCancel(baseState(), {
+      now: T0 + 1000,
+      menuVisible: false,
+      hasPrompt: true,
+      isBusy: false,
+      quietMs: 100,              // < SETTLE_QUIET (600ms)
+    });
+    expect(action).toBe('wait');
+  });
+
+  it('submits once the menu is gone and the prompt is idle and quiet', () => {
+    const action = decideMenuCancel(baseState(), {
+      now: T0 + 1200,
+      menuVisible: false,
+      hasPrompt: true,
+      isBusy: false,
+      quietMs: 700,
+    });
+    expect(action).toBe('submit');
+  });
+
+  it('re-sends ESC when the menu lingers (ESC swallowed) within the retry cap', () => {
+    const action = decideMenuCancel(
+      { since: T0, lastEscAt: T0, escs: 1 },
+      {
+        now: T0 + 2000,          // > ESC_RETRY (1500ms) since last ESC
+        menuVisible: true,       // menu still on screen
+        hasPrompt: false,
+        isBusy: false,
+        quietMs: 800,
+      },
+    );
+    expect(action).toBe('resend-esc');
+  });
+
+  it('stops re-sending ESC after the cap and just waits', () => {
+    const action = decideMenuCancel(
+      { since: T0, lastEscAt: T0, escs: 3 },   // at MAX_ESC
+      {
+        now: T0 + 5000,
+        menuVisible: true,
+        hasPrompt: false,
+        isBusy: false,
+        quietMs: 800,
+      },
+    );
+    expect(action).toBe('wait');
+  });
+
+  it('force-submits after the hard timeout so the session never hangs', () => {
+    const action = decideMenuCancel(baseState(), {
+      now: T0 + 16_000,          // > TIMEOUT (15s)
+      menuVisible: true,         // even if the menu is somehow still up
+      hasPrompt: false,
+      isBusy: true,
+      quietMs: 0,
+    });
+    expect(action).toBe('submit');
+  });
+});
+
+describe('pty-shell /stop interrupt settle decision', () => {
+  // Models the /stop bug: user issues /stop (SIGINT → ESC interrupts the turn),
+  // then sends another message. The interrupted turn writes no turn_duration, so
+  // the wrapper must end it once the TUI returns to an idle prompt before draining
+  // the queued message — otherwise it hangs behind a dead turn until the watchdog.
+  // The interrupt path reuses decideMenuCancel with menuVisible ALWAYS false, so it
+  // must never return 'resend-esc' (an ESC then would cancel something unrelated).
+  const T0 = 200_000;
+  const armed = (): MenuCancelState => ({ since: T0, lastEscAt: T0, escs: 1 });
+
+  it('waits while the TUI is still busy reacting to the ESC interrupt', () => {
+    const action = decideMenuCancel(armed(), {
+      now: T0 + 1000,            // past MIN_WAIT
+      menuVisible: false,        // no menu is involved in /stop
+      hasPrompt: false,          // not back to an idle prompt yet
+      isBusy: true,              // Claude is still cancelling the turn
+      quietMs: 50,
+    });
+    expect(action).toBe('wait');
+  });
+
+  it('ends the interrupted turn once the prompt is idle and quiet', () => {
+    const action = decideMenuCancel(armed(), {
+      now: T0 + 1200,
+      menuVisible: false,
+      hasPrompt: true,
+      isBusy: false,
+      quietMs: 700,
+    });
+    expect(action).toBe('submit');
+  });
+
+  it('never re-sends ESC during a /stop interrupt (no menu on screen)', () => {
+    // Even long after the ESC with the screen quiet but no prompt yet, a /stop
+    // settle must not emit ESC — menuVisible is false so resend-esc is impossible.
+    const action = decideMenuCancel(armed(), {
+      now: T0 + 5000,            // well past ESC_RETRY
+      menuVisible: false,
+      hasPrompt: false,
+      isBusy: false,
+      quietMs: 2000,
+    });
+    expect(action).toBe('wait');
+  });
+
+  it('force-ends after the hard timeout so /stop never wedges the queue', () => {
+    const action = decideMenuCancel(armed(), {
+      now: T0 + 16_000,          // > TIMEOUT (15s)
+      menuVisible: false,
+      hasPrompt: false,          // TUI never settled
+      isBusy: true,
+      quietMs: 0,
+    });
+    expect(action).toBe('submit');
   });
 });

--- a/tests/unit/pty-stream-registry.test.ts
+++ b/tests/unit/pty-stream-registry.test.ts
@@ -127,46 +127,72 @@ describe('PtyStreamRegistry', () => {
     });
   });
 
-  describe('scrollback replay', () => {
-    it('replays buffered output to a client that subscribes after data arrived', () => {
-      // Data broadcast before anyone is subscribed is still buffered.
-      reg.broadcast('agent1', 'old-line-1\n');
-      reg.broadcast('agent1', 'old-line-2\n');
+  describe('screen replay', () => {
+    // The serialized frame is delivered inside xterm's write-flush callback
+    // (async), so a late subscriber's frame lands on a later tick than subscribe().
+    async function waitForFrame(ws: any, timeoutMs = 1000): Promise<void> {
+      const start = Date.now();
+      while (ws.sentBuffers.length === 0 && Date.now() - start < timeoutMs) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+    }
+    const frameText = (ws: any): string => Buffer.concat(ws.sentBuffers).toString('utf8');
+
+    it('replays the current screen to a client that subscribes after data arrived', async () => {
+      // Data broadcast before anyone is subscribed still builds the screen mirror.
+      reg.broadcast('agent1', 'old-line-1\r\n');
+      reg.broadcast('agent1', 'old-line-2\r\n');
 
       const ws = makeWs(1);
       reg.subscribe('agent1', ws);
+      await waitForFrame(ws);
 
-      // First send to the late subscriber is the replayed scrollback.
+      // The late subscriber receives one serialized frame reconstructing the screen.
       expect(ws.sentBuffers).toHaveLength(1);
-      expect(ws.sentBuffers[0]).toEqual(Buffer.from('old-line-1\nold-line-2\n', 'latin1'));
+      const text = frameText(ws);
+      expect(text).toContain('old-line-1');
+      expect(text).toContain('old-line-2');
     });
 
-    it('does not replay across agents', () => {
+    it('does not replay across agents', async () => {
       reg.broadcast('agent1', 'a1-data');
       const ws = makeWs(1);
       reg.subscribe('agent2', ws);
+      await new Promise((r) => setTimeout(r, 30));
       expect(ws.sentBuffers).toHaveLength(0);
     });
 
-    it('resets scrollback when a fresh session (first socket) starts', () => {
+    it('resets the screen when a fresh session (first socket) starts', async () => {
       const sockPath = path.join(tmpDir, 'sb.sock');
       reg.broadcast('agent1', 'stale-from-previous-session');
-      // New session begins → first listen() for the agent clears stale scrollback.
+      // New session begins → first listen() for the agent clears the stale screen.
       reg.listen('agent1', sockPath);
       const ws = makeWs(1);
       reg.subscribe('agent1', ws);
-      expect(ws.sentBuffers).toHaveLength(0);
+      await waitForFrame(ws, 100);
+      // A frame may be sent, but it must NOT carry content from the prior session.
+      expect(frameText(ws)).not.toContain('stale-from-previous-session');
       reg.close(sockPath);
     });
 
-    it('trims scrollback to the byte cap', () => {
-      // Push well over the 256 KiB cap; the retained buffer must stay bounded.
-      const chunk = 'x'.repeat(64 * 1024);
-      for (let i = 0; i < 8; i++) reg.broadcast('agent1', chunk);
+    it('replays the latest screen, not a truncated byte history, after heavy output', async () => {
+      // Push far past any byte ring-buffer cap, then a final repaint. The frame
+      // must reflect the live grid (final content), and stay bounded by screen size.
+      reg.broadcast('agent1', '\x1b[?1049h\x1b[2J');
+      const noise = 'x'.repeat(64 * 1024);
+      for (let i = 0; i < 8; i++) reg.broadcast('agent1', '\x1b[1;1H' + noise);
+      reg.broadcast('agent1', '\x1b[2J\x1b[1;1HFINAL-TOP\x1b[50;1HFINAL-BOTTOM');
+
       const ws = makeWs(1);
       reg.subscribe('agent1', ws);
-      expect(ws.sentBuffers).toHaveLength(1);
-      expect(ws.sentBuffers[0].length).toBeLessThanOrEqual(256 * 1024);
+      await waitForFrame(ws);
+
+      const text = frameText(ws);
+      expect(text).toContain('FINAL-TOP');
+      expect(text).toContain('FINAL-BOTTOM');
+      expect(text).not.toContain('xxxxxxxxxx'); // stale noise must be gone
+      // A 200x50 screen frame is far smaller than the old 256 KiB raw cap.
+      expect(Buffer.concat(ws.sentBuffers).length).toBeLessThanOrEqual(256 * 1024);
     });
   });
 });

--- a/tests/unit/pty-stream-registry.test.ts
+++ b/tests/unit/pty-stream-registry.test.ts
@@ -1,0 +1,129 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { PtyStreamRegistry } from '../../src/shell/pty-stream-registry';
+
+function makeWs(state: number = 1 /* OPEN */) {
+  return {
+    readyState: state,
+    sentBuffers: [] as Buffer[],
+    send(buf: Buffer) { this.sentBuffers.push(buf); },
+    OPEN: 1,
+  } as any;
+}
+
+describe('PtyStreamRegistry', () => {
+  let tmpDir: string;
+  let reg: PtyStreamRegistry;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pty-reg-test-'));
+    reg = new PtyStreamRegistry();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('socketPath', () => {
+    it('strips non-alphanumeric chars from sessionKey', () => {
+      const p = reg.socketPath('agent1', 'abc/def:xyz');
+      expect(path.basename(p)).not.toMatch(/[^a-z0-9_\-.]/i);
+    });
+
+    it('truncates sessionKey to 32 chars', () => {
+      const longKey = 'a'.repeat(100);
+      const p = reg.socketPath('agent1', longKey);
+      const safePart = path.basename(p).replace('gw-pty-', '').replace('.sock', '');
+      expect(safePart.length).toBeLessThanOrEqual(32);
+    });
+  });
+
+  describe('hasSockets', () => {
+    it('returns false when no sockets registered', () => {
+      expect(reg.hasSockets('agent1')).toBe(false);
+    });
+
+    it('returns true after listen()', () => {
+      const sockPath = path.join(tmpDir, 'test.sock');
+      reg.listen('agent1', sockPath);
+      expect(reg.hasSockets('agent1')).toBe(true);
+      reg.close(sockPath);
+    });
+
+    it('returns false after close()', () => {
+      const sockPath = path.join(tmpDir, 'test2.sock');
+      reg.listen('agent1', sockPath);
+      reg.close(sockPath);
+      expect(reg.hasSockets('agent1')).toBe(false);
+    });
+
+    it('does not cross-contaminate agents', () => {
+      const sockPath = path.join(tmpDir, 'agent2.sock');
+      reg.listen('agent2', sockPath);
+      expect(reg.hasSockets('agent1')).toBe(false);
+      expect(reg.hasSockets('agent2')).toBe(true);
+      reg.close(sockPath);
+    });
+  });
+
+  describe('subscribe / unsubscribe', () => {
+    it('unsubscribe after subscribe is a no-op', () => {
+      const ws = makeWs();
+      reg.subscribe('agent1', ws);
+      reg.unsubscribe('agent1', ws);
+      expect(() => reg.broadcast('agent1', 'hello')).not.toThrow();
+    });
+
+    it('unsubscribe on unknown agent is a no-op', () => {
+      const ws = makeWs();
+      expect(() => reg.unsubscribe('nobody', ws)).not.toThrow();
+    });
+
+    it('cleans up empty Set after last unsubscribe', () => {
+      const ws = makeWs();
+      reg.subscribe('agent1', ws);
+      reg.unsubscribe('agent1', ws);
+      expect((reg as any).clients.has('agent1')).toBe(false);
+    });
+  });
+
+  describe('broadcast', () => {
+    it('sends binary buffer to OPEN ws clients', () => {
+      const ws = makeWs(1);
+      reg.subscribe('agent1', ws);
+      reg.broadcast('agent1', 'hello');
+      expect(ws.sentBuffers).toHaveLength(1);
+      expect(ws.sentBuffers[0]).toEqual(Buffer.from('hello', 'latin1'));
+    });
+
+    it('skips non-OPEN clients', () => {
+      const ws = makeWs(3); // CLOSING
+      reg.subscribe('agent1', ws);
+      reg.broadcast('agent1', 'hello');
+      expect(ws.sentBuffers).toHaveLength(0);
+    });
+
+    it('preserves latin1 bytes faithfully (ANSI escapes)', () => {
+      const ws = makeWs(1);
+      reg.subscribe('agent1', ws);
+      const raw = '\x1b[32mGreen\x1b[0m';
+      reg.broadcast('agent1', raw);
+      expect(ws.sentBuffers[0]).toEqual(Buffer.from(raw, 'latin1'));
+    });
+
+    it('is a no-op when no subscribers', () => {
+      expect(() => reg.broadcast('ghost', 'data')).not.toThrow();
+    });
+
+    it('broadcasts to multiple subscribers', () => {
+      const ws1 = makeWs(1);
+      const ws2 = makeWs(1);
+      reg.subscribe('agent1', ws1);
+      reg.subscribe('agent1', ws2);
+      reg.broadcast('agent1', 'hi');
+      expect(ws1.sentBuffers).toHaveLength(1);
+      expect(ws2.sentBuffers).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/pty-stream-registry.test.ts
+++ b/tests/unit/pty-stream-registry.test.ts
@@ -26,16 +26,22 @@ describe('PtyStreamRegistry', () => {
   });
 
   describe('socketPath', () => {
-    it('strips non-alphanumeric chars from sessionKey', () => {
-      const p = reg.socketPath('agent1', 'abc/def:xyz');
+    it('strips non-alphanumeric chars from the stream key', () => {
+      const p = reg.socketPath('abc/def:xyz');
       expect(path.basename(p)).not.toMatch(/[^a-z0-9_\-.]/i);
     });
 
-    it('truncates sessionKey to 32 chars', () => {
+    it('truncates the stream key to 48 chars (fits a full UUID)', () => {
       const longKey = 'a'.repeat(100);
-      const p = reg.socketPath('agent1', longKey);
+      const p = reg.socketPath(longKey);
       const safePart = path.basename(p).replace('gw-pty-', '').replace('.sock', '');
-      expect(safePart.length).toBeLessThanOrEqual(32);
+      expect(safePart.length).toBeLessThanOrEqual(48);
+    });
+
+    it('gives two distinct session ids distinct socket paths (no collision)', () => {
+      const a = reg.socketPath('53c1e240-0dd4-4a5f-8a65-5f3448368aab');
+      const b = reg.socketPath('3c01897c-204e-470a-a856-f3a260c49392');
+      expect(a).not.toEqual(b);
     });
   });
 
@@ -193,6 +199,100 @@ describe('PtyStreamRegistry', () => {
       expect(text).not.toContain('xxxxxxxxxx'); // stale noise must be gone
       // A 200x50 screen frame is far smaller than the old 256 KiB raw cap.
       expect(Buffer.concat(ws.sentBuffers).length).toBeLessThanOrEqual(256 * 1024);
+    });
+
+    it('isolates concurrent sessions of the same agent (regression: keyed by sessionId)', async () => {
+      // Two sessions for one agent — keyed by their own session ids. The bug was
+      // keying by agentId, which merged both into one interleaved mirror and made
+      // the viewer unable to target a specific session.
+      const sessA = 'sess-aaaa';
+      const sessB = 'sess-bbbb';
+      reg.broadcast(sessA, '\x1b[2J\x1b[1;1HSESSION-A-CONTENT');
+      reg.broadcast(sessB, '\x1b[2J\x1b[1;1HSESSION-B-CONTENT');
+
+      const wsA = makeWs(1);
+      const wsB = makeWs(1);
+      reg.subscribe(sessA, wsA);
+      reg.subscribe(sessB, wsB);
+      await waitForFrame(wsA);
+      await waitForFrame(wsB);
+
+      const textA = frameText(wsA);
+      const textB = frameText(wsB);
+      // Each subscriber sees only its own session's screen — no interleaving.
+      expect(textA).toContain('SESSION-A-CONTENT');
+      expect(textA).not.toContain('SESSION-B-CONTENT');
+      expect(textB).toContain('SESSION-B-CONTENT');
+      expect(textB).not.toContain('SESSION-A-CONTENT');
+    });
+
+    it('broadcast to one session does not reach another session\'s subscriber', () => {
+      const wsA = makeWs(1);
+      reg.subscribe('sess-A', wsA);
+      reg.broadcast('sess-B', 'only-for-B');
+      // Live byte for session B must not be delivered to session A's client.
+      expect(wsA.sentBuffers.every((b: Buffer) => !b.toString('latin1').includes('only-for-B'))).toBe(true);
+    });
+  });
+
+  describe('screenText', () => {
+    it('returns null when no mirror exists for the session', async () => {
+      expect(await reg.screenText('nonexistent')).toBeNull();
+    });
+
+    it('returns plain text with ANSI codes stripped', async () => {
+      // Feed ANSI-decorated content: bold + color + text
+      reg.broadcast('sess-st', '\x1b[2J\x1b[1;1H\x1b[1;32mHello\x1b[0m World');
+      const snap = await reg.screenText('sess-st');
+      expect(snap).not.toBeNull();
+      // Text content only — no escape sequences
+      expect(snap!.text).toContain('Hello World');
+      expect(snap!.text).not.toContain('\x1b[');
+    });
+
+    it('returns cursor position and dimensions', async () => {
+      reg.broadcast('sess-cur', '\x1b[2J\x1b[3;5HX');
+      const snap = await reg.screenText('sess-cur');
+      expect(snap).not.toBeNull();
+      expect(snap!.cursorRow).toBeGreaterThanOrEqual(0);
+      expect(snap!.cursorCol).toBeGreaterThanOrEqual(0);
+      expect(snap!.cols).toBe(200);
+      expect(snap!.rows).toBe(50);
+    });
+
+    it('trims trailing blank lines', async () => {
+      // Write only on row 1; rows 2-50 are blank
+      reg.broadcast('sess-trim', '\x1b[2J\x1b[1;1HOnlyOneLine');
+      const snap = await reg.screenText('sess-trim');
+      expect(snap).not.toBeNull();
+      const lines = snap!.text.split('\n');
+      // Last line should not be blank
+      expect(lines[lines.length - 1]).not.toBe('');
+      expect(snap!.text).toContain('OnlyOneLine');
+    });
+
+    it('handles multi-byte UTF-8 (Thai) without mojibake', async () => {
+      // Simulate production path: UTF-8 bytes → latin1 string (socket encoding)
+      const thaiMsg = 'สวัสดี';
+      const latin1 = Buffer.from(thaiMsg, 'utf8').toString('latin1');
+      reg.broadcast('sess-thai', `\x1b[2J\x1b[1;1H${latin1}`);
+      const snap = await reg.screenText('sess-thai');
+      expect(snap).not.toBeNull();
+      expect(snap!.text).toContain(thaiMsg);
+      expect(snap!.text).not.toMatch(/à¸/); // no mojibake
+    });
+
+    it('two sessions have independent screen snapshots', async () => {
+      reg.broadcast('sess-x', '\x1b[2J\x1b[1;1HSCREEN-X');
+      reg.broadcast('sess-y', '\x1b[2J\x1b[1;1HSCREEN-Y');
+      const [snapX, snapY] = await Promise.all([
+        reg.screenText('sess-x'),
+        reg.screenText('sess-y'),
+      ]);
+      expect(snapX!.text).toContain('SCREEN-X');
+      expect(snapX!.text).not.toContain('SCREEN-Y');
+      expect(snapY!.text).toContain('SCREEN-Y');
+      expect(snapY!.text).not.toContain('SCREEN-X');
     });
   });
 });

--- a/tests/unit/pty-stream-registry.test.ts
+++ b/tests/unit/pty-stream-registry.test.ts
@@ -126,4 +126,47 @@ describe('PtyStreamRegistry', () => {
       expect(ws2.sentBuffers).toHaveLength(1);
     });
   });
+
+  describe('scrollback replay', () => {
+    it('replays buffered output to a client that subscribes after data arrived', () => {
+      // Data broadcast before anyone is subscribed is still buffered.
+      reg.broadcast('agent1', 'old-line-1\n');
+      reg.broadcast('agent1', 'old-line-2\n');
+
+      const ws = makeWs(1);
+      reg.subscribe('agent1', ws);
+
+      // First send to the late subscriber is the replayed scrollback.
+      expect(ws.sentBuffers).toHaveLength(1);
+      expect(ws.sentBuffers[0]).toEqual(Buffer.from('old-line-1\nold-line-2\n', 'latin1'));
+    });
+
+    it('does not replay across agents', () => {
+      reg.broadcast('agent1', 'a1-data');
+      const ws = makeWs(1);
+      reg.subscribe('agent2', ws);
+      expect(ws.sentBuffers).toHaveLength(0);
+    });
+
+    it('resets scrollback when a fresh session (first socket) starts', () => {
+      const sockPath = path.join(tmpDir, 'sb.sock');
+      reg.broadcast('agent1', 'stale-from-previous-session');
+      // New session begins → first listen() for the agent clears stale scrollback.
+      reg.listen('agent1', sockPath);
+      const ws = makeWs(1);
+      reg.subscribe('agent1', ws);
+      expect(ws.sentBuffers).toHaveLength(0);
+      reg.close(sockPath);
+    });
+
+    it('trims scrollback to the byte cap', () => {
+      // Push well over the 256 KiB cap; the retained buffer must stay bounded.
+      const chunk = 'x'.repeat(64 * 1024);
+      for (let i = 0; i < 8; i++) reg.broadcast('agent1', chunk);
+      const ws = makeWs(1);
+      reg.subscribe('agent1', ws);
+      expect(ws.sentBuffers).toHaveLength(1);
+      expect(ws.sentBuffers[0].length).toBeLessThanOrEqual(256 * 1024);
+    });
+  });
 });

--- a/tests/unit/telegram-plugin/menu-parser.test.ts
+++ b/tests/unit/telegram-plugin/menu-parser.test.ts
@@ -1,0 +1,50 @@
+import { parseMenuFileContent } from '../../../mcp/tools/telegram/menu-parser';
+
+describe('parseMenuFileContent', () => {
+  it('parses a valid menu file into text + inline_keyboard', () => {
+    const raw = JSON.stringify({
+      text: 'Pick an option:',
+      options: [{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }],
+    });
+    const result = parseMenuFileContent(raw);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('Pick an option:');
+    expect(result!.inline_keyboard).toHaveLength(3);
+    expect(result!.inline_keyboard[0]).toEqual([{ text: '1. Alpha', callback_data: 'choice:1' }]);
+    expect(result!.inline_keyboard[2]).toEqual([{ text: '3. Gamma', callback_data: 'choice:3' }]);
+  });
+
+  it('caps button label at 60 characters', () => {
+    const longLabel = 'Z'.repeat(80);
+    const raw = JSON.stringify({ text: 'Q', options: [{ label: longLabel }] });
+    const result = parseMenuFileContent(raw);
+    expect(result!.inline_keyboard[0][0].text.length).toBeLessThanOrEqual(60);
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseMenuFileContent('not json')).toBeNull();
+    expect(parseMenuFileContent('')).toBeNull();
+  });
+
+  it('returns null when text is missing', () => {
+    const raw = JSON.stringify({ options: [{ label: 'A' }] });
+    expect(parseMenuFileContent(raw)).toBeNull();
+  });
+
+  it('returns null when options array is empty', () => {
+    const raw = JSON.stringify({ text: 'Q', options: [] });
+    expect(parseMenuFileContent(raw)).toBeNull();
+  });
+
+  it('skips options with non-string labels', () => {
+    const raw = JSON.stringify({ text: 'Q', options: [{ label: 42 }, { label: null }, { label: 'Valid' }] });
+    const result = parseMenuFileContent(raw);
+    expect(result!.inline_keyboard).toHaveLength(1);
+    expect(result!.inline_keyboard[0][0].callback_data).toBe('choice:1');
+  });
+
+  it('returns null when all options have invalid labels', () => {
+    const raw = JSON.stringify({ text: 'Q', options: [{ label: null }] });
+    expect(parseMenuFileContent(raw)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- **PTY stream viewer**: real-time xterm.js mirror via WebSocket (`/api/v1/agents/:id/pty-stream`)
- **Interactive menu bridge**: AskUserQuestion / plan menus rendered as native inline buttons on Telegram & Discord; button tap routes back as a normal turn
- **Session dashboard**: live sessions table with source/model badge colours, CPU/mem, uptime, token count; PTY Live viewer with ↺ refresh
- **Dev hot-reload**: `make start-dev` — `tsc --watch` + `DEV_MODE=1` module cache-bust per request

## Security & reliability fixes (post-review)

- **Ephemeral WS ticket** (`POST /api/v1/pty-stream-ticket`): API key never appears in WS URLs (which land in server access logs). Dashboard exchanges key → short-lived ticket → connects with `?ticket=`.
- **Async `/processes`** + 3 s TTL cache: replaced blocking `execSync` so the event loop is never held during `ps` execution.
- **Stream socket warn log**: connection errors in `claude-pty-shell` are now logged (not silently swallowed) for easier timing-issue diagnosis.
- **Menu file parser extracted** (`mcp/tools/telegram/menu-parser.ts`): pure module, no bot runtime dependency — importable in tests.

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] `buildChoiceComponents` — 5 unit tests
- [x] `parseMenuFileContent` — 7 unit tests (valid, malformed, empty, bad labels)
- [x] `writeMenuForward` atomic rename — 2 unit tests
- [x] `getSessionsSummary` dedup — 4 unit tests (existing)
- [x] `PtyStreamRegistry` — 14 unit tests (existing)
- [x] All 388 existing tests pass
- [x] Telegram menu bridge tested end-to-end (buttons rendered + tap routed)
- [x] Discord menu bridge tested end-to-end (buttons rendered + tap routed)
- [ ] Ephemeral ticket flow in browser (ticket obtained → WS connected without `?key=` in URL)

Closes #158