### PR TITLE
fix(pty-shell): /stop now clears stuck input text from PTY prompt

### DIFF
--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -237,6 +237,11 @@ class Driver {
           const t = Date.now();
           this.interrupting = { since: t, lastEscAt: t, escs: 1 };
         }
+      } else if (this.queue.length > 0) {
+        // No active turn: the message is still in the queue (not yet pasted into
+        // the PTY input). Drop it so /stop doesn't silently submit it later.
+        logWarn(`SIGINT with no active turn — dropping ${this.queue.length} queued message(s)`);
+        this.queue.length = 0;
       }
     });
     process.on('SIGTERM', () => {
@@ -333,6 +338,13 @@ class Driver {
       await this.host.writeChunked(`\x1b[200~${text}\x1b[201~`);
     }
     await new Promise((r) => setTimeout(r, SUBMIT_ENTER_DELAY_MS));
+    // If interrupted while waiting (SIGINT arrived after paste but before Enter),
+    // clear the PTY input line instead of submitting — prevents stuck text in the
+    // prompt that would be prepended to the user's next message.
+    if (this.interrupting || !this.turn) {
+      this.host.writeRaw('\x15'); // Ctrl+U: clear input line
+      return;
+    }
     this.host.writeRaw('\r');
     if (this.turn) this.turn.submittedAt = Date.now();
   }

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -341,8 +341,11 @@ class Driver {
     // If interrupted while waiting (SIGINT arrived after paste but before Enter),
     // clear the PTY input line instead of submitting — prevents stuck text in the
     // prompt that would be prepended to the user's next message.
+    // Also clear the queue so any messages queued behind this one don't surface
+    // after the turn is abandoned (matches the SIGINT queue-drop logic above).
     if (this.interrupting || !this.turn) {
       this.host.writeRaw('\x15'); // Ctrl+U: clear input line
+      this.queue.length = 0;
       return;
     }
     this.host.writeRaw('\r');


### PR DESCRIPTION
## Summary

- **Queue drop**: If `/stop` arrived before `trySubmit()` (no active turn, message still in `queue[]`), SIGINT did nothing — the message got submitted on the next `trySubmit()` call. Fix: SIGINT handler now clears `queue[]` when `this.turn` is null.
- **typeAndSubmit race**: Text was bracketed-pasted into the PTY but `\r` (Enter) hadn't been sent yet when SIGINT arrived. ESC from the interrupt handler did not clear the input buffer, and `\r` was still sent after the delay — submitting the stale text. Fix: check `this.interrupting` before sending `\r`; if interrupted, send `Ctrl+U` (`\x15`) to clear the input line and return early.

## Test plan
- [ ] Send a message via Telegram, then immediately `/stop` before Claude processes it — next message should not be prepended with stale text
- [ ] Send a message, wait for Claude to start typing, then `/stop` — existing interrupt settle flow unchanged
- [ ] tsc clean · 101/101 tests passing