### PR TITLE
refactor: address code review nits from PR #164

### DIFF
--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -106,6 +106,11 @@ export class GatewayRouter {
   private processesCache: { data: unknown[]; ts: number } | null = null;
   private static readonly PROCESSES_CACHE_TTL_MS = 3_000;
 
+  /** Core count is constant for the process lifetime — read once instead of
+   *  calling os.cpus() (a syscall) on every /processes poll. Used to normalize
+   *  ps per-core %CPU into a 0–100% figure on the dashboard. */
+  private static readonly NUM_CPUS = Math.max(1, os.cpus().length);
+
   /** Short-lived WS auth tickets: ticket → { agentId, sessionId, expiresAt }. One-time use. */
   private readonly ptyStreamTickets = new Map<string, { agentId: string; sessionId: string; expiresAt: number }>();
   private ticketPruner: ReturnType<typeof setInterval> | null = null;
@@ -399,7 +404,7 @@ export class GatewayRouter {
     this.app.get('/processes', (_req: Request, res: Response) => {
       const now = Date.now();
       if (this.processesCache && now - this.processesCache.ts < GatewayRouter.PROCESSES_CACHE_TTL_MS) {
-        res.json({ processes: this.processesCache.data, numCpus: os.cpus().length });
+        res.json({ processes: this.processesCache.data, numCpus: GatewayRouter.NUM_CPUS });
         return;
       }
       exec(
@@ -421,7 +426,7 @@ export class GatewayRouter {
             };
           }).filter(Boolean);
           this.processesCache = { data: processes, ts: Date.now() };
-          res.json({ processes, numCpus: os.cpus().length });
+          res.json({ processes, numCpus: GatewayRouter.NUM_CPUS });
         },
       );
     });

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -338,6 +338,10 @@ export function generateDashboardHtml(dashToken = ''): string {
     let ptyReconnectTimer = null;
     let ptyReconnectAttempts = 0;
     const PTY_RECONNECT_MAX_MS = 10000;
+    // Absolute cap so a session that ends without a clean 4404 (e.g. the gateway
+    // is gone for good) doesn't retry every 10s forever. After this many failed
+    // attempts in a row we give up and tell the user to click View again.
+    const PTY_RECONNECT_MAX_ATTEMPTS = 10;
     // Streaming UTF-8 decoder. The PTY stream carries raw UTF-8 bytes (box-drawing
     // chars, spinner braille, emoji). Decoding them as latin1 mangles every
     // multi-byte char into noise — decode as UTF-8 with {stream:true} so sequences
@@ -461,6 +465,10 @@ export function generateDashboardHtml(dashToken = ''): string {
     function schedulePtyReconnect(agentId, sessionId) {
       if (ptyReconnectTimer) return;                // already pending
       if (currentPtySession !== sessionId) return;  // viewer no longer wants this
+      if (ptyReconnectAttempts >= PTY_RECONNECT_MAX_ATTEMPTS) {
+        if (term) term.writeln('\\r\\n\\x1b[31m[disconnected — click View to retry]\\x1b[0m');
+        return;
+      }
       if (ptyReconnectAttempts === 0 && term) {
         term.writeln('\\r\\n\\x1b[33m[reconnecting\\u2026]\\x1b[0m');
       }

--- a/tests/unit/gateway-router-stop.test.ts
+++ b/tests/unit/gateway-router-stop.test.ts
@@ -20,6 +20,28 @@ describe('GatewayRouter.stop() — graceful shutdown', () => {
     );
   }
 
+  // Race a promise against a deadline, clearing the timer when the promise wins.
+  // A leaked setTimeout would keep firing after the test finished (Jest open-handle
+  // warnings / cross-test bleed). The deadline only needs to be far above the real
+  // resolve time (~ms) to flag a genuine hang, so it's generous to avoid CI flakiness
+  // under CPU contention rather than tight.
+  async function resolvesWithin<T>(p: Promise<T>, ms: number): Promise<'ok' | 'timeout'> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        p.then(() => 'ok' as const),
+        new Promise<'timeout'>((resolve) => {
+          timer = setTimeout(() => resolve('timeout'), ms);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  // The fix resolves in single-digit ms; this ceiling only catches a true hang.
+  const STOP_DEADLINE_MS = 5000;
+
   it('GR-STOP-1: resolves promptly even with a live keep-alive HTTP connection', async () => {
     const router = newRouter();
     await router.start(0);
@@ -40,27 +62,20 @@ describe('GatewayRouter.stop() — graceful shutdown', () => {
       req.on('error', reject);
     });
 
-    // stop() must resolve quickly; if closeAllConnections() were missing this
-    // would hang until the keep-alive socket idle-timed out (and the test would
-    // fail on the race timeout below).
-    const stopped = await Promise.race([
-      router.stop().then(() => 'stopped' as const),
-      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 2000)),
-    ]);
+    // stop() must resolve quickly; without closeAllConnections() this would hang
+    // until the keep-alive socket idle-timed out (and fail the deadline below).
+    const result = await resolvesWithin(router.stop(), STOP_DEADLINE_MS);
 
     agent.destroy();
-    expect(stopped).toBe('stopped');
+    expect(result).toBe('ok');
   });
 
   it('GR-STOP-2: resolves cleanly when there are no open connections', async () => {
     const router = newRouter();
     await router.start(0);
 
-    const stopped = await Promise.race([
-      router.stop().then(() => 'stopped' as const),
-      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 2000)),
-    ]);
+    const result = await resolvesWithin(router.stop(), STOP_DEADLINE_MS);
 
-    expect(stopped).toBe('stopped');
+    expect(result).toBe('ok');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up nits from the review of #164.

- **Cache `os.cpus().length`** — was called on every `/processes` request (both cache-hit and fresh paths); now read once at class init via `static NUM_CPUS`
- **PTY viewer reconnect cap** — added absolute 10-attempt limit with a user-visible `[disconnected — click View to retry]` message to prevent an infinite retry loop
- **Harden GR-STOP test** — replaced bare `Promise.race` with a `resolvesWithin()` helper that self-clears its timeout to prevent timer leaks; increased ceiling from 2s → 5s to reduce CI flakiness on slow machines

## Testing
- `tsc` clean
- All unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)