### PR TITLE
fix(runner): stop idle cleanup from deleting history-referenced media

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -659,7 +659,7 @@ export class AgentRunner extends EventEmitter {
       if (idleEntry) {
         await idleEntry[1].stop();
         this.sessions.delete(idleEntry[0]);
-        this.cleanupApiSessionMediaDir(idleEntry[0], idleEntry[1].source);
+        this.evictApiSessionMapping(idleEntry[0], idleEntry[1].source);
         this.logger.info('Evicted idle session', { sessionId: idleEntry[0] });
       } else {
         throw new Error(`Session pool full: ${this.maxConcurrent} concurrent sessions`);
@@ -1280,7 +1280,7 @@ export class AgentRunner extends EventEmitter {
           this.logger.info('Stopping idle session', { sessionId: id });
           await proc.stop();
           this.sessions.delete(id);
-          this.cleanupApiSessionMediaDir(id, proc.source);
+          this.evictApiSessionMapping(id, proc.source);
         }
       }
     }, 5 * 60 * 1000);
@@ -1904,16 +1904,18 @@ export class AgentRunner extends EventEmitter {
       .filter((a): a is ApiAttachment => a !== null);
   }
 
-  private cleanupApiSessionMediaDir(sessionId: string, source: string): void {
-    // Always evict the chat-id mapping — safe no-op for non-api sessions.
+  private evictApiSessionMapping(sessionId: string, _source: string): void {
+    // Evict the in-memory chat-id mapping only — safe no-op for non-api sessions.
+    //
+    // IMPORTANT: do NOT delete the session's media dir here. Stopping a session
+    // (idle eviction or the idle cleaner) is a lifecycle event decoupled from
+    // history. The screenshots under media/api-<sessionId>/ are referenced by
+    // rows in history.db that outlive the running process, so removing them
+    // here leaves dangling references → GET /media returns 404 → the client
+    // renders "Unavailable". Media is correctly reclaimed elsewhere, tied to
+    // history lifetime: MediaStore.clearChatMedia (/clear) and the daily
+    // retention sweep (deleteMediaFiles for messages pruned by pruneOlderThan).
     this.apiChatIds.delete(sessionId);
-    if (source !== 'api') return;
-    const mediaDir = path.join(this.agentsBaseDir, this.agentConfig.id, 'media', `api-${sessionId}`);
-    try {
-      fs.rmSync(mediaDir, { recursive: true, force: true });
-    } catch {
-      // best-effort — log nothing, just don't crash the cleaner
-    }
   }
 
   getAgentsBaseDir(): string {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -659,7 +659,7 @@ export class AgentRunner extends EventEmitter {
       if (idleEntry) {
         await idleEntry[1].stop();
         this.sessions.delete(idleEntry[0]);
-        this.evictApiSessionMapping(idleEntry[0], idleEntry[1].source);
+        this.evictApiSessionMapping(idleEntry[0]);
         this.logger.info('Evicted idle session', { sessionId: idleEntry[0] });
       } else {
         throw new Error(`Session pool full: ${this.maxConcurrent} concurrent sessions`);
@@ -1280,7 +1280,7 @@ export class AgentRunner extends EventEmitter {
           this.logger.info('Stopping idle session', { sessionId: id });
           await proc.stop();
           this.sessions.delete(id);
-          this.evictApiSessionMapping(id, proc.source);
+          this.evictApiSessionMapping(id);
         }
       }
     }, 5 * 60 * 1000);
@@ -1904,7 +1904,7 @@ export class AgentRunner extends EventEmitter {
       .filter((a): a is ApiAttachment => a !== null);
   }
 
-  private evictApiSessionMapping(sessionId: string, _source: string): void {
+  private evictApiSessionMapping(sessionId: string): void {
     // Evict the in-memory chat-id mapping only — safe no-op for non-api sessions.
     //
     // IMPORTANT: do NOT delete the session's media dir here. Stopping a session

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -3452,3 +3452,73 @@ describe('AgentRunner — writeMenuForward', () => {
     expect(fs.existsSync(tmpPath)).toBe(false);
   });
 });
+
+// ── Idle eviction must not delete history-referenced media ─────────────────────
+//
+// Regression for the "Unavailable" screenshot bug: stopping an api session (idle
+// eviction or the idle cleaner) used to fs.rmSync the whole media/api-<sessionId>
+// dir, deleting files still referenced by rows in history.db. The DB row outlived
+// the file → GET /media 404 → the client rendered "Unavailable". Eviction must
+// only drop the in-memory chat-id mapping; media lives as long as its history.
+
+describe('AgentRunner — idle eviction preserves media', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-evict-media-'));
+    const workspace = path.join(tmpDir, 'agents', 'alfred', 'workspace');
+    agentConfig = makeAgentConfig(workspace);
+    fs.mkdirSync(workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  function callEvict(r: AgentRunner, sessionId: string, source: string): void {
+    (r as unknown as { evictApiSessionMapping(s: string, src: string): void })
+      .evictApiSessionMapping(sessionId, source);
+  }
+
+  function getApiChatIds(r: AgentRunner): Map<string, string> {
+    return (r as unknown as { apiChatIds: Map<string, string> }).apiChatIds;
+  }
+
+  // EM-01: evicting an api session keeps its media dir on disk
+  it('EM-01: evicting an api session does not delete its media dir', () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+
+    const sessionId = 'evict-1';
+    const mediaAbs = path.join(tmpDir, 'agents', 'alfred', 'media', `api-${sessionId}`, 'shot.jpg');
+    fs.mkdirSync(path.dirname(mediaAbs), { recursive: true });
+    fs.writeFileSync(mediaAbs, 'fake-image');
+
+    // Simulate a live mapping created during the turn, then evict.
+    getApiChatIds(runner).set(sessionId, 'test-chat');
+    callEvict(runner, sessionId, 'api');
+
+    // Media survives — history rows still reference it.
+    expect(fs.existsSync(mediaAbs)).toBe(true);
+    // In-memory mapping is cleared.
+    expect(getApiChatIds(runner).has(sessionId)).toBe(false);
+  });
+
+  // EM-02: non-api sessions are a safe no-op (mapping cleared, nothing else touched)
+  it('EM-02: evicting a non-api session is a safe no-op', () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+
+    const sessionId = 'chat:telegram-1';
+    getApiChatIds(runner).set(sessionId, 'chat:telegram-1');
+
+    expect(() => callEvict(runner, sessionId, 'telegram')).not.toThrow();
+    expect(getApiChatIds(runner).has(sessionId)).toBe(false);
+  });
+});

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -3483,9 +3483,12 @@ describe('AgentRunner — idle eviction preserves media', () => {
     jest.clearAllMocks();
   });
 
