### PR TITLE
[Fix] Route api session commands (/compact, /session, /clear) to the flat context store

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1914,18 +1914,21 @@ export class AgentRunner extends EventEmitter {
         const index = await this.sessionStore.listSessions(agentId, storeChatId, 'api').catch(() => null);
         const meta = index?.sessions.find((s) => s.id === sessionId);
         const effectiveModel = this.agentConfig.claude.model;
+        // The api append path doesn't maintain the index messageCount, so count the flat store
+        // (the real conversation) directly rather than trusting meta.messageCount.
+        const messageCount = (await this.sessionStore.loadSession(agentId, sessionId).catch(() => [])).length;
         if (!meta) {
-          result = { sessionId, sessionName: null, messageCount: 0, archivedCount: 0, contextUsedPct: 0, model: effectiveModel };
-          responseText = `Session: (unnamed)\nMessages: 0\nContext used: 0%\nModel: ${effectiveModel}`;
+          result = { sessionId, sessionName: null, messageCount, archivedCount: 0, contextUsedPct: 0, model: effectiveModel };
+          responseText = `Session: (unnamed)\nMessages: ${messageCount}\nContext used: 0%\nModel: ${effectiveModel}`;
         } else {
           const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
           const modelConfig = availableModels.find((m) => m.id === effectiveModel);
           const contextWindow = modelConfig?.contextWindow ?? 200000;
           const contextUsedPct = Math.round(((meta.lastInputTokens ?? 0) / contextWindow) * 100);
-          result = { sessionId, sessionName: meta.name, messageCount: meta.messageCount, archivedCount: meta.archivedCount ?? 0, contextUsedPct, model: effectiveModel };
+          result = { sessionId, sessionName: meta.name, messageCount, archivedCount: meta.archivedCount ?? 0, contextUsedPct, model: effectiveModel };
           responseText = [
             `Session: ${meta.name ?? '(unnamed)'}`,
-            `Messages: ${meta.messageCount}${(meta.archivedCount ?? 0) > 0 ? ` (${meta.archivedCount} archived)` : ''}`,
+            `Messages: ${messageCount}${(meta.archivedCount ?? 0) > 0 ? ` (${meta.archivedCount} archived)` : ''}`,
             `Context used: ${contextUsedPct}%`,
             `Model: ${effectiveModel}`,
           ].join('\n');
@@ -1935,19 +1938,26 @@ export class AgentRunner extends EventEmitter {
         // telegram /sessions list. Marks the session this command runs in as (current).
         const index = await this.sessionStore.listSessions(agentId, storeChatId, 'api').catch(() => null);
         const list = index?.sessions ?? [];
-        result = {
-          sessions: list.map((s) => ({ id: s.id, name: s.name, messageCount: s.messageCount, current: s.id === sessionId })),
-          count: list.length,
-        };
-        if (!list.length) {
+        // Count each session's flat store directly — the api append path doesn't keep the
+        // index messageCount in sync.
+        const withCounts = await Promise.all(
+          list.map(async (s) => ({
+            id: s.id,
+            name: s.name,
+            messageCount: (await this.sessionStore.loadSession(agentId, s.id).catch(() => [])).length,
+            current: s.id === sessionId,
+          })),
+        );
+        result = { sessions: withCounts, count: withCounts.length };
+        if (!withCounts.length) {
           responseText = 'No sessions.';
         } else {
-          const lines = list.map((s) => {
+          const lines = withCounts.map((s) => {
             const n = s.messageCount;
-            const marker = s.id === sessionId ? ' (current)' : '';
+            const marker = s.current ? ' (current)' : '';
             return `• ${s.name ?? '(unnamed)'} — ${n} message${n === 1 ? '' : 's'}${marker}`;
           });
-          responseText = `Sessions (${list.length}):\n${lines.join('\n')}`;
+          responseText = `Sessions (${withCounts.length}):\n${lines.join('\n')}`;
         }
       } else if (cmd === '/clear') {
         const ch = 'api' as const;

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -398,14 +398,22 @@ export class SessionStore {
     // sessionId, loaded at spawn via loadSession) — not the structured per-chat store. Clearing
     // the structured store would leave the real context untouched, so truncate the flat file.
     if (channel === 'api') {
-      await this.resetSession(agentId, sessionId);
-      const apiIndex = await this.loadIndex(agentId, chatId, channel);
-      const apiMeta = apiIndex?.sessions.find((s) => s.id === sessionId);
-      if (apiIndex && apiMeta) {
-        apiMeta.messageCount = 0;
-        apiMeta.lastActive = Date.now();
-        await this.saveIndex(agentId, chatId, apiIndex, channel);
-      }
+      // Run both the flat-file truncation and the index update atomically on the
+      // session queue so a concurrent appendMessage cannot sneak in between and
+      // leave the index count at 0 while the flat store already has new messages.
+      // Inline the truncation (instead of calling resetSession) to avoid re-entrancy.
+      const sessionQueue = this.getQueue(agentId, sessionId);
+      await sessionQueue.add(async () => {
+        const filePath = this.resolvePath(agentId, sessionId);
+        try { fs.writeFileSync(filePath, '', 'utf-8'); } catch { /* file may not exist */ }
+        const apiIndex = await this.loadIndex(agentId, chatId, channel);
+        const apiMeta = apiIndex?.sessions.find((s) => s.id === sessionId);
+        if (apiIndex && apiMeta) {
+          apiMeta.messageCount = 0;
+          apiMeta.lastActive = Date.now();
+          await this.saveIndex(agentId, chatId, apiIndex, channel);
+        }
+      });
       return;
     }
     const queue = this.getTelegramQueue(agentId, chatId);

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -394,6 +394,20 @@ export class SessionStore {
   }
 
   async clearTelegramSessionHistory(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
+    // api sessions keep their context in the flat sessions/{sessionId}.jsonl store (keyed by
+    // sessionId, loaded at spawn via loadSession) — not the structured per-chat store. Clearing
+    // the structured store would leave the real context untouched, so truncate the flat file.
+    if (channel === 'api') {
+      await this.resetSession(agentId, sessionId);
+      const apiIndex = await this.loadIndex(agentId, chatId, channel);
+      const apiMeta = apiIndex?.sessions.find((s) => s.id === sessionId);
+      if (apiIndex && apiMeta) {
+        apiMeta.messageCount = 0;
+        apiMeta.lastActive = Date.now();
+        await this.saveIndex(agentId, chatId, apiIndex, channel);
+      }
+      return;
+    }
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
       const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId, channel);
@@ -437,6 +451,12 @@ export class SessionStore {
   }
 
   async loadTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<Message[]> {
+    // api context lives in the flat sessions/{sessionId}.jsonl store, consistent with how api
+    // messages are appended (appendMessage keyed by sessionId) and how buildInitialPrompt loads
+    // them at spawn (loadSession). Read from there so /compact sees the real conversation.
+    if (channel === 'api') {
+      return this.loadSession(agentId, sessionId);
+    }
     const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId, channel);
     if (!fs.existsSync(sessionPath)) {
       return [];
@@ -457,6 +477,21 @@ export class SessionStore {
     messages: Message[],
     channel: 'telegram' | 'discord' | 'api' = 'telegram',
   ): Promise<void> {
+    // api: overwrite the flat sessions/{sessionId}.jsonl store (newline-delimited, keyed by
+    // sessionId, serialized on the same queue as appendMessage) so /compact's result is exactly
+    // what buildInitialPrompt loads at the next spawn.
+    if (channel === 'api') {
+      const apiQueue = this.getQueue(agentId, sessionId);
+      await apiQueue.add(async () => {
+        const filePath = this.resolvePath(agentId, sessionId);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        const data = messages.length ? messages.map((m) => JSON.stringify(m)).join('\n') + '\n' : '';
+        const tmp = filePath + '.tmp';
+        fs.writeFileSync(tmp, data, 'utf-8');
+        fs.renameSync(tmp, filePath);
+      });
+      return;
+    }
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
       const sessionPath = this.resolveTelegramSessionPath(agentId, chatId, sessionId, channel);

--- a/tests/unit/api-session-commands.test.ts
+++ b/tests/unit/api-session-commands.test.ts
@@ -38,8 +38,11 @@ function makeMockProcess(): MockChildProcess {
   return proc;
 }
 
+const mockSpawnSync = jest.fn();
+
 jest.mock('child_process', () => ({
   spawn: jest.fn(() => makeMockProcess()),
+  spawnSync: (...args: unknown[]) => mockSpawnSync(...args),
 }));
 
 // ── Imports ───────────────────────────────────────────────────────────────────
@@ -91,6 +94,7 @@ describe('executeApiCommand session counting (#160)', () => {
       JSON.stringify({ agents: [{ id: 'alfred', claude: { model: 'claude-opus-4-6' } }] }, null, 2) + '\n',
     );
     runner = new AgentRunner(makeAgentConfig(workspaceDir), makeGatewayConfig());
+    mockSpawnSync.mockReset();
   });
 
   afterEach(async () => {
@@ -150,6 +154,23 @@ describe('executeApiCommand session counting (#160)', () => {
     // Exactly one session is marked current.
     expect(sessions.filter((s) => s.current)).toHaveLength(1);
     expect(responseText).toContain('(current)');
+  });
+
+  it('U-RUN-05: /compact end-to-end — compacts the flat store and returns keptMessages count', async () => {
+    await seedFlatStore(sessionId, 6);
+    mockSpawnSync.mockReturnValueOnce({ status: 0, stdout: 'Compact summary.', stderr: '', error: undefined });
+
+    const { result, responseText } = await runner.executeApiCommand(sessionId, chatId, '/compact', { skipPersist: true });
+
+    expect(result.success).toBe(true);
+    // afterMessages = 1 summary + 6 verbatim (all < KEEP_LAST_MESSAGES default)
+    expect(result.keptMessages).toBe(7);
+    expect(responseText).toContain('compacted');
+    // The flat store must have been overwritten with the compacted result.
+    const flat = await getSessionStore(runner).loadSession(agentId, sessionId);
+    expect(flat.length).toBeGreaterThan(0);
+    expect(flat[0].role).toBe('system');
+    expect((flat[0].content as string)).toContain('[Conversation Summary]');
   });
 
   it('U-RUN-06: an unknown command throws before persisting anything', async () => {

--- a/tests/unit/api-session-commands.test.ts
+++ b/tests/unit/api-session-commands.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for executeApiCommand /session and /sessions message counting (#160).
+ *
+ * api session context lives in the flat sessions/{sessionId}.jsonl store, but the
+ * structured index's messageCount is never maintained on the api append path. Before
+ * the fix /session and /sessions reported `0` messages. These drive executeApiCommand
+ * directly and assert the counts come from the flat store (via loadSession).
+ */
+
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── Mock child_process (restartProcess on /clear spawns a child) ──────────────
+
+interface MockChildProcess extends EventEmitter {
+  stdin: { writable: boolean; write: jest.Mock } | null;
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+}
+
+function makeMockProcess(): MockChildProcess {
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdin = { writable: true, write: jest.fn() };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.killed = false;
+  proc.pid = Math.floor(Math.random() * 90000) + 10000;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = true;
+    process.nextTick(() => proc.emit('exit', 0, signal ?? 'SIGTERM'));
+    return true;
+  });
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(() => makeMockProcess()),
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { AgentRunner } from '../../src/agent/runner';
+import { AgentConfig, GatewayConfig, Message } from '../../src/types';
+import { SessionStore } from '../../src/session/store';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────────
+
+function makeAgentConfig(workspace: string): AgentConfig {
+  return {
+    id: 'alfred',
+    description: 'test agent',
+    workspace,
+    env: '',
+    telegram: { botToken: 'test-token' },
+    claude: { model: 'claude-opus-4-6', dangerouslySkipPermissions: false, extraFlags: [] },
+  };
+}
+
+function makeGatewayConfig(): GatewayConfig {
+  return { gateway: { logDir: '/tmp/test-api-cmd-logs', timezone: 'UTC' }, agents: [] };
+}
+
+function getSessionStore(runner: AgentRunner): SessionStore {
+  return (runner as unknown as { sessionStore: SessionStore }).sessionStore;
+}
+
+function makeMsg(role: 'user' | 'assistant', content: string): Message {
+  return { role, content, ts: Date.now() };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('executeApiCommand session counting (#160)', () => {
+  let tmpDir: string;
+  let runner: AgentRunner;
+  const agentId = 'alfred';
+  const chatId = 'web-1';        // executeApiCommand uses chatId as the store chatId
+  const sessionId = 'sess-1';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'api-cmd-test-'));
+    const workspaceDir = path.join(tmpDir, 'agents', 'alfred', 'workspace');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'config.json'),
+      JSON.stringify({ agents: [{ id: 'alfred', claude: { model: 'claude-opus-4-6' } }] }, null, 2) + '\n',
+    );
+    runner = new AgentRunner(makeAgentConfig(workspaceDir), makeGatewayConfig());
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Seed the flat store the same way the api message path does (keyed by sessionId).
+  async function seedFlatStore(sid: string, count: number): Promise<void> {
+    const store = getSessionStore(runner);
+    for (let i = 0; i < count; i++) {
+      await store.appendMessage(agentId, sid, makeMsg(i % 2 === 0 ? 'user' : 'assistant', `m${i}`));
+    }
+  }
+
+  it('U-RUN-01: /session reports the real flat-store message count, not the stale index 0', async () => {
+    await seedFlatStore(sessionId, 5);
+
+    const { result, responseText } = await runner.executeApiCommand(sessionId, chatId, '/session', { skipPersist: true });
+
+    expect(result.messageCount).toBe(5);
+    expect(responseText).toContain('Messages: 5');
+  });
+
+  it('U-RUN-02: /session reports 0 for an empty session without throwing', async () => {
+    const { result, responseText } = await runner.executeApiCommand(sessionId, chatId, '/session', { skipPersist: true });
+
+    expect(result.messageCount).toBe(0);
+    expect(responseText).toContain('Messages: 0');
+  });
+
+  it('U-RUN-03: /session dispatches on the first token, so trailing args still resolve', async () => {
+    await seedFlatStore(sessionId, 3);
+
+    const { result } = await runner.executeApiCommand(sessionId, chatId, '/session please', { skipPersist: true });
+
+    expect(result.messageCount).toBe(3);
+  });
+
+  it('U-RUN-04: /sessions lists each session with its real flat-store count and marks current', async () => {
+    // Two api sessions, each with a different number of flat-store messages.
+    await seedFlatStore(sessionId, 4);
+    await seedFlatStore('sess-2', 2);
+    // Register both in the api index (as ensureApiSession would on first use).
+    await getSessionStore(runner).ensureApiSession(agentId, chatId, sessionId);
+    await getSessionStore(runner).ensureApiSession(agentId, chatId, 'sess-2');
+
+    const { result, responseText } = await runner.executeApiCommand(sessionId, chatId, '/sessions', { skipPersist: true });
+
+    const sessions = result.sessions as Array<{ id: string; messageCount: number; current: boolean }>;
+    const s1 = sessions.find((s) => s.id === sessionId)!;
+    const s2 = sessions.find((s) => s.id === 'sess-2')!;
+    expect(s1.messageCount).toBe(4); // from the flat store, not the stale index count
+    expect(s2.messageCount).toBe(2);
+    expect(s1.current).toBe(true);
+    expect(s2.current).toBe(false);
+    // Exactly one session is marked current.
+    expect(sessions.filter((s) => s.current)).toHaveLength(1);
+    expect(responseText).toContain('(current)');
+  });
+
+  it('U-RUN-06: an unknown command throws before persisting anything', async () => {
+    await expect(
+      runner.executeApiCommand(sessionId, chatId, '/bogus', { skipPersist: true }),
+    ).rejects.toThrow('Unknown command: /bogus');
+  });
+
+  it('U-RUN-07: /clear empties the flat store the model reloads at spawn', async () => {
+    await seedFlatStore(sessionId, 6);
+    expect(await getSessionStore(runner).loadSession(agentId, sessionId)).toHaveLength(6);
+
+    const { result } = await runner.executeApiCommand(sessionId, chatId, '/clear', { skipPersist: true });
+
+    expect(result.success).toBe(true);
+    expect(await getSessionStore(runner).loadSession(agentId, sessionId)).toEqual([]);
+  });
+});

--- a/tests/unit/session-compactor.test.ts
+++ b/tests/unit/session-compactor.test.ts
@@ -254,4 +254,86 @@ describe('SessionCompactor', () => {
     const archiveFiles = fs.readdirSync(telegramDir).filter(f => f.includes('.pre-compact-'));
     expect(archiveFiles).toHaveLength(1);
   });
+
+  // ─── API channel /compact against the flat store (#160) ──────────────────────
+  //
+  // For the api channel, the conversation lives in the flat sessions/{sessionId}.jsonl
+  // store (appended by the api message path), NOT the structured telegram-style store.
+  // Before the fix, compact() read the empty structured store and always failed with
+  // "Not enough messages to compact (0 messages)". These exercise the end-to-end fix:
+  // SessionStore api routing + SessionCompactor.
+  describe('api channel (#160)', () => {
+    // The runner passes storeChatId = api-{chatId}; the flat store is keyed by sessionId.
+    const apiStoreChatId = 'api-777000';
+    const apiSessionId = 'sess-compact-1';
+
+    it('U-CMP-API-1: regression — pre-fix the structured store is empty so /compact would see 0 messages', async () => {
+      // Seed only the flat store, exactly as the api message path does.
+      for (let i = 0; i < 6; i++) {
+        const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+        await sessionStore.appendMessage(agentId, apiSessionId, makeMsg(role, `api message ${i}`));
+      }
+
+      // The OLD (buggy) behaviour read the structured store with the telegram default channel.
+      const structuredView = await sessionStore.loadTelegramSession(agentId, apiStoreChatId, apiSessionId /* telegram default */);
+      expect(structuredView).toEqual([]); // empty → would throw NotEnoughMessagesError(0)
+
+      // The fix: reading with the api channel surfaces the real conversation.
+      const apiView = await sessionStore.loadTelegramSession(agentId, apiStoreChatId, apiSessionId, 'api');
+      expect(apiView).toHaveLength(6);
+    });
+
+    it('U-CMP-API-2: compact(api) succeeds on a flat-store conversation and writes the result back to the flat store', async () => {
+      const messages: Message[] = [];
+      for (let i = 0; i < 6; i++) {
+        const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+        const msg = makeMsg(role, `api message ${i}`, Date.now() + i);
+        messages.push(msg);
+        await sessionStore.appendMessage(agentId, apiSessionId, msg);
+      }
+
+      mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('Concise api summary.'));
+
+      const result = await compactor.compact(agentId, apiStoreChatId, apiSessionId, 'claude-sonnet-4-6', 200000, 'api');
+
+      expect(result.beforeMessages).toBe(6);
+      expect(result.afterMessages).toBe(7); // 1 summary + 6 verbatim (all < KEEP_LAST_MESSAGES)
+
+      // The compacted result must land in the flat store — what buildInitialPrompt reloads at spawn.
+      const flat = await sessionStore.loadSession(agentId, apiSessionId);
+      expect(flat).toHaveLength(7);
+      expect(flat[0].role).toBe('system');
+      expect(flat[0].content).toContain('[Conversation Summary]');
+      expect(flat[0].content).toContain('Concise api summary.');
+      expect(flat[flat.length - 1].content).toBe('api message 5');
+    });
+
+    it('U-CMP-API-3: compact(api) archives the original under the structured api-{chatId} dir', async () => {
+      for (let i = 0; i < 6; i++) {
+        const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+        await sessionStore.appendMessage(agentId, apiSessionId, makeMsg(role, `api message ${i}`));
+      }
+
+      mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('summary'));
+      await compactor.compact(agentId, apiStoreChatId, apiSessionId, 'claude-sonnet-4-6', 200000, 'api');
+
+      const apiDir = path.join(tmpDir, agentId, 'sessions', `api-${apiStoreChatId}`);
+      const archives = fs.readdirSync(apiDir).filter(f => f.includes('.pre-compact-'));
+      expect(archives).toHaveLength(1);
+      const archived = JSON.parse(fs.readFileSync(path.join(apiDir, archives[0]), 'utf-8')) as Message[];
+      expect(archived).toHaveLength(6);
+    });
+
+    it('U-CMP-API-4: compact(api) with fewer than 5 flat-store messages still throws NotEnoughMessagesError', async () => {
+      await sessionStore.appendMessage(agentId, apiSessionId, makeMsg('user', 'one'));
+      await sessionStore.appendMessage(agentId, apiSessionId, makeMsg('assistant', 'two'));
+
+      await expect(
+        compactor.compact(agentId, apiStoreChatId, apiSessionId, 'claude-sonnet-4-6', 200000, 'api'),
+      ).rejects.toThrow(NotEnoughMessagesError);
+
+      // CLI must never be invoked when there's nothing to compact.
+      expect(mockSpawnSync).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/unit/session-compactor.test.ts
+++ b/tests/unit/session-compactor.test.ts
@@ -263,8 +263,9 @@ describe('SessionCompactor', () => {
   // "Not enough messages to compact (0 messages)". These exercise the end-to-end fix:
   // SessionStore api routing + SessionCompactor.
   describe('api channel (#160)', () => {
-    // The runner passes storeChatId = api-{chatId}; the flat store is keyed by sessionId.
-    const apiStoreChatId = 'api-777000';
+    // The runner passes storeChatId = chatId (raw, no prefix) — the store adds the channel
+    // prefix internally. Using a raw chatId here matches real usage.
+    const apiStoreChatId = '777000';
     const apiSessionId = 'sess-compact-1';
 
     it('U-CMP-API-1: regression — pre-fix the structured store is empty so /compact would see 0 messages', async () => {
@@ -317,7 +318,7 @@ describe('SessionCompactor', () => {
       mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('summary'));
       await compactor.compact(agentId, apiStoreChatId, apiSessionId, 'claude-sonnet-4-6', 200000, 'api');
 
-      const apiDir = path.join(tmpDir, agentId, 'sessions', `api-${apiStoreChatId}`);
+      const apiDir = path.join(tmpDir, agentId, 'sessions', `api-${apiStoreChatId}`); // → sessions/api-777000
       const archives = fs.readdirSync(apiDir).filter(f => f.includes('.pre-compact-'));
       expect(archives).toHaveLength(1);
       const archived = JSON.parse(fs.readFileSync(path.join(apiDir, archives[0]), 'utf-8')) as Message[];

--- a/tests/unit/session-store.test.ts
+++ b/tests/unit/session-store.test.ts
@@ -375,4 +375,140 @@ describe('session-store', () => {
     expect(meta!.createdAt).toBe(originalCreatedAt);
     expect(meta!.messageCount).toBe(0);
   });
+
+  // ─── API channel routing (#160) ──────────────────────────────────────────────
+  //
+  // api sessions keep their conversation context in the flat sessions/{sessionId}.jsonl
+  // store (where appendMessage writes and buildInitialPrompt loads at spawn) — NOT the
+  // structured per-chat telegram-style store. The three SessionStore methods used by
+  // /compact and /clear must therefore route to the flat store when channel === 'api'.
+
+  const apiChatId = 'api-998877';            // storeChatId used by the runner (api-{chatId})
+  const apiSessionId = 'sess-abc123';        // the flat store is keyed by sessionId
+
+  // The flat store path the api branches must read/write.
+  const flatPath = (agentId: string, sessionId: string) =>
+    path.join(tmpDir, agentId, 'sessions', `${sessionId}.jsonl`);
+  // The structured api store dir that must stay untouched.
+  const structuredDir = (agentId: string, chatId: string) =>
+    path.join(tmpDir, agentId, 'sessions', `api-${chatId}`);
+
+  it('U-API-1: loadTelegramSession(api) reads from the flat sessions/{sessionId}.jsonl store', async () => {
+    // Seed the flat store exactly as the api append path does (keyed by sessionId).
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('user', 'hello from api'));
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('assistant', 'hi'));
+
+    const loaded = await store.loadTelegramSession('agent-x', apiChatId, apiSessionId, 'api');
+
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0].content).toBe('hello from api');
+    expect(loaded[1].content).toBe('hi');
+    // Same data loadSession returns directly — they must agree.
+    expect(loaded).toEqual(await store.loadSession('agent-x', apiSessionId));
+  });
+
+  it('U-API-2: loadTelegramSession(api) ignores the structured per-chat store', async () => {
+    // Messages written only to the structured store must NOT surface for api.
+    await store.getOrCreateIndex('agent-x', apiChatId, 'api');
+    await store.appendTelegramMessage('agent-x', apiChatId, apiSessionId, makeMsg('user', 'structured only'), 'api')
+      .catch(() => {/* index may not contain sessionId; fine — flat store is what matters */});
+
+    const loaded = await store.loadTelegramSession('agent-x', apiChatId, apiSessionId, 'api');
+    // Flat store was never written → empty, regardless of the structured store.
+    expect(loaded).toEqual([]);
+  });
+
+  it('U-API-3: saveTelegramSession(api) overwrites the flat store and leaves the structured store empty', async () => {
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('user', 'old 1'));
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('assistant', 'old 2'));
+
+    const compacted = [
+      makeMsg('user', 'summary tail 1'),
+      makeMsg('assistant', 'summary tail 2'),
+    ];
+    await store.saveTelegramSession('agent-x', apiChatId, apiSessionId, compacted, 'api');
+
+    // Flat store now holds exactly the overwritten messages (what spawn will reload).
+    const reloaded = await store.loadSession('agent-x', apiSessionId);
+    expect(reloaded).toHaveLength(2);
+    expect(reloaded[0].content).toBe('summary tail 1');
+    expect(reloaded[1].content).toBe('summary tail 2');
+
+    // The structured api store dir must not have been created/written by the save.
+    const structuredSessionFile = path.join(structuredDir('agent-x', apiChatId), `${apiSessionId}.json`);
+    expect(fs.existsSync(structuredSessionFile)).toBe(false);
+  });
+
+  it('U-API-4: saveTelegramSession(api) writes newline-delimited JSONL the flat reader round-trips', async () => {
+    await store.saveTelegramSession('agent-x', apiChatId, apiSessionId, [makeMsg('user', 'only')], 'api');
+
+    const raw = fs.readFileSync(flatPath('agent-x', apiSessionId), 'utf-8');
+    expect(raw.endsWith('\n')).toBe(true);
+    expect(raw.trim().split('\n')).toHaveLength(1);
+    expect(JSON.parse(raw.trim())).toMatchObject({ role: 'user', content: 'only' });
+  });
+
+  it('U-API-5: saveTelegramSession(api) with [] empties the flat file', async () => {
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('user', 'will be wiped'));
+
+    await store.saveTelegramSession('agent-x', apiChatId, apiSessionId, [], 'api');
+
+    expect(fs.readFileSync(flatPath('agent-x', apiSessionId), 'utf-8')).toBe('');
+    expect(await store.loadSession('agent-x', apiSessionId)).toEqual([]);
+  });
+
+  it('U-API-6: clearTelegramSessionHistory(api) truncates the flat store', async () => {
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('user', 'a'));
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('assistant', 'b'));
+    expect(await store.loadSession('agent-x', apiSessionId)).toHaveLength(2);
+
+    await store.clearTelegramSessionHistory('agent-x', apiChatId, apiSessionId, 'api');
+
+    // The flat file — what buildInitialPrompt loads at the next spawn — is now empty.
+    expect(await store.loadSession('agent-x', apiSessionId)).toEqual([]);
+    expect(await store.loadTelegramSession('agent-x', apiChatId, apiSessionId, 'api')).toEqual([]);
+  });
+
+  it('U-API-7: clearTelegramSessionHistory(api) resets the index messageCount when present', async () => {
+    // Register the session in the structured index (as ensureApiSession does).
+    await store.getOrCreateIndex('agent-x', apiChatId, 'api');
+    const idx = await store.loadIndex('agent-x', apiChatId, 'api');
+    expect(idx).not.toBeNull();
+    const seededId = idx!.sessions[0].id;
+    idx!.sessions[0].messageCount = 7;
+    await store.saveIndex('agent-x', apiChatId, idx!, 'api');
+
+    await store.clearTelegramSessionHistory('agent-x', apiChatId, seededId, 'api');
+
+    const after = await store.loadIndex('agent-x', apiChatId, 'api');
+    const meta = after!.sessions.find((s) => s.id === seededId);
+    expect(meta!.messageCount).toBe(0);
+  });
+
+  it('U-API-8: clearTelegramSessionHistory(api) is a no-op-safe when no index exists', async () => {
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('user', 'a'));
+
+    // No structured index was created — clear must still truncate the flat store and not throw.
+    await expect(
+      store.clearTelegramSessionHistory('agent-x', apiChatId, apiSessionId, 'api'),
+    ).resolves.toBeUndefined();
+    expect(await store.loadSession('agent-x', apiSessionId)).toEqual([]);
+  });
+
+  it('U-API-9: api routing leaves the telegram store path completely untouched', async () => {
+    // A telegram session for the same agent must be unaffected by api operations.
+    const tgIndex = await store.getOrCreateIndex('agent-x', 'tg-555');
+    const tgSessionId = tgIndex.activeSessionId;
+    await store.appendTelegramMessage('agent-x', 'tg-555', tgSessionId, makeMsg('user', 'telegram msg'));
+
+    // Drive the api branches.
+    await store.appendMessage('agent-x', apiSessionId, makeMsg('user', 'api msg'));
+    await store.saveTelegramSession('agent-x', apiChatId, apiSessionId, [makeMsg('user', 'api compacted')], 'api');
+    await store.clearTelegramSessionHistory('agent-x', apiChatId, apiSessionId, 'api');
+
+    // Telegram session still has its message and intact meta.
+    const tgMsgs = await store.loadTelegramSession('agent-x', 'tg-555', tgSessionId);
+    expect(tgMsgs).toHaveLength(1);
+    expect(tgMsgs[0].content).toBe('telegram msg');
+  });
 });


### PR DESCRIPTION
## Summary
Fixes `/compact`, `/session`, `/sessions`, and `/clear` for **api/web sessions**, which operated on the wrong on-disk store. Api session context lives in the flat `sessions/{sessionId}.jsonl` store (where api messages are appended, and what `buildInitialPrompt` loads at spawn via `loadSession`), but those commands read/wrote the structured telegram-style store (`sessions/api-{chatId}/{sessionId}.json`), which stays empty. Result: `/compact` always failed with `Not enough messages to compact (0 messages)`, `/session` reported `Messages: 0`, `/clear` truncated the wrong file.

## Type of Change
- [x] Bug fix

## Related Issues
Closes #160

> ⚠️ **Stacked on #157** — this branch is cut from `fix/persist-builtin-command-messages-and-respond-with-sse` and includes its commits (the `/session` & `/sessions` edits build on the command dispatch added there). Please merge #157 first, then this diff reduces to the two files below. Happy to rebase onto `main` once #157 lands.

## Changes Made
- `src/session/store.ts` — `loadTelegramSession`, `saveTelegramSession`, and `clearTelegramSessionHistory` now operate on the flat `sessions/{sessionId}.jsonl` store when `channel === 'api'` (serialized on the same per-session queue as `appendMessage`). This fixes `/compact` (via `SessionCompactor`, which calls these) and `/clear` with no caller changes.
- `src/agent/runner.ts` — `executeApiCommand` `/session` and `/sessions` count messages via `loadSession` directly, since the index `messageCount` isn't maintained on the api append path.

## Scope / Safety
- The only api callers of the three `SessionStore` methods are `SessionCompactor` (`/compact`) and `/clear`; both want the flat store. `buildInitialPrompt` already uses `loadSession` for api (`src/session/process.ts:154-156`).
- Telegram/Discord paths are unchanged — every new branch is guarded by `channel === 'api'`.

## How to Test (verified via curl)
With an api session whose flat store holds ≥5 messages:
1. `/session` → reports the real message count (was `0`).
2. `/compact` → succeeds, writing summary + tail back to the flat store (was `Command failed: Not enough messages…`).
3. `/clear` → the flat `sessions/{sessionId}.jsonl` is emptied (0 bytes); a following `/session` reports `0`.
4. `/sessions` → lists each session's real message count (was all `0`).
5. `/compact` with <5 messages still returns the existing `Not enough messages…` error.

## Notes
- Pre-existing compactor quirk (out of scope): for sessions smaller than `KEEP_LAST_MESSAGES`, `/compact` reports a negative `archived` count because the summary is prepended to all kept messages. Independent of this storage fix.
- Follow-up candidate: the structured-store `index.json` `messageCount` for api remains stale (the api append path doesn't update it); commands now bypass it by counting the flat store. REST session-list endpoints that read the index could be aligned similarly later.

## Checklist
- [x] Reviewed my own code
- [x] Manually tested /session, /compact, /clear, /sessions on a seeded api session
- [x] Telegram/Discord paths untouched (guarded by channel === 'api')
