### PR TITLE
fix(pty-shell): stuck typing, 5-min stall dump, and 32MB brick

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -784,6 +784,21 @@ export class AgentRunner extends EventEmitter {
               });
             }
           }
+          // PTY shell hit the recoverable "Request too large (max 32MB)" error.
+          // The wrapper already dismissed the TUI overlay (double-ESC). Restart the
+          // session so the oversized in-memory context (large images/files) is
+          // dropped — a fresh process reloads the much smaller text-only history
+          // from the store, so the next message isn't doomed to re-hit 32MB. The
+          // proc exit handler clears the typing indicator; tell the user to resend.
+          if (obj['type'] === 'system' && obj['subtype'] === 'request_too_large') {
+            this.logger.warn('Request too large (32MB) — restarting session to clear oversized context', { mapKey });
+            proc.setProcessing(false);
+            this.writeAutoForward(
+              mapKey,
+              '⚠️ Context too large — hit Anthropic\'s 32MB request limit (usually from large images or files in context). Restarting this session with a fresh context. Your last message was not processed — please resend it.',
+            );
+            void this.restartProcess(mapKey);
+          }
           if (obj['type'] === 'result') {
             proc.setProcessing(false);
             // Telegram: accumulate image size via stat of local file (FIFO, one per turn)
@@ -823,9 +838,13 @@ export class AgentRunner extends EventEmitter {
             if (isSocketError) {
               this.writeAutoForward(mapKey, '⚡ Connection to Anthropic API dropped. Please resend your message.');
             }
+            // Suppress the "Request too large (max 32MB)" result: the dedicated
+            // request_too_large event already sent a friendly notice and kicked off
+            // a restart, so the raw TUI error text must not be forwarded as a duplicate.
+            const isRequestTooLarge = obj['is_error'] === true && resultText.includes('Request too large (max');
             // Skip when a menu was rendered to buttons this turn — the result
             // text is the same numbered list and would duplicate the menu message.
-            if (!isSocketError && resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption && !menuSentThisTurn) {
+            if (!isSocketError && !isRequestTooLarge && resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption && !menuSentThisTurn) {
               const text = resultText.trim();
               const channelSrcForResult = this.channelSourceMap.get(mapKey) ?? 'telegram';
               // Persist assistant reply to permanent history DB
@@ -901,8 +920,13 @@ export class AgentRunner extends EventEmitter {
         }, this.channelFor(mapKey)).catch(() => {});
       }
 
-      // Clean up pending typing-done timer when session stops
-      proc.once('exit', () => {
+      // Tear down per-chat typing/processing state whenever the subprocess dies.
+      // Uses `on` (not `once`): a single SessionProcess can auto-restart its child
+      // multiple times over its lifetime, and each death that lacks a final
+      // result/session_idle would otherwise leave the typing indicator stuck until
+      // the 5-min stalled detector fires. writeTypingDone/setProcessing(false) are
+      // idempotent, so firing on every exit is safe.
+      proc.on('exit', () => {
         proc.setProcessing(false);
         if (typingDoneTimer) {
           clearTimeout(typingDoneTimer);

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -14,6 +14,7 @@ import { DiscordReceiver } from '../discord/receiver';
 import { hasMarkdown, toTelegramHtml } from '../telegram/markdown';
 import { detectSkillCommand, formatSkillContext, type SkillRegistry } from '../skills';
 import { isBuiltinCommand } from './builtin-commands';
+import { TUI_REQUEST_TOO_LARGE } from '../shell/screen';
 import { HistoryDB } from '../history/db';
 import { MediaStore } from '../history/media-store';
 import { scheduleCleanup, resolveRetentionDays } from '../history/cleanup';
@@ -793,6 +794,13 @@ export class AgentRunner extends EventEmitter {
           if (obj['type'] === 'system' && obj['subtype'] === 'request_too_large') {
             this.logger.warn('Request too large (32MB) — restarting session to clear oversized context', { mapKey });
             proc.setProcessing(false);
+            // Ordering matters and makes the notice delivery race-free: writeAutoForward
+            // persists the `.forward` file synchronously HERE, before restartProcess()
+            // begins its async stop/kill. The typing-loop tear-down (stop() in typing.ts)
+            // drains and sends `.forward` synchronously before it removes the typing
+            // signal, so by the time the proc exit fires and the loop stops, the file is
+            // already on disk and is delivered — no dependency on poll timing. Do not
+            // reorder restartProcess() ahead of writeAutoForward().
             this.writeAutoForward(
               mapKey,
               '⚠️ Context too large — hit Anthropic\'s 32MB request limit (usually from large images or files in context). Restarting this session with a fresh context. Your last message was not processed — please resend it.',
@@ -841,7 +849,7 @@ export class AgentRunner extends EventEmitter {
             // Suppress the "Request too large (max 32MB)" result: the dedicated
             // request_too_large event already sent a friendly notice and kicked off
             // a restart, so the raw TUI error text must not be forwarded as a duplicate.
-            const isRequestTooLarge = obj['is_error'] === true && resultText.includes('Request too large (max');
+            const isRequestTooLarge = obj['is_error'] === true && resultText.includes(TUI_REQUEST_TOO_LARGE);
             // Skip when a menu was rendered to buttons this turn — the result
             // text is the same numbered list and would duplicate the menu message.
             if (!isSocketError && !isRequestTooLarge && resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption && !menuSentThisTurn) {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -661,6 +661,14 @@ export class SessionProcess extends EventEmitter {
       });
       if (ptyStreamSocketPath) ptyStreamRegistry.close(ptyStreamSocketPath);
       this.process = null;
+      // Notify listeners that the underlying subprocess died. The runner relies
+      // on this to tear down per-chat typing/processing state when a session is
+      // stopped or restarted mid-turn (without a final result/session_idle).
+      // Without it the typing indicator stays stuck until the 5-min stalled
+      // detector fires. Idempotent on the listener side (writeTypingDone uses
+      // rmSync(force)), so emitting on every child exit — including auto-restart
+      // — is safe.
+      this.emit('exit', code, signal);
       if (!this.stopping) this.scheduleRestart();
     });
 

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -99,6 +99,14 @@ class Driver {
   // a turn that never ends (until the watchdog). Reuses the menu-cancel settle
   // decision (menuVisible is always false here, so it never re-sends ESC).
   private interrupting: { since: number; lastEscAt: number; escs: number } | null = null;
+  // True once session_idle has been emitted for the current idle stretch. Reset on
+  // any new activity (turn start / assistant record). Drives the screen-driven idle
+  // reconciliation in tick() so typing is always torn down even when finishTurn()
+  // never ran (turn-tracking desync, external stop) — fires exactly once per idle.
+  private idleNotified = false;
+  // Guards the recoverable "Request too large (max 32MB)" handler so ESC isn't
+  // re-sent every poll while the error overlay lingers. Reset when a new turn begins.
+  private requestTooLargeHandled = false;
   private lastDialogActionAt = 0;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   private host!: PtyHost;
@@ -256,6 +264,9 @@ class Driver {
     const usage = record.message.usage;
     if (usage) this.emitter.emitMessageStartShim(usage, this.args.sessionId);
     const text = this.emitter.emitAssistant(record, this.args.sessionId);
+    // New output = activity: re-arm idle reconciliation so a fresh session_idle is
+    // emitted once Claude settles, even if this record arrived outside a tracked turn.
+    this.idleNotified = false;
     if (this.turn) {
       this.turn.sawAssistant = true;
       this.turn.lastProgressAt = Date.now();
@@ -294,6 +305,7 @@ class Driver {
     // Emit session_idle so runner.ts can stop the typing indicator cleanly,
     // without relying on the short per-result timer that fires during tool-call gaps.
     if (!this.turn && this.queue.length === 0) {
+      this.idleNotified = true;
       this.emitter.emitSessionIdle(this.args.sessionId);
     }
   }
@@ -313,6 +325,8 @@ class Driver {
   /** Initialize a fresh active turn (shared by normal submit and menu selection). */
   private beginTurn(): void {
     const now = Date.now();
+    this.idleNotified = false;
+    this.requestTooLargeHandled = false;
     this.turn = {
       startedAt: now,
       submittedAt: 0,
@@ -387,6 +401,56 @@ class Driver {
       return;
     }
 
+    // Heartbeat follows the screen's busy state, NOT turn tracking. During a long
+    // request assembly (the TUI shows "Baked for 6m…"), an interrupt/menu-cancel
+    // settle, or a turn-tracking desync, `this.turn` may be null or unsubmitted
+    // while Claude is genuinely working. Beating whenever the busy spinner is on
+    // screen keeps the receiver's 5-min stalled detector from firing a false
+    // "Claude has not responded" warning while work is actually ongoing.
+    if (this.heartbeatPath
+        && this.screen.isBusy()
+        && now - this.lastHeartbeatAt >= HEARTBEAT_INTERVAL_MS) {
+      this.lastHeartbeatAt = now;
+      try { fs.writeFileSync(this.heartbeatPath, String(now)); } catch {}
+    }
+
+    // Recoverable "Request too large (max 32MB)" TUI error: the request payload
+    // (history + attachments) exceeded Anthropic's 32MB API limit. The TUI shows
+    // "Double press esc to go back". Dismiss it with ESC so the input prompt is
+    // usable again, then signal the gateway to notify the user and restart — the
+    // context is too big, so another message would just re-hit the limit and the
+    // session would be bricked. Gated quiet so we act on a settled error, not a
+    // transient redraw, and once per occurrence via requestTooLargeHandled.
+    if (!this.requestTooLargeHandled
+        && this.screen.quietMs() >= 400
+        && this.screen.detectRequestTooLarge()) {
+      this.requestTooLargeHandled = true;
+      logWarn('Request too large (32MB) detected — dismissing TUI error and signalling restart');
+      this.host.writeRaw('\x1b'); // "Double press esc to go back" — send both.
+      this.host.writeRaw('\x1b');
+      this.emitter.emitRequestTooLarge(this.args.sessionId);
+      if (this.turn) {
+        this.finishTurn(true, 'Request too large (max 32MB) — the conversation exceeded Anthropic\'s 32MB request limit. Restarting with a fresh context.');
+      }
+      return;
+    }
+
+    // Screen-driven idle reconciliation (typing-teardown safety net). If the TUI
+    // is sitting at a quiet idle prompt with no pending work, the session is idle —
+    // emit session_idle so runner.ts tears down the typing indicator. This covers
+    // turn-tracking desyncs where finishTurn() ended `this.turn` early (or never
+    // ran) while Claude kept working: without it the typing bubble + tool-call
+    // status stick forever. Fires once per idle stretch via the idleNotified guard.
+    if (!this.idleNotified
+        && !this.turn && !this.interrupting && !this.menuCancel && !this.pendingMenu
+        && this.queue.length === 0
+        && this.screen.hasPrompt() && !this.screen.isBusy()
+        && this.screen.quietMs() >= FALLBACK_IDLE_QUIET_MS) {
+      logDebug('screen idle with no pending work — emitting session_idle (reconciliation)');
+      this.idleNotified = true;
+      this.emitter.emitSessionIdle(this.args.sessionId);
+    }
+
     // Waiting for the TUI to settle after ESC-cancelling a bridged menu (the user
     // typed a free-text reply instead of a number). Submit the queued prompt only
     // once the menu is gone and the prompt is idle — otherwise the paste races
@@ -440,12 +504,8 @@ class Driver {
     const turn = this.turn;
     if (!turn || turn.submittedAt === 0) return;
 
-    // Touch heartbeat so the receiver's stalled detector doesn't fire during
-    // long sub-agent tasks where the PTY is busy but no JSON lines are emitted.
-    if (this.heartbeatPath && now - this.lastHeartbeatAt >= HEARTBEAT_INTERVAL_MS) {
-      this.lastHeartbeatAt = now;
-      try { fs.writeFileSync(this.heartbeatPath, String(now)); } catch {}
-    }
+    // (Heartbeat is written above, gated on the busy spinner — covers this active
+    // turn as well as settle/desync states where `this.turn` is null.)
 
     if (this.screen.consumeBusySeen() || this.screen.isBusy()) {
       turn.sawBusy = true;

--- a/src/shell/emitter.ts
+++ b/src/shell/emitter.ts
@@ -101,6 +101,18 @@ export class ProtocolEmitter {
     this.writeLine({ type: 'session_idle', session_id: sessionId });
   }
 
+  /**
+   * Emitted when the TUI hit the recoverable "Request too large (max 32MB)"
+   * error: the request payload (history + attachments) exceeded Anthropic's
+   * 32MB limit. The wrapper has already dismissed the TUI overlay (double-ESC);
+   * runner.ts handles this by notifying the user and restarting the session so
+   * the oversized in-memory context is dropped — otherwise the next message
+   * re-hits the same limit and the session is effectively bricked.
+   */
+  emitRequestTooLarge(sessionId: string): void {
+    this.writeLine({ type: 'system', subtype: 'request_too_large', session_id: sessionId });
+  }
+
   emitResult(opts: {
     sessionId: string;
     isError: boolean;

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -32,11 +32,18 @@ export const TUI_BYPASS_PERMS = ['Bypass Permissions mode', 'Yes, I accept'] as 
  * The recoverable "Request too large (max 32MB)" TUI error overlay. The request
  * payload (conversation history + attachments) exceeded Anthropic's 32MB API
  * limit — distinct from the token context window, since it counts raw bytes
- * (images/files), so it can fire well below 100% context. The TUI footer reads
- * "Double press esc to go back"; ESC dismisses it. Matched on the stable prefix
- * so a wording/size change ("max 32MB" → other) still hits.
+ * (images/files), so it can fire well below 100% context.
+ *
+ * Detection requires BOTH the error prefix AND the dismiss-footer marker. The
+ * prefix alone appears in ordinary text too (e.g. the agent explaining this very
+ * error in a reply), and matching it on the live screen would auto-fire the
+ * double-ESC + restart on innocuous prose. The footer "Double press esc to go
+ * back" only renders on the actual dismissable overlay — and is exactly the
+ * affordance our double-ESC relies on, so gating on it keeps detection and the
+ * recovery action consistent: we only auto-dismiss when the dismiss hint is real.
  */
 export const TUI_REQUEST_TOO_LARGE = 'Request too large (max';
+export const TUI_REQUEST_TOO_LARGE_DISMISS = 'esc to go back';
 
 /**
  * Interactive select-menu footer markers (e.g. AskUserQuestion). The footer reads
@@ -132,9 +139,14 @@ export class ScreenModel {
     return TUI_PROMPT_RE.test(this.text());
   }
 
-  /** The TUI is showing the recoverable "Request too large (max 32MB)" error. */
+  /**
+   * The TUI is showing the recoverable "Request too large (max 32MB)" error.
+   * Requires both the error prefix and the dismiss-footer marker so ordinary
+   * text mentioning the phrase (e.g. an agent reply) never trips the auto-ESC.
+   */
   detectRequestTooLarge(): boolean {
-    return this.text().includes(TUI_REQUEST_TOO_LARGE);
+    const text = this.text();
+    return text.includes(TUI_REQUEST_TOO_LARGE) && text.includes(TUI_REQUEST_TOO_LARGE_DISMISS);
   }
 
   detectDialog(): DialogKind | null {

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -29,6 +29,16 @@ export const TUI_PROMPT_RE = /^❯ /m;
 export const TUI_BYPASS_PERMS = ['Bypass Permissions mode', 'Yes, I accept'] as const;
 
 /**
+ * The recoverable "Request too large (max 32MB)" TUI error overlay. The request
+ * payload (conversation history + attachments) exceeded Anthropic's 32MB API
+ * limit — distinct from the token context window, since it counts raw bytes
+ * (images/files), so it can fire well below 100% context. The TUI footer reads
+ * "Double press esc to go back"; ESC dismisses it. Matched on the stable prefix
+ * so a wording/size change ("max 32MB" → other) still hits.
+ */
+export const TUI_REQUEST_TOO_LARGE = 'Request too large (max';
+
+/**
  * Interactive select-menu footer markers (e.g. AskUserQuestion). The footer reads
  * "Enter to select · ↑/↓ to navigate · Esc to cancel"; we match on the two stable
  * fragments so spacing/middle-dot variations across TUI versions don't break it.
@@ -120,6 +130,11 @@ export class ScreenModel {
   /** Idle input prompt is on screen. */
   hasPrompt(): boolean {
     return TUI_PROMPT_RE.test(this.text());
+  }
+
+  /** The TUI is showing the recoverable "Request too large (max 32MB)" error. */
+  detectRequestTooLarge(): boolean {
+    return this.text().includes(TUI_REQUEST_TOO_LARGE);
   }
 
   detectDialog(): DialogKind | null {

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -4,10 +4,13 @@ import {
   ScreenModel,
   TUI_BUSY_MARKER,
   TUI_BYPASS_PERMS,
+  TUI_REQUEST_TOO_LARGE,
   parseMenuChoice,
   formatMenuPrompt,
   extractChannelContent,
 } from '../../src/shell/screen';
+import { ProtocolEmitter } from '../../src/shell/emitter';
+import { Writable } from 'stream';
 import { preTrustWorkspace, checkAuthStatus } from '../../src/shell/trust';
 import { decideMenuCancel, MenuCancelState } from '../../src/shell/menu-cancel';
 import * as os from 'os';
@@ -99,6 +102,39 @@ describe('ScreenModel TUI constants (Claude Code v2.1.x)', () => {
     expect(TUI_BYPASS_PERMS).toContain('Yes, I accept');
   });
 
+  it('REQUEST_TOO_LARGE matches the recoverable 32MB error prefix', () => {
+    expect(TUI_REQUEST_TOO_LARGE).toBe('Request too large (max');
+  });
+
+});
+
+describe('ScreenModel detectRequestTooLarge', () => {
+  it('detects the recoverable 32MB error overlay', async () => {
+    const screen = await renderScreen([
+      '  Read 1 file',
+      '',
+      '  Request too large (max 32MB). Double press esc to go back',
+      '',
+    ]);
+    expect(screen.detectRequestTooLarge()).toBe(true);
+  });
+
+  it('is false on a normal idle screen', async () => {
+    const screen = await renderScreen([
+      '❯ ',
+      'ready for input',
+    ]);
+    expect(screen.detectRequestTooLarge()).toBe(false);
+  });
+
+  it('does not false-positive on prose merely discussing the error', async () => {
+    // The matcher keys on the exact "(max" suffix the TUI renders, so an agent
+    // explaining the concept ("a request that is too large") never trips it.
+    const screen = await renderScreen([
+      'If a request is too large the API rejects it.',
+    ]);
+    expect(screen.detectRequestTooLarge()).toBe(false);
+  });
 });
 
 // consumeBusySeen is set synchronously from raw PTY bytes — no xterm async needed.
@@ -537,5 +573,35 @@ describe('pty-shell /stop interrupt settle decision', () => {
       quietMs: 0,
     });
     expect(action).toBe('submit');
+  });
+});
+
+describe('ProtocolEmitter signals', () => {
+  const SID = '11111111-2222-3333-4444-555555555555';
+
+  // Collect each newline-delimited JSON line the emitter writes.
+  function captureEmitter(): { emitter: ProtocolEmitter; lines: () => Record<string, unknown>[] } {
+    const out: string[] = [];
+    const sink = new Writable({
+      write(chunk, _enc, cb) { out.push(chunk.toString()); cb(); },
+    });
+    return {
+      emitter: new ProtocolEmitter(sink),
+      lines: () => out.join('').split('\n').filter(Boolean).map((l) => JSON.parse(l)),
+    };
+  }
+
+  it('emitRequestTooLarge emits a request_too_large system event', () => {
+    const { emitter, lines } = captureEmitter();
+    emitter.emitRequestTooLarge(SID);
+    expect(lines()).toEqual([
+      { type: 'system', subtype: 'request_too_large', session_id: SID },
+    ]);
+  });
+
+  it('emitSessionIdle emits a session_idle event runner uses to stop typing', () => {
+    const { emitter, lines } = captureEmitter();
+    emitter.emitSessionIdle(SID);
+    expect(lines()).toEqual([{ type: 'session_idle', session_id: SID }]);
   });
 });

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -5,6 +5,7 @@ import {
   TUI_BUSY_MARKER,
   TUI_BYPASS_PERMS,
   TUI_REQUEST_TOO_LARGE,
+  TUI_REQUEST_TOO_LARGE_DISMISS,
   parseMenuChoice,
   formatMenuPrompt,
   extractChannelContent,
@@ -106,6 +107,10 @@ describe('ScreenModel TUI constants (Claude Code v2.1.x)', () => {
     expect(TUI_REQUEST_TOO_LARGE).toBe('Request too large (max');
   });
 
+  it('REQUEST_TOO_LARGE_DISMISS matches the overlay dismiss footer', () => {
+    expect(TUI_REQUEST_TOO_LARGE_DISMISS).toBe('esc to go back');
+  });
+
 });
 
 describe('ScreenModel detectRequestTooLarge', () => {
@@ -132,6 +137,17 @@ describe('ScreenModel detectRequestTooLarge', () => {
     // explaining the concept ("a request that is too large") never trips it.
     const screen = await renderScreen([
       'If a request is too large the API rejects it.',
+    ]);
+    expect(screen.detectRequestTooLarge()).toBe(false);
+  });
+
+  it('does not trip when the agent quotes the exact error text without the dismiss footer', async () => {
+    // Self-trigger guard: the agent's own reply may contain the verbatim error
+    // string (e.g. explaining this very bug). Detection requires the dismiss
+    // footer too, which only the real overlay renders — so quoted prose is inert.
+    const screen = await renderScreen([
+      'When the TUI shows "Request too large (max 32MB)" the session must restart.',
+      '❯ ',
     ]);
     expect(screen.detectRequestTooLarge()).toBe(false);
   });

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -170,6 +170,29 @@ describe('SessionProcess', () => {
   });
 
   // --------------------------------------------------------------------------
+  // U-SP-03a: SessionProcess re-emits 'exit' when the child subprocess dies.
+  // The runner's typing/processing teardown (runner.ts) listens for this event;
+  // without it the Telegram typing indicator stays stuck after a session is
+  // stopped/restarted until the 5-min stalled detector fires.
+  // --------------------------------------------------------------------------
+  it("U-SP-03a: re-emits 'exit' to listeners when the child subprocess exits", async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const exitSpy = jest.fn();
+    sp.on('exit', exitSpy);
+
+    // Simulate an external kill (e.g. restartProcess/stop) — the mock child
+    // emits 'exit' on the next tick after kill().
+    await sp.stop();
+    // Allow any queued microtasks/nextTick exit handlers to flush.
+    await new Promise((r) => setImmediate(r));
+
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(0, 'SIGTERM');
+  });
+
+  // --------------------------------------------------------------------------
   // U-SP-04: isIdle() / touch() behaviour
   // --------------------------------------------------------------------------
   it('U-SP-04: isIdle() returns true after idle window, touch() resets it', async () => {


### PR DESCRIPTION
## Summary
Fixes **three related failures in `headless=false` (pty-shell) mode**, all facets of one incident chain: an oversized context assembled a >32MB request over a single long turn → heartbeat went stale → 5-min stall fired and dumped raw reasoning → hit the 32MB limit → the turn never finished so typing stuck → resending re-hit 32MB and the session was effectively bricked.

## Bug 1 — Telegram typing indicator stuck after the session already stopped
**Root cause:** `runner.ts` registered `proc.once('exit', …)` to tear down typing/processing on process death, but `SessionProcess` **never emitted an `'exit'` event** — so that teardown was dead code, and typing stayed up until the 5-min stalled detector fired.

- `SessionProcess` now re-emits `'exit'(code, signal)` when its child subprocess exits (`src/session/process.ts`).
- `runner.ts` switches the teardown listener from `once` → `on`: a single `SessionProcess` can auto-restart its child multiple times, and every death without a final `result`/`session_idle` must clear typing. `writeTypingDone` / `setProcessing(false)` are idempotent.
- `pty-shell` `tick()` also reconciles screen-idle → `session_idle` as a secondary safety net for the alive-but-desynced case.

## Bug 2 — "Claude has not responded in 5 minutes" + raw reasoning dump on a long turn
Heartbeat now follows the TUI screen busy-state, so a genuinely-working long turn keeps the heartbeat fresh instead of tripping the stalled detector.

## Bug 3 — "Request too large (max 32MB)" left the session bricked
`pty-shell` now detects the recoverable TUI overlay, dismisses it (double-ESC), emits `request_too_large`, and finishes the turn; `runner.ts` restarts the session with a fresh context and tells the user to resend. Raw error text is suppressed from being force-forwarded as a duplicate.

## Tests
- `tsc --noEmit`: clean
- `+U-SP-03a` — asserts `SessionProcess` emits `'exit'` on child death
- `+6` pty-shell tests — Request-too-large detection + emitter events
- process + runner suites: **179 passed**; related unit set: **1680 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)