### PR TITLE
feat(channel): coalesce image + text into a single turn

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -41,6 +41,12 @@ const PROTECTED_WORKSPACE_FILES = [
 
 const MAX_API_IMAGES = 5;
 
+// Trailing-edge window for coalescing channel messages that carry an image (or that
+// arrive while an image is already buffered) into a single turn. Reset on every new
+// related update, so an album burst or a client-split photo+caption is gathered
+// whole. Plain text with no pending buffer bypasses this entirely (zero added latency).
+export const CHANNEL_COALESCE_WINDOW_MS = 1200;
+
 /**
  * Move UI-uploaded files from staging (ui-upload/) to permanent per-session storage
  * (media/api-{sessionId}/), matching the same pattern Telegram uses.
@@ -121,6 +127,24 @@ export class AgentRunner extends EventEmitter {
   // Tracks pending Telegram image paths per chatId (queue) for size accumulation after each turn.
   private readonly pendingImagePaths = new Map<string, string[]>();
 
+  // Coalescing buffer: collects channel messages that arrive close together so a
+  // photo and its instruction text (which Telegram may deliver as separate updates
+  // — long caption split, album burst, or photo sent before/after the text) are
+  // injected as ONE turn instead of two. Keyed by chatId. A trailing-edge timer
+  // flushes the buffer once no new related update has arrived for the window.
+  private readonly channelCoalesce = new Map<
+    string,
+    {
+      channelSource: 'telegram' | 'discord';
+      entries: Array<{ content?: string; meta?: Record<string, string> }>;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  // Trailing-edge debounce window for channelCoalesce, resolved once at construction.
+  // Overridable via the CHANNEL_COALESCE_WINDOW_MS env var (tests shrink it for speed).
+  private readonly coalesceWindowMs: number;
+
   // Buffers attachment file paths registered via api_reply tool for the current API session turn.
   private readonly pendingApiAttachments = new Map<string, string[]>();
 
@@ -169,6 +193,8 @@ export class AgentRunner extends EventEmitter {
     this.idleTimeoutMs =
       (agentConfig.session?.idleTimeoutMinutes ?? DEFAULT_IDLE_TIMEOUT_MINUTES) * 60 * 1000;
     this.maxConcurrent = agentConfig.session?.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+    this.coalesceWindowMs =
+      Number(process.env.CHANNEL_COALESCE_WINDOW_MS) || CHANNEL_COALESCE_WINDOW_MS;
   }
 
   /**
@@ -242,91 +268,32 @@ export class AgentRunner extends EventEmitter {
             return;
           }
 
-          // Get active session ID and route message to it
-          this.sessionStore.getActiveSessionId(this.agentConfig.id, chatId, channelSource)
-            .then(async (sessionId) => {
-              // Append user message to the active session
-              const userContent = content || (meta['attachment_file_id'] ? '(photo)' : '');
-              const userTs = Date.now();
-              await this.sessionStore.appendTelegramMessage(this.agentConfig.id, chatId, sessionId, {
-                role: 'user',
-                content: userContent,
-                ts: userTs,
-              }, channelSource);
+          // Coalesce messages that carry an image (or that arrive while an image is
+          // already buffered) so a photo and its instruction text are injected as
+          // ONE turn — Telegram can split them across updates (long-caption split,
+          // album burst, or photo sent just before/after the text). Plain text with
+          // nothing buffered takes the fast path and is injected immediately.
+          const hasImage = !!meta['image_path'];
+          const pending = this.channelCoalesce.get(chatId);
+          if (hasImage || pending) {
+            const buf = pending ?? {
+              channelSource,
+              entries: [] as Array<{ content?: string; meta?: Record<string, string> }>,
+              timer: undefined as unknown as ReturnType<typeof setTimeout>,
+            };
+            buf.channelSource = channelSource;
+            buf.entries.push(params);
+            if (buf.timer) clearTimeout(buf.timer);
+            buf.timer = setTimeout(() => {
+              const flushed = this.channelCoalesce.get(chatId);
+              this.channelCoalesce.delete(chatId);
+              if (flushed) this.routeChannelTurn(chatId, flushed.channelSource, flushed.entries);
+            }, this.coalesceWindowMs);
+            this.channelCoalesce.set(chatId, buf);
+            return;
+          }
 
-              // Persist to permanent history DB (separate from session context)
-              const mediaFiles: string[] = [];
-              if (meta['image_path']) {
-                try {
-                  const rel = MediaStore.copyToMedia(this.agentsBaseDir, this.agentConfig.id, `${channelSource}-${chatId}`, meta['image_path']);
-                  mediaFiles.push(rel);
-                } catch {
-                  // Non-fatal — continue without media
-                }
-              }
-              this.historyDb.insertMessage({
-                chatId: `${channelSource}-${chatId}`,
-                sessionId,
-                source: channelSource as HistorySource,
-                role: 'user',
-                content: userContent,
-                senderName: meta['user'] ?? undefined,
-                senderId: meta['user_id'] ?? meta['chat_id'] ?? undefined,
-                platformMessageId: meta['message_id'] ?? undefined,
-                mediaFiles: mediaFiles.length > 0 ? mediaFiles : undefined,
-                ts: userTs,
-              });
-              // Restart session before this turn if accumulated image size exceeded threshold
-              if (this.pendingRestarts.has(chatId)) {
-                const existingSession = this.sessions.get(chatId);
-                if (existingSession) {
-                  await existingSession.stop();
-                  this.sessions.delete(chatId);
-                }
-                this.pendingRestarts.delete(chatId);
-                this.imageSizePerChat.delete(chatId);
-              }
-
-              // Route to session process (map key = chatId, actual sessionId passed separately)
-              // Channel sessions use agent-level model (not per-session)
-              const session = await this.getOrSpawnSession(chatId, channelSource, sessionId);
-              let channelXml = AgentRunner.buildChannelXml(params);
-
-              // Detect skill commands and inject skill content
-              const skillInvocation = detectSkillCommand(content, this.skillRegistry);
-              if (skillInvocation) {
-                channelXml += formatSkillContext(skillInvocation);
-                this.logger.info('Skill invoked', {
-                  skill: skillInvocation.skillKey,
-                  args: skillInvocation.args,
-                  chatId,
-                });
-              }
-
-              const imagePath = meta['image_path'];
-              if (imagePath) {
-                const queue = this.pendingImagePaths.get(chatId) ?? [];
-                queue.push(imagePath);
-                this.pendingImagePaths.set(chatId, queue);
-              }
-
-              session.setProcessing(true);
-              session.sendMessage(channelXml);
-              session.touch();
-              this.logger.debug('Injected channel turn into session', {
-                chatId,
-                sessionId,
-                user: meta['user'],
-              });
-            })
-            .catch((err) => {
-              this.logger.error('Failed to route message to session', {
-                chatId,
-                error: (err as Error).message,
-              });
-              const code = (err as Error).message.includes('pool full') ? 'POOL_FULL' : 'SPAWN_FAILED';
-              this.writeTypingError(chatId, code);
-            });
+          this.routeChannelTurn(chatId, channelSource, [params]);
         } catch (err) {
           this.logger.warn('Failed to parse channel callback body', {
             error: (err as Error).message,
@@ -560,6 +527,114 @@ export class AgentRunner extends EventEmitter {
       }
     }
     return paths;
+  }
+
+  /**
+   * Inject one or more coalesced channel messages as a SINGLE turn. Each entry is
+   * still recorded individually (session history + permanent history DB), but their
+   * channel XML blocks are concatenated and delivered in one sendMessage() call so
+   * a photo and its instruction text are read together in the same turn.
+   */
+  private routeChannelTurn(
+    chatId: string,
+    channelSource: 'telegram' | 'discord',
+    entries: Array<{ content?: string; meta?: Record<string, string> }>,
+  ): void {
+    if (entries.length === 0) return;
+    this.sessionStore.getActiveSessionId(this.agentConfig.id, chatId, channelSource)
+      .then(async (sessionId) => {
+        // Record each buffered message individually (history + session context).
+        for (const entry of entries) {
+          const meta = entry.meta ?? {};
+          const content = entry.content ?? '';
+          const userContent = content || (meta['attachment_file_id'] || meta['image_path'] ? '(photo)' : '');
+          const userTs = Date.now();
+          await this.sessionStore.appendTelegramMessage(this.agentConfig.id, chatId, sessionId, {
+            role: 'user',
+            content: userContent,
+            ts: userTs,
+          }, channelSource);
+
+          // Persist to permanent history DB (separate from session context)
+          const mediaFiles: string[] = [];
+          if (meta['image_path']) {
+            try {
+              const rel = MediaStore.copyToMedia(this.agentsBaseDir, this.agentConfig.id, `${channelSource}-${chatId}`, meta['image_path']);
+              mediaFiles.push(rel);
+            } catch {
+              // Non-fatal — continue without media
+            }
+          }
+          this.historyDb.insertMessage({
+            chatId: `${channelSource}-${chatId}`,
+            sessionId,
+            source: channelSource as HistorySource,
+            role: 'user',
+            content: userContent,
+            senderName: meta['user'] ?? undefined,
+            senderId: meta['user_id'] ?? meta['chat_id'] ?? undefined,
+            platformMessageId: meta['message_id'] ?? undefined,
+            mediaFiles: mediaFiles.length > 0 ? mediaFiles : undefined,
+            ts: userTs,
+          });
+        }
+
+        // Restart session before this turn if accumulated image size exceeded threshold
+        if (this.pendingRestarts.has(chatId)) {
+          const existingSession = this.sessions.get(chatId);
+          if (existingSession) {
+            await existingSession.stop();
+            this.sessions.delete(chatId);
+          }
+          this.pendingRestarts.delete(chatId);
+          this.imageSizePerChat.delete(chatId);
+        }
+
+        // Route to session process (map key = chatId, actual sessionId passed separately)
+        // Channel sessions use agent-level model (not per-session)
+        const session = await this.getOrSpawnSession(chatId, channelSource, sessionId);
+
+        // Merge buffered messages into one turn: concat channel XML blocks, append
+        // any skill context, and accumulate image paths for size tracking.
+        const blocks: string[] = [];
+        for (const entry of entries) {
+          let channelXml = AgentRunner.buildChannelXml(entry);
+          const skillInvocation = detectSkillCommand(entry.content ?? '', this.skillRegistry);
+          if (skillInvocation) {
+            channelXml += formatSkillContext(skillInvocation);
+            this.logger.info('Skill invoked', {
+              skill: skillInvocation.skillKey,
+              args: skillInvocation.args,
+              chatId,
+            });
+          }
+          blocks.push(channelXml);
+
+          const imagePath = entry.meta?.['image_path'];
+          if (imagePath) {
+            const queue = this.pendingImagePaths.get(chatId) ?? [];
+            queue.push(imagePath);
+            this.pendingImagePaths.set(chatId, queue);
+          }
+        }
+
+        session.setProcessing(true);
+        session.sendMessage(blocks.join('\n'));
+        session.touch();
+        this.logger.debug('Injected channel turn into session', {
+          chatId,
+          sessionId,
+          messages: entries.length,
+        });
+      })
+      .catch((err) => {
+        this.logger.error('Failed to route message to session', {
+          chatId,
+          error: (err as Error).message,
+        });
+        const code = (err as Error).message.includes('pool full') ? 'POOL_FULL' : 'SPAWN_FAILED';
+        this.writeTypingError(chatId, code);
+      });
   }
 
   private static buildChannelXml(params: {
@@ -1447,6 +1522,10 @@ export class AgentRunner extends EventEmitter {
       srv.closeAllConnections?.();
       await new Promise<void>((resolve) => srv.close(() => resolve()));
     }
+    for (const buf of this.channelCoalesce.values()) {
+      clearTimeout(buf.timer);
+    }
+    this.channelCoalesce.clear();
     this.receiver?.stop();
     this.discordReceiver?.stop();
     await Promise.all([...this.sessions.values()].map((s) => s.stop()));

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -123,6 +123,16 @@ function getIdleCleaner(runner: AgentRunner): ReturnType<typeof setInterval> | u
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
+// Shrink the channel-coalescing debounce window file-wide so image POSTs flush
+// almost immediately — existing image tests assume a near-instant spawn. Tests
+// that exercise the debounce timing itself set their own larger value.
+beforeAll(() => {
+  process.env.CHANNEL_COALESCE_WINDOW_MS = '20';
+});
+afterAll(() => {
+  delete process.env.CHANNEL_COALESCE_WINDOW_MS;
+});
+
 describe('AgentRunner (session pool)', () => {
   let tmpDir: string;
   let agentConfig: AgentConfig;
@@ -3567,4 +3577,151 @@ describe('AgentRunner — idle eviction preserves media', () => {
     // No files should be deleted — media dir still intact
     expect(fs.existsSync(mediaAbs)).toBe(true);
   });
+});
+
+// ── Channel message coalescing (image + text → one turn) ───────────────────────
+describe('AgentRunner — channel coalescing (US-IMG-COALESCE)', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+
+  beforeEach(() => {
+    // Use a deliberately wide window here so debounce timing is observable.
+    process.env.CHANNEL_COALESCE_WINDOW_MS = '300';
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-coalesce-'));
+    agentConfig = makeAgentConfig(path.join(tmpDir, 'workspace'));
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    process.env.CHANNEL_COALESCE_WINDOW_MS = '20'; // restore file-wide default
+    jest.clearAllMocks();
+  });
+
+  async function postImage(
+    port: number,
+    chatId: string,
+    imagePath: string,
+    content = '',
+    messageId = '1',
+  ): Promise<void> {
+    await fetch(`http://127.0.0.1:${port}/channel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content,
+        meta: { chat_id: chatId, message_id: messageId, user: 'testuser', ts: new Date().toISOString(), image_path: imagePath },
+      }),
+    });
+  }
+
+  function turnWritesOf(): string[] {
+    const proc = allProcesses.find(p => !p.killed && p.stdin!.write.mock.calls.length > 0);
+    return proc ? proc.stdin!.write.mock.calls.map((c: unknown[]) => String(c[0])) : [];
+  }
+
+  // CL-01: plain text takes the fast path — spawns immediately despite a wide window.
+  it('CL-01: plain text message is injected immediately (no debounce)', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    await sendChannelPost(port, 'chat:cl01', 'hello there');
+    // Well under the 300ms window — a buffered message would NOT be here yet.
+    await new Promise(r => setTimeout(r, 120));
+
+    expect(getSessions(runner).has('chat:cl01')).toBe(true);
+  }, 15000);
+
+  // CL-02: a message carrying an image is held until the debounce window elapses.
+  it('CL-02: image message is debounced until the window elapses', async () => {
+    const img = path.join(tmpDir, 'cl02.jpg');
+    fs.writeFileSync(img, Buffer.alloc(64));
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    await postImage(port, 'chat:cl02', img, 'look at this');
+    await new Promise(r => setTimeout(r, 120));
+    // Still inside the window → not flushed yet.
+    expect(getSessions(runner).has('chat:cl02')).toBe(false);
+
+    await new Promise(r => setTimeout(r, 350));
+    // Past the window → flushed and spawned.
+    expect(getSessions(runner).has('chat:cl02')).toBe(true);
+  }, 15000);
+
+  // CL-03: an image followed by a separate text message within the window are
+  // merged into ONE turn (the photo and its instruction land together).
+  it('CL-03: image then follow-up text merge into a single turn', async () => {
+    const img = path.join(tmpDir, 'merge-img.jpg');
+    fs.writeFileSync(img, Buffer.alloc(64));
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    await postImage(port, 'chat:cl03', img, '', '10');
+    await new Promise(r => setTimeout(r, 80)); // within window
+    await sendChannelPost(port, 'chat:cl03', 'MERGE_MARKER_TEXT');
+
+    await new Promise(r => setTimeout(r, 450)); // let the window flush
+
+    // Exactly one session for the chat.
+    expect(getSessions(runner).has('chat:cl03')).toBe(true);
+
+    // The injected turn carries BOTH the image and the text in a single write.
+    const writes = turnWritesOf();
+    const turn = writes.find(w => w.includes('merge-img.jpg'));
+    expect(turn).toBeDefined();
+    expect(turn).toContain('MERGE_MARKER_TEXT');
+  }, 15000);
+
+  // CL-04: an album burst (two rapid images) coalesces — both image paths in one turn.
+  it('CL-04: rapid image burst coalesces into one turn with both images', async () => {
+    const img1 = path.join(tmpDir, 'album-a.jpg');
+    const img2 = path.join(tmpDir, 'album-b.jpg');
+    fs.writeFileSync(img1, Buffer.alloc(64));
+    fs.writeFileSync(img2, Buffer.alloc(64));
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    await postImage(port, 'chat:cl04', img1, 'album caption', '20');
+    await postImage(port, 'chat:cl04', img2, '', '21');
+
+    await new Promise(r => setTimeout(r, 450));
+
+    const writes = turnWritesOf();
+    const turn = writes.find(w => w.includes('album-a.jpg'));
+    expect(turn).toBeDefined();
+    expect(turn).toContain('album-b.jpg');
+  }, 15000);
+
+  // CL-05: pending coalesce timers are cleared on stop() (no dangling buffers).
+  it('CL-05: stop() clears any pending coalesce buffer', async () => {
+    const img = path.join(tmpDir, 'cl05.jpg');
+    fs.writeFileSync(img, Buffer.alloc(64));
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    await postImage(port, 'chat:cl05', img, 'pending');
+    await new Promise(r => setTimeout(r, 80)); // still buffered
+
+    const buffers = (runner as unknown as { channelCoalesce: Map<string, unknown> }).channelCoalesce;
+    expect(buffers.size).toBe(1);
+
+    await runner.stop();
+    expect(buffers.size).toBe(0);
+  }, 15000);
 });


### PR DESCRIPTION
## Problem

In **headless=false (PTY) mode**, when a Telegram photo and its instruction text arrive as **separate updates** (long-caption split, album burst, or photo sent just before/after the text), the runner injected each callback as its own turn. The text turn completed and replied first, then the image turn ran in a **second turn** — the agent "just read the image" with incomplete context, splitting the instruction from its attachment.

A single photo+caption message (one Telegram update) already worked; only the split-update cases broke.

## Fix

Add a per-chatId **trailing-edge coalescing buffer** in `AgentRunner`:

- A message carrying an image (`image_path`) **or** arriving while an image is already buffered → held for a short window (reset on each new related update) and **merged into ONE turn**: channel XML blocks concatenated, all image paths preserved + size-accounted.
- **Plain text with nothing buffered → fast path, injected immediately** (zero added latency).
- Each message is still recorded individually in session history + the history DB; only the turn injection is merged.
- Pending timers cleared on `stop()`.

Window is tunable via the `CHANNEL_COALESCE_WINDOW_MS` env var (default `1200ms`; tests shrink it).

### Covered cases
- text only → immediate ⚡
- photo + caption (1 msg) → short debounce then fire
- photo → follow-up text within window → **merged** (B)
- album burst → merged into one turn

### Known residual
Sending a **text message first**, then a photo **after the window**, still splits (the text already took the fast path). Avoid by attaching the photo and typing in one message.

## Tests
- `agent-runner` **107/107** — 5 new (`CL-01..05`: fast-path, debounce, merge, album, timer-cleanup)
- Existing image-size tests (US-002/003/004/005) unchanged — no regression
- `tsc` clean · build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)