### PR TITLE
fix: socket error notify, menu cancel button, pty-shell typing persistence

### DIFF
--- a/mcp/tools/discord/module.ts
+++ b/mcp/tools/discord/module.ts
@@ -281,6 +281,42 @@ export class DiscordModule implements ChannelModule {
     this.client.on('interactionCreate', async (interaction: ButtonInteraction) => {
       try {
         if (!interaction.isButton?.()) return;
+
+        // Cancel button: send ESC sentinel to dismiss the pending menu cleanly.
+        if ((interaction.customId ?? '') === 'menu:cancel') {
+          const isDM = !interaction.guildId;
+          const isThread = interaction.channel?.isThread?.() ?? false;
+          const context: DiscordMessageContext = {
+            guildId: interaction.guildId ?? null,
+            channelId: interaction.channelId,
+            threadId: isThread ? interaction.channelId : null,
+            userId: interaction.user.id,
+            username: interaction.user.username,
+            messageId: interaction.message?.id ?? '',
+            isDM,
+            isThread,
+          };
+          const access = loadAccessFn();
+          const result = gate(access, context, saveAccessFn, () => randomBytes(3).toString('hex'));
+          if (result.action !== 'deliver') {
+            await interaction.reply({ content: 'Not authorized.', ephemeral: true }).catch(() => {});
+            return;
+          }
+          await interaction.update({ components: [] }).catch(() => {});
+          const inbound: InboundMessage = {
+            channel: 'discord',
+            accountId: interaction.client.user?.id ?? 'discord',
+            senderId: interaction.user.id,
+            chatId: interaction.channelId,
+            chatType: isDM ? 'direct' : 'group',
+            text: '__MENU_CANCEL__',
+            messageId: interaction.message?.id ?? '',
+            ts: Date.now(),
+          };
+          await handler(inbound);
+          return;
+        }
+
         const m = /^choice:(\d+)$/.exec(interaction.customId ?? '');
         if (!m) return;
 

--- a/mcp/tools/discord/outbound.ts
+++ b/mcp/tools/discord/outbound.ts
@@ -88,6 +88,11 @@ export function buildChoiceComponents(options: Array<{ label: string }>): unknow
     });
     rows.push({ type: 1, components: buttons }); // ActionRow
   }
+  // Always append a cancel button (Danger style) so the user can dismiss the
+  // menu cleanly. Sends ESC to the PTY without injecting text into Claude's context.
+  if (rows.length > 0 && rows.length < 5) {
+    rows.push({ type: 1, components: [{ type: 2, style: 4, label: '❌ Cancel', custom_id: 'menu:cancel' }] });
+  }
   return rows;
 }
 

--- a/mcp/tools/telegram/menu-parser.ts
+++ b/mcp/tools/telegram/menu-parser.ts
@@ -33,5 +33,9 @@ export function parseMenuFileContent(raw: string): MenuMessage | null {
     text: `${i + 1}. ${label}`.slice(0, 60),
     callback_data: `choice:${i + 1}`,
   }]);
+  // Always append a cancel button so the user can dismiss the menu without
+  // sending a numbered reply. Tapping it sends ESC to the PTY, clearing
+  // pendingMenu cleanly without injecting spurious text into Claude's context.
+  inline_keyboard.push([{ text: '❌ Cancel', callback_data: 'menu:cancel' }]);
   return { text, inline_keyboard };
 }

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1153,6 +1153,13 @@ bot.command('clear', async ctx => {
   ).catch(() => {})
 })
 
+// Shared auth check for all callback_query:data handlers.
+// Mirrors the text-reply path: sender must be in allowFrom.
+function isCallbackAuthorized(ctx: Context): boolean {
+  const access = loadAccess()
+  return access.allowFrom.includes(String(ctx.from?.id ?? ''))
+}
+
 // Inline-button handler for permission requests. Callback data is
 // `perm:allow:<id>`, `perm:deny:<id>`, or `perm:more:<id>`.
 // Security mirrors the text-reply path: allowFrom must contain the sender.
