### PR TITLE
fix(apps): start app containers on gateway restart

### DIFF
--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -87,6 +87,10 @@ const DEFAULT_APPS_DIR = path.join(os.homedir(), '.claude-gateway', 'apps');
 // keeps its child process alive — not the gateway's responsiveness. Shorter than
 // the install path's 600s because restore images are already built (no pull/build).
 const RESTORE_COMPOSE_TIMEOUT_MS = 180_000;
+// Max apps brought up concurrently during boot restore. Bounds the docker/CPU
+// spike when many apps are marked running, while still parallelising the common
+// case. Typical installs have 1-3 apps, so this rarely binds.
+const RESTORE_MAX_CONCURRENCY = 4;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
 const APP_NAME_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
 // Disallow '..' in owner/repo segments — prevents path traversal via edge-case git URL parsing.
@@ -268,11 +272,11 @@ export class AppInstaller {
    * close that gap. It is idempotent: already-healthy containers return fast.
    *
    * Runs fully async and non-blocking: each app is brought up via {@link
-   * composeUpAsync} (a real child process, not spawnSync), and all running apps
-   * are started concurrently. The caller (boot) does NOT await this before
-   * wiring routes, so the gateway stays responsive throughout — at the cost of a
-   * brief ECONNREFUSED window per app until its `--wait` completes, which
-   * self-heals within seconds.
+   * composeUpAsync} (a real child process, not spawnSync), with up to
+   * {@link RESTORE_MAX_CONCURRENCY} apps in flight at once. The caller (boot)
+   * does NOT await this before wiring routes, so the gateway stays responsive
+   * throughout — at the cost of a brief ECONNREFUSED window per app until its
+   * `--wait` completes, which self-heals within seconds.
    *
    * Best-effort and non-fatal — a failure for one app is collected and the rest
    * still proceed, so one broken app cannot block the others or gateway startup.
