### PR TITLE
fix(session): defer history+activation to first user turn to prevent double-response on PTY-shell restart

### DIFF
--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -493,11 +493,22 @@ export class SessionProcess extends EventEmitter {
     // first API turn and cause sendApiMessage to resolve with the wrong result.
     // Instead, if there is conversation history to restore (model-switch respawn),
     // stash it in pendingInitialPrompt so sendMessage() prepends it to the first turn.
+    //
+    // Non-API sessions with history also use pendingInitialPrompt to avoid a
+    // double-response bug: if the session died while an interactive menu was pending
+    // (e.g. ExitPlanMode Pre-flight Summary), sending history + activation immediately
+    // makes Claude respond to that context as Turn 1, then the user's reply (e.g. "Y")
+    // becomes Turn 2 — two separate responses forwarded to the channel. Deferring
+    // history to sendMessage() bundles [history + activation + user reply] into a
+    // single turn so Claude produces exactly one response.
     if (this.source !== 'api') {
-      const initialPrompt = historyPrompt
-        ? `${historyPrompt}\n\n${CHANNELS_ACTIVATION_PROMPT}`
-        : CHANNELS_ACTIVATION_PROMPT;
-      proc.stdin?.write(SessionProcess.toStreamJsonTurn(initialPrompt) + '\n');
+      if (historyPrompt) {
+        // Has history: defer to first incoming user message to prevent double-response.
+        this.pendingInitialPrompt = `${historyPrompt}\n\n${CHANNELS_ACTIVATION_PROMPT}`;
+      } else {
+        // No history: send activation-only prompt immediately (fresh session).
+        proc.stdin?.write(SessionProcess.toStreamJsonTurn(CHANNELS_ACTIVATION_PROMPT) + '\n');
+      }
     } else if (historyPrompt) {
       this.pendingInitialPrompt = historyPrompt;
     }

--- a/tests/helpers/mock-claude-mcp.js
+++ b/tests/helpers/mock-claude-mcp.js
@@ -125,7 +125,10 @@ function parseChannelFromStdin(line) {
   try {
     const obj = JSON.parse(line)
     const text = obj?.message?.content?.[0]?.text ?? ''
-    const m = text.match(/<channel([^>]*)>([\s\S]*?)<\/channel>/)
+    // Take the LAST match — the current user turn is always appended last,
+    // so if history happens to contain a <channel> string we skip it.
+    const allMatches = [...text.matchAll(/<channel([^>]*)>([\s\S]*?)<\/channel>/g)]
+    const m = allMatches.length > 0 ? allMatches[allMatches.length - 1] : null
     if (!m) return null
     const attrsStr = m[1]
     const content = m[2].trim()

--- a/tests/helpers/mock-claude-mcp.js
+++ b/tests/helpers/mock-claude-mcp.js
@@ -118,12 +118,14 @@ const pendingChannels = []
 /**
  * Parse a channel message from a stream-json stdin injection line.
  * agent-runner wraps channelXml in: {"type":"user","message":{"role":"user","content":[{"type":"text","text":"<channel ...>...</channel>"}]}}
+ * The channel XML may appear at the end of a bundled first turn (history + activation + channel XML),
+ * so we search anywhere in the text rather than anchoring to the start.
  */
 function parseChannelFromStdin(line) {
   try {
     const obj = JSON.parse(line)
     const text = obj?.message?.content?.[0]?.text ?? ''
-    const m = text.match(/^<channel([^>]*)>([\s\S]*?)<\/channel>/)
+    const m = text.match(/<channel([^>]*)>([\s\S]*?)<\/channel>/)
     if (!m) return null
     const attrsStr = m[1]
     const content = m[2].trim()
@@ -174,10 +176,20 @@ async function main() {
     const trimmed = line.trim()
     if (!trimmed) return
 
-    // First line is always the initial prompt from agent-runner
+    // First line is always the initial prompt from agent-runner.
+    // When history is deferred and bundled with the first user message, the channel
+    // XML may be embedded at the end of this first line — parse it here too.
     if (!firstLineDone) {
       firstLineDone = true
       process.stdout.write(`[mock-claude-mcp] prompt: ${trimmed}\n`)
+      const ch = parseChannelFromStdin(trimmed)
+      if (ch) {
+        if (mcpReady) {
+          handleChannel(ch)
+        } else {
+          pendingChannels.push(ch)
+        }
+      }
       return
     }
 

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -255,14 +255,16 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // The first stdin.write call contains the initial prompt
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // With history, the initial prompt is deferred to pendingInitialPrompt so it
+    // can be bundled with the first user message into a single turn (prevents
+    // double-response when the session restarts mid-menu).
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     expect(text).toContain('Conversation history');
     expect(text).toContain('User: Hello');
     expect(text).toContain('Assistant: Hi there!');
+    // Nothing written to stdin yet (deferred)
+    expect(lastProcess!.stdin!.write.mock.calls.length).toBe(0);
   });
 
   // --------------------------------------------------------------------------
@@ -296,9 +298,8 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     // Should contain Message 59 (last) but NOT Message 0 (first — truncated)
     expect(text).toContain('Message 59');
@@ -328,9 +329,8 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     // Summary and last message must be present
     expect(text).toContain('[Conversation Summary]');
@@ -354,9 +354,8 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     expect(text).toContain('Msg 59');
     expect(text).not.toContain('Msg 0');
@@ -383,9 +382,8 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     expect(text).toContain('[Conversation Summary]');
     expect(text).toContain('Short 1');
@@ -419,9 +417,8 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     // Last 50 messages = indices 11–60, so 'First normal message' (idx 0) is out
     expect(text).not.toContain('First normal message');
@@ -445,9 +442,8 @@ describe('SessionProcess', () => {
     sp.historyLimit = 10; // escalated rung (e.g. after several 32MB recoveries)
     await sp.start();
 
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     // Only the last 10 messages (50–59) survive; 49 and older are dropped.
     expect(text).toContain('Rung 59');
@@ -1473,9 +1469,8 @@ describe('SessionProcess — buildInitialPrompt system role', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     expect(text).toContain('System: [Image Context Summary]');
     expect(text).not.toContain('Assistant: [Image Context Summary]');
@@ -1495,9 +1490,8 @@ describe('SessionProcess — buildInitialPrompt system role', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    const firstWrite = lastProcess!.stdin!.write.mock.calls[0][0] as string;
-    const parsed = JSON.parse(firstWrite);
-    const text: string = parsed.message.content[0].text;
+    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
 
     expect(text).toContain('User: show me a picture');
     expect(text).toContain('Assistant: Here is the image.');
@@ -1804,10 +1798,9 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
     const respawned = lastProcess!;
     expect(respawned).not.toBe(firstProcess);
 
-    // The respawned subprocess gets a fresh prompt rebuilt from text history —
-    // clean, with no corrupted thinking content.
-    const initialWrite = respawned.stdin!.write.mock.calls[0][0] as string;
-    const text: string = JSON.parse(initialWrite).message.content[0].text;
+    // The respawned subprocess defers history to pendingInitialPrompt so it can
+    // be bundled with the next user message — clean, with no corrupted thinking.
+    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
     expect(text).toContain('Conversation history');
     expect(text).toContain('clean reply');
     expect(text).not.toContain('cannot be modified');

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -255,16 +255,15 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // With history, the initial prompt is deferred to pendingInitialPrompt so it
-    // can be bundled with the first user message into a single turn (prevents
-    // double-response when the session restarts mid-menu).
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // Nothing written to stdin yet — history is deferred to first sendMessage call
+    expect(lastProcess!.stdin!.write.mock.calls.length).toBe(0);
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     expect(text).toContain('Conversation history');
     expect(text).toContain('User: Hello');
     expect(text).toContain('Assistant: Hi there!');
-    // Nothing written to stdin yet (deferred)
-    expect(lastProcess!.stdin!.write.mock.calls.length).toBe(0);
   });
 
   // --------------------------------------------------------------------------
@@ -298,8 +297,9 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     // Should contain Message 59 (last) but NOT Message 0 (first — truncated)
     expect(text).toContain('Message 59');
@@ -329,8 +329,9 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     // Summary and last message must be present
     expect(text).toContain('[Conversation Summary]');
@@ -354,8 +355,9 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     expect(text).toContain('Msg 59');
     expect(text).not.toContain('Msg 0');
@@ -382,8 +384,9 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     expect(text).toContain('[Conversation Summary]');
     expect(text).toContain('Short 1');
@@ -417,8 +420,9 @@ describe('SessionProcess', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     // Last 50 messages = indices 11–60, so 'First normal message' (idx 0) is out
     expect(text).not.toContain('First normal message');
@@ -442,8 +446,9 @@ describe('SessionProcess', () => {
     sp.historyLimit = 10; // escalated rung (e.g. after several 32MB recoveries)
     await sp.start();
 
-    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     // Only the last 10 messages (50–59) survive; 49 and older are dropped.
     expect(text).toContain('Rung 59');
@@ -476,6 +481,61 @@ describe('SessionProcess', () => {
     expect(text).not.toContain('Fresh 0');
     expect(text).not.toContain('Fresh 4');
     expect(text).not.toContain('Conversation history with this user');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-RESTART-01: subprocess crash + restart with prior history must produce
+  //   exactly ONE stdin write when the next user message arrives (no double-response).
+  //   Before the fix, activation was sent at spawn (Turn 1) and the channel XML
+  //   arrived separately (Turn 2), causing two Claude responses forwarded to the
+  //   channel. After the fix, both are bundled into a single stdin write.
+  // --------------------------------------------------------------------------
+  it('U-SP-RESTART-01: session restart with history produces one bundled stdin write, not two separate turns', async () => {
+    await sessionStore.appendTelegramMessage('alfred', 'chat:rst', 'chat:rst', {
+      role: 'user', content: 'Prior question', ts: 1000,
+    });
+    await sessionStore.appendTelegramMessage('alfred', 'chat:rst', 'chat:rst', {
+      role: 'assistant', content: 'Prior answer', ts: 1001,
+    });
+
+    const sp = new SessionProcess('chat:rst', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    const firstProcess = lastProcess!;
+    spawnMock.mockClear();
+
+    // Verify: nothing written to stdin yet (activation deferred, no double-response risk)
+    expect(firstProcess.stdin!.write.mock.calls.length).toBe(0);
+
+    jest.useFakeTimers();
+    try {
+      // Simulate subprocess crash
+      firstProcess.emit('exit', 1, null);
+      jest.advanceTimersByTime(1); // drain nextTick from kill()
+      jest.advanceTimersByTime(6000); // fire AUTO_RESTART_DELAY_MS (5s) timer
+      for (let i = 0; i < 5; i++) await Promise.resolve(); // drain spawnProcess promises
+    } finally {
+      jest.useRealTimers();
+    }
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const restarted = lastProcess!;
+    expect(restarted).not.toBe(firstProcess);
+
+    // Verify: still nothing written to the restarted process (history still deferred)
+    expect(restarted.stdin!.write.mock.calls.length).toBe(0);
+
+    // Simulates the user's next message arriving (e.g. "Y" to a pending plan menu)
+    sp.sendMessage('<channel source="telegram" chat_id="chat:rst">Y</channel>');
+
+    // Exactly ONE write — history + activation + user message bundled together
+    expect(restarted.stdin!.write.mock.calls.length).toBe(1);
+    const bundled: string = JSON.parse(restarted.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
+    expect(bundled).toContain('Prior question');
+    expect(bundled).toContain('Prior answer');
+    expect(bundled).toContain('Channels mode is active');
+    expect(bundled).toContain('Y');
+
+    await sp.stop();
   });
 
   // --------------------------------------------------------------------------
@@ -1469,8 +1529,9 @@ describe('SessionProcess — buildInitialPrompt system role', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     expect(text).toContain('System: [Image Context Summary]');
     expect(text).not.toContain('Assistant: [Image Context Summary]');
@@ -1490,8 +1551,9 @@ describe('SessionProcess — buildInitialPrompt system role', () => {
     const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
 
-    // History is deferred to pendingInitialPrompt (not written to stdin immediately)
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // sendMessage bundles history + activation + user message into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(lastProcess!.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
 
     expect(text).toContain('User: show me a picture');
     expect(text).toContain('Assistant: Here is the image.');
@@ -1798,9 +1860,11 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
     const respawned = lastProcess!;
     expect(respawned).not.toBe(firstProcess);
 
-    // The respawned subprocess defers history to pendingInitialPrompt so it can
-    // be bundled with the next user message — clean, with no corrupted thinking.
-    const text = (sp as unknown as { pendingInitialPrompt?: string }).pendingInitialPrompt ?? '';
+    // Nothing written to the new process yet — history deferred to first sendMessage
+    expect(respawned.stdin!.write.mock.calls.length).toBe(0);
+    // sendMessage bundles clean text-only history + activation into one stdin write
+    sp.sendMessage('probe');
+    const text: string = JSON.parse(respawned.stdin!.write.mock.calls[0][0] as string).message.content[0].text;
     expect(text).toContain('Conversation history');
     expect(text).toContain('clean reply');
     expect(text).not.toContain('cannot be modified');


### PR DESCRIPTION
## Problem

When a PTY-shell session (headless=false) dies while an interactive menu is pending (e.g. ExitPlanMode Pre-flight Summary) and the subprocess auto-restarts:

1. `buildInitialPrompt()` loads the conversation history (which now includes the user's latest message, e.g. "Y", because `appendTelegramMessage` runs before `getOrSpawnSession`)
2. The old code sent **history + activation prompt immediately** to stdin → this becomes **Turn 1** → Claude responds (Response 1)
3. Then `sendMessage(channelXml)` delivers the user's actual reply as **Turn 2** → Claude responds again (Response 2)

Result: two separate responses forwarded to the Telegram channel.

## Fix

For non-API sessions **with history**, store the combined `history + CHANNELS_ACTIVATION_PROMPT` in `pendingInitialPrompt` instead of writing to stdin immediately.

`sendMessage()` already checks `pendingInitialPrompt` and prepends it to the first user message, bundling everything into a **single stdin turn**:
```
[history + activation]\n\n[user's channelXml]
```

Claude processes this as one turn → one response. Fresh sessions (no history) continue to send the activation prompt immediately, so there is no regression on first-ever messages.

## Files changed

| File | Change |
|------|--------|
| `src/session/process.ts` | Defer history+activation to `pendingInitialPrompt` for non-API sessions with history |
| `tests/unit/session-process.test.ts` | 10 tests updated to check `pendingInitialPrompt` instead of `stdin.write` |
| `tests/helpers/mock-claude-mcp.js` | Fix regex (`^` removed) and check first line for embedded channel XML |

## Testing

- All 80 tests in `session-process.test.ts` pass ✅
- `pipeline-mcp.test.ts` Step 3b passes ✅  
- `phase-manual.test.ts` failures (P3-10, P3-11, P3-12, P4-12) are **pre-existing** — confirmed by running on `main` before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)