-  function callEvict(r: AgentRunner, sessionId: string, source: string): void {
-    (r as unknown as { evictApiSessionMapping(s: string, src: string): void })
-      .evictApiSessionMapping(sessionId, source);
+  function callEvict(r: AgentRunner, sessionId: string): void {
+    const runner = r as unknown as Record<string, unknown>;
+    if (typeof runner['evictApiSessionMapping'] !== 'function') {
+      throw new Error('evictApiSessionMapping not found — method may have been renamed');
+    }
+    (runner['evictApiSessionMapping'] as (s: string) => void)(sessionId);
   }
 
   function getApiChatIds(r: AgentRunner): Map<string, string> {
@@ -3503,7 +3506,7 @@ describe('AgentRunner — idle eviction preserves media', () => {
 
     // Simulate a live mapping created during the turn, then evict.
     getApiChatIds(runner).set(sessionId, 'test-chat');
-    callEvict(runner, sessionId, 'api');
+    callEvict(runner, sessionId);
 
     // Media survives — history rows still reference it.
     expect(fs.existsSync(mediaAbs)).toBe(true);
@@ -3516,9 +3519,15 @@ describe('AgentRunner — idle eviction preserves media', () => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
 
     const sessionId = 'chat:telegram-1';
+    const mediaAbs = path.join(tmpDir, 'agents', 'alfred', 'media', `api-${sessionId}`, 'shot.jpg');
+    fs.mkdirSync(path.dirname(mediaAbs), { recursive: true });
+    fs.writeFileSync(mediaAbs, 'fake-image');
+
     getApiChatIds(runner).set(sessionId, 'chat:telegram-1');
 
-    expect(() => callEvict(runner, sessionId, 'telegram')).not.toThrow();
+    expect(() => callEvict(runner, sessionId)).not.toThrow();
     expect(getApiChatIds(runner).has(sessionId)).toBe(false);
+    // No files should be deleted — media dir still intact
+    expect(fs.existsSync(mediaAbs)).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

Agent screenshots render as **"Unavailable"** in chat history a few minutes after a session goes idle. This is the deepest of the three layers behind the attachment-history bug (#1108 on getpod):

1. **Persistence** (gateway#155) — old gateways didn't write attachments to history. Fixed.
2. **Rendering** (getpod#1149) — the frontend only recognized `/v1/agents/...` URLs, not the relative `media/...` paths the gateway stores. Fixed; the `<img>` now renders at the correct URL.
3. **This PR** — even with correct DB rows and a correct `<img>` src, the file itself is gone from disk → GET `/v1/agents/<id>/media/...` returns **404** → client shows "Unavailable".

## Root cause

`cleanupApiSessionMediaDir` ran `fs.rmSync(media/api-<sessionId>, { recursive })` on two pure lifecycle events:
- idle eviction when the session pool is at capacity (`spawnSession`)
- the 5-minute idle cleaner (`startIdleCleaner`)

Those screenshot files are referenced by rows in `history.db` that **outlive the running process**. Deleting the dir on idle leaves the DB row pointing at a missing file. Verified in production: SSH'd into a pod, confirmed the history row for `browser_shot_...jpg` survives while the whole `media/api-<sessionId>/` folder is gone; curl with a valid admin key returns `404 Not found` (not auth).

## Fix

Rename `cleanupApiSessionMediaDir` → `evictApiSessionMapping` and drop the `rmSync`. Eviction now only clears the in-memory `apiChatIds` mapping.

Media is still reclaimed correctly, tied to **history lifetime** (not process lifetime), exactly as before:
- `MediaStore.clearChatMedia` on `/clear`
- the daily retention sweep — `deleteMediaFiles` for messages pruned by `pruneOlderThan`

## Tests

- `EM-01`: evicting an api session preserves its `media/api-<sessionId>` dir and clears the mapping
- `EM-02`: evicting a non-api session is a safe no-op

Full `agent-runner` suite: **101/101 pass**. Typecheck + build clean.

## Note

Files already deleted by the old behavior cannot be backfilled. New screenshots persist for the life of their history once this lands.