@@ -281,15 +285,25 @@ export class AppInstaller {
   async restoreRunningApps(): Promise<{ attempted: number; failures: Array<{ app: string; error: string }> }> {
     const apps = await this.registry.list();
     const running = apps.filter((e) => e.status === 'running');
-    const results = await Promise.allSettled(
-      running.map((entry) => this.composeUpAsync(entry.name, entry.installPath)),
-    );
     const failures: Array<{ app: string; error: string }> = [];
-    results.forEach((result, i) => {
-      if (result.status === 'rejected') {
-        failures.push({ app: running[i].name, error: (result.reason as Error).message });
+
+    // Bounded-concurrency worker pool: workers pull from a shared cursor until
+    // the list is drained, so at most RESTORE_MAX_CONCURRENCY compose-ups run at
+    // once. push() is safe across workers — JS is single-threaded between awaits.
+    let cursor = 0;
+    const worker = async (): Promise<void> => {
+      while (cursor < running.length) {
+        const entry = running[cursor++];
+        try {
+          await this.composeUpAsync(entry.name, entry.installPath);
+        } catch (err) {
+          failures.push({ app: entry.name, error: (err as Error).message });
+        }
       }
-    });
+    };
+    const poolSize = Math.min(RESTORE_MAX_CONCURRENCY, running.length);
+    await Promise.all(Array.from({ length: poolSize }, () => worker()));
+
     return { attempted: running.length, failures };
   }
 
@@ -1104,6 +1118,13 @@ function defaultSpawn(
  * Async spawn used by the boot-time restore. Buffers stdout/stderr and resolves
  * with the exit status (never rejects on a non-zero exit — the caller maps that
  * to a failure). On timeout the child is SIGKILLed and the promise rejects.
+ *
+ * NOTE on timeout semantics for `docker compose up --wait`: SIGKILL kills the
+ * `docker compose` CLI process we spawned, NOT the containers. dockerd keeps
+ * bringing them up in the background, so a timeout means "we stopped waiting on
+ * the healthcheck", not "the start was cancelled" — the app may well come up
+ * healthy moments later. That's acceptable for restore: we only abandon the
+ * blocking wait, the container lifecycle is owned by dockerd regardless.
  */
 function defaultAsyncSpawn(
   cmd: string,
@@ -1118,22 +1139,30 @@ function defaultAsyncSpawn(
     let stdout = '';
     let stderr = '';
     let settled = false;
-    const timer = opts?.timeoutMs
-      ? setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          child.kill('SIGKILL');
-          reject(new Error(`Command timed out after ${opts.timeoutMs}ms: ${cmd} ${args[0] ?? ''}`));
-        }, opts.timeoutMs)
-      : null;
-    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
-    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
-    child.on('error', (err) => {
+    const fail = (err: Error) => {
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
       reject(err);
-    });
+    };
+    const timer = opts?.timeoutMs
+      ? setTimeout(() => {
+          if (settled) return;
+          // SIGKILL the compose CLI; dockerd keeps starting the containers.
+          child.kill('SIGKILL');
+          fail(new Error(`Command timed out after ${opts.timeoutMs}ms: ${cmd} ${args[0] ?? ''}`));
+        }, opts.timeoutMs)
+      : null;
+    // setEncoding uses an internal StringDecoder so multi-byte characters split
+    // across chunk boundaries are decoded correctly. Stream 'error's (rare) are
+    // routed to the same reject path so they never surface as uncaught.
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (d: string) => { stdout += d; });
+    child.stderr?.on('data', (d: string) => { stderr += d; });
+    child.stdout?.on('error', fail);
+    child.stderr?.on('error', fail);
+    child.on('error', fail);
     child.on('close', (code) => {
       if (settled) return;
       settled = true;

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as crypto from 'node:crypto';
-import { SpawnSyncOptionsWithStringEncoding, spawnSync } from 'node:child_process';
+import { SpawnSyncOptionsWithStringEncoding, spawnSync, spawn } from 'node:child_process';
 import { AppsRegistry, AppEntry, PortEntry } from './registry';
 import { RegistryClient, RegistryVersion } from './registry-client';
 import {
@@ -67,9 +67,26 @@ type SpawnFn = (
   opts?: SpawnSyncOptionsWithStringEncoding,
 ) => { stdout: string; stderr: string; status: number | null };
 
+/**
+ * Async (non-blocking) command runner used by the boot-time container restore.
+ * Unlike {@link SpawnFn} (spawnSync — freezes the event loop for the command's
+ * whole duration), this returns a Promise so a slow `compose up --wait` can run
+ * in the background while the gateway keeps serving Telegram/cron/other apps.
+ */
+type AsyncSpawnFn = (
+  cmd: string,
+  args: string[],
+  opts?: { cwd?: string; timeoutMs?: number },
+) => Promise<{ stdout: string; stderr: string; status: number | null }>;
+
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const DEFAULT_APPS_DIR = path.join(os.homedir(), '.claude-gateway', 'apps');
+// Per-app ceiling for the boot-time `compose up --wait` during restore. Runs in
+// the background (non-blocking), so this only bounds how long a hung container
+// keeps its child process alive — not the gateway's responsiveness. Shorter than
+// the install path's 600s because restore images are already built (no pull/build).
+const RESTORE_COMPOSE_TIMEOUT_MS = 180_000;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
 const APP_NAME_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
 // Disallow '..' in owner/repo segments — prevents path traversal via edge-case git URL parsing.
@@ -90,6 +107,7 @@ export class AppInstaller {
     private readonly spawn: SpawnFn = defaultSpawn,
     appsDir?: string,
     private readonly agentManager?: AgentManager,
+    private readonly spawnAsync: AsyncSpawnFn = defaultAsyncSpawn,
   ) {
     this.appsDir = appsDir ?? DEFAULT_APPS_DIR;
   }
@@ -249,22 +267,30 @@ export class AppInstaller {
    * (ECONNREFUSED). This re-runs `compose up -d --wait` for each running app to
    * close that gap. It is idempotent: already-healthy containers return fast.
    *
+   * Runs fully async and non-blocking: each app is brought up via {@link
+   * composeUpAsync} (a real child process, not spawnSync), and all running apps
+   * are started concurrently. The caller (boot) does NOT await this before
+   * wiring routes, so the gateway stays responsive throughout — at the cost of a
+   * brief ECONNREFUSED window per app until its `--wait` completes, which
+   * self-heals within seconds.
+   *
    * Best-effort and non-fatal — a failure for one app is collected and the rest
    * still proceed, so one broken app cannot block the others or gateway startup.
-   * Returns the apps that failed to start.
+   * Returns the apps that failed to start (and the count attempted, for logging).
    */
-  async restoreRunningApps(): Promise<Array<{ app: string; error: string }>> {
-    const failures: Array<{ app: string; error: string }> = [];
+  async restoreRunningApps(): Promise<{ attempted: number; failures: Array<{ app: string; error: string }> }> {
     const apps = await this.registry.list();
-    for (const entry of apps) {
-      if (entry.status !== 'running') continue;
-      try {
-        this.composeUp(entry.name, entry.installPath);
-      } catch (err) {
-        failures.push({ app: entry.name, error: (err as Error).message });
+    const running = apps.filter((e) => e.status === 'running');
+    const results = await Promise.allSettled(
+      running.map((entry) => this.composeUpAsync(entry.name, entry.installPath)),
+    );
+    const failures: Array<{ app: string; error: string }> = [];
+    results.forEach((result, i) => {
+      if (result.status === 'rejected') {
+        failures.push({ app: running[i].name, error: (result.reason as Error).message });
       }
-    }
-    return failures;
+    });
+    return { attempted: running.length, failures };
   }
 
   // ─── Internal install pipeline ────────────────────────────────────────────
@@ -940,6 +966,32 @@ export class AppInstaller {
     }
   }
 
+  /**
+   * Async, non-blocking counterpart of {@link composeUp} for the boot-time
+   * restore. Uses the async spawn seam so a slow `--wait` never freezes the
+   * event loop. Skips {@link stopConflictingContainers} on purpose: that guards
+   * dev-time port clashes during install/update, but after a host reboot nothing
+   * is running (the very reason this restore exists), so there is nothing to
+   * conflict with — and keeping it out avoids extra synchronous docker calls.
+   */
+  private async composeUpAsync(appName: string, dir: string): Promise<void> {
+    await this.runAsync(
+      ['docker', 'compose', '-p', appName, 'up', '-d', '--wait'],
+      dir,
+      RESTORE_COMPOSE_TIMEOUT_MS,
+    );
+  }
+
+  /** Async equivalent of {@link run}: throws on non-zero exit. */
+  private async runAsync(args: string[], cwd?: string, timeoutMs?: number): Promise<{ stdout: string; stderr: string }> {
+    const result = await this.spawnAsync(args[0], args.slice(1), { cwd, timeoutMs });
+    if (result.status !== 0) {
+      const errDetail = (result.stderr.trim() || result.stdout.trim()).slice(-2000);
+      throw new Error(`Command failed: ${args[0]} ${args[1]} — ${errDetail}`);
+    }
+    return { stdout: result.stdout, stderr: result.stderr };
+  }
+
   /** Evict terminal jobs older than 24 hours to bound memory growth. */
   private pruneOldJobs(): void {
     const cutoff = Date.now() - 24 * 60 * 60 * 1000;
@@ -1046,4 +1098,47 @@ function defaultSpawn(
     stderr: result.stderr ?? '',
     status: result.status,
   };
+}
+
+/**
+ * Async spawn used by the boot-time restore. Buffers stdout/stderr and resolves
+ * with the exit status (never rejects on a non-zero exit — the caller maps that
+ * to a failure). On timeout the child is SIGKILLed and the promise rejects.
+ */
+function defaultAsyncSpawn(
+  cmd: string,
+  args: string[],
+  opts?: { cwd?: string; timeoutMs?: number },
+): Promise<{ stdout: string; stderr: string; status: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      ...(opts?.cwd ? { cwd: opts.cwd } : {}),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const timer = opts?.timeoutMs
+      ? setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          child.kill('SIGKILL');
+          reject(new Error(`Command timed out after ${opts.timeoutMs}ms: ${cmd} ${args[0] ?? ''}`));
+        }, opts.timeoutMs)
+      : null;
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve({ stdout, stderr, status: code });
+    });
+  });
 }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -240,6 +240,33 @@ export class AppInstaller {
     }
   }
 