@@ -1165,8 +1172,7 @@ bot.on('callback_query:data', async ctx => {
   // text path: the tapper must be in allowFrom.
   const choiceMatch = /^choice:(\d+)$/.exec(data)
   if (choiceMatch) {
-    const access = loadAccess()
-    if (!access.allowFrom.includes(String(ctx.from.id))) {
+    if (!isCallbackAuthorized(ctx)) {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
       return
     }
@@ -1202,8 +1208,7 @@ bot.on('callback_query:data', async ctx => {
   // any text to the session. Posts a special sentinel that the PTY wrapper
   // translates to ESC, clearing pendingMenu cleanly.
   if (data === 'menu:cancel') {
-    const access = loadAccess()
-    if (!access.allowFrom.includes(String(ctx.from.id))) {
+    if (!isCallbackAuthorized(ctx)) {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
       return
     }
@@ -1234,8 +1239,7 @@ bot.on('callback_query:data', async ctx => {
   // Handle model selection callback: model:<model_id>
   const modelMatch = /^model:(.+)$/.exec(data)
   if (modelMatch) {
-    const access = loadAccess()
-    if (!access.allowFrom.includes(String(ctx.from.id))) {
+    if (!isCallbackAuthorized(ctx)) {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
       return
     }

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1198,6 +1198,39 @@ bot.on('callback_query:data', async ctx => {
     return
   }
 
+  // Handle interactive-menu cancel: dismiss the pending menu without sending
+  // any text to the session. Posts a special sentinel that the PTY wrapper
+  // translates to ESC, clearing pendingMenu cleanly.
+  if (data === 'menu:cancel') {
+    const access = loadAccess()
+    if (!access.allowFrom.includes(String(ctx.from.id))) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    const chat_id = String(ctx.callbackQuery.message?.chat.id ?? ctx.from.id)
+    await ctx.editMessageReplyMarkup({ reply_markup: undefined }).catch(() => {})
+    await ctx.answerCallbackQuery({ text: '✓ Cancelled' }).catch(() => {})
+    const callbackUrl = process.env.CLAUDE_CHANNEL_CALLBACK
+    if (callbackUrl) {
+      fetch(callbackUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content: '__MENU_CANCEL__',
+          meta: {
+            chat_id,
+            user: ctx.from.username ?? String(ctx.from.id),
+            user_id: String(ctx.from.id),
+            ts: new Date().toISOString(),
+          },
+        }),
+      }).catch(err => {
+        process.stderr.write(`telegram channel: menu cancel callback POST failed: ${err}\n`)
+      })
+    }
+    return
+  }
+
   // Handle model selection callback: model:<model_id>
   const modelMatch = /^model:(.+)$/.exec(data)
   if (modelMatch) {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -21,6 +21,7 @@ import type { HistorySource } from '../history/types';
 
 const DEFAULT_IDLE_TIMEOUT_MINUTES = 30;
 const DEFAULT_MAX_CONCURRENT = 20;
+const ANTHROPIC_SOCKET_ERROR = 'socket connection was closed unexpectedly';
 
 export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
@@ -818,7 +819,7 @@ export class AgentRunner extends EventEmitter {
             // with "API Error: The socket connection was closed unexpectedly". The error
             // bypasses the replyCalled gate so the user always gets notified, even when
             // the agent already called the reply tool earlier in the same turn.
-            const isSocketError = !proc.queryMode && resultText.includes('socket connection was closed unexpectedly');
+            const isSocketError = !proc.queryMode && resultText.includes(ANTHROPIC_SOCKET_ERROR);
             if (isSocketError) {
               this.writeAutoForward(mapKey, '⚡ Connection to Anthropic API dropped. Please resend your message.');
             }

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -208,6 +208,11 @@ export class AgentRunner extends EventEmitter {
         }
 
         // Default: /channel — existing channel message handler
+        // Connection: close prevents keep-alive pool reuse: after the OS's
+        // keepAliveTimeout expires the server closes the TCP connection, and the
+        // receiver (Bun) can try to reuse the stale socket → "socket connection
+        // was closed unexpectedly". Closing per-request avoids the race entirely.
+        res.setHeader('Connection', 'close');
         res.writeHead(200);
         res.end('ok');
         try {
@@ -809,9 +814,17 @@ export class AgentRunner extends EventEmitter {
             // so the raw API error must not reach the user's chat or the history DB.
             const isThinkingCorruption =
               obj['is_error'] === true && SessionProcess.isThinkingCorruptionError(resultText);
+            // Detect Anthropic API socket drop — Claude CLI emits this as is_error:false
+            // with "API Error: The socket connection was closed unexpectedly". The error
+            // bypasses the replyCalled gate so the user always gets notified, even when
+            // the agent already called the reply tool earlier in the same turn.
+            const isSocketError = !proc.queryMode && resultText.includes('socket connection was closed unexpectedly');
+            if (isSocketError) {
+              this.writeAutoForward(mapKey, '⚡ Connection to Anthropic API dropped. Please resend your message.');
+            }
             // Skip when a menu was rendered to buttons this turn — the result
             // text is the same numbered list and would duplicate the menu message.
-            if (resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption && !menuSentThisTurn) {
+            if (!isSocketError && resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption && !menuSentThisTurn) {
               const text = resultText.trim();
               const channelSrcForResult = this.channelSourceMap.get(mapKey) ?? 'telegram';
               // Persist assistant reply to permanent history DB
@@ -833,7 +846,23 @@ export class AgentRunner extends EventEmitter {
             replyCalled = false; // reset for next turn
             replyToolUseId = null;
             menuSentThisTurn = false;
-            // Delay typing done — agent may continue with more work
+            // In pty-shell mode, a `result` fires after every Claude API sub-turn
+            // (there can be many per user message, separated by tool-call gaps of
+            // arbitrary length). Starting the typing-done timer here would stop
+            // the indicator during those inter-turn gaps. Instead, pty-shell emits
+            // `session_idle` once it is truly done; headless mode only produces
+            // one `result` per message, so the timer pattern still applies there.
+            if (proc.backend !== 'pty-shell') {
+              typingDoneTimer = setTimeout(() => {
+                this.writeTypingDone(mapKey);
+                typingDoneTimer = null;
+              }, TYPING_DONE_DELAY_MS);
+            }
+          }
+          // PTY shell signals "truly idle" (no active turn, empty queue) with this
+          // event. Start the typing-done timer here so the indicator stays alive
+          // through multi-turn tool-call sequences and only stops when all work is done.
+          if (obj['type'] === 'session_idle' && proc.backend === 'pty-shell') {
             typingDoneTimer = setTimeout(() => {
               this.writeTypingDone(mapKey);
               typingDoneTimer = null;

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -285,6 +285,12 @@ class Driver {
     });
     if (isError) logError(`turn failed: ${errMsg ?? '(no detail)'}`);
     this.trySubmit();
+    // If no new turn started and the queue is empty, the session is truly idle.
+    // Emit session_idle so runner.ts can stop the typing indicator cleanly,
+    // without relying on the short per-result timer that fires during tool-call gaps.
+    if (!this.turn && this.queue.length === 0) {
+      this.emitter.emitSessionIdle(this.args.sessionId);
+    }
   }
 
   // ---- turn submission -----------------------------------------------------
@@ -527,6 +533,18 @@ class Driver {
     // Channel turns arrive wrapped in a <channel …>…</channel> envelope, so the
     // bare "1" is buried inside it — unwrap before parsing the selection.
     const choiceText = extractChannelContent(text);
+    // Explicit cancel from a "❌ Cancel" button (Telegram/Discord): send ESC to
+    // dismiss the menu cleanly without queuing any text into Claude's context.
+    // Unlike the "invalid text → ESC + re-queue" path, this leaves the queue
+    // empty so the session just returns to the idle prompt with no side-effects.
+    if (choiceText === '__MENU_CANCEL__') {
+      logWarn('menu cancel received — sending ESC to dismiss');
+      this.host.writeRaw('\x1b');
+      this.pendingMenu = null;
+      // No queue push, no menuCancel needed: ESC dismisses the TUI menu and
+      // Claude resumes normally. The session is simply idle again.
+      return;
+    }
     const n = parseMenuChoice(choiceText, menu.options.length);
     if (n === null) {
       // Not a valid choice — cancel the menu and treat the text as a new prompt

--- a/src/shell/emitter.ts
+++ b/src/shell/emitter.ts
@@ -91,6 +91,16 @@ export class ProtocolEmitter {
     });
   }
 
+  /**
+   * Emitted by the PTY shell when the session returns to truly idle state:
+   * no active turn and the user-message queue is empty. Signals runner.ts
+   * that typing can stop. Contrast with `result` which fires after every
+   * individual Claude API sub-turn (there can be many per user message).
+   */
+  emitSessionIdle(sessionId: string): void {
+    this.writeLine({ type: 'session_idle', session_id: sessionId });
+  }
+
   emitResult(opts: {
     sessionId: string;
     isError: boolean;

--- a/tests/unit/discord-plugin/outbound.test.ts
+++ b/tests/unit/discord-plugin/outbound.test.ts
@@ -90,24 +90,30 @@ describe('sendMessage', () => {
 });
 
 describe('buildChoiceComponents', () => {
-  it('builds one ActionRow for 3 options', () => {
+  it('builds one ActionRow for 3 options plus cancel row', () => {
     const rows = buildChoiceComponents([{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }]);
-    expect(rows).toHaveLength(1);
+    // 1 option row + 1 cancel row
+    expect(rows).toHaveLength(2);
     const row = rows[0] as { type: number; components: Array<{ type: number; style: number; label: string; custom_id: string }> };
     expect(row.type).toBe(1);
     expect(row.components).toHaveLength(3);
     expect(row.components[0]).toMatchObject({ type: 2, style: 2, label: '1. Alpha', custom_id: 'choice:1' });
     expect(row.components[2]).toMatchObject({ custom_id: 'choice:3' });
+    const cancelRow = rows[1] as { type: number; components: Array<{ type: number; style: number; label: string; custom_id: string }> };
+    expect(cancelRow.components[0]).toMatchObject({ type: 2, style: 4, label: '❌ Cancel', custom_id: 'menu:cancel' });
   });
 
   it('splits into multiple ActionRows when >5 options', () => {
     const opts = Array.from({ length: 7 }, (_, i) => ({ label: `Option ${i + 1}` }));
     const rows = buildChoiceComponents(opts);
-    expect(rows).toHaveLength(2);
+    // 2 option rows + 1 cancel row
+    expect(rows).toHaveLength(3);
     const row0 = rows[0] as { components: unknown[] };
     const row1 = rows[1] as { components: unknown[] };
+    const row2 = rows[2] as { components: Array<{ custom_id: string }> };
     expect(row0.components).toHaveLength(5);
     expect(row1.components).toHaveLength(2);
+    expect(row2.components[0].custom_id).toBe('menu:cancel');
   });
 
   it('caps label at 80 characters', () => {

--- a/tests/unit/telegram-plugin/menu-parser.test.ts
+++ b/tests/unit/telegram-plugin/menu-parser.test.ts
@@ -1,7 +1,7 @@
 import { parseMenuFileContent } from '../../../mcp/tools/telegram/menu-parser';
 
 describe('parseMenuFileContent', () => {
-  it('parses a valid menu file into text + inline_keyboard', () => {
+  it('parses a valid menu file into text + inline_keyboard with cancel button', () => {
     const raw = JSON.stringify({
       text: 'Pick an option:',
       options: [{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }],
@@ -9,9 +9,12 @@ describe('parseMenuFileContent', () => {
     const result = parseMenuFileContent(raw);
     expect(result).not.toBeNull();
     expect(result!.text).toBe('Pick an option:');
-    expect(result!.inline_keyboard).toHaveLength(3);
+    // 3 option rows + 1 cancel row
+    expect(result!.inline_keyboard).toHaveLength(4);
     expect(result!.inline_keyboard[0]).toEqual([{ text: '1. Alpha', callback_data: 'choice:1' }]);
     expect(result!.inline_keyboard[2]).toEqual([{ text: '3. Gamma', callback_data: 'choice:3' }]);
+    // Cancel button is always appended as the last row
+    expect(result!.inline_keyboard[3]).toEqual([{ text: '❌ Cancel', callback_data: 'menu:cancel' }]);
   });
 
   it('caps button label at 60 characters', () => {
@@ -39,8 +42,10 @@ describe('parseMenuFileContent', () => {
   it('skips options with non-string labels', () => {
     const raw = JSON.stringify({ text: 'Q', options: [{ label: 42 }, { label: null }, { label: 'Valid' }] });
     const result = parseMenuFileContent(raw);
-    expect(result!.inline_keyboard).toHaveLength(1);
+    // 1 valid option row + 1 cancel row
+    expect(result!.inline_keyboard).toHaveLength(2);
     expect(result!.inline_keyboard[0][0].callback_data).toBe('choice:1');
+    expect(result!.inline_keyboard[1][0].callback_data).toBe('menu:cancel');
   });
 
   it('returns null when all options have invalid labels', () => {


### PR DESCRIPTION
## Summary

- **Socket error notify**: Detect Anthropic API socket drops → forward `⚡ Connection to Anthropic API dropped. Please resend your message.` to user immediately (previously silently swallowed)
- **Connection: close header**: Fix keep-alive pool reuse in callback server causing silent `POST failed` errors (root cause of menu buttons occasionally not registering)
- **❌ Cancel button**: Add Cancel to Telegram and Discord inline menus; `__MENU_CANCEL__` sentinel routes back to PTY as ESC → session unblocks instead of hanging indefinitely
- **PTY-shell typing persistence**: Typing indicator now persists across multi-tool turns (bash tool calls etc.) — only stops on `session_idle` event emitted when session is truly idle, not between sub-turns

## Files changed

| File | Change |
|------|--------|
| `src/agent/runner.ts` | Socket error detection + notify; `Connection: close` header; `session_idle` typing timer for pty-shell |
| `src/shell/claude-pty-shell.ts` | Emit `session_idle` when truly idle |
| `src/shell/emitter.ts` | Add `session_idle` to event types |
| `mcp/tools/telegram/menu-parser.ts` | Add ❌ Cancel button |
| `mcp/tools/telegram/receiver-server.ts` | Handle `menu:cancel` → send `__MENU_CANCEL__` to PTY |
| `mcp/tools/discord/outbound.ts` | Add ❌ Cancel button |
| `mcp/tools/discord/module.ts` | Handle Cancel interaction → send `__MENU_CANCEL__` to PTY |

## Test plan

- [ ] Anthropic API drop → user sees ⚡ message instead of silent hang
- [ ] Telegram/Discord menu → Cancel button appears → session unblocks
- [ ] pty-shell (headless=false) multi-tool turn → typing indicator persists throughout
- [ ] headless=true unaffected (typing timer path unchanged)
- [ ] 1648 unit tests passing, tsc clean, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)