+  /**
+   * Bring up containers for every app marked `running` in the registry.
+   *
+   * Compose has no host-reboot restart policy here, so after the gateway (or
+   * its host) restarts, an app's proxy route is restored but its containers are
+   * not running — leaving the route live while the upstream port is dead
+   * (ECONNREFUSED). This re-runs `compose up -d --wait` for each running app to
+   * close that gap. It is idempotent: already-healthy containers return fast.
+   *
+   * Best-effort and non-fatal — a failure for one app is collected and the rest
+   * still proceed, so one broken app cannot block the others or gateway startup.
+   * Returns the apps that failed to start.
+   */
+  async restoreRunningApps(): Promise<Array<{ app: string; error: string }>> {
+    const failures: Array<{ app: string; error: string }> = [];
+    const apps = await this.registry.list();
+    for (const entry of apps) {
+      if (entry.status !== 'running') continue;
+      try {
+        this.composeUp(entry.name, entry.installPath);
+      } catch (err) {
+        failures.push({ app: entry.name, error: (err as Error).message });
+      }
+    }
+    return failures;
+  }
+
   // ─── Internal install pipeline ────────────────────────────────────────────
 
   private async runInstall(job: JobState, options: InstallOptions): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -604,6 +604,13 @@ async function main(): Promise<void> {
 
   // Restore proxy routes, sockets, and agent entries for apps that were running before restart
   try {
+    // Compose has no host-reboot restart policy, so a running app's containers
+    // are down after a restart. Bring them up before wiring routes, otherwise
+    // the restored proxy route points at a dead port (ECONNREFUSED).
+    const startFailures = await appInstaller.restoreRunningApps();
+    for (const f of startFailures) {
+      globalLogger.warn(`App store: failed to start "${f.app}" containers on restore (non-fatal): ${f.error}`);
+    }
     await router.loadProxyRoutes(appsRegistry);
     await restoreSockets(appsRegistry, socketServer);
     const reconcileErrors = await agentManager.reconcileAgents(appsRegistry);

--- a/src/index.ts
+++ b/src/index.ts
@@ -602,15 +602,27 @@ async function main(): Promise<void> {
     socketServer.stopApp(appName);
   };
 
+  // Compose has no host-reboot restart policy, so a running app's containers are
+  // down after a restart. Bring them up in the BACKGROUND — fire-and-forget so it
+  // never blocks the event loop or route wiring. Routes come up immediately below;
+  // until each app's containers finish `compose up --wait`, a request may briefly
+  // 502 (ECONNREFUSED), which self-heals within seconds. Non-fatal per app.
+  void appInstaller
+    .restoreRunningApps()
+    .then(({ attempted, failures }) => {
+      for (const f of failures) {
+        globalLogger.warn(`App store: failed to start "${f.app}" containers on restore (non-fatal): ${f.error}`);
+      }
+      if (attempted > 0) {
+        globalLogger.info(`App store: background container restore complete (${attempted - failures.length}/${attempted} started)`);
+      }
+    })
+    .catch((err) => {
+      globalLogger.warn('App store: background container restore failed (non-fatal)', { error: (err as Error).message });
+    });
+
   // Restore proxy routes, sockets, and agent entries for apps that were running before restart
   try {
-    // Compose has no host-reboot restart policy, so a running app's containers
-    // are down after a restart. Bring them up before wiring routes, otherwise
-    // the restored proxy route points at a dead port (ECONNREFUSED).
-    const startFailures = await appInstaller.restoreRunningApps();
-    for (const f of startFailures) {
-      globalLogger.warn(`App store: failed to start "${f.app}" containers on restore (non-fatal): ${f.error}`);
-    }
     await router.loadProxyRoutes(appsRegistry);
     await restoreSockets(appsRegistry, socketServer);
     const reconcileErrors = await agentManager.reconcileAgents(appsRegistry);

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -436,6 +436,40 @@ services:
       expect(failures).toHaveLength(1);
       expect(failures[0].app).toBe('my-app');
     });
+
+    it('caps concurrency at RESTORE_MAX_CONCURRENCY while starting every app', async () => {
+      // Install 6 running apps — more than the concurrency cap of 4.
+      const names = ['app-a', 'app-b', 'app-c', 'app-d', 'app-e', 'app-f'];
+      for (let i = 0; i < names.length; i++) {
+        const dir = makeAppDir(srcDir, names[i], 5001 + i);
+        const inst = makeInstaller();
+        await waitForJob(inst, inst.install({ localPath: dir }), 5000);
+      }
+
+      // Async spawn that holds each `up` briefly so workers genuinely overlap,
+      // tracking the peak number in flight at once.
+      let inFlight = 0;
+      let maxInFlight = 0;
+      let started = 0;
+      const trackAsyncSpawn = jest.fn(async (_cmd: string, args: string[]) => {
+        if (args.includes('up')) {
+          inFlight++;
+          started++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise((r) => setTimeout(r, 10));
+          inFlight--;
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer2 = makeInstaller(successSpawn, trackAsyncSpawn);
+
+      const { attempted, failures } = await installer2.restoreRunningApps();
+      expect(attempted).toBe(6);
+      expect(failures).toEqual([]);
+      expect(started).toBe(6); // every app was started
+      expect(maxInFlight).toBeLessThanOrEqual(4); // never exceeded the cap
+      expect(maxInFlight).toBeGreaterThan(1); // and it actually parallelised
+    });
   });
 
   // ─── GitHub URL install — validation ─────────────────────────────────────

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -77,6 +77,25 @@ function failingSpawn(failOn: string) {
   });
 }
 
+/** Async spawn mock (used by the boot-time container restore path). */
+const successAsyncSpawn = jest.fn(
+  async (_cmd: string, _args: string[], _opts?: object) => ({
+    stdout: '',
+    stderr: '',
+    status: 0,
+  }),
+);
+
+/** Async spawn mock that fails on matching command */
+function failingAsyncSpawn(failOn: string) {
+  return jest.fn(async (_cmd: string, args: string[], _opts?: object) => {
+    if (args.some((a) => a.includes(failOn))) {
+      return { stdout: '', stderr: `mocked error: ${failOn}`, status: 1 };
+    }
+    return { stdout: '', stderr: '', status: 0 };
+  });
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('AppInstaller', () => {
@@ -97,13 +116,15 @@ describe('AppInstaller', () => {
     callbacks = makeCallbacks();
   });
 
-  function makeInstaller(spawnFn = successSpawn) {
+  function makeInstaller(spawnFn = successSpawn, asyncSpawnFn = successAsyncSpawn) {
     return new AppInstaller(
       registry,
       new RegistryClient(),
       callbacks,
       spawnFn,
       appsDir,
+      undefined, // agentManager
+      asyncSpawnFn as unknown as ConstructorParameters<typeof AppInstaller>[6],
     );
   }
 
@@ -365,20 +386,22 @@ services:
   // ─── restoreRunningApps() ─────────────────────────────────────────────────
 
   describe('restoreRunningApps()', () => {
-    it('brings up containers for apps marked running', async () => {
+    it('brings up containers for apps marked running (via the async spawn seam)', async () => {
       const appDir = makeAppDir(srcDir, 'my-app');
       const installer = makeInstaller();
       await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
 
+      // Restore runs through the async (non-blocking) spawn, NOT the sync one.
       const calls: string[][] = [];
-      const trackSpawn = jest.fn((cmd: string, args: string[]) => {
+      const trackAsyncSpawn = jest.fn(async (cmd: string, args: string[]) => {
         calls.push([cmd, ...args]);
         return { stdout: '', stderr: '', status: 0 };
       });
-      const installer2 = makeInstaller(trackSpawn as typeof successSpawn);
+      const installer2 = makeInstaller(successSpawn, trackAsyncSpawn);
 
-      const failures = await installer2.restoreRunningApps();
+      const { attempted, failures } = await installer2.restoreRunningApps();
       expect(failures).toEqual([]);
+      expect(attempted).toBe(1);
       expect(calls.some((c) => c.includes('up'))).toBe(true);
     });
 
@@ -389,14 +412,15 @@ services:
       await installer.startStopRestart('my-app', 'stop');
 
       const calls: string[][] = [];
-      const trackSpawn = jest.fn((cmd: string, args: string[]) => {
+      const trackAsyncSpawn = jest.fn(async (cmd: string, args: string[]) => {
         calls.push([cmd, ...args]);
         return { stdout: '', stderr: '', status: 0 };
       });
-      const installer2 = makeInstaller(trackSpawn as typeof successSpawn);
+      const installer2 = makeInstaller(successSpawn, trackAsyncSpawn);
 
-      const failures = await installer2.restoreRunningApps();
+      const { attempted, failures } = await installer2.restoreRunningApps();
       expect(failures).toEqual([]);
+      expect(attempted).toBe(0);
       expect(calls.some((c) => c.includes('up'))).toBe(false);
     });
 
@@ -405,10 +429,10 @@ services:
       const installer = makeInstaller();
       await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
 
-      const failSpawn = failingSpawn('up');
-      const installer2 = makeInstaller(failSpawn as typeof successSpawn);
+      const installer2 = makeInstaller(successSpawn, failingAsyncSpawn('up'));
 
-      const failures = await installer2.restoreRunningApps();
+      const { attempted, failures } = await installer2.restoreRunningApps();
+      expect(attempted).toBe(1);
       expect(failures).toHaveLength(1);
       expect(failures[0].app).toBe('my-app');
     });

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -362,6 +362,58 @@ services:
     });
   });
 
+  // ─── restoreRunningApps() ─────────────────────────────────────────────────
+
+  describe('restoreRunningApps()', () => {
+    it('brings up containers for apps marked running', async () => {
+      const appDir = makeAppDir(srcDir, 'my-app');
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+
+      const calls: string[][] = [];
+      const trackSpawn = jest.fn((cmd: string, args: string[]) => {
+        calls.push([cmd, ...args]);
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer2 = makeInstaller(trackSpawn as typeof successSpawn);
+
+      const failures = await installer2.restoreRunningApps();
+      expect(failures).toEqual([]);
+      expect(calls.some((c) => c.includes('up'))).toBe(true);
+    });
+
+    it('skips apps that are not running', async () => {
+      const appDir = makeAppDir(srcDir, 'my-app');
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+      await installer.startStopRestart('my-app', 'stop');
+
+      const calls: string[][] = [];
+      const trackSpawn = jest.fn((cmd: string, args: string[]) => {
+        calls.push([cmd, ...args]);
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer2 = makeInstaller(trackSpawn as typeof successSpawn);
+
+      const failures = await installer2.restoreRunningApps();
+      expect(failures).toEqual([]);
+      expect(calls.some((c) => c.includes('up'))).toBe(false);
+    });
+
+    it('is non-fatal: collects failures without throwing when compose up fails', async () => {
+      const appDir = makeAppDir(srcDir, 'my-app');
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+
+      const failSpawn = failingSpawn('up');
+      const installer2 = makeInstaller(failSpawn as typeof successSpawn);
+
+      const failures = await installer2.restoreRunningApps();
+      expect(failures).toHaveLength(1);
+      expect(failures[0].app).toBe('my-app');
+    });
+  });
+
   // ─── GitHub URL install — validation ─────────────────────────────────────
 
   describe('install() — github URL validation', () => {


### PR DESCRIPTION
## Problem

After a gateway (or host) restart, an installed app's **proxy route is restored but its containers are not running**. Compose has no host-reboot restart policy in this setup, so the route points at a dead upstream port and every request returns `ECONNREFUSED`.

Observed in production on a fresh pod boot:

```
{"error":"App unavailable: connect ECONNREFUSED 127.0.0.1:5990"}
GET /app/getpod-manager/api/metrics   → 502
GET /app/getpod-manager/api/ssh-keys  → 502
```

The startup restore block (`src/index.ts`) calls `loadProxyRoutes` + `restoreSockets` + `reconcileAgents`, logs *"proxy routes, sockets, and agent entries restored"* — but nothing ever runs `docker compose up` for the apps. `docker ps` is empty, 5990 is dead, the route is live. Manually running `docker compose up -d` in the app dir fixes it immediately (5990 healthy, endpoints return 401 auth instead of ECONNREFUSED), confirming it's purely the missing boot-time start.

## Fix

Add `AppInstaller.restoreRunningApps()`: iterate the registry and re-run `compose up -d --wait` (reusing the existing private `composeUp`) for every app marked `running`. Call it from the boot restore block **before** route wiring so the upstream is live when the route comes up.

- **Idempotent** — already-healthy containers return fast under `--wait`.
- **Best-effort & non-fatal** — a failure for one app is collected and returned; the rest still proceed, so one broken app can't block the others or gateway startup (mirrors the existing `reconcileAgents` non-fatal pattern).

## Tests

`restoreRunningApps()` unit coverage in `tests/unit/apps/installer.test.ts`:
- brings up containers for apps marked `running`
- skips apps that are not `running`
- stays non-fatal (collects failures, doesn't throw) when `compose up` fails

Local: `tsc --noEmit` clean, `npm run build` clean, full unit suite green (1668 passed).

## Note for review

`composeUp` uses `spawnSync`, so this restore step is synchronous and runs after the HTTP server is already listening (server starts at `router.start` before the restore block). For the common case (a single prebuilt app with a fast healthcheck) the boot delay is small and arguably desirable — the upstream is healthy before the route serves traffic. Worst case is bounded by the per-app `--wait` timeout. If you'd prefer the restore to never block the event loop, I'm happy to convert `composeUp` to an async spawn variant in a follow-up — flagging it so you can decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)