### PR TITLE
feat(line): LINE chat channel — DM/group access, pairing, slow-LLM button, images

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -78,6 +78,10 @@
       "telegram": {
         "botToken": "${BAERBEL_BOT_TOKEN}"
       },
+      "line": {
+        "channelAccessToken": "${BAERBEL_LINE_CHANNEL_ACCESS_TOKEN}",
+        "channelSecret": "${BAERBEL_LINE_CHANNEL_SECRET}"
+      },
       "claude": {
         "model": "claude-sonnet-4-6",
         "extraFlags": []

--- a/mcp/bun.lock
+++ b/mcp/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "claude-gateway-plugin",
       "dependencies": {
+        "@line/bot-sdk": "^11.0.2",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "discord.js": "^14.16.0",
         "grammy": "^1.21.0",
@@ -29,6 +30,8 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
+    "@line/bot-sdk": ["@line/bot-sdk@11.0.2", "", { "dependencies": { "@types/node": "^24.0.0" } }, "sha512-Y2PCEIlKw5ytu56HhrZt0Wfb8ZxBjrpKTlsmaZ4nWkbHKV2F0T7ZpwFfT7FqXryyqOrl8+RdvFYBBXE4B464SA=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
@@ -37,7 +40,7 @@
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -235,7 +238,7 @@
 
     "undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -260,5 +263,9 @@
     "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
 
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@types/ws/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }
 }

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -7,6 +7,7 @@
     "start": "bun install --no-summary && bun server.ts"
   },
   "dependencies": {
+    "@line/bot-sdk": "^11.0.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "discord.js": "^14.16.0",
     "grammy": "^1.21.0",

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -14,6 +14,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { TelegramModule } from './tools/telegram/module';
 import { DiscordModule } from './tools/discord/module';
+import { LineModule } from './tools/line/module';
 import { CronModule } from './tools/cron/module';
 import { SkillsModule } from './tools/skills/module';
 import { AgentModule } from './tools/agent/module';
@@ -33,6 +34,7 @@ function isChannelModule(mod: AnyModule): mod is ChannelModule {
 const modules: AnyModule[] = [
   new TelegramModule(),
   new DiscordModule(),
+  new LineModule(),
   new CronModule(),
   new SkillsModule(),
   new AgentModule(),

--- a/mcp/tools/line/module.ts
+++ b/mcp/tools/line/module.ts
@@ -1,0 +1,127 @@
+/**
+ * LINE outbound tool module — exposes `line_reply` to the Claude session.
+ *
+ * LINE is a ToolModule (reply-only, like ApiModule): inbound arrives via the
+ * gateway's Express webhook route (src/api/line-webhook-router.ts), not here.
+ *
+ * Delivery is reply-token-first → push fallback (matches openclaw/hermes-agent):
+ * LINE counts push/broadcast against the OA's monthly quota but reply-token
+ * messages are FREE, so we send via the reply API when a (still-valid) reply_token
+ * is passed, and fall back to push if it's absent or expired/used (the single-use
+ * token has no guaranteed lifetime — ~1 min — so push remains the safety net).
+ */
+import type { ToolModule, McpToolDefinition, McpToolResult, ToolVisibility } from '../../types';
+import { messagingApi } from '@line/bot-sdk';
+import { chunkText, planLineSend, LINE_TEXT_LIMIT } from './pure';
+
+export class LineModule implements ToolModule {
+  id = 'line';
+  toolVisibility: ToolVisibility = 'current-channel';
+
+  isEnabled(): boolean {
+    return process.env.GATEWAY_ORIGIN_CHANNEL === 'line';
+  }
+
+  getTools(): McpToolDefinition[] {
+    return [
+      {
+        name: 'line_reply',
+        description:
+          'Send a reply to the current LINE user. ' +
+          'Pass chat_id (the LINE userId shown in the <channel> tag) and text. ' +
+          'Also pass reply_token from the <channel> tag when present — it sends the ' +
+          'reply for FREE (push messages count against the LINE quota); the tool ' +
+          'automatically falls back to push if the token is expired/used. ' +
+          'Long text is split into multiple messages automatically.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            chat_id: {
+              type: 'string',
+              description: 'LINE userId to send to (the chat_id from the channel turn).',
+            },
+            text: {
+              type: 'string',
+              description: 'Message text. Automatically split into <=5000-char messages.',
+            },
+            reply_token: {
+              type: 'string',
+              description:
+                'Optional single-use reply token from the <channel> tag. When valid, the ' +
+                'reply is sent free via the reply API; falls back to push automatically.',
+            },
+          },
+          required: ['chat_id', 'text'],
+        },
+      },
+    ];
+  }
+
+  async handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+    if (name === 'line_reply') return this.handleReply(args);
+    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+  }
+
+  private async handleReply(args: Record<string, unknown>): Promise<McpToolResult> {
+    const chatId = typeof args.chat_id === 'string' ? args.chat_id : '';
+    const text = typeof args.text === 'string' ? args.text : '';
+    const replyToken = typeof args.reply_token === 'string' ? args.reply_token : '';
+    const token = process.env.LINE_CHANNEL_ACCESS_TOKEN ?? '';
+
+    if (!chatId) {
+      return { content: [{ type: 'text', text: 'line_reply: missing chat_id' }], isError: true };
+    }
+    if (!text) {
+      return { content: [{ type: 'text', text: 'line_reply: text cannot be empty' }], isError: true };
+    }
+
+    // Refresh mode: the gateway (LineReplyManager) is the sole LINE sender — it
+    // observes this tool call in the session output stream and delivers the
+    // reply (free reply, or cache + postback button when slow). Sending here too
+    // would double-send and contend for the single-use reply token, so skip it.
+    if (process.env.LINE_REPLY_REFRESH === '1') {
+      return { content: [{ type: 'text', text: 'Reply handed to gateway for delivery.' }] };
+    }
+    if (!token) {
+      return {
+        content: [{ type: 'text', text: 'line_reply: missing LINE_CHANNEL_ACCESS_TOKEN' }],
+        isError: true,
+      };
+    }
+
+    const client = new messagingApi.MessagingApiClient({
+      channelAccessToken: token,
+    });
+
+    const toMessages = (group: string[]) =>
+      group.map((t) => ({ type: 'text' as const, text: t }));
+    const push = (group: string[]) => client.pushMessage({ to: chatId, messages: toMessages(group) });
+
+    const chunks = chunkText(text, LINE_TEXT_LIMIT);
+    const plan = planLineSend(chunks, replyToken.length > 0);
+    let via = 'push';
+    try {
+      // Reply-token-first: the first batch goes via the FREE reply API when a token
+      // is present, falling back to push if the token is expired/used. Remaining
+      // batches always push (a reply token is single-use).
+      if (plan.replyBatch) {
+        try {
+          await client.replyMessage({ replyToken, messages: toMessages(plan.replyBatch) });
+          via = plan.pushBatches.length > 0 ? 'reply + push' : 'reply';
+        } catch {
+          await push(plan.replyBatch); // token expired/used → push fallback
+          via = 'push (reply fallback)';
+        }
+      }
+      for (const group of plan.pushBatches) await push(group);
+      return {
+        content: [{ type: 'text', text: `Sent ${chunks.length} message(s) to LINE (${via}).` }],
+      };
+    } catch (err) {
+      return {
+        content: [{ type: 'text', text: `line_reply failed: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+}

--- a/mcp/tools/line/pure.ts
+++ b/mcp/tools/line/pure.ts
@@ -20,7 +20,8 @@ export function chunkText(text: string, limit = LINE_TEXT_LIMIT): string[] {
   let rest = text;
   while (rest.length > limit) {
     let cut = rest.lastIndexOf('\n', limit);
-    if (cut <= 0) cut = limit; // no newline in range — hard cut
+    if (cut < 0) cut = limit; // not found — hard cut
+    else if (cut === 0) { rest = rest.slice(1); continue; } // leading newline — skip, retry
     out.push(rest.slice(0, cut));
     rest = rest.slice(cut).replace(/^\n/, '');
   }

--- a/mcp/tools/line/pure.ts
+++ b/mcp/tools/line/pure.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure, dependency-free helpers for the LINE channel — unit-tested in isolation
+ * (mirrors mcp/tools/telegram/pure.ts and mcp/tools/discord/outbound.ts chunkText).
+ */
+
+/** LINE hard limit: max characters in a single text message object. */
+export const LINE_TEXT_LIMIT = 5000;
+/** LINE hard limit: max message objects per push/reply request. */
+export const LINE_MAX_MESSAGES_PER_REQUEST = 5;
+
+/**
+ * Split text into chunks each <= limit chars. Prefers to break on a newline
+ * within the limit; falls back to a hard cut. Always returns at least one chunk
+ * (an empty string in → [''], so callers always have something to send).
+ */
+export function chunkText(text: string, limit = LINE_TEXT_LIMIT): string[] {
+  if (limit <= 0) return [text];
+  if (text.length === 0) return [''];
+  const out: string[] = [];
+  let rest = text;
+  while (rest.length > limit) {
+    let cut = rest.lastIndexOf('\n', limit);
+    if (cut <= 0) cut = limit; // no newline in range — hard cut
+    out.push(rest.slice(0, cut));
+    rest = rest.slice(cut).replace(/^\n/, '');
+  }
+  if (rest.length > 0) out.push(rest);
+  return out.length > 0 ? out : [''];
+}
+
+/** Group items into batches of <= size (default = LINE per-request message cap). */
+export function batch<T>(items: T[], size = LINE_MAX_MESSAGES_PER_REQUEST): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+export interface LineSendPlan {
+  /** First batch (<=5 objects) to send via the FREE reply API, or null when no usable reply token. */
+  replyBatch: string[] | null;
+  /** Remaining batches to send via the metered push API. */
+  pushBatches: string[][];
+}
+
+/**
+ * Decide how to deliver chunked text given whether a usable reply token exists.
+ *
+ * Reply-token-first to save push quota: LINE counts push/broadcast against the OA
+ * monthly message quota but **reply-token messages are free**. The single-use token
+ * can carry one reply call of up to LINE_MAX_MESSAGES_PER_REQUEST objects, so it
+ * takes the FIRST batch; anything beyond one batch must push. With no token,
+ * everything pushes. The runtime falls back to push if the reply call fails (token
+ * expired/invalid/already used) — that fallback lives in module.ts, not here.
+ */
+export function planLineSend(chunks: string[], hasReplyToken: boolean): LineSendPlan {
+  const batches = batch(chunks);
+  if (!hasReplyToken || batches.length === 0) {
+    return { replyBatch: null, pushBatches: batches };
+  }
+  return { replyBatch: batches[0], pushBatches: batches.slice(1) };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "claude-gateway",
+  "name": "@0xmaxma/claude-gateway",
   "version": "1.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-gateway",
+      "name": "@0xmaxma/claude-gateway",
       "version": "1.3.16",
       "hasInstallScript": true,
       "dependencies": {
+        "@line/bot-sdk": "^11.0.2",
         "@xterm/headless": "^6.0.0",
         "chokidar": "^3.5.0",
         "cron-parser": "^5.5.0",
@@ -1015,6 +1016,33 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@line/bot-sdk": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.0.2.tgz",
+      "integrity": "sha512-Y2PCEIlKw5ytu56HhrZt0Wfb8ZxBjrpKTlsmaZ4nWkbHKV2F0T7ZpwFfT7FqXryyqOrl8+RdvFYBBXE4B464SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^24.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@line/bot-sdk/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@line/bot-sdk/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@line/bot-sdk": "^11.0.2",
     "@xterm/headless": "^6.0.0",
     "chokidar": "^3.5.0",
     "cron-parser": "^5.5.0",

--- a/scripts/mock-line-webhook.ts
+++ b/scripts/mock-line-webhook.ts
@@ -1,0 +1,59 @@
+/**
+ * mock-line-webhook.ts — simulate "a LINE user said X" against a running gateway,
+ * without the LINE app or a tunnel. Builds a valid webhook payload, signs it with
+ * the channel secret (x-line-signature), and POSTs it to the gateway route.
+ *
+ * Usage:
+ *   LINE_CHANNEL_SECRET=... bun scripts/mock-line-webhook.ts "สวัสดี"
+ *
+ * Env overrides:
+ *   LINE_CHANNEL_SECRET   (required) the agent's channel secret used to sign
+ *   LINE_WEBHOOK_URL      target route (default http://localhost:3021/line/webhook)
+ *   LINE_MOCK_USER_ID     sender userId (default Umock00000000000000000000000000)
+ */
+import { createHmac } from 'node:crypto';
+
+const text = process.argv.slice(2).join(' ') || 'hello from mock-line-webhook';
+const secret = process.env.LINE_CHANNEL_SECRET ?? '';
+const url = process.env.LINE_WEBHOOK_URL ?? 'http://localhost:3021/line/webhook';
+const userId = process.env.LINE_MOCK_USER_ID ?? 'Umock00000000000000000000000000';
+
+if (!secret) {
+  console.error('error: set LINE_CHANNEL_SECRET to the agent channel secret');
+  process.exit(1);
+}
+
+const body = JSON.stringify({
+  destination: 'mock',
+  events: [
+    {
+      type: 'message',
+      timestamp: Date.now(),
+      replyToken: `mock-reply-${Date.now()}`,
+      source: { type: 'user', userId },
+      message: { type: 'text', id: `mock-${Date.now()}`, text },
+    },
+  ],
+});
+
+const signature = createHmac('sha256', secret).update(body).digest('base64');
+
+async function main(): Promise<void> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-line-signature': signature },
+    body,
+  });
+  console.log(`POST ${url}`);
+  console.log(`→ ${res.status} ${res.statusText}`);
+  console.log(`  user=${userId} text=${JSON.stringify(text)}`);
+  if (res.status !== 200) {
+    console.error('  (non-200 — check the channel secret matches the agent config)');
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('mock-line-webhook failed:', err);
+  process.exit(1);
+});

--- a/src/agent/builtin-commands.ts
+++ b/src/agent/builtin-commands.ts
@@ -1,4 +1,4 @@
-export type CommandChannel = 'telegram' | 'discord' | 'api';
+export type CommandChannel = 'telegram' | 'discord' | 'line' | 'api';
 
 interface CommandDef {
   channels: CommandChannel[];
@@ -30,6 +30,10 @@ function buildRegex(channel: CommandChannel): RegExp {
     .map(([cmd, def]) =>
       def.wordBoundary === false ? `^\/${cmd}(\\s|$)` : `^\/${cmd}\\b`
     );
+  // No commands registered for this channel (e.g. 'line') → match nothing.
+  // `new RegExp('')` matches EVERY string, which would misroute all messages
+  // into the command handler so they'd never reach the agent.
+  if (parts.length === 0) return /(?!)/;
   return new RegExp(parts.join('|'));
 }
 

--- a/src/agent/line-pure.ts
+++ b/src/agent/line-pure.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure, dependency-free LINE text helpers used by the gateway-side
+ * LineReplyManager (src/agent/line-reply-manager.ts).
+ *
+ * These mirror the chunking the MCP `line_reply` tool does in
+ * mcp/tools/line/pure.ts, but live under src/ because tsc's rootDir is ./src —
+ * src cannot import from mcp/. Ported from hermes-agent
+ * plugins/platforms/line/adapter.py (strip_markdown_preserving_urls /
+ * split_for_line, PR #18153).
+ */
+
+/** LINE hard limit: max message objects per push/reply request. */
+export const LINE_MAX_MESSAGES_PER_REQUEST = 5;
+/** Conservative per-bubble char budget for chunking (below the 5000 hard limit). */
+export const LINE_SAFE_BUBBLE_CHARS = 4500;
+
+// Markdown patterns LINE's text bubble can't render.
+const MD_LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+const MD_BOLD_RE = /\*\*([\s\S]+?)\*\*/g;
+const MD_ITALIC_RE = /(?<!\*)\*(?!\s)([\s\S]+?)(?<!\s)\*(?!\*)/g;
+const MD_CODE_INLINE_RE = /`([^`]+)`/g;
+const MD_CODE_BLOCK_RE = /```[a-zA-Z0-9_+-]*\n?([\s\S]*?)```/g;
+const MD_HEADING_RE = /^#{1,6}\s+/gm;
+const MD_BULLET_RE = /^[ \t]*[-*+]\s+/gm;
+
+/**
+ * Strip Markdown that LINE can't render, but keep URLs tappable.
+ *
+ * LINE's text bubble has zero Markdown support; bare URLs auto-link but
+ * `[label](url)` does not. So convert links to `label (url)`, keep code-block
+ * and inline-code *content* (drop the fences/backticks), and strip bold/italic/
+ * heading/bullet markers. Port of hermes `strip_markdown_preserving_urls`.
+ */
+export function stripMarkdownPreservingUrls(text: string): string {
+  if (!text) return text;
+  let t = text;
+  // Code blocks first — keep inner content, drop the fences.
+  t = t.replace(MD_CODE_BLOCK_RE, (_m, inner: string) => inner.replace(/\n+$/, ''));
+  // Inline code: keep content, drop backticks.
+  t = t.replace(MD_CODE_INLINE_RE, '$1');
+  // Markdown links → "label (url)".
+  t = t.replace(MD_LINK_RE, (_m, label: string, url: string) => `${label} (${url})`);
+  // Bold/italic markers — strip.
+  t = t.replace(MD_BOLD_RE, '$1');
+  t = t.replace(MD_ITALIC_RE, '$1');
+  // Headings + bullet markers — strip the prefix only.
+  t = t.replace(MD_HEADING_RE, '');
+  t = t.replace(MD_BULLET_RE, '• ');
+  return t;
+}
+
+/**
+ * Split text into LINE-sized bubbles, preferring paragraph/line/space breaks.
+ * Returns at most LINE_MAX_MESSAGES_PER_REQUEST chunks; overflow truncates the
+ * final chunk with an ellipsis (so the whole reply fits one Reply/Push call).
+ * Port of hermes `split_for_line`.
+ */
+export function splitForLine(text: string, maxChars = LINE_SAFE_BUBBLE_CHARS): string[] {
+  if (!text) return [];
+  if (text.length <= maxChars) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+  const half = Math.floor(maxChars * 0.5);
+  while (remaining && chunks.length < LINE_MAX_MESSAGES_PER_REQUEST) {
+    if (remaining.length <= maxChars) {
+      chunks.push(remaining);
+      remaining = '';
+      break;
+    }
+    // Break on the latest paragraph, then newline, then space within budget.
+    let cut = remaining.lastIndexOf('\n\n', maxChars);
+    if (cut < half) cut = remaining.lastIndexOf('\n', maxChars);
+    if (cut < half) cut = remaining.lastIndexOf(' ', maxChars);
+    if (cut <= 0) cut = maxChars;
+    chunks.push(remaining.slice(0, cut).replace(/\s+$/, ''));
+    remaining = remaining.slice(cut).replace(/^\s+/, '');
+  }
+
+  if (remaining) {
+    // Truncate gracefully — the 5-bubble budget is spent.
+    if (chunks.length > 0) {
+      let tail = chunks[chunks.length - 1];
+      if (tail.length > maxChars - 1) tail = tail.slice(0, maxChars - 1);
+      chunks[chunks.length - 1] = tail.replace(/\s+$/, '') + '…';
+    } else {
+      chunks.push(remaining.slice(0, maxChars - 1) + '…');
+    }
+  }
+  return chunks;
+}

--- a/src/agent/line-reply-manager.ts
+++ b/src/agent/line-reply-manager.ts
@@ -235,18 +235,18 @@ export class LineReplyManager {
       const messages = chunks
         .slice(0, LINE_MAX_MESSAGES_PER_REQUEST)
         .map((c) => this.textMessage(c));
+      // Flip to DELIVERED synchronously before any await so that a concurrent
+      // tap sees DELIVERED and short-circuits instead of double-sending.
+      this.markDelivered(requestId);
+      this.clearPendingButton(chatId, requestId);
       try {
         await this.client.replyMessage({ replyToken: freshToken, messages });
-        this.markDelivered(requestId);
-        this.clearPendingButton(chatId, requestId);
       } catch (err) {
         this.logger.warn('LINE: postback reply failed; falling back to push', {
           error: (err as Error).message,
         });
         try {
           await this.client.pushMessage({ to: chatId, messages });
-          this.markDelivered(requestId);
-          this.clearPendingButton(chatId, requestId);
         } catch (err2) {
           this.logger.error('LINE: postback push fallback failed', {
             error: (err2 as Error).message,

--- a/src/agent/line-reply-manager.ts
+++ b/src/agent/line-reply-manager.ts
@@ -1,0 +1,402 @@
+/**
+ * LineReplyManager — gateway-side LINE outbound + slow-LLM postback button.
+ *
+ * Direct port of hermes-agent's `plugins/platforms/line/adapter.py` slow-LLM
+ * flow (PR #18153, leepoweii), adapted to claude-gateway: the LLM runs in a
+ * subprocess and LINE inbound arrives via the webhook router, so the token
+ * lifecycle + state machine live here (one instance per LINE-enabled agent,
+ * owned by AgentRunner) instead of in the channel adapter.
+ *
+ * Why it exists: LINE reply tokens are single-use and expire ~60s after the
+ * user's message; replying with the token is FREE, push is metered. When the
+ * agent is slow, we burn the token (before it expires) to send a tappable
+ * Template Buttons bubble; tapping it delivers a fresh reply token, so the
+ * cached answer goes out free. No tap → the answer waits in cache and expires
+ * (no auto-push). Push happens only as a fallback when a reply-token send fails.
+ *
+ * Mapping to the python source:
+ *   onInbound        ← reply-token stash + _keep_typing timer arm
+ *   fireButton       ← _fire_postback (1188–1213)
+ *   onAnswer         ← send + _send_text_chunks (1079–1133)
+ *   handlePostback   ← _handle_postback_event (996–1053)
+ *   markInterrupted  ← interrupt_session_activity (1226–1231)
+ *   RequestCache     ← RequestCache (283–366)
+ */
+import { messagingApi } from '@line/bot-sdk';
+import { createLogger } from '../logger';
+import {
+  splitForLine,
+  stripMarkdownPreservingUrls,
+  LINE_MAX_MESSAGES_PER_REQUEST,
+} from './line-pure';
+
+// hermes constants (adapter.py 114, 123–129, 309–310).
+const REPLY_TOKEN_TTL_MS = 50_000; // conservative cap below LINE's ~60s
+const READY_TTL_MS = 3_600_000; // 1h for READY/ERROR/DELIVERED entries
+const PENDING_TTL_MS = 86_400_000; // 24h for PENDING (button sent, LLM running)
+const PRUNE_INTERVAL_MS = 600_000; // 10 min
+
+const DEFAULT_BUTTON_LABEL = 'Get answer';
+const DEFAULT_PENDING_TEXT =
+  '🤔 Still thinking. Tap below to fetch the answer when it\'s ready.';
+const DEFAULT_DELIVERED_TEXT = 'Already replied ✅';
+const DEFAULT_INTERRUPTED_TEXT = 'Run was interrupted before completion.';
+
+enum State {
+  PENDING = 'pending', // button sent, LLM still running
+  READY = 'ready', // LLM done, response cached, waiting for postback tap
+  DELIVERED = 'delivered',
+  ERROR = 'error', // LLM raised / interrupted; cached error text waiting
+}
+
+interface CacheEntry {
+  state: State;
+  payload: string;
+  chatId: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface LineReplyManagerOptions {
+  agentId: string;
+  logDir: string;
+  accessToken: string;
+  /** Seconds before the button fires. Caller guarantees > 0. */
+  thresholdSeconds: number;
+  buttonLabel?: string;
+  pendingText?: string;
+}
+
+export class LineReplyManager {
+  private readonly client: messagingApi.MessagingApiClient;
+  private readonly logger: ReturnType<typeof createLogger>;
+  private readonly thresholdMs: number;
+  private readonly buttonLabel: string;
+  private readonly pendingText: string;
+  private readonly deliveredText = DEFAULT_DELIVERED_TEXT;
+  private readonly interruptedText = DEFAULT_INTERRUPTED_TEXT;
+
+  // Cache state machine (RequestCache).
+  private readonly cache = new Map<string, CacheEntry>();
+  private ridSeq = 0;
+
+  // Per-chat runtime state.
+  private readonly replyTokens = new Map<string, { token: string; expiresAt: number }>();
+  private readonly pendingButtons = new Map<string, string>(); // chatId → rid
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly turns = new Map<string, number>();
+  private readonly answeredTurn = new Map<string, number>();
+
+  private readonly pruneTimer: NodeJS.Timeout;
+
+  constructor(opts: LineReplyManagerOptions) {
+    this.client = new messagingApi.MessagingApiClient({
+      channelAccessToken: opts.accessToken,
+    });
+    this.logger = createLogger(`line-reply:${opts.agentId}`, opts.logDir);
+    this.thresholdMs = Math.max(1, opts.thresholdSeconds) * 1000;
+    this.buttonLabel = (opts.buttonLabel || DEFAULT_BUTTON_LABEL).slice(0, 20) || DEFAULT_BUTTON_LABEL;
+    this.pendingText = opts.pendingText || DEFAULT_PENDING_TEXT;
+    this.pruneTimer = setInterval(() => this.prune(), PRUNE_INTERVAL_MS);
+    this.pruneTimer.unref?.();
+  }
+
+  // ── Inbound: new user turn ────────────────────────────────────────────────
+  /**
+   * A user message arrived: stash its reply token and (by default) arm the
+   * slow-button timer.
+   *
+   * `opts.armButton === false` stashes the token + bumps the turn counter but
+   * does NOT arm the button — used for group/room turns, where the shared-tap
+   * button is disabled but the answer must still be delivered. Crucially the
+   * reply token is still stashed so `onAnswer` can reply→push (the subprocess
+   * suppresses its own LINE send under LINE_REPLY_REFRESH, so the gateway is the
+   * only thing that delivers; skipping the stash would silently drop the answer).
+   */
+  onInbound(chatId: string, replyToken: string, opts?: { armButton?: boolean }): void {
+    if (!chatId || !replyToken) return;
+    this.clearTimer(chatId);
+    // A new turn supersedes a PREVIOUS turn's button only once that turn's answer
+    // has resolved (READY/ERROR/DELIVERED): retiring it from the one-button guard
+    // lets THIS turn fire its own button so its answer isn't swallowed (a prior
+    // READY-but-untapped button would otherwise block fireButton, and onAnswer's
+    // setReady would no-op). A still-PENDING button (rapid messages, answer not
+    // yet in) is kept, preserving the one-outstanding-button invariant. The old
+    // cache entry stays intact either way, so a tap on the old bubble in chat
+    // history still resolves.
+    const prevRid = this.pendingButtons.get(chatId);
+    if (prevRid && this.cache.get(prevRid)?.state !== State.PENDING) {
+      this.pendingButtons.delete(chatId);
+    }
+    this.turns.set(chatId, (this.turns.get(chatId) ?? 0) + 1);
+    this.answeredTurn.delete(chatId);
+    this.replyTokens.set(chatId, { token: replyToken, expiresAt: Date.now() + REPLY_TOKEN_TTL_MS });
+    if (opts?.armButton === false) return; // group/room: deliver via onAnswer, no button
+    const t = setTimeout(() => {
+      void this.fireButton(chatId);
+    }, this.thresholdMs);
+    t.unref?.();
+    this.timers.set(chatId, t);
+  }
+
+  // ── Slow path: send the Template Buttons bubble (_fire_postback) ───────────
+  private async fireButton(chatId: string): Promise<void> {
+    this.timers.delete(chatId);
+    // Agent already answered (token consumed) → nothing to do.
+    if (!this.replyTokens.has(chatId)) return;
+    // One outstanding button per chat.
+    if (this.pendingButtons.has(chatId)) return;
+
+    const rid = this.registerPending(chatId);
+    this.pendingButtons.set(chatId, rid);
+    const token = this.consumeReplyToken(chatId);
+    if (!token) {
+      this.pendingButtons.delete(chatId);
+      this.cache.delete(rid);
+      return;
+    }
+    try {
+      await this.client.replyMessage({
+        replyToken: token,
+        messages: [this.buildButtonMessage(rid)],
+      });
+      this.logger.info('LINE: sent slow-LLM postback button', { chatId, rid });
+    } catch (err) {
+      this.logger.warn('LINE: postback button send failed', { error: (err as Error).message });
+      this.pendingButtons.delete(chatId);
+    }
+  }
+
+  // ── Answer ready (send + _send_text_chunks) ───────────────────────────────
+  /** The agent produced its reply text for this turn. */
+  async onAnswer(chatId: string, text: string): Promise<void> {
+    if (!chatId) return;
+    // Idempotency: tool_use and result can both surface the same answer.
+    const turn = this.turns.get(chatId);
+    if (turn !== undefined) {
+      if (this.answeredTurn.get(chatId) === turn) return;
+      this.answeredTurn.set(chatId, turn);
+    }
+    this.clearTimer(chatId);
+
+    // A button is outstanding → cache the answer for the user to fetch via tap.
+    const pendingRid = this.pendingButtons.get(chatId);
+    if (pendingRid) {
+      this.setReady(pendingRid, text);
+      return;
+    }
+    await this.sendChunks(chatId, text);
+  }
+
+  private async sendChunks(chatId: string, text: string): Promise<void> {
+    const chunks = splitForLine(stripMarkdownPreservingUrls(text));
+    if (chunks.length === 0) return;
+    const messages = chunks.slice(0, LINE_MAX_MESSAGES_PER_REQUEST).map((c) => this.textMessage(c));
+
+    const token = this.consumeReplyToken(chatId);
+    if (token) {
+      try {
+        await this.client.replyMessage({ replyToken: token, messages });
+        return;
+      } catch (err) {
+        this.logger.info('LINE: reply token rejected; falling back to push', {
+          error: (err as Error).message,
+        });
+        // fall through to push
+      }
+    }
+    try {
+      await this.client.pushMessage({ to: chatId, messages });
+    } catch (err) {
+      this.logger.error('LINE: push send failed', { error: (err as Error).message });
+    }
+  }
+
+  // ── Postback tap (_handle_postback_event) ─────────────────────────────────
+  /**
+   * Handle a tapped postback. Returns true when it is OUR refresh button (so the
+   * caller must NOT forward it to the agent); false for any other postback.
+   */
+  async handlePostback(chatId: string, freshToken: string, data: string): Promise<boolean> {
+    let parsed: { action?: string; request_id?: string };
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return false;
+    }
+    if (parsed?.action !== 'show_response') return false;
+    // From here on it's ours — never wake the agent, even if malformed/stale.
+    const requestId = parsed.request_id ?? '';
+    const entry = requestId ? this.cache.get(requestId) : undefined;
+    if (!freshToken || !entry) return true;
+
+    if (entry.state === State.READY) {
+      const chunks = splitForLine(stripMarkdownPreservingUrls(entry.payload));
+      const messages = chunks
+        .slice(0, LINE_MAX_MESSAGES_PER_REQUEST)
+        .map((c) => this.textMessage(c));
+      try {
+        await this.client.replyMessage({ replyToken: freshToken, messages });
+        this.markDelivered(requestId);
+        this.clearPendingButton(chatId, requestId);
+      } catch (err) {
+        this.logger.warn('LINE: postback reply failed; falling back to push', {
+          error: (err as Error).message,
+        });
+        try {
+          await this.client.pushMessage({ to: chatId, messages });
+          this.markDelivered(requestId);
+          this.clearPendingButton(chatId, requestId);
+        } catch (err2) {
+          this.logger.error('LINE: postback push fallback failed', {
+            error: (err2 as Error).message,
+          });
+        }
+      }
+    } else if (entry.state === State.ERROR) {
+      await this.safeReply(freshToken, entry.payload || this.interruptedText);
+      this.markDelivered(requestId);
+      this.clearPendingButton(chatId, requestId);
+    } else if (entry.state === State.DELIVERED) {
+      await this.safeReply(freshToken, this.deliveredText);
+    } else if (entry.state === State.PENDING) {
+      // Still working — re-issue the wait notice; the original button stays
+      // tappable in chat history for a later tap.
+      await this.safeReply(freshToken, this.pendingText);
+    }
+    return true;
+  }
+
+  /** The turn was interrupted/cancelled — surface an error for any pending button. */
+  markInterrupted(chatId: string): void {
+    this.clearTimer(chatId);
+    const rid = this.pendingButtons.get(chatId);
+    if (rid) {
+      this.setError(rid, this.interruptedText);
+      this.pendingButtons.delete(chatId);
+    }
+  }
+
+  disposeChat(chatId: string): void {
+    this.clearTimer(chatId);
+    this.replyTokens.delete(chatId);
+    this.pendingButtons.delete(chatId);
+    this.turns.delete(chatId);
+    this.answeredTurn.delete(chatId);
+  }
+
+  disposeAll(): void {
+    for (const t of this.timers.values()) clearTimeout(t);
+    this.timers.clear();
+    clearInterval(this.pruneTimer);
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+  private clearTimer(chatId: string): void {
+    const t = this.timers.get(chatId);
+    if (t) {
+      clearTimeout(t);
+      this.timers.delete(chatId);
+    }
+  }
+
+  /** Clear the chat's pending-button guard only if it still points at `rid`
+   *  (so delivering/tapping a superseded button can't clear a newer one). */
+  private clearPendingButton(chatId: string, rid: string): void {
+    if (this.pendingButtons.get(chatId) === rid) this.pendingButtons.delete(chatId);
+  }
+
+  private consumeReplyToken(chatId: string): string {
+    const entry = this.replyTokens.get(chatId);
+    if (!entry) return '';
+    this.replyTokens.delete(chatId); // single-use
+    if (!entry.token || Date.now() >= entry.expiresAt) return '';
+    return entry.token;
+  }
+
+  private async safeReply(token: string, text: string): Promise<void> {
+    try {
+      await this.client.replyMessage({ replyToken: token, messages: [this.textMessage(text)] });
+    } catch (err) {
+      this.logger.debug('LINE: safeReply failed', { error: (err as Error).message });
+    }
+  }
+
+  private textMessage(text: string): messagingApi.TextMessage {
+    return { type: 'text', text };
+  }
+
+  private buildButtonMessage(rid: string): messagingApi.TemplateMessage {
+    const truncated = this.pendingText.length <= 160 ? this.pendingText : this.pendingText.slice(0, 157) + '...';
+    const alt = this.pendingText.length <= 400 ? this.pendingText : this.pendingText.slice(0, 397) + '...';
+    return {
+      type: 'template',
+      altText: alt,
+      template: {
+        type: 'buttons',
+        text: truncated,
+        actions: [
+          {
+            type: 'postback',
+            label: this.buttonLabel,
+            data: JSON.stringify({ action: 'show_response', request_id: rid }),
+            displayText: this.buttonLabel,
+          },
+        ],
+      },
+    };
+  }
+
+  // ── RequestCache ──────────────────────────────────────────────────────────
+  private registerPending(chatId: string): string {
+    const rid = `rr-${Date.now().toString(36)}-${(this.ridSeq++).toString(36)}`;
+    const now = Date.now();
+    this.cache.set(rid, { state: State.PENDING, payload: '', chatId, createdAt: now, updatedAt: now });
+    return rid;
+  }
+
+  private setReady(rid: string, payload: string): void {
+    const e = this.cache.get(rid);
+    if (!e || e.state !== State.PENDING) return;
+    e.state = State.READY;
+    e.payload = payload;
+    e.updatedAt = Date.now();
+  }
+
+  private setError(rid: string, message: string): void {
+    const e = this.cache.get(rid);
+    if (!e || e.state !== State.PENDING) return;
+    e.state = State.ERROR;
+    e.payload = message;
+    e.updatedAt = Date.now();
+  }
+
+  private markDelivered(rid: string): void {
+    const e = this.cache.get(rid);
+    if (!e || (e.state !== State.READY && e.state !== State.ERROR)) return;
+    e.state = State.DELIVERED;
+    e.payload = ''; // free the LLM answer text immediately; DELIVERED sentinel is all we need
+    e.updatedAt = Date.now();
+  }
+
+  private prune(): void {
+    const now = Date.now();
+    for (const [rid, e] of this.cache) {
+      const ttl = e.state === State.PENDING ? PENDING_TTL_MS : READY_TTL_MS;
+      const stamp = e.state === State.PENDING ? e.createdAt : e.updatedAt;
+      if (now - stamp > ttl) this.cache.delete(rid);
+    }
+    // Reap per-chat turn counters for chats with no live state left, so they
+    // don't grow unbounded as distinct users come and go. A chat is "active"
+    // if it still has a cached request, an armed timer, an outstanding button,
+    // or a stashed reply token. Dropping a stale counter is safe: answeredTurn
+    // is reaped in lockstep, so the next inbound restarts idempotency cleanly.
+    const active = new Set<string>();
+    for (const e of this.cache.values()) active.add(e.chatId);
+    for (const id of this.timers.keys()) active.add(id);
+    for (const id of this.pendingButtons.keys()) active.add(id);
+    for (const id of this.replyTokens.keys()) active.add(id);
+    for (const id of this.turns.keys()) if (!active.has(id)) this.turns.delete(id);
+    for (const id of this.answeredTurn.keys()) if (!active.has(id)) this.answeredTurn.delete(id);
+  }
+}

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1535,6 +1535,11 @@ export class AgentRunner extends EventEmitter {
   }
 
   private writeAutoForward(chatId: string, text: string, format: 'text' | 'html' = 'text'): void {
+    // LINE has no .forward consumer — route through LineReplyManager's push path.
+    if (this.channelFor(chatId) === 'line') {
+      if (this.lineReply) void this.lineReply.onAnswer(chatId, text);
+      return;
+    }
     const typingDir = this.getTypingDir(chatId);
     try {
       fs.mkdirSync(typingDir, { recursive: true });
@@ -1616,7 +1621,7 @@ export class AgentRunner extends EventEmitter {
 
   startLineReply(): void {
     const lineThreshold = this.agentConfig.line?.slowResponseThreshold ?? 45;
-    if (!this.agentConfig.line?.channelSecret || lineThreshold <= 0) return;
+    if (!this.agentConfig.line?.channelSecret || !this.agentConfig.line?.channelAccessToken || lineThreshold <= 0) return;
     if (this.lineReply) return; // already running
     this.lineReply = new LineReplyManager({
       agentId: this.agentConfig.id,

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -11,6 +11,7 @@ import { SessionStore, SessionNotInIndexError } from '../session/store';
 import { SessionCompactor } from '../session/compactor';
 import { TelegramReceiver } from '../telegram/receiver';
 import { DiscordReceiver } from '../discord/receiver';
+import { LineReplyManager } from './line-reply-manager';
 import { hasMarkdown, toTelegramHtml } from '../telegram/markdown';
 import { detectSkillCommand, formatSkillContext, type SkillRegistry } from '../skills';
 import { isBuiltinCommand } from './builtin-commands';
@@ -114,15 +115,17 @@ export class AgentRunner extends EventEmitter {
   imageSize(chatId: string): number { return this.imageSizePerChat.get(chatId) ?? 0; }
   restartPending(chatId: string): boolean { return this.pendingRestarts.has(chatId); }
 
-  private channelFor(chatId: string): 'telegram' | 'discord' {
+  private channelFor(chatId: string): 'telegram' | 'discord' | 'line' {
     return this.channelSourceMap.get(chatId) ?? 'telegram';
   }
 
   // Session pool
   private readonly sessions = new Map<string, SessionProcess>();
-  private readonly channelSourceMap = new Map<string, 'telegram' | 'discord'>();
+  private readonly channelSourceMap = new Map<string, 'telegram' | 'discord' | 'line'>();
   private receiver: TelegramReceiver | null = null;
   private discordReceiver: DiscordReceiver | null = null;
+  // LINE slow-LLM postback button manager (null when LINE disabled or threshold=0).
+  private lineReply: LineReplyManager | null = null;
   private readonly sessionStore: SessionStore;
   private readonly idleTimeoutMs: number;
   private readonly maxConcurrent: number;
@@ -156,7 +159,7 @@ export class AgentRunner extends EventEmitter {
   private readonly channelCoalesce = new Map<
     string,
     {
-      channelSource: 'telegram' | 'discord';
+      channelSource: 'telegram' | 'discord' | 'line';
       entries: Array<{ content?: string; meta?: Record<string, string> }>;
       timer: ReturnType<typeof setTimeout>;
     }
@@ -274,8 +277,23 @@ export class AgentRunner extends EventEmitter {
           const content = params.content ?? '';
 
           // Set channel early so all handlers (including session commands) have it
-          const channelSource = (meta['source'] === 'discord' ? 'discord' : 'telegram') as 'telegram' | 'discord';
+          const channelSource = (meta['source'] === 'discord'
+            ? 'discord'
+            : meta['source'] === 'line'
+              ? 'line'
+              : 'telegram') as 'telegram' | 'discord' | 'line';
           this.channelSourceMap.set(chatId, channelSource);
+
+          // LINE slow-LLM postback: stash this turn's reply token + arm the
+          // button timer before the token expires. In groups/rooms the shared
+          // button is disabled (armButton:false) — the token is still stashed so
+          // onAnswer delivers (reply→push), just without a button.
+          if (channelSource === 'line' && this.lineReply && meta['reply_token']) {
+            const chatType = meta['line_chat_type'];
+            this.lineReply.onInbound(chatId, meta['reply_token'], {
+              armButton: chatType === undefined || chatType === 'user',
+            });
+          }
 
           // Check if this is a built-in channel command
           const trimmedContent = content.trim();
@@ -558,7 +576,7 @@ export class AgentRunner extends EventEmitter {
    */
   private routeChannelTurn(
     chatId: string,
-    channelSource: 'telegram' | 'discord',
+    channelSource: 'telegram' | 'discord' | 'line',
     entries: Array<{ content?: string; meta?: Record<string, string> }>,
   ): void {
     if (entries.length === 0) return;
@@ -669,6 +687,8 @@ export class AgentRunner extends EventEmitter {
       'attachment_kind',
       'attachment_mime',
       'attachment_name',
+      'user_id',     // LINE: the userId the session passes back to line_reply
+      'reply_token', // LINE: single-use reply token (push is preferred; surfaced for completeness)
     ]
       .filter(k => meta[k])
       .map(k => ` ${k}="${meta[k]!.replace(/"/g, '&quot;')}"`)
@@ -700,7 +720,7 @@ export class AgentRunner extends EventEmitter {
 
   private async getOrSpawnSession(
     mapKey: string,              // Map lookup key (chatId for telegram/discord, sessionId for API)
-    source: 'telegram' | 'discord' | 'api',
+    source: 'telegram' | 'discord' | 'line' | 'api',
     sessionId?: string,          // actual session UUID (only for channel sessions; equals mapKey for API)
     modelOverride?: string,      // per-session model override from SessionMeta
   ): Promise<SessionProcess> {
@@ -748,7 +768,7 @@ export class AgentRunner extends EventEmitter {
 
   private async spawnSession(
     mapKey: string,
-    source: 'telegram' | 'discord' | 'api',
+    source: 'telegram' | 'discord' | 'line' | 'api',
     sessionId?: string,
     modelOverride?: string,
   ): Promise<SessionProcess> {
@@ -809,6 +829,9 @@ export class AgentRunner extends EventEmitter {
       proc.once('failed', () => {
         this.writeTypingError(mapKey, 'PROCESS_FAILED');
         this.sessions.delete(mapKey);
+        // LINE: surface an error for any outstanding postback button so a tap
+        // returns the interrupted notice instead of a stale "still thinking".
+        if (!proc.queryMode) this.lineReply?.markInterrupted(mapKey);
       });
       // Stop typing loop when Claude's turn truly ends.
       // Typing done is delayed 3s after result event — if new output arrives within
@@ -821,7 +844,12 @@ export class AgentRunner extends EventEmitter {
       let menuSentThisTurn = false;
       let typingDoneTimer: ReturnType<typeof setTimeout> | null = null;
       const TYPING_DONE_DELAY_MS = 3000;
-      const replyToolName = source === 'discord' ? 'mcp__gateway__discord_reply' : 'mcp__gateway__telegram_reply';
+      const replyToolName =
+        source === 'discord'
+          ? 'mcp__gateway__discord_reply'
+          : source === 'line'
+            ? 'mcp__gateway__line_reply'
+            : 'mcp__gateway__telegram_reply';
 
       proc.on('output', (line: string) => {
         try {
@@ -853,6 +881,12 @@ export class AgentRunner extends EventEmitter {
                       content: replyText,
                       ts: Date.now(),
                     });
+                    // LINE: the MCP line_reply tool's send is suppressed in
+                    // refresh mode; the gateway delivers (free reply, or cache +
+                    // postback button when slow). See LineReplyManager.
+                    if (channelSrc === 'line' && this.lineReply) {
+                      void this.lineReply.onAnswer(mapKey, replyText);
+                    }
                   }
                 }
               }
@@ -970,8 +1004,12 @@ export class AgentRunner extends EventEmitter {
                 content: text,
                 ts: Date.now(),
               });
-              // Forward to channel
-              if (channelSrcForResult !== 'discord' && hasMarkdown(text)) {
+              // Forward to channel. LINE has no .forward consumer — the gateway
+              // delivers via LineReplyManager (free reply, or cache + postback
+              // button when slow) instead of writeAutoForward.
+              if (channelSrcForResult === 'line' && this.lineReply) {
+                void this.lineReply.onAnswer(mapKey, text);
+              } else if (channelSrcForResult !== 'discord' && hasMarkdown(text)) {
                 this.writeAutoForward(mapKey, toTelegramHtml(text), 'html');
               } else {
                 this.writeAutoForward(mapKey, text);
@@ -1047,6 +1085,15 @@ export class AgentRunner extends EventEmitter {
           typingDoneTimer = null;
         }
         this.writeTypingDone(mapKey);
+        // LINE: a process exit with a button whose answer never arrived (crash /
+        // teardown mid-turn) → surface the interrupted notice so a tap returns it
+        // instead of a stale "still thinking". markInterrupted no-ops on a READY
+        // entry, so an already-answered, untapped button stays deliverable. Then
+        // clear the armed timer + stashed reply token for this chat.
+        if (!proc.queryMode) {
+          this.lineReply?.markInterrupted(mapKey);
+          this.lineReply?.disposeChat(mapKey);
+        }
       });
 
       // Deferred restart: stop session after its current turn completes
@@ -1550,6 +1597,10 @@ export class AgentRunner extends EventEmitter {
       );
       this.discordReceiver.start();
     }
+    // LINE slow-LLM postback button: gateway-side token lifecycle + cache.
+    // Enabled for any LINE agent unless its threshold is 0 (then the MCP
+    // line_reply tool keeps the plain reply-first → push-fallback path).
+    this.startLineReply();
     this.startIdleCleaner();
     this._startCleanupScheduler();
     this.logger.info('AgentRunner started', { agentId: this.agentConfig.id });
@@ -1557,6 +1608,32 @@ export class AgentRunner extends EventEmitter {
 
   updateAgentConfig(newConfig: AgentConfig): void {
     this.agentConfig = newConfig;
+    // Restart LineReplyManager if the LINE config changed so the live instance
+    // picks up a new access token, threshold, or labels without a full restart.
+    this.stopLineReply();
+    this.startLineReply();
+  }
+
+  startLineReply(): void {
+    const lineThreshold = this.agentConfig.line?.slowResponseThreshold ?? 45;
+    if (!this.agentConfig.line?.channelSecret || lineThreshold <= 0) return;
+    if (this.lineReply) return; // already running
+    this.lineReply = new LineReplyManager({
+      agentId: this.agentConfig.id,
+      logDir: this.gatewayConfig.gateway.logDir,
+      accessToken: this.agentConfig.line.channelAccessToken,
+      thresholdSeconds: lineThreshold,
+      buttonLabel: this.agentConfig.line.slowButtonLabel,
+      pendingText: this.agentConfig.line.slowPendingText,
+    });
+    this.logger.info('LineReplyManager hot-started', { agentId: this.agentConfig.id });
+  }
+
+  stopLineReply(): void {
+    if (!this.lineReply) return;
+    this.lineReply.disposeAll();
+    this.lineReply = null;
+    this.logger.info('LineReplyManager stopped', { agentId: this.agentConfig.id });
   }
 
   getAgentConfig(): AgentConfig {
@@ -1621,8 +1698,19 @@ export class AgentRunner extends EventEmitter {
     this.channelCoalesce.clear();
     this.receiver?.stop();
     this.discordReceiver?.stop();
+    this.stopLineReply();
     await Promise.all([...this.sessions.values()].map((s) => s.stop()));
     this.sessions.clear();
+  }
+
+  /**
+   * Deliver a tapped LINE postback (the slow-LLM "Get answer" button).
+   * Returns true when it was our refresh button (caller must NOT forward it to
+   * the agent); false for any other postback.
+   */
+  async handleLinePostback(chatId: string, replyToken: string, data: string): Promise<boolean> {
+    if (!this.lineReply) return false;
+    return this.lineReply.handlePostback(chatId, replyToken, data);
   }
 
   private _startCleanupScheduler(): void {
@@ -2183,7 +2271,7 @@ export class AgentRunner extends EventEmitter {
     return this.sessionStore.getAllSessionMeta(this.agentConfig.id);
   }
 
-  async listSessionsForChat(chatId: string, channel: 'telegram' | 'discord'): Promise<import('../types').SessionIndex> {
+  async listSessionsForChat(chatId: string, channel: 'telegram' | 'discord' | 'line'): Promise<import('../types').SessionIndex> {
     return this.sessionStore.listSessions(this.agentConfig.id, chatId, channel);
   }
 
@@ -2455,7 +2543,7 @@ export class AgentRunner extends EventEmitter {
    */
   async sendMessageToSession(
     rawChatId: string,
-    channel: 'telegram' | 'discord',
+    channel: 'telegram' | 'discord' | 'line',
     sessionId: string,
     message: string,
     senderName: string | undefined,

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -19,6 +19,7 @@ import { createCronRouter } from './cron-router';
 import { createWorkspaceRouter } from './workspace-router';
 import { createSkillsRouter } from './skills-router';
 import { createPackagesRouter } from './packages';
+import { createLineWebhookRouter } from './line-webhook-router';
 import { AppsRegistry } from '../apps/registry';
 import { AppInstaller } from '../apps/installer';
 import { RegistryClient } from '../apps/registry-client';
@@ -199,6 +200,12 @@ export class GatewayRouter {
     if (process.env.DEV_MODE) {
       process.stderr.write('[gateway] DEV_MODE=1 active — module cache busted on every /dashboard request. Never enable in production.\n');
     }
+    // LINE webhook MUST be mounted before express.json() — it needs the raw
+    // request bytes for x-line-signature validation (it uses its own express.raw).
+    this.app.use(
+      createLineWebhookRouter(this.agents, this.gatewayConfig?.gateway?.logDir ?? '/tmp'),
+    );
+
     this.app.use(express.json());
 
     // Ephemeral WS ticket — exchange a short-lived token for PTY stream access.

--- a/src/api/line-access.ts
+++ b/src/api/line-access.ts
@@ -1,0 +1,106 @@
+/**
+ * LINE DM access control (Tier 1) — pure, stateless sender gate.
+ *
+ * Mirrors the simple DM branches of `mcp/tools/discord/access.ts` (minus the
+ * pairing/state machine) and the closed-by-default posture of hermes-agent's
+ * three-list gate (`plugins/platforms/line/adapter.py:_allowed_for_source`) and
+ * openclaw's LINE `dmPolicy`. The webhook router reads `line` config directly
+ * and calls this once per inbound event — no env plumbing, no state files.
+ *
+ * Default (policy absent) is CLOSED: only userIds in the allowlist pass. Set
+ * `dmPolicy: 'open'` to restore "reply to anyone" behavior.
+ */
+export function isLineSenderAllowed(
+  policy: 'open' | 'allowlist' | 'disabled' | undefined,
+  allowlist: string[] | undefined,
+  userId: string,
+): boolean {
+  if (policy === 'open') return true;
+  if (policy === 'disabled') return false;
+  // 'allowlist' OR undefined (closed default) → only listed senders pass.
+  return !!userId && (allowlist ?? []).includes(userId);
+}
+
+/**
+ * Structural view of a LINE event `source` block — the only fields the gate
+ * needs. Kept local (not the SDK type) so this module stays pure and trivially
+ * testable. LINE sources are one of:
+ *   user  → { type: 'user',  userId }
+ *   group → { type: 'group', groupId, userId? }   (userId present if the sender
+ *   room  → { type: 'room',  roomId,  userId? }     consented to profile access)
+ */
+export interface LineSourceLike {
+  type?: string;
+  userId?: string;
+  groupId?: string;
+  roomId?: string;
+}
+
+export type LineSourceKind = 'user' | 'group' | 'room' | 'other';
+
+export interface ResolvedLineSource {
+  /** Conversation key — the reply/push target: userId (DM) / groupId / roomId. */
+  conversationId: string;
+  /** The human who sent the event (may be '' in groups w/o profile consent). */
+  senderId: string;
+  kind: LineSourceKind;
+}
+
+/** Map a raw LINE source to {conversationId, senderId, kind}. */
+export function resolveLineSource(source: LineSourceLike | undefined | null): ResolvedLineSource {
+  const type = source?.type;
+  if (type === 'user') {
+    const userId = source?.userId ?? '';
+    return { conversationId: userId, senderId: userId, kind: 'user' };
+  }
+  if (type === 'group') {
+    return { conversationId: source?.groupId ?? '', senderId: source?.userId ?? '', kind: 'group' };
+  }
+  if (type === 'room') {
+    return { conversationId: source?.roomId ?? '', senderId: source?.userId ?? '', kind: 'room' };
+  }
+  return { conversationId: '', senderId: '', kind: 'other' };
+}
+
+/** The subset of `line` config the conversation gate reads. */
+export interface LineAccessConfig {
+  dmPolicy?: 'open' | 'allowlist' | 'disabled';
+  dmAllowlist?: string[];
+  groupPolicy?: 'open' | 'allowlist' | 'disabled';
+  groupAllowlist?: string[];
+}
+
+/**
+ * Gate an already-resolved LINE source (the hermes three-list model). DMs keep
+ * the exact `isLineSenderAllowed` behavior; group/room are gated on the
+ * conversation id (groupId/roomId) against `groupPolicy` + `groupAllowlist`,
+ * closed by default — same posture as DMs. Unknown source kinds are denied.
+ *
+ * The webhook resolves the source once per event and reuses that result here (and
+ * for `normalizeLineEvent`) rather than re-parsing the raw source three times.
+ */
+export function isResolvedSourceAllowed(
+  cfg: LineAccessConfig | undefined,
+  resolved: ResolvedLineSource,
+): boolean {
+  const { conversationId, kind } = resolved;
+  if (kind === 'user') {
+    return isLineSenderAllowed(cfg?.dmPolicy, cfg?.dmAllowlist, conversationId);
+  }
+  if (kind === 'group' || kind === 'room') {
+    // Reuse the same closed-by-default semantics, keyed on the group/room id.
+    return isLineSenderAllowed(cfg?.groupPolicy, cfg?.groupAllowlist, conversationId);
+  }
+  return false;
+}
+
+/**
+ * Convenience wrapper that resolves a raw source and gates it in one call.
+ * Equivalent to `isResolvedSourceAllowed(cfg, resolveLineSource(source))`.
+ */
+export function isLineConversationAllowed(
+  cfg: LineAccessConfig | undefined,
+  source: LineSourceLike | undefined | null,
+): boolean {
+  return isResolvedSourceAllowed(cfg, resolveLineSource(source));
+}

--- a/src/api/line-mention.ts
+++ b/src/api/line-mention.ts
@@ -1,0 +1,44 @@
+/**
+ * LINE bot-mention detection — pure helper for the group/room activation gate.
+ *
+ * In groups/rooms the bot answers only when it is @mentioned (see
+ * `line.requireMention`), and only via LINE's NATIVE mention:
+ * `message.mention.mentionees[]`, each carrying `isSelf` — true when that
+ * mentionee IS the bot receiving the webhook. This is the reliable signal and
+ * needs no knowledge of the bot's own userId.
+ *
+ * A user who merely TYPES the bot's name as plain text (no native mention) is
+ * intentionally NOT treated as calling the bot — that message is let through
+ * silently. `@All` (mentionee `type: 'all'`) is likewise NOT a bot mention —
+ * otherwise the bot would wake on every group-wide announcement.
+ */
+
+interface MentioneeLike {
+  type?: string;
+  isSelf?: boolean;
+}
+
+interface MentionLike {
+  mentionees?: MentioneeLike[];
+}
+
+export interface LineMessageLike {
+  type?: string;
+  text?: string;
+  mention?: MentionLike;
+}
+
+/** True if the bot itself is a named mentionee (excludes @All). */
+export function hasNativeBotMention(message: LineMessageLike | undefined | null): boolean {
+  const mentionees = message?.mention?.mentionees;
+  if (!Array.isArray(mentionees)) return false;
+  return mentionees.some((m) => m?.type === 'user' && m?.isSelf === true);
+}
+
+/**
+ * Whether the bot was mentioned in this message. Native `isSelf` only — a typed
+ * `@name` in plain text does not count, and `@All` never counts.
+ */
+export function wasBotMentioned(message: LineMessageLike | undefined | null): boolean {
+  return hasNativeBotMention(message);
+}

--- a/src/api/line-pending-senders.ts
+++ b/src/api/line-pending-senders.ts
@@ -1,0 +1,142 @@
+/**
+ * LINE "pending senders" — in-memory discovery aid for the Tier 1 allowlist.
+ * When the webhook access gate drops a sender that is not on the allowlist, we
+ * remember them here (with their LINE display name, best-effort) so the admin
+ * can see who is pending and one-click-add them from the UI instead of grepping
+ * `line-webhook.log`.
+ *
+ * Intentionally ephemeral: a process-lifetime Map, no persistence. Adding to the
+ * allowlist is the durable action (config.json via the agent PATCH API); this is
+ * just a transient "pending list". Bounded per agent so a flood can't grow it.
+ */
+import { randomBytes } from 'crypto';
+
+export interface PendingSender {
+  /** The conversation/sender id: a userId (DM), groupId, or roomId. */
+  userId: string;
+  /** Best-effort display name: LINE profile name (user) or group name (group). */
+  displayName?: string;
+  /** Source kind, so the UI can label rooms and filter against the right list. */
+  kind?: 'user' | 'group' | 'room';
+  /**
+   * One-time pairing code (pairing mode). Minted once when the entry is created
+   * and never overwritten on dedup, so it stays stable for the admin to match
+   * against what the sender reports. Absent when pairing is off.
+   */
+  code?: string;
+  firstSeen: number;
+  lastSeen: number;
+  count: number;
+}
+
+/** Mint a short visual-match pairing code (6 uppercase hex). */
+export function generatePairingCode(): string {
+  return randomBytes(3).toString('hex').toUpperCase();
+}
+
+/** Max distinct senders retained per agent (oldest evicted first). */
+export const MAX_PENDING_PER_AGENT = 20;
+
+// agentId -> (id -> entry)  (id = userId | groupId | roomId)
+const store = new Map<string, Map<string, PendingSender>>();
+
+/**
+ * Record a denied knock (DM sender or group/room conversation). Dedups by id
+ * (bumps count + lastSeen, fills in a name/kind if newly resolved). Evicts the
+ * least-recently-seen entry when the per-agent cap is exceeded.
+ *
+ * `code` is set only when the entry is newly created (never overwritten on
+ * dedup), so a pairing code stays stable. Returns `true` when this call created
+ * a new entry (first contact) — the webhook uses this to send the pairing code
+ * exactly once.
+ */
+function recordDenied(
+  agentId: string,
+  id: string,
+  kind: 'user' | 'group' | 'room',
+  displayName: string | undefined,
+  now: number,
+  code?: string,
+): boolean {
+  if (!agentId || !id) return false;
+  let byId = store.get(agentId);
+  if (!byId) {
+    byId = new Map<string, PendingSender>();
+    store.set(agentId, byId);
+  }
+
+  const existing = byId.get(id);
+  if (existing) {
+    existing.lastSeen = now;
+    existing.count += 1;
+    if (displayName && !existing.displayName) existing.displayName = displayName;
+    if (!existing.kind) existing.kind = kind;
+    return false;
+  }
+
+  byId.set(id, { userId: id, displayName, kind, code, firstSeen: now, lastSeen: now, count: 1 });
+
+  if (byId.size > MAX_PENDING_PER_AGENT) {
+    let oldestId: string | null = null;
+    let oldestTs = Infinity;
+    for (const [eid, entry] of byId) {
+      if (entry.lastSeen < oldestTs) {
+        oldestTs = entry.lastSeen;
+        oldestId = eid;
+      }
+    }
+    if (oldestId) byId.delete(oldestId);
+  }
+  return true;
+}
+
+/**
+ * Record a denied 1:1 DM sender (Tier 1 discovery). Returns true on first
+ * contact (entry newly created).
+ */
+export function recordDeniedSender(
+  agentId: string,
+  userId: string,
+  displayName?: string,
+  now: number = Date.now(),
+  code?: string,
+): boolean {
+  return recordDenied(agentId, userId, 'user', displayName, now, code);
+}
+
+/**
+ * Record a denied group/room conversation (Tier 3 discovery). Returns true on
+ * first contact (entry newly created).
+ */
+export function recordDeniedConversation(
+  agentId: string,
+  conversationId: string,
+  kind: 'group' | 'room',
+  name?: string,
+  now: number = Date.now(),
+  code?: string,
+): boolean {
+  return recordDenied(agentId, conversationId, kind, name, now, code);
+}
+
+/** Pending senders for an agent, most-recent first. */
+export function getPendingSenders(agentId: string): PendingSender[] {
+  const byId = store.get(agentId);
+  if (!byId) return [];
+  return [...byId.values()].sort((a, b) => b.lastSeen - a.lastSeen);
+}
+
+/** One pending-sender entry by id (used to reuse an already-minted pairing code). */
+export function getPendingSender(agentId: string, id: string): PendingSender | undefined {
+  return store.get(agentId)?.get(id);
+}
+
+/** Drop an entry from the pending list (e.g. once added to an allowlist). */
+export function clearPendingSender(agentId: string, id: string): void {
+  store.get(agentId)?.delete(id);
+}
+
+/** Test/maintenance helper — wipe all retained senders. */
+export function _resetPendingSenders(): void {
+  store.clear();
+}

--- a/src/api/line-webhook-router.ts
+++ b/src/api/line-webhook-router.ts
@@ -1,0 +1,405 @@
+/**
+ * LINE inbound webhook route (openclaw-style: LINE is webhook-only, no polling).
+ *
+ * Mounted on the gateway's Express app BEFORE express.json() so the raw request
+ * bytes are available for signature validation (LINE signs the raw body; a
+ * re-serialized parsed body would not match).
+ *
+ * Flow: verify x-line-signature → 200 → for each text message from a 1:1 user,
+ * show a loading animation and forward a normalized {content, meta} to the
+ * target agent's existing /channel callback (the same intake Telegram uses).
+ */
+import express, { Router, type Request, type Response } from 'express';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { validateSignature, messagingApi, type webhook } from '@line/bot-sdk';
+import type { AgentRunner } from '../agent/runner';
+import { createLogger } from '../logger';
+import {
+  isResolvedSourceAllowed,
+  resolveLineSource,
+  type ResolvedLineSource,
+} from './line-access';
+import {
+  recordDeniedSender,
+  recordDeniedConversation,
+  getPendingSender,
+  generatePairingCode,
+} from './line-pending-senders';
+import { wasBotMentioned, type LineMessageLike } from './line-mention';
+
+const DEFAULT_WEBHOOK_PATH = '/line/webhook';
+const MAX_BODY_BYTES = 256 * 1024; // pre-auth body cap
+const LOADING_SECONDS = 20; // 5..60, multiple of 5; 1:1 chats only
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024; // matches MediaStore.maxUploadBytes
+
+/** Pick a file extension from an image's magic bytes; default jpg (LINE photos). */
+function sniffImageExt(buf: Buffer): string {
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpg';
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png';
+  if (buf.length >= 3 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return 'gif';
+  if (
+    buf.length >= 12 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return 'webp';
+  return 'jpg';
+}
+
+/**
+ * Fetch an inbound LINE image's bytes via the blob (data) API and write them to
+ * a temp file, returning its absolute path. The runner copies this into the
+ * agent's permanent MediaStore and tells the agent to Read it (meta.image_path).
+ * Returns null on failure; the turn still forwards (agent sees the text/empty).
+ */
+async function downloadLineImage(
+  blobClient: messagingApi.MessagingApiBlobClient,
+  messageId: string,
+): Promise<string | null> {
+  const stream = await blobClient.getMessageContent(messageId);
+  const dest = path.join(os.tmpdir(), `line-img-${messageId}-${Date.now()}.tmp`);
+  const fileStream = fs.createWriteStream(dest);
+  let total = 0;
+  let ext = 'jpg';
+  let firstChunk = true;
+  for await (const chunk of stream as AsyncIterable<Buffer | string>) {
+    const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += b.length;
+    if (total > MAX_IMAGE_BYTES) {
+      (stream as { destroy?: () => void }).destroy?.();
+      fileStream.destroy();
+      fs.rmSync(dest, { force: true });
+      throw new Error(`image exceeds ${MAX_IMAGE_BYTES} byte cap`);
+    }
+    if (firstChunk) { ext = sniffImageExt(b); firstChunk = false; }
+    fileStream.write(b);
+  }
+  await new Promise<void>((resolve, reject) => fileStream.end((err?: Error | null) => err ? reject(err) : resolve()));
+  if (total === 0) { fs.rmSync(dest, { force: true }); return null; }
+  const finalDest = dest.replace(/\.tmp$/, `.${ext}`);
+  fs.renameSync(dest, finalDest);
+  return finalDest;
+}
+
+/**
+ * One-time pairing-code message. The code is a VISUAL-MATCH token: the sender
+ * reports it to the admin, who matches it against the UI before adding them to
+ * the allowlist. The sender does NOT reply with it — say so explicitly so they
+ * don't paste it back expecting an automated unlock. Bilingual TH/EN.
+ */
+function pairingMessage(code: string, kind: 'user' | 'group' | 'room' | 'other'): string {
+  const inGroup = kind === 'group' || kind === 'room';
+  const thWhere = inGroup ? 'ในกลุ่มนี้' : '';
+  const enWhere = inGroup ? ' in this group' : '';
+  return (
+    `รหัสจับคู่ (pairing code) ของคุณคือ: ${code}\n` +
+    `กรุณาแจ้งรหัสนี้ให้แอดมินเพื่อขอเปิดใช้งานบอท${thWhere} (ไม่ต้องพิมพ์รหัสตอบกลับ)\n\n` +
+    `Your pairing code: ${code}\n` +
+    `Share this code with the admin to get access${enWhere}. (No need to reply with it.)`
+  );
+}
+
+export type NormalizedLineMessage = {
+  content: string;
+  meta: Record<string, string>;
+};
+
+/**
+ * Normalize a LINE webhook event into the gateway's {content, meta} intake shape.
+ * Returns null for anything we don't handle in the POC (non-text, non-user source).
+ *
+ * `resolved` lets the caller pass the source it already resolved for the access
+ * gate, so a single event isn't re-parsed; omitted, it resolves here.
+ */
+export function normalizeLineEvent(
+  event: webhook.Event,
+  resolved?: ResolvedLineSource,
+): NormalizedLineMessage | null {
+  if (event.type !== 'message') return null;
+  const msg = (event as webhook.MessageEvent).message;
+  // Text and image are handled; image bytes are fetched separately in handlePost
+  // (via the LINE blob API) and surfaced to the agent through meta.image_path.
+  if (!msg || (msg.type !== 'text' && msg.type !== 'image')) return null;
+  // Accept 1:1 user, group, and room sources. chat_id is the conversation key
+  // (userId / groupId / roomId — the reply/push target); user_id is the human
+  // who sent it (may be absent in groups → falls back to the conversation id).
+  const { conversationId, senderId, kind } = resolved ?? resolveLineSource(event.source);
+  if (kind === 'other' || !conversationId) return null;
+
+  const sender = senderId || conversationId;
+  const text = msg.type === 'text' ? ((msg as webhook.TextMessageContent).text ?? '') : '';
+  const meta: Record<string, string> = {
+    source: 'line',
+    chat_id: conversationId,
+    user_id: sender,
+    user: sender,
+    message_id: String(msg.id ?? ''),
+    ts: new Date(event.timestamp ?? Date.now()).toISOString(),
+    line_chat_type: kind, // 'user' | 'group' | 'room'
+  };
+  if (msg.type === 'image') meta.media_type = 'image';
+  if (typeof (event as webhook.MessageEvent).replyToken === 'string') {
+    meta.reply_token = (event as webhook.MessageEvent).replyToken as string;
+  }
+  return { content: text, meta };
+}
+
+export type NormalizedLinePostback = { chatId: string; replyToken: string; data: string };
+
+/**
+ * Normalize a LINE postback event (the slow-LLM "Get answer" button tap) into
+ * {chatId, replyToken, data}. Returns null for non-postback / non-user / tokenless
+ * events. `normalizeLineEvent` still drops postbacks; this is handled separately.
+ */
+export function normalizeLinePostback(event: webhook.Event): NormalizedLinePostback | null {
+  if (event.type !== 'postback') return null;
+  const source = event.source;
+  if (!source || source.type !== 'user' || !source.userId) return null;
+  const pe = event as webhook.PostbackEvent;
+  const data = pe.postback?.data ?? '';
+  const replyToken = typeof pe.replyToken === 'string' ? pe.replyToken : '';
+  if (!data || !replyToken) return null;
+  return { chatId: source.userId, replyToken, data };
+}
+
+/** Find the agent that has LINE configured (POC: single line-enabled agent, or by id). */
+function resolveLineAgent(
+  agents: Map<string, AgentRunner>,
+  agentId?: string,
+): AgentRunner | null {
+  if (agentId) {
+    const r = agents.get(agentId);
+    return r && r.getAgentConfig().line?.channelSecret ? r : null;
+  }
+  for (const runner of agents.values()) {
+    if (runner.getAgentConfig().line?.channelSecret) return runner;
+  }
+  return null;
+}
+
+/**
+ * Optional outbound base-URL overrides — only used to point the LINE SDK at a
+ * mock server in tests. Production passes nothing, so the SDK uses its real
+ * defaults (api.line.me / api-data.line.me). Replaces the former
+ * LINE_API_BASE / LINE_DATA_API_BASE env reads so there's no test-only env seam
+ * leaking into production code.
+ */
+export interface LineWebhookOptions {
+  apiBase?: string;
+  dataApiBase?: string;
+}
+
+export function createLineWebhookRouter(
+  agents: Map<string, AgentRunner>,
+  logDir: string,
+  opts: LineWebhookOptions = {},
+): Router {
+  const router = Router();
+  const logger = createLogger('line-webhook', logDir);
+  const rawBody = express.raw({ type: '*/*', limit: MAX_BODY_BYTES });
+
+  // LINE webhook URL verification (Console "Verify" sends a GET / empty POST).
+  const handleGet = (_req: Request, res: Response): void => {
+    res.status(200).json({ ok: true });
+  };
+
+  const handlePost = async (req: Request, res: Response): Promise<void> => {
+    const agentId = req.params.agentId as string | undefined;
+    const runner = resolveLineAgent(agents, agentId);
+    if (!runner) {
+      res.status(404).json({ error: 'no LINE-enabled agent' });
+      return;
+    }
+    const cfg = runner.getAgentConfig().line;
+    const secret = cfg?.channelSecret ?? '';
+    const signature = req.header('x-line-signature') ?? '';
+    const buf: Buffer = Buffer.isBuffer(req.body) ? req.body : Buffer.from('');
+
+    if (!secret || !signature || !validateSignature(buf, secret, signature)) {
+      logger.warn('LINE webhook rejected: bad signature', { agentId: runner.getAgentConfig().id });
+      res.status(401).json({ error: 'invalid signature' });
+      return;
+    }
+
+    // Acknowledge immediately; process events after responding.
+    res.status(200).json({ ok: true });
+
+    let events: webhook.Event[] = [];
+    try {
+      events = (JSON.parse(buf.toString('utf8')) as { events?: webhook.Event[] }).events ?? [];
+    } catch (err) {
+      logger.warn('LINE webhook: bad JSON', { error: (err as Error).message });
+      return;
+    }
+
+    const token = cfg?.channelAccessToken ?? '';
+    const client = token
+      ? new messagingApi.MessagingApiClient({
+          channelAccessToken: token,
+          ...(opts.apiBase ? { baseURL: opts.apiBase } : {}),
+        })
+      : null;
+    // Blob/data API lives on a different host (api-data.line.me) than the
+    // messaging API, so it takes its own base override (used by tests).
+    const blobClient = token
+      ? new messagingApi.MessagingApiBlobClient({
+          channelAccessToken: token,
+          ...(opts.dataApiBase ? { baseURL: opts.dataApiBase } : {}),
+        })
+      : null;
+
+    for (const event of events) {
+      // Access gate (single choke point — mirrors hermes _dispatch_event):
+      // resolve the source once and gate before any postback/message handling.
+      // Closed by default for both DMs (dmPolicy/dmAllowlist) and groups/rooms
+      // (groupPolicy/groupAllowlist). `'open'` restores answer-to-anyone.
+      const resolved = resolveLineSource(event.source);
+      if (!isResolvedSourceAllowed(cfg, resolved)) {
+        logger.debug('LINE webhook: source not allowed', {
+          agentId: runner.getAgentConfig().id,
+          kind: resolved.kind,
+          policy:
+            (resolved.kind === 'user' ? cfg?.dmPolicy : cfg?.groupPolicy) ?? '(closed)',
+          conversationId: resolved.conversationId,
+        });
+        // Remember the knock so an admin can find + add it from the UI without
+        // grepping logs, and (pairing mode) reply a one-time code the admin can
+        // visually match before +Add. The id we track is the sender (DM) or the
+        // conversation (group/room). Names are backfilled best-effort without
+        // bumping the knock count.
+        const deniedAgentId = runner.getAgentConfig().id;
+        const knockId =
+          resolved.kind === 'user' ? resolved.senderId : resolved.conversationId;
+        if (knockId) {
+          // Pairing applies only under allowlist/closed-default (open never
+          // denies; disabled is hard-off) and unless explicitly turned off.
+          const sourcePolicy = resolved.kind === 'user' ? cfg?.dmPolicy : cfg?.groupPolicy;
+          const isPairing =
+            cfg?.pairing !== false && sourcePolicy !== 'open' && sourcePolicy !== 'disabled';
+          const prev = getPendingSender(deniedAgentId, knockId);
+          const code = prev?.code ?? (isPairing ? generatePairingCode() : undefined);
+
+          let wasNew = false;
+          if (resolved.kind === 'user') {
+            wasNew = recordDeniedSender(deniedAgentId, knockId, undefined, Date.now(), code);
+            if (client) {
+              void client
+                .getProfile(knockId)
+                .then((p) => {
+                  const e = getPendingSender(deniedAgentId, knockId);
+                  if (e && p?.displayName && !e.displayName) e.displayName = p.displayName;
+                })
+                .catch(() => {});
+            }
+          } else if (resolved.kind === 'group') {
+            wasNew = recordDeniedConversation(deniedAgentId, knockId, 'group', undefined, Date.now(), code);
+            if (client) {
+              void client
+                .getGroupSummary(knockId)
+                .then((s) => {
+                  const e = getPendingSender(deniedAgentId, knockId);
+                  if (e && s?.groupName && !e.displayName) e.displayName = s.groupName;
+                })
+                .catch(() => {});
+            }
+          } else if (resolved.kind === 'room') {
+            wasNew = recordDeniedConversation(deniedAgentId, knockId, 'room', undefined, Date.now(), code);
+          }
+
+          // Send the pairing code exactly once — on first contact only — via the
+          // free reply token (never push; don't spend quota on strangers).
+          const replyToken = (event as webhook.MessageEvent).replyToken;
+          if (isPairing && wasNew && code && client && typeof replyToken === 'string' && replyToken) {
+            void client
+              .replyMessage({
+                replyToken,
+                messages: [{ type: 'text', text: pairingMessage(code, resolved.kind) }],
+              })
+              .catch((err) =>
+                logger.debug('LINE pairing code reply failed', { error: (err as Error).message }),
+              );
+          }
+        }
+        continue;
+      }
+
+      // Slow-LLM postback button tap → deliver the cached answer via the fresh
+      // reply token. Our refresh button is handled here and must NOT wake the
+      // agent; any other postback is dropped (nothing else consumes them).
+      const pb = normalizeLinePostback(event);
+      if (pb) {
+        try {
+          await runner.handleLinePostback(pb.chatId, pb.replyToken, pb.data);
+        } catch (err) {
+          logger.error('LINE webhook: postback handling failed', {
+            error: (err as Error).message,
+          });
+        }
+        continue;
+      }
+
+      const norm = normalizeLineEvent(event, resolved);
+      if (!norm) continue;
+      const userId = norm.meta.chat_id;
+
+      // Group/room activation gate: unless requireMention is explicitly false,
+      // only respond when the bot is @mentioned (native isSelf or its name).
+      // DMs (line_chat_type === 'user') always pass. This runs after normalize
+      // so non-message / non-text-image events are already filtered out.
+      if (norm.meta.line_chat_type !== 'user' && cfg?.requireMention !== false) {
+        const msg = (event as webhook.MessageEvent).message;
+        if (!wasBotMentioned(msg as unknown as LineMessageLike)) {
+          logger.debug('LINE webhook: group/room message without bot mention, ignoring', {
+            agentId: runner.getAgentConfig().id,
+            chatType: norm.meta.line_chat_type,
+            conversationId: userId,
+          });
+          continue;
+        }
+      }
+
+      // Inbound image: fetch the bytes via the blob API and hand the agent an
+      // absolute path (meta.image_path). The runner persists it to MediaStore
+      // and instructs the agent to Read it, same as Telegram attachments.
+      if (norm.meta.media_type === 'image' && blobClient && norm.meta.message_id) {
+        try {
+          const imgPath = await downloadLineImage(blobClient, norm.meta.message_id);
+          if (imgPath) norm.meta.image_path = imgPath;
+        } catch (err) {
+          logger.warn('LINE webhook: image download failed', {
+            messageId: norm.meta.message_id,
+            error: (err as Error).message,
+          });
+        }
+      }
+
+      // Loading animation (best-effort, 1:1 only — LINE rejects it for
+      // groups/rooms, where chat_id is a groupId/roomId).
+      if (client && norm.meta.line_chat_type === 'user') {
+        client
+          .showLoadingAnimation({ chatId: userId, loadingSeconds: LOADING_SECONDS })
+          .catch((err) => logger.debug('showLoadingAnimation failed', { error: (err as Error).message }));
+      }
+
+      // Forward to the agent's existing /channel intake (same path Telegram uses).
+      try {
+        await fetch(`http://127.0.0.1:${runner.getCallbackPort()}/channel`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(norm),
+        });
+      } catch (err) {
+        logger.error('LINE webhook: failed to forward to callback', {
+          error: (err as Error).message,
+        });
+      }
+    }
+  };
+
+  router.get(DEFAULT_WEBHOOK_PATH, handleGet);
+  router.get(`${DEFAULT_WEBHOOK_PATH}/:agentId`, handleGet);
+  router.post(DEFAULT_WEBHOOK_PATH, rawBody, (req, res) => void handlePost(req, res));
+  router.post(`${DEFAULT_WEBHOOK_PATH}/:agentId`, rawBody, (req, res) => void handlePost(req, res));
+
+  return router;
+}

--- a/src/api/line-webhook-router.ts
+++ b/src/api/line-webhook-router.ts
@@ -154,12 +154,27 @@ export type NormalizedLinePostback = { chatId: string; replyToken: string; data:
 export function normalizeLinePostback(event: webhook.Event): NormalizedLinePostback | null {
   if (event.type !== 'postback') return null;
   const source = event.source;
-  if (!source || source.type !== 'user' || !source.userId) return null;
+  if (!source) return null;
   const pe = event as webhook.PostbackEvent;
   const data = pe.postback?.data ?? '';
   const replyToken = typeof pe.replyToken === 'string' ? pe.replyToken : '';
   if (!data || !replyToken) return null;
-  return { chatId: source.userId, replyToken, data };
+
+  let chatId: string;
+  if (source.type === 'user') {
+    if (!source.userId) return null;
+    chatId = source.userId;
+  } else if (source.type === 'group') {
+    if (!source.groupId) return null;
+    chatId = source.groupId;
+  } else if (source.type === 'room') {
+    if (!source.roomId) return null;
+    chatId = source.roomId;
+  } else {
+    return null;
+  }
+
+  return { chatId, replyToken, data };
 }
 
 /** Find the agent that has LINE configured (POC: single line-enabled agent, or by id). */
@@ -249,8 +264,24 @@ export function createLineWebhookRouter(
       : null;
 
     for (const event of events) {
+      // Postback BEFORE access gate: a tap on our slow-LLM button must reach the
+      // cache even if the user's allowlist status changed since the button was sent.
+      // The postback data is opaque (request_id we issued), so bypassing the gate here
+      // is safe — only users who received the button can tap it.
+      const pb = normalizeLinePostback(event);
+      if (pb) {
+        try {
+          await runner.handleLinePostback(pb.chatId, pb.replyToken, pb.data);
+        } catch (err) {
+          logger.error('LINE webhook: postback handling failed', {
+            error: (err as Error).message,
+          });
+        }
+        continue;
+      }
+
       // Access gate (single choke point — mirrors hermes _dispatch_event):
-      // resolve the source once and gate before any postback/message handling.
+      // resolve the source once and gate before any message handling.
       // Closed by default for both DMs (dmPolicy/dmAllowlist) and groups/rooms
       // (groupPolicy/groupAllowlist). `'open'` restores answer-to-anyone.
       const resolved = resolveLineSource(event.source);
@@ -323,21 +354,7 @@ export function createLineWebhookRouter(
         continue;
       }
 
-      // Slow-LLM postback button tap → deliver the cached answer via the fresh
-      // reply token. Our refresh button is handled here and must NOT wake the
-      // agent; any other postback is dropped (nothing else consumes them).
-      const pb = normalizeLinePostback(event);
-      if (pb) {
-        try {
-          await runner.handleLinePostback(pb.chatId, pb.replyToken, pb.data);
-        } catch (err) {
-          logger.error('LINE webhook: postback handling failed', {
-            error: (err as Error).message,
-          });
-        }
-        continue;
-      }
-
+      // Normalize the event into our /channel intake format.
       const norm = normalizeLineEvent(event, resolved);
       if (!norm) continue;
       const userId = norm.meta.chat_id;

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -12,6 +12,7 @@ import { MediaStore } from '../history/media-store';
 import { HistoryDB } from '../history/db';
 import type { AgentSessionSummary } from '../history/types';
 import { wizardStore } from './wizard-state';
+import { getPendingSenders, clearPendingSender } from './line-pending-senders';
 import { buildGenerationPrompt, parseGeneratedFiles } from '../agent/create-agent-prompts';
 
 const MAX_MESSAGE_LENGTH = 10_000;
@@ -523,6 +524,24 @@ export function createApiRouter(
         telegram_token_preview: cfg.telegram?.botToken ? maskToken(cfg.telegram.botToken) : null,
         discord_token_preview: cfg.discord?.botToken ? maskToken(cfg.discord.botToken) : null,
         telegram_dm_policy: cfg.telegram?.botToken ? readTelegramAccess(id).dmPolicy : null,
+        line_connected: !!cfg.line?.channelSecret,
+        line_token_preview: cfg.line?.channelAccessToken ? maskToken(cfg.line.channelAccessToken) : null,
+        line_webhook_path: cfg.line?.channelSecret ? `/line/webhook/${id}` : null,
+        // DM access (Tier 1). Stored directly in the line config (no separate
+        // access file like Telegram). `dmPolicy` absent ⇒ closed/allowlist
+        // semantics at runtime; surface the raw value (null when unset) so the
+        // UI can render the effective state.
+        line_dm_policy: cfg.line?.channelSecret ? (cfg.line?.dmPolicy ?? null) : null,
+        line_dm_allowlist: cfg.line?.channelSecret ? (cfg.line?.dmAllowlist ?? []) : null,
+        // Group/room access (Tier 3). Same storage + semantics as DM, keyed on
+        // group/room ids. `requireMention` absent ⇒ true (only answer when the
+        // bot is @mentioned in a group).
+        line_group_policy: cfg.line?.channelSecret ? (cfg.line?.groupPolicy ?? null) : null,
+        line_group_allowlist: cfg.line?.channelSecret ? (cfg.line?.groupAllowlist ?? []) : null,
+        line_require_mention: cfg.line?.channelSecret ? (cfg.line?.requireMention ?? null) : null,
+        // Pairing toggle (orthogonal to dm/groupPolicy). Absent ⇒ on; surface a
+        // concrete boolean so the UI toggle reflects the effective default.
+        line_pairing: cfg.line?.channelSecret ? (cfg.line?.pairing ?? true) : null,
       }));
     res.json({ agents });
   });
@@ -1120,8 +1139,8 @@ export function createApiRouter(
       return;
     }
 
-    const body = req.body as { description?: unknown; model?: unknown; allow_tools?: unknown; telegram_bot_token?: unknown; discord_bot_token?: unknown };
-    const { description, model, allow_tools, telegram_bot_token, discord_bot_token } = body;
+    const body = req.body as { description?: unknown; model?: unknown; allow_tools?: unknown; telegram_bot_token?: unknown; discord_bot_token?: unknown; line_channel_access_token?: unknown; line_channel_secret?: unknown; line_dm_policy?: unknown; line_dm_allowlist?: unknown; line_group_policy?: unknown; line_group_allowlist?: unknown; line_require_mention?: unknown; line_pairing?: unknown };
+    const { description, model, allow_tools, telegram_bot_token, discord_bot_token, line_channel_access_token, line_channel_secret, line_dm_policy, line_dm_allowlist, line_group_policy, line_group_allowlist, line_require_mention, line_pairing } = body;
     if (description !== undefined && (typeof description !== 'string' || !description.trim())) {
       res.status(400).json({ error: 'description must be a non-empty string' });
       return;
@@ -1142,6 +1161,63 @@ export function createApiRouter(
       res.status(400).json({ error: 'discord_bot_token must be a string or null' });
       return;
     }
+    if (line_channel_access_token !== undefined && line_channel_access_token !== null && typeof line_channel_access_token !== 'string') {
+      res.status(400).json({ error: 'line_channel_access_token must be a string or null' });
+      return;
+    }
+    if (line_channel_secret !== undefined && line_channel_secret !== null && typeof line_channel_secret !== 'string') {
+      res.status(400).json({ error: 'line_channel_secret must be a string or null' });
+      return;
+    }
+    // LINE needs BOTH credentials together. Reject a half-set (one without the other),
+    // unless both are being cleared (disconnect).
+    const lineTouched = line_channel_access_token !== undefined || line_channel_secret !== undefined;
+    if (lineTouched) {
+      const at = typeof line_channel_access_token === 'string' ? line_channel_access_token.trim() : '';
+      const sec = typeof line_channel_secret === 'string' ? line_channel_secret.trim() : '';
+      const bothSet = at !== '' && sec !== '';
+      const bothClear = at === '' && sec === '';
+      if (!bothSet && !bothClear) {
+        res.status(400).json({ error: 'line_channel_access_token and line_channel_secret must be provided together' });
+        return;
+      }
+    }
+    // LINE DM access control (Tier 1). Validated independently of the credentials so
+    // policy/allowlist can be changed without re-sending the tokens.
+    if (line_dm_policy !== undefined && line_dm_policy !== null &&
+        !(typeof line_dm_policy === 'string' && ['open', 'allowlist', 'disabled'].includes(line_dm_policy))) {
+      res.status(400).json({ error: "line_dm_policy must be 'open', 'allowlist', 'disabled', or null" });
+      return;
+    }
+    if (line_dm_allowlist !== undefined && line_dm_allowlist !== null &&
+        !(Array.isArray(line_dm_allowlist) && line_dm_allowlist.every((u) => typeof u === 'string'))) {
+      res.status(400).json({ error: 'line_dm_allowlist must be an array of strings or null' });
+      return;
+    }
+    // LINE group/room access control (Tier 3). Same independence as DM access.
+    if (line_group_policy !== undefined && line_group_policy !== null &&
+        !(typeof line_group_policy === 'string' && ['open', 'allowlist', 'disabled'].includes(line_group_policy))) {
+      res.status(400).json({ error: "line_group_policy must be 'open', 'allowlist', 'disabled', or null" });
+      return;
+    }
+    if (line_group_allowlist !== undefined && line_group_allowlist !== null &&
+        !(Array.isArray(line_group_allowlist) && line_group_allowlist.every((u) => typeof u === 'string'))) {
+      res.status(400).json({ error: 'line_group_allowlist must be an array of strings or null' });
+      return;
+    }
+    if (line_require_mention !== undefined && line_require_mention !== null &&
+        typeof line_require_mention !== 'boolean') {
+      res.status(400).json({ error: 'line_require_mention must be a boolean or null' });
+      return;
+    }
+    if (line_pairing !== undefined && line_pairing !== null &&
+        typeof line_pairing !== 'boolean') {
+      res.status(400).json({ error: 'line_pairing must be a boolean or null' });
+      return;
+    }
+    const lineAccessTouched = line_dm_policy !== undefined || line_dm_allowlist !== undefined ||
+      line_group_policy !== undefined || line_group_allowlist !== undefined || line_require_mention !== undefined ||
+      line_pairing !== undefined;
 
     try {
       await writeAgentsToConfig(configPath, (agents) => {
@@ -1166,6 +1242,48 @@ export function createApiRouter(
           } else {
             const existing = agent.discord as Record<string, unknown> | undefined;
             agent.discord = { ...(existing ?? {}), botToken: (discord_bot_token as string).trim() };
+          }
+        }
+        if (lineTouched) {
+          const at = typeof line_channel_access_token === 'string' ? line_channel_access_token.trim() : '';
+          const sec = typeof line_channel_secret === 'string' ? line_channel_secret.trim() : '';
+          if (at === '' && sec === '') {
+            delete (agent as Record<string, unknown>).line;
+          } else {
+            const existing = agent.line as Record<string, unknown> | undefined;
+            agent.line = { ...(existing ?? {}), channelAccessToken: at, channelSecret: sec };
+          }
+        }
+        // DM access — merge into the existing line block (re-read after the token
+        // block above, which may have just created or deleted it). Skip silently
+        // when no line channel exists; policy without credentials is meaningless.
+        if (lineAccessTouched) {
+          const existing = agent.line as Record<string, unknown> | undefined;
+          if (existing) {
+            if (line_dm_policy !== undefined) {
+              if (line_dm_policy === null) delete existing.dmPolicy;
+              else existing.dmPolicy = line_dm_policy;
+            }
+            if (line_dm_allowlist !== undefined) {
+              if (line_dm_allowlist === null) delete existing.dmAllowlist;
+              else existing.dmAllowlist = line_dm_allowlist;
+            }
+            if (line_group_policy !== undefined) {
+              if (line_group_policy === null) delete existing.groupPolicy;
+              else existing.groupPolicy = line_group_policy;
+            }
+            if (line_group_allowlist !== undefined) {
+              if (line_group_allowlist === null) delete existing.groupAllowlist;
+              else existing.groupAllowlist = line_group_allowlist;
+            }
+            if (line_require_mention !== undefined) {
+              if (line_require_mention === null) delete existing.requireMention;
+              else existing.requireMention = line_require_mention;
+            }
+            if (line_pairing !== undefined) {
+              if (line_pairing === null) delete existing.pairing;
+              else existing.pairing = line_pairing;
+            }
           }
         }
       });
@@ -1209,6 +1327,53 @@ export function createApiRouter(
         agentRunners.get(agentId)?.stopDiscordReceiver();
       }
     }
+    if (lineTouched) {
+      const at = typeof line_channel_access_token === 'string' ? line_channel_access_token.trim() : '';
+      const sec = typeof line_channel_secret === 'string' ? line_channel_secret.trim() : '';
+      if (at && sec) {
+        cfg.line = { ...(cfg.line ?? {}), channelAccessToken: at, channelSecret: sec };
+      } else {
+        delete cfg.line;
+      }
+      // LINE is webhook-based — no receiver to start/stop. The webhook router reads
+      // config live via runner.getAgentConfig(); just keep the runner's copy in sync.
+      agentRunners.get(agentId)?.updateAgentConfig(cfg);
+    }
+    if (lineAccessTouched && cfg.line) {
+      if (line_dm_policy !== undefined) {
+        if (line_dm_policy === null) delete cfg.line.dmPolicy;
+        else cfg.line.dmPolicy = line_dm_policy as 'open' | 'allowlist' | 'disabled';
+      }
+      if (line_dm_allowlist !== undefined) {
+        if (line_dm_allowlist === null) delete cfg.line.dmAllowlist;
+        else cfg.line.dmAllowlist = line_dm_allowlist as string[];
+      }
+      if (line_group_policy !== undefined) {
+        if (line_group_policy === null) delete cfg.line.groupPolicy;
+        else cfg.line.groupPolicy = line_group_policy as 'open' | 'allowlist' | 'disabled';
+      }
+      if (line_group_allowlist !== undefined) {
+        if (line_group_allowlist === null) delete cfg.line.groupAllowlist;
+        else cfg.line.groupAllowlist = line_group_allowlist as string[];
+      }
+      if (line_require_mention !== undefined) {
+        if (line_require_mention === null) delete cfg.line.requireMention;
+        else cfg.line.requireMention = line_require_mention as boolean;
+      }
+      if (line_pairing !== undefined) {
+        if (line_pairing === null) delete cfg.line.pairing;
+        else cfg.line.pairing = line_pairing as boolean;
+      }
+      agentRunners.get(agentId)?.updateAgentConfig(cfg);
+      // Anyone just added to an allowlist is now allowed — drop them from the
+      // in-memory knock list so the discovery UI stops surfacing them.
+      if (Array.isArray(line_dm_allowlist)) {
+        for (const userId of line_dm_allowlist) clearPendingSender(agentId, userId);
+      }
+      if (Array.isArray(line_group_allowlist)) {
+        for (const id of line_group_allowlist) clearPendingSender(agentId, id);
+      }
+    }
 
     res.json({
       agent: {
@@ -1221,6 +1386,9 @@ export function createApiRouter(
         telegram_token_preview: cfg.telegram?.botToken ? maskToken(cfg.telegram.botToken) : null,
         discord_token_preview: cfg.discord?.botToken ? maskToken(cfg.discord.botToken) : null,
         telegram_dm_policy: cfg.telegram?.botToken ? readTelegramAccess(agentId).dmPolicy : null,
+        line_connected: !!cfg.line?.channelSecret,
+        line_token_preview: cfg.line?.channelAccessToken ? maskToken(cfg.line.channelAccessToken) : null,
+        line_webhook_path: cfg.line?.channelSecret ? `/line/webhook/${agentId}` : null,
       },
     });
   });
@@ -1374,6 +1542,36 @@ export function createApiRouter(
   });
 
   /**
+   * GET /api/v1/agents/:agentId/line/pending
+   * Recently denied LINE senders (Tier 1 allowlist discovery aid). Admin only.
+   * In-memory + ephemeral — populated by the webhook gate when it drops a sender.
+   */
+  router.get('/v1/agents/:agentId/line/pending', auth, (req: Request, res: Response) => {
+    const { agentId } = req.params as { agentId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!isAdmin(apiKey)) { res.status(403).json({ error: 'Admin key required' }); return; }
+    if (!agentConfigs.has(agentId)) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return; }
+    res.json({ senders: getPendingSenders(agentId) });
+  });
+
+  /**
+   * DELETE /api/v1/agents/:agentId/line/pending/:senderId
+   * Dismiss one knock from the in-memory pending list (admin only). Used
+   * by the UI "Delete" action — distinct from "+ Add" (which allowlists). The
+   * id is a LINE userId/groupId/roomId (U/C/R + hex), so no numeric validation.
+   * Idempotent: clearing an unknown id is a no-op. Ephemeral — a later message
+   * from the same sender re-adds it (and, under pairing, re-mints a code).
+   */
+  router.delete('/v1/agents/:agentId/line/pending/:senderId', auth, (req: Request, res: Response) => {
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!isAdmin(apiKey)) { res.status(403).json({ error: 'Admin key required' }); return; }
+    const { agentId, senderId } = req.params as { agentId: string; senderId: string };
+    if (!agentConfigs.has(agentId)) { res.status(404).json({ error: `Agent '${agentId}' not found` }); return; }
+    clearPendingSender(agentId, senderId);
+    res.json({ ok: true });
+  });
+
+  /**
    * DELETE /api/v1/agents/:agentId/telegram/allow/:userId
    * Remove a user from the allowFrom list. Admin only.
    */
@@ -1477,12 +1675,12 @@ export function createApiRouter(
       return;
     }
     const { source, rawChatId } = parseHistoryChatId(chatId);
-    if (source !== 'telegram' && source !== 'discord') {
-      res.status(400).json({ error: 'Sessions endpoint only supports telegram/discord chats' });
+    if (source !== 'telegram' && source !== 'discord' && source !== 'line') {
+      res.status(400).json({ error: 'Sessions endpoint only supports telegram/discord/line chats' });
       return;
     }
     try {
-      const index = await runner.listSessionsForChat(rawChatId, source as 'telegram' | 'discord');
+      const index = await runner.listSessionsForChat(rawChatId, source as 'telegram' | 'discord' | 'line');
       res.json(index);
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
@@ -1565,8 +1763,8 @@ export function createApiRouter(
       return;
     }
     const { source, rawChatId } = parseHistoryChatId(chatId);
-    if (source !== 'telegram' && source !== 'discord') {
-      res.status(400).json({ error: 'Cross-channel messaging only supported for telegram/discord chats' });
+    if (source !== 'telegram' && source !== 'discord' && source !== 'line') {
+      res.status(400).json({ error: 'Cross-channel messaging only supported for telegram/discord/line chats' });
       return;
     }
 
@@ -1614,7 +1812,7 @@ export function createApiRouter(
 
       cleanup = await runner.sendMessageToSession(
         rawChatId,
-        source as 'telegram' | 'discord',
+        source as 'telegram' | 'discord' | 'line',
         sessionId,
         content.trim(),
         senderName,
@@ -2327,5 +2525,6 @@ export function createApiRouter(
 function parseHistoryChatId(fullChatId: string): { source: string; rawChatId: string } {
   if (fullChatId.startsWith('telegram-')) return { source: 'telegram', rawChatId: fullChatId.slice(9) };
   if (fullChatId.startsWith('discord-')) return { source: 'discord', rawChatId: fullChatId.slice(8) };
+  if (fullChatId.startsWith('line-')) return { source: 'line', rawChatId: fullChatId.slice(5) };
   return { source: 'api', rawChatId: fullChatId };
 }

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -1,4 +1,4 @@
-export type HistorySource = 'telegram' | 'discord' | 'api' | 'ui';
+export type HistorySource = 'telegram' | 'discord' | 'line' | 'api' | 'ui';
 export type MessageRole = 'user' | 'assistant' | 'system';
 
 export interface HistoryMessage {

--- a/src/session/compactor.ts
+++ b/src/session/compactor.ts
@@ -49,7 +49,7 @@ export class SessionCompactor {
     sessionId: string,
     model: string,
     contextWindow: number,
-    channel: 'telegram' | 'discord' | 'api' = 'telegram',
+    channel: 'telegram' | 'discord' | 'line' | 'api' = 'telegram',
   ): Promise<CompactionResult> {
     // Load current history
     const messages = await this.sessionStore.loadTelegramSession(agentId, chatId, sessionId, channel);

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -28,8 +28,8 @@ const CHANNELS_ACTIVATION_PROMPT =
 export class SessionProcess extends EventEmitter {
   readonly sessionId: string;
   readonly chatId: string;
-  readonly source: 'telegram' | 'discord' | 'api';
-  private readonly sessionChannel: 'telegram' | 'discord';
+  readonly source: 'telegram' | 'discord' | 'line' | 'api';
+  private readonly sessionChannel: 'telegram' | 'discord' | 'line';
   lastActivityAt = Date.now(); // accessible by AgentRunner for eviction sort
   readonly spawnedAt = Date.now();
   /** Backend used to run the subprocess. Set during start(); 'headless' until then. */
@@ -70,7 +70,7 @@ export class SessionProcess extends EventEmitter {
 
   constructor(
     sessionId: string,
-    source: 'telegram' | 'discord' | 'api',
+    source: 'telegram' | 'discord' | 'line' | 'api',
     agentConfig: AgentConfig,
     gatewayConfig: GatewayConfig,
     sessionStore: SessionStore,
@@ -80,7 +80,8 @@ export class SessionProcess extends EventEmitter {
     this.sessionId = sessionId;
     this.source = source;
     this.chatId = chatId ?? sessionId;
-    this.sessionChannel = source === 'discord' ? 'discord' : 'telegram';
+    this.sessionChannel =
+      source === 'discord' ? 'discord' : source === 'line' ? 'line' : 'telegram';
     this.agentConfig = agentConfig;
     this.gatewayConfig = gatewayConfig;
     this.sessionStore = sessionStore;
@@ -90,7 +91,7 @@ export class SessionProcess extends EventEmitter {
     );
     // config.json lives 3 levels above workspace: <base>/<agentId>/workspace → <base>/config.json
     this.configPath = path.resolve(agentConfig.workspace, '..', '..', '..', 'config.json');
-    const stateSubDir = source === 'discord' ? '.discord-state' : '.telegram-state';
+    const stateSubDir = source === 'discord' ? '.discord-state' : source === 'line' ? '.line-state' : '.telegram-state';
     this.restartSignalPath = path.join(agentConfig.workspace, stateSubDir, `restart-${sessionId}`);
   }
 
@@ -99,7 +100,7 @@ export class SessionProcess extends EventEmitter {
    * Priority: per-session override > config.json on disk > cached agentConfig.
    */
   private get typingDir(): string {
-    const sub = this.source === 'discord' ? '.discord-state' : '.telegram-state';
+    const sub = this.source === 'discord' ? '.discord-state' : this.source === 'line' ? '.line-state' : '.telegram-state';
     return path.join(this.agentConfig.workspace, sub, 'typing');
   }
 
@@ -301,6 +302,17 @@ export class SessionProcess extends EventEmitter {
             DISCORD_CHANNEL_ALLOWLIST: (this.agentConfig.discord?.channelAllowlist ?? []).join(','),
             DISCORD_DM_POLICY: this.agentConfig.discord?.dmPolicy ?? 'disabled',
             DISCORD_DM_ALLOWLIST: (this.agentConfig.discord?.dmAllowlist ?? []).join(','),
+            // LINE outbound: line_reply pushes via the Messaging API. The MCP
+            // subprocess only sees the env we hand it, so the token must be
+            // forwarded explicitly. The SDK targets api.line.me by default.
+            LINE_CHANNEL_ACCESS_TOKEN: this.agentConfig.line?.channelAccessToken ?? '',
+            // Refresh mode (slow-LLM postback button): when on, the gateway is the
+            // sole LINE sender, so line_reply must NOT send from the subprocess.
+            // Mirrors the runner's `slowResponseThreshold > 0` gate.
+            LINE_REPLY_REFRESH:
+              this.agentConfig.line && (this.agentConfig.line.slowResponseThreshold ?? 45) > 0
+                ? '1'
+                : '',
             GATEWAY_AGENT_ID: this.agentConfig.id,
             // Must be the base URL without /api suffix (e.g. http://127.0.0.1:10850).
             // MCP tools append /api/v1/... themselves — a trailing /api here causes double-prefix 404s.

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -163,28 +163,28 @@ export class SessionStore {
   /**
    * Resolve the directory for a chat's multi-session data.
    */
-  private resolveTelegramDir(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): string {
+  private resolveTelegramDir(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): string {
     return path.join(this.agentsBaseDir, agentId, 'sessions', `${channel}-${chatId}`);
   }
 
   /**
    * Resolve the path to the session index file for a chat.
    */
-  private resolveTelegramIndexPath(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): string {
+  private resolveTelegramIndexPath(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): string {
     return path.join(this.resolveTelegramDir(agentId, chatId, channel), 'index.json');
   }
 
   /**
    * Resolve the path to a specific session's message file.
    */
-  private resolveTelegramSessionPath(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): string {
+  private resolveTelegramSessionPath(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): string {
     return path.join(this.resolveTelegramDir(agentId, chatId, channel), `${sessionId}.json`);
   }
 
   /**
    * Read index.json for a chat. Returns null if file doesn't exist.
    */
-  async loadIndex(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionIndex | null> {
+  async loadIndex(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<SessionIndex | null> {
     const indexPath = this.resolveTelegramIndexPath(agentId, chatId, channel);
     if (!fs.existsSync(indexPath)) {
       return null;
@@ -200,7 +200,7 @@ export class SessionStore {
   /**
    * Write index.json atomically (tmp + rename).
    */
-  async saveIndex(agentId: string, chatId: string, index: SessionIndex, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
+  async saveIndex(agentId: string, chatId: string, index: SessionIndex, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<void> {
     const indexPath = this.resolveTelegramIndexPath(agentId, chatId, channel);
     const dir = path.dirname(indexPath);
     fs.mkdirSync(dir, { recursive: true });
@@ -223,7 +223,7 @@ export class SessionStore {
    * Internal (unlocked) version — call this only from WITHIN a getTelegramQueue task
    * to avoid deadlock. The public getOrCreateIndex wraps this in the queue.
    */
-  private async loadOrCreateIndexUnlocked(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionIndex> {
+  private async loadOrCreateIndexUnlocked(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<SessionIndex> {
     // 1. Check for existing index
     const existingIndex = await this.loadIndex(agentId, chatId, channel);
     if (existingIndex !== null) {
@@ -292,7 +292,7 @@ export class SessionStore {
     return index;
   }
 
-  async getOrCreateIndex(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionIndex> {
+  async getOrCreateIndex(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<SessionIndex> {
     const queue = this.getTelegramQueue(agentId, chatId);
     return queue.add(() => this.loadOrCreateIndexUnlocked(agentId, chatId, channel)) as Promise<SessionIndex>;
   }
@@ -301,7 +301,7 @@ export class SessionStore {
    * Create a new session for a chat, add it to the index, and return the SessionMeta.
    * If name is not provided, auto-generates "Session N" based on current session count.
    */
-  async createTelegramSession(agentId: string, chatId: string, name?: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionMeta> {
+  async createTelegramSession(agentId: string, chatId: string, name?: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<SessionMeta> {
     const queue = this.getTelegramQueue(agentId, chatId);
     return queue.add(async () => {
       const index = await this.loadOrCreateIndexUnlocked(agentId, chatId, channel);
@@ -332,16 +332,16 @@ export class SessionStore {
     }) as Promise<SessionMeta>;
   }
 
-  async listSessions(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<SessionIndex> {
+  async listSessions(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<SessionIndex> {
     return this.getOrCreateIndex(agentId, chatId, channel);
   }
 
-  async getActiveSessionId(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<string> {
+  async getActiveSessionId(agentId: string, chatId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<string> {
     const index = await this.getOrCreateIndex(agentId, chatId, channel);
     return index.activeSessionId;
   }
 
-  async setActiveSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
+  async setActiveSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
       const index = await this.loadIndex(agentId, chatId, channel);
@@ -357,7 +357,7 @@ export class SessionStore {
     });
   }
 
-  async deleteTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
+  async deleteTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
       const index = await this.loadIndex(agentId, chatId, channel);
@@ -393,7 +393,7 @@ export class SessionStore {
     });
   }
 
-  async clearTelegramSessionHistory(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<void> {
+  async clearTelegramSessionHistory(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<void> {
     // api sessions keep their context in the flat sessions/{sessionId}.jsonl store (keyed by
     // sessionId, loaded at spawn via loadSession) — not the structured per-chat store. Clearing
     // the structured store would leave the real context untouched, so truncate the flat file.
@@ -440,7 +440,7 @@ export class SessionStore {
     chatId: string,
     sessionId: string,
     meta: Partial<Pick<SessionMeta, 'name' | 'totalTokensUsed' | 'messageCount' | 'lastInputTokens' | 'loadedAtSpawn' | 'archivedCount' | 'messageCountAtSpawn'>>,
-    channel: 'telegram' | 'discord' | 'api' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram',
   ): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
@@ -458,7 +458,7 @@ export class SessionStore {
     });
   }
 
-  async loadTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' = 'telegram'): Promise<Message[]> {
+  async loadTelegramSession(agentId: string, chatId: string, sessionId: string, channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram'): Promise<Message[]> {
     // api context lives in the flat sessions/{sessionId}.jsonl store, consistent with how api
     // messages are appended (appendMessage keyed by sessionId) and how buildInitialPrompt loads
     // them at spawn (loadSession). Read from there so /compact sees the real conversation.
@@ -483,7 +483,7 @@ export class SessionStore {
     chatId: string,
     sessionId: string,
     messages: Message[],
-    channel: 'telegram' | 'discord' | 'api' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram',
   ): Promise<void> {
     // api: overwrite the flat sessions/{sessionId}.jsonl store (newline-delimited, keyed by
     // sessionId, serialized on the same queue as appendMessage) so /compact's result is exactly
@@ -519,7 +519,7 @@ export class SessionStore {
     chatId: string,
     sessionId: string,
     message: Message,
-    channel: 'telegram' | 'discord' | 'api' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram',
   ): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
     await queue.add(async () => {
@@ -555,7 +555,7 @@ export class SessionStore {
     chatId: string,
     sessionId: string,
     count: number,
-    channel: 'telegram' | 'discord' | 'api' = 'telegram',
+    channel: 'telegram' | 'discord' | 'api' | 'line' = 'telegram',
   ): Promise<void> {
     const index = await this.loadIndex(agentId, chatId, channel);
     if (index) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,66 @@ export interface AgentConfig {
     dmAllowlist?: string[];
     autoThread?: boolean;
   };
+  line?: {
+    channelAccessToken: string;
+    channelSecret: string;
+    /** default true when the block is present */
+    enabled?: boolean;
+    /** default "/line/webhook" */
+    webhookPath?: string;
+    /**
+     * Slow-LLM postback button (ported from hermes-agent). Seconds to wait for
+     * the agent's answer before burning the reply token to send a tappable
+     * "Get answer" button; tapping yields a fresh (free) reply token. Default
+     * 45 (leaves margin under LINE's ~60s token TTL). Set 0 to disable — the
+     * agent then uses the plain reply-token-first → push-fallback path.
+     */
+    slowResponseThreshold?: number;
+    /** Button label (default "Get answer", max 20 chars on LINE). */
+    slowButtonLabel?: string;
+    /** Bubble text shown with the button (default a "still thinking" notice). */
+    slowPendingText?: string;
+    /**
+     * DM access policy (mirrors `discord.dmPolicy`). Closed by default: when
+     * absent, only senders in `dmAllowlist` may reach the agent (same posture as
+     * hermes/openclaw). 'open' replies to any 1:1 sender; 'allowlist' replies
+     * only to `dmAllowlist`; 'disabled' ignores all DMs.
+     */
+    dmPolicy?: 'open' | 'allowlist' | 'disabled';
+    /** LINE userIds allowed under allowlist / closed-default (case-sensitive "U"+32hex). */
+    dmAllowlist?: string[];
+    /**
+     * Group/room access policy (the group analogue of `dmPolicy`). Closed by
+     * default: when absent, only conversations whose groupId/roomId is in
+     * `groupAllowlist` are answered. 'open' answers in any group/room the bot is
+     * invited to; 'allowlist' answers only listed ones; 'disabled' ignores all
+     * group/room traffic. Applies to both `group` and `room` sources.
+     */
+    groupPolicy?: 'open' | 'allowlist' | 'disabled';
+    /**
+     * Allowed conversation ids for groups and rooms — groupIds ("C"+32hex) and
+     * roomIds ("R"+32hex) share one list (the webhook tells us which). Used under
+     * allowlist / closed-default.
+     */
+    groupAllowlist?: string[];
+    /**
+     * In groups/rooms, only respond when the bot is @mentioned (native LINE
+     * mention or its name). Default true (absent ⇒ true). No effect on DMs.
+     * Set false to make the bot answer every allowed group message.
+     */
+    requireMention?: boolean;
+    /**
+     * Pairing aid for the allowlist (orthogonal to dm/groupPolicy — not a policy
+     * value). When on, an un-allowlisted sender (DM or group/room) gets a one-time
+     * pairing code replied to them via the free reply token, and the same code
+     * shows in the UI "pending" row so an admin can visually match it
+     * before clicking "+ Add". Default true (absent ⇒ on). Only has an effect
+     * under `allowlist` (closed-default) — `open` never denies and `disabled`
+     * is hard-off, so neither sends a code. Set false to restore the silent
+     * closed-allowlist behavior.
+     */
+    pairing?: boolean;
+  };
   claude: {
     model: string;
     /** @deprecated --dangerously-skip-permissions is always passed now; this field is ignored. */

--- a/tests/integration/line-config-to-chat.test.ts
+++ b/tests/integration/line-config-to-chat.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Integration: the full "getpod configures LINE → user chats via LINE" path,
+ * minus the real LINE servers. Proves the two halves connect through one shared
+ * agent-config map:
+ *
+ *   1. PATCH /api/v1/agents/:id with line_channel_access_token + line_channel_secret
+ *      (exactly what getpod's LINE card sends) writes AgentConfig.line and syncs
+ *      the runner via updateAgentConfig().
+ *   2. A signed LINE webhook to /line/webhook/:id is then accepted using THOSE
+ *      just-configured credentials and the message is forwarded to the agent's
+ *      /channel intake.
+ *   3. Clearing the credentials via PATCH makes the same webhook fail (404 — no
+ *      LINE-enabled agent).
+ *
+ * The LINE outbound (reply/push) contract is covered by the LineReplyManager
+ * unit tests (tests/unit/line-reply-manager.test.ts); here we focus on
+ * config → inbound wiring, which is the new getpod-driven surface.
+ */
+import express from 'express';
+import * as supertest from 'supertest';
+import * as http from 'http';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createApiRouter } from '../../src/api/router';
+import {
+  createLineWebhookRouter,
+  type LineWebhookOptions,
+} from '../../src/api/line-webhook-router';
+import { getPendingSenders, _resetPendingSenders } from '../../src/api/line-pending-senders';
+import { AgentConfig, ApiKey } from '../../src/types';
+import type { AgentRunner } from '../../src/agent/runner';
+
+const AGENT_ID = 'baerbel';
+const ADMIN = { Authorization: 'Bearer sk-admin' };
+const ACCESS_TOKEN = 'line-access-token-xyz';
+const SECRET = 'line-channel-secret-xyz';
+const USER_ID = 'Uconfig00000000000000000000000000';
+const KNOCKER_ID = 'Uknock000000000000000000000000000';
+
+const listen = (server: http.Server): Promise<number> =>
+  new Promise((res) => server.listen(0, '127.0.0.1', () => res((server.address() as { port: number }).port)));
+
+describe('LINE: getpod config → chat (inbound) integration', () => {
+  let tmpDir: string;
+  let configPath: string;
+  let configs: Map<string, AgentConfig>;
+  let runners: Map<string, AgentRunner>;
+  let callbackServer: http.Server;
+  let callbackPort: number;
+  const intake: unknown[] = [];
+
+  // Minimal runner that mirrors how the real one exposes config + callback port.
+  // updateAgentConfig() must mutate what getAgentConfig() returns — that is the
+  // exact mechanism the PATCH route relies on to make the webhook see new creds.
+  function makeRunner(): AgentRunner {
+    let cfg = configs.get(AGENT_ID)!;
+    return {
+      getAgentConfig: () => cfg,
+      updateAgentConfig: (next: AgentConfig) => { cfg = next; },
+      getCallbackPort: () => callbackPort,
+    } as unknown as AgentRunner;
+  }
+
+  beforeEach(async () => {
+    intake.length = 0;
+    _resetPendingSenders();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-line-int-'));
+    configPath = path.join(tmpDir, 'config.json');
+    const baseAgent: AgentConfig = {
+      id: AGENT_ID,
+      description: 'test',
+      workspace: path.join(tmpDir, 'ws'),
+      env: '',
+      claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+    };
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ gateway: { logDir: tmpDir, timezone: 'UTC' }, agents: [baseAgent] }, null, 2),
+    );
+    configs = new Map([[AGENT_ID, { ...baseAgent }]]);
+
+    // Agent /channel intake recorder
+    callbackServer = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        if (req.method === 'POST' && req.url === '/channel') intake.push(JSON.parse(body || '{}'));
+        res.writeHead(200).end('{}');
+      });
+    });
+    callbackPort = await listen(callbackServer);
+
+    runners = new Map([[AGENT_ID, makeRunner()]]);
+  });
+
+  afterEach(() => {
+    callbackServer.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function buildApp(lineOpts: LineWebhookOptions = {}): express.Express {
+    const app = express();
+    // LINE webhook must be mounted before express.json() (raw body for signature).
+    app.use(createLineWebhookRouter(runners, tmpDir, lineOpts));
+    app.use(express.json());
+    const apiKeys: ApiKey[] = [{ key: 'sk-admin', agents: '*', admin: true }];
+    app.use('/api', createApiRouter(runners, configs, apiKeys, configPath));
+    return app;
+  }
+
+  const signedWebhook = (app: express.Express, text: string) => {
+    const raw = JSON.stringify({
+      destination: 'x',
+      events: [
+        {
+          type: 'message',
+          timestamp: 1700000000000,
+          replyToken: 'rt-int',
+          source: { type: 'user', userId: USER_ID },
+          message: { type: 'text', id: 'm1', text },
+        },
+      ],
+    });
+    const sig = crypto.createHmac('sha256', SECRET).update(raw).digest('base64');
+    return supertest
+      .default(app)
+      .post(`/line/webhook/${AGENT_ID}`)
+      .set('Content-Type', 'application/json')
+      .set('x-line-signature', sig)
+      .send(raw);
+  };
+
+  it('config via PATCH then a signed webhook is accepted and forwarded', async () => {
+    const app = buildApp();
+
+    // Before config: webhook has no LINE-enabled agent → 404.
+    const pre = await signedWebhook(app, 'too early');
+    expect(pre.status).toBe(404);
+
+    // getpod's LINE card → PATCH credentials. dmPolicy 'open' so this test stays
+    // focused on the forwarding path (the closed default + allowlist denial is
+    // covered by the denied-sender test below).
+    const patch = await supertest
+      .default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}`)
+      .set(ADMIN)
+      .send({
+        line_channel_access_token: ACCESS_TOKEN,
+        line_channel_secret: SECRET,
+        line_dm_policy: 'open',
+      });
+    expect(patch.status).toBe(200);
+    expect(patch.body.agent.line_connected).toBe(true);
+    expect(patch.body.agent.line_webhook_path).toBe(`/line/webhook/${AGENT_ID}`);
+
+    // Now the same signed webhook is accepted with the configured secret.
+    const ok = await signedWebhook(app, 'สวัสดีจาก LINE');
+    expect(ok.status).toBe(200);
+
+    // Intake forwarded to the agent's /channel (async after ack).
+    await new Promise((r) => setTimeout(r, 300));
+    expect(intake).toHaveLength(1);
+    const post = intake[0] as { content: string; meta: Record<string, string> };
+    expect(post.content).toBe('สวัสดีจาก LINE');
+    expect(post.meta.source).toBe('line');
+    expect(post.meta.chat_id).toBe(USER_ID);
+    expect(post.meta.reply_token).toBe('rt-int');
+  });
+
+  it('a wrong signature is rejected even after config', async () => {
+    const app = buildApp();
+    await supertest
+      .default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}`)
+      .set(ADMIN)
+      .send({ line_channel_access_token: ACCESS_TOKEN, line_channel_secret: SECRET });
+
+    const raw = JSON.stringify({ events: [] });
+    const res = await supertest
+      .default(app)
+      .post(`/line/webhook/${AGENT_ID}`)
+      .set('Content-Type', 'application/json')
+      .set('x-line-signature', 'not-a-valid-signature')
+      .send(raw);
+    expect(res.status).toBe(401);
+  });
+
+  it('records a denied (off-allowlist) sender on the knock list, not forwarded', async () => {
+    // Stand up a local LINE API mock so the gate's best-effort getProfile()
+    // resolves fast (returns {}) instead of hitting the real api.line.me.
+    const lineMock = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' }).end('{}');
+    });
+    const lineMockPort = await listen(lineMock);
+    // Point the webhook's outbound LINE client at the mock via the router's
+    // apiBase option (no global env — the base URL is a constructor param now).
+
+    try {
+      const app = buildApp({ apiBase: `http://127.0.0.1:${lineMockPort}` });
+      // Configure creds + allowlist policy that allows only USER_ID.
+      await supertest
+        .default(app)
+        .patch(`/api/v1/agents/${AGENT_ID}`)
+        .set(ADMIN)
+        .send({
+          line_channel_access_token: ACCESS_TOKEN,
+          line_channel_secret: SECRET,
+          line_dm_policy: 'allowlist',
+          line_dm_allowlist: [USER_ID],
+        });
+
+      // A different user DMs the bot → denied by the gate.
+      const raw = JSON.stringify({
+        destination: 'x',
+        events: [
+          {
+            type: 'message',
+            timestamp: 1700000000000,
+            replyToken: 'rt-knock',
+            source: { type: 'user', userId: KNOCKER_ID },
+            message: { type: 'text', id: 'mk', text: 'let me in' },
+          },
+        ],
+      });
+      const sig = crypto.createHmac('sha256', SECRET).update(raw).digest('base64');
+      const res = await supertest
+        .default(app)
+        .post(`/line/webhook/${AGENT_ID}`)
+        .set('Content-Type', 'application/json')
+        .set('x-line-signature', sig)
+        .send(raw);
+      expect(res.status).toBe(200); // webhook is always ack'd
+
+      // Async gate work settles: not forwarded, but recorded on the knock list.
+      await new Promise((r) => setTimeout(r, 300));
+      expect(intake).toHaveLength(0);
+      expect(getPendingSenders(AGENT_ID).map((s) => s.userId)).toContain(KNOCKER_ID);
+    } finally {
+      lineMock.close();
+    }
+  });
+
+  it('clearing credentials via PATCH disables the webhook again', async () => {
+    const app = buildApp();
+    await supertest
+      .default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}`)
+      .set(ADMIN)
+      .send({ line_channel_access_token: ACCESS_TOKEN, line_channel_secret: SECRET });
+
+    const clear = await supertest
+      .default(app)
+      .patch(`/api/v1/agents/${AGENT_ID}`)
+      .set(ADMIN)
+      .send({ line_channel_access_token: '', line_channel_secret: '' });
+    expect(clear.body.agent.line_connected).toBe(false);
+
+    const res = await signedWebhook(app, 'after disconnect');
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/api-router-line.test.ts
+++ b/tests/unit/api-router-line.test.ts
@@ -1,0 +1,424 @@
+/**
+ * HTTP-level tests for the LINE channel management surface on the agents API:
+ *  - PATCH /api/v1/agents/:id accepts line_channel_access_token + line_channel_secret
+ *    (both-or-neither), writes AgentConfig.line to config.json, and keeps the
+ *    in-memory config in sync.
+ *  - GET  /api/v1/agents exposes line_connected / line_token_preview / line_webhook_path.
+ *
+ * Mirrors the telegram/discord PATCH plumbing in src/api/router.ts. Uses a real
+ * temp config.json because the route persists via writeAgentsToConfig().
+ */
+import express from 'express';
+import * as supertest from 'supertest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createApiRouter } from '../../src/api/router';
+import {
+  recordDeniedSender,
+  recordDeniedConversation,
+  getPendingSenders,
+  _resetPendingSenders,
+} from '../../src/api/line-pending-senders';
+import { AgentConfig, ApiKey } from '../../src/types';
+
+const AGENT_ID = 'alfred';
+const ADMIN = { Authorization: 'Bearer sk-test-admin' };
+const USER = { Authorization: 'Bearer sk-test-user' };
+const VALID_AT = 'line-channel-access-token-1234567890';
+const VALID_SECRET = 'line-channel-secret-abcdef';
+
+function makeAgentConfig(): AgentConfig {
+  return {
+    id: AGENT_ID,
+    description: 'Personal assistant',
+    workspace: '/tmp/alfred',
+    env: '',
+    claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+  };
+}
+
+describe('LINE channel management API', () => {
+  let tmpDir: string;
+  let configPath: string;
+  let configs: Map<string, AgentConfig>;
+  let app: express.Express;
+
+  const apiKeys: ApiKey[] = [
+    { key: 'sk-test-admin', agents: '*', admin: true },
+    { key: 'sk-test-user', agents: '*' },
+  ];
+
+  beforeEach(() => {
+    _resetPendingSenders();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-line-api-'));
+    configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          gateway: { logDir: '~/logs', timezone: 'UTC' },
+          agents: [makeAgentConfig()],
+        },
+        null,
+        2,
+      ),
+    );
+    configs = new Map([[AGENT_ID, makeAgentConfig()]]);
+    // No runners — LINE is webhook-based; PATCH only does updateAgentConfig() if a
+    // runner exists, and the route must work without one.
+    const runners = new Map();
+    app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys, configPath));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const patch = (body: Record<string, unknown>) =>
+    supertest.default(app).patch(`/api/v1/agents/${AGENT_ID}`).set(ADMIN).send(body);
+
+  it('connects LINE when both credentials are provided', async () => {
+    const res = await patch({
+      line_channel_access_token: VALID_AT,
+      line_channel_secret: VALID_SECRET,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.agent.line_connected).toBe(true);
+    expect(res.body.agent.line_webhook_path).toBe(`/line/webhook/${AGENT_ID}`);
+    expect(res.body.agent.line_token_preview).toBeTruthy();
+    expect(res.body.agent.line_token_preview).not.toContain(VALID_AT); // masked
+
+    // persisted to disk
+    const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(onDisk.agents[0].line).toEqual({
+      channelAccessToken: VALID_AT,
+      channelSecret: VALID_SECRET,
+    });
+    // in-memory map synced
+    expect(configs.get(AGENT_ID)!.line).toEqual({
+      channelAccessToken: VALID_AT,
+      channelSecret: VALID_SECRET,
+    });
+  });
+
+  it('rejects a half-set (one credential without the other) with 400', async () => {
+    const res = await patch({ line_channel_access_token: VALID_AT });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/together/i);
+    // nothing written
+    const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(onDisk.agents[0].line).toBeUndefined();
+  });
+
+  it('rejects non-string credential with 400', async () => {
+    const res = await patch({ line_channel_access_token: 123, line_channel_secret: VALID_SECRET });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/line_channel_access_token must be a string/i);
+  });
+
+  it('disconnects LINE when both credentials are cleared', async () => {
+    await patch({ line_channel_access_token: VALID_AT, line_channel_secret: VALID_SECRET });
+    const res = await patch({ line_channel_access_token: '', line_channel_secret: '' });
+    expect(res.status).toBe(200);
+    expect(res.body.agent.line_connected).toBe(false);
+    expect(res.body.agent.line_webhook_path).toBeNull();
+
+    const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(onDisk.agents[0].line).toBeUndefined();
+    expect(configs.get(AGENT_ID)!.line).toBeUndefined();
+  });
+
+  it('GET /agents reflects LINE connection status', async () => {
+    await patch({ line_channel_access_token: VALID_AT, line_channel_secret: VALID_SECRET });
+    const res = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+    expect(res.status).toBe(200);
+    const agent = res.body.agents.find((a: { id: string }) => a.id === AGENT_ID);
+    expect(agent.line_connected).toBe(true);
+    expect(agent.line_webhook_path).toBe(`/line/webhook/${AGENT_ID}`);
+    expect(agent.line_token_preview).toBeTruthy();
+  });
+
+  it('leaves LINE untouched when the PATCH omits LINE fields', async () => {
+    await patch({ line_channel_access_token: VALID_AT, line_channel_secret: VALID_SECRET });
+    const res = await patch({ description: 'updated desc' });
+    expect(res.status).toBe(200);
+    expect(res.body.agent.line_connected).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(onDisk.agents[0].line.channelSecret).toBe(VALID_SECRET);
+  });
+
+  describe('DM access control (Tier 1: dmPolicy + dmAllowlist)', () => {
+    const connect = () =>
+      patch({ line_channel_access_token: VALID_AT, line_channel_secret: VALID_SECRET });
+
+    it('sets dmPolicy + dmAllowlist without resending credentials', async () => {
+      await connect();
+      const res = await patch({
+        line_dm_policy: 'allowlist',
+        line_dm_allowlist: ['Uabc', 'Udef'],
+      });
+      expect(res.status).toBe(200);
+
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(onDisk.agents[0].line).toEqual({
+        channelAccessToken: VALID_AT,
+        channelSecret: VALID_SECRET,
+        dmPolicy: 'allowlist',
+        dmAllowlist: ['Uabc', 'Udef'],
+      });
+      // in-memory synced (webhook router reads this live)
+      expect(configs.get(AGENT_ID)!.line!.dmPolicy).toBe('allowlist');
+      expect(configs.get(AGENT_ID)!.line!.dmAllowlist).toEqual(['Uabc', 'Udef']);
+    });
+
+    it('exposes line_dm_policy + line_dm_allowlist on GET /agents', async () => {
+      await connect();
+      await patch({ line_dm_policy: 'allowlist', line_dm_allowlist: ['Uabc'] });
+      const res = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+      const agent = res.body.agents.find((a: { id: string }) => a.id === AGENT_ID);
+      expect(agent.line_dm_policy).toBe('allowlist');
+      expect(agent.line_dm_allowlist).toEqual(['Uabc']);
+    });
+
+    it('returns null policy + empty allowlist when unset (closed default)', async () => {
+      await connect();
+      const res = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+      const agent = res.body.agents.find((a: { id: string }) => a.id === AGENT_ID);
+      expect(agent.line_dm_policy).toBeNull();
+      expect(agent.line_dm_allowlist).toEqual([]);
+    });
+
+    it('clears fields when passed null', async () => {
+      await connect();
+      await patch({ line_dm_policy: 'open', line_dm_allowlist: ['Uabc'] });
+      const res = await patch({ line_dm_policy: null, line_dm_allowlist: null });
+      expect(res.status).toBe(200);
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(onDisk.agents[0].line.dmPolicy).toBeUndefined();
+      expect(onDisk.agents[0].line.dmAllowlist).toBeUndefined();
+      // credentials survive the clear
+      expect(onDisk.agents[0].line.channelSecret).toBe(VALID_SECRET);
+    });
+
+    it('rejects an invalid policy value with 400', async () => {
+      await connect();
+      const res = await patch({ line_dm_policy: 'pairing' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/line_dm_policy/i);
+    });
+
+    it('rejects a non-string allowlist entry with 400', async () => {
+      await connect();
+      const res = await patch({ line_dm_allowlist: ['Uok', 123] });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/line_dm_allowlist/i);
+    });
+
+    it('ignores access fields when no LINE channel exists', async () => {
+      const res = await patch({ line_dm_policy: 'allowlist', line_dm_allowlist: ['Uabc'] });
+      expect(res.status).toBe(200);
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(onDisk.agents[0].line).toBeUndefined();
+    });
+
+    it('sets credentials and access policy together in one PATCH', async () => {
+      const res = await patch({
+        line_channel_access_token: VALID_AT,
+        line_channel_secret: VALID_SECRET,
+        line_dm_policy: 'allowlist',
+        line_dm_allowlist: ['Uabc'],
+      });
+      expect(res.status).toBe(200);
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(onDisk.agents[0].line).toEqual({
+        channelAccessToken: VALID_AT,
+        channelSecret: VALID_SECRET,
+        dmPolicy: 'allowlist',
+        dmAllowlist: ['Uabc'],
+      });
+    });
+
+    it('drops a user from the knock list when added to the allowlist', async () => {
+      await connect();
+      recordDeniedSender(AGENT_ID, 'Uknocker', 'Knocker', 1000);
+      recordDeniedSender(AGENT_ID, 'Uother', 'Other', 1000);
+      const res = await patch({ line_dm_policy: 'allowlist', line_dm_allowlist: ['Uknocker'] });
+      expect(res.status).toBe(200);
+      // Uknocker is now allowed → gone from the knock list; Uother stays.
+      expect(getPendingSenders(AGENT_ID).map((s) => s.userId)).toEqual(['Uother']);
+    });
+  });
+
+  describe('GET /agents/:id/line/pending', () => {
+    const url = `/api/v1/agents/${AGENT_ID}/line/pending`;
+
+    it('returns recorded denied senders to an admin (most-recent first)', async () => {
+      recordDeniedSender(AGENT_ID, 'Ualice', 'Alice', 1000);
+      recordDeniedSender(AGENT_ID, 'Ubob', 'Bob', 2000);
+      const res = await supertest.default(app).get(url).set(ADMIN);
+      expect(res.status).toBe(200);
+      expect(res.body.senders.map((s: { userId: string }) => s.userId)).toEqual(['Ubob', 'Ualice']);
+      expect(res.body.senders[0]).toMatchObject({ userId: 'Ubob', displayName: 'Bob', count: 1 });
+    });
+
+    it('rejects a non-admin key with 403', async () => {
+      const res = await supertest.default(app).get(url).set(USER);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 for an unknown agent', async () => {
+      const res = await supertest.default(app)
+        .get('/api/v1/agents/ghost/line/pending')
+        .set(ADMIN);
+      expect(res.status).toBe(404);
+    });
+
+    it('is empty when nothing has been denied', async () => {
+      const res = await supertest.default(app).get(url).set(ADMIN);
+      expect(res.status).toBe(200);
+      expect(res.body.senders).toEqual([]);
+    });
+
+    it('exposes the pairing code on each sender (pairing mode)', async () => {
+      recordDeniedSender(AGENT_ID, 'Ualice', 'Alice', 1000, 'ABC123');
+      const res = await supertest.default(app).get(url).set(ADMIN);
+      expect(res.status).toBe(200);
+      expect(res.body.senders[0]).toMatchObject({ userId: 'Ualice', code: 'ABC123' });
+    });
+
+    it('DELETE removes one sender from the knock list (admin)', async () => {
+      recordDeniedSender(AGENT_ID, 'Ualice', 'Alice', 1000);
+      recordDeniedConversation(AGENT_ID, 'Cteam', 'group', 'Team', 1000);
+      const res = await supertest.default(app)
+        .delete(`${url}/Ualice`)
+        .set(ADMIN);
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(getPendingSenders(AGENT_ID).map((s) => s.userId)).toEqual(['Cteam']);
+    });
+
+    it('DELETE is idempotent for an unknown id', async () => {
+      const res = await supertest.default(app).delete(`${url}/Unobody`).set(ADMIN);
+      expect(res.status).toBe(200);
+    });
+
+    it('DELETE rejects a non-admin key with 403', async () => {
+      recordDeniedSender(AGENT_ID, 'Ualice', 'Alice', 1000);
+      const res = await supertest.default(app).delete(`${url}/Ualice`).set(USER);
+      expect(res.status).toBe(403);
+      expect(getPendingSenders(AGENT_ID)).toHaveLength(1); // untouched
+    });
+
+    it('DELETE returns 404 for an unknown agent', async () => {
+      const res = await supertest.default(app)
+        .delete('/api/v1/agents/ghost/line/pending/Ualice')
+        .set(ADMIN);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('pairing toggle (line_pairing)', () => {
+    const connect = () =>
+      patch({ line_channel_access_token: VALID_AT, line_channel_secret: VALID_SECRET });
+
+    it('accepts line_pairing true/false and persists it', async () => {
+      await connect();
+      const off = await patch({ line_pairing: false });
+      expect(off.status).toBe(200);
+      expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).agents[0].line.pairing).toBe(false);
+      expect(configs.get(AGENT_ID)!.line!.pairing).toBe(false);
+
+      const on = await patch({ line_pairing: true });
+      expect(on.status).toBe(200);
+      expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).agents[0].line.pairing).toBe(true);
+    });
+
+    it('exposes line_pairing on GET /agents, defaulting to true when unset', async () => {
+      await connect();
+      const res = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+      const agent = res.body.agents.find((a: { id: string }) => a.id === AGENT_ID);
+      expect(agent.line_pairing).toBe(true);
+
+      await patch({ line_pairing: false });
+      const res2 = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+      const agent2 = res2.body.agents.find((a: { id: string }) => a.id === AGENT_ID);
+      expect(agent2.line_pairing).toBe(false);
+    });
+
+    it('clears line_pairing back to default when set to null', async () => {
+      await connect();
+      await patch({ line_pairing: false });
+      const res = await patch({ line_pairing: null });
+      expect(res.status).toBe(200);
+      expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).agents[0].line.pairing).toBeUndefined();
+    });
+
+    it('rejects a non-boolean line_pairing with 400', async () => {
+      await connect();
+      const res = await patch({ line_pairing: 'yes' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/line_pairing/i);
+    });
+  });
+
+  describe('Group/room access control (Tier 3: groupPolicy + groupAllowlist + requireMention)', () => {
+    const connect = () =>
+      patch({ line_channel_access_token: VALID_AT, line_channel_secret: VALID_SECRET });
+
+    it('sets group policy/allowlist + requireMention without resending credentials', async () => {
+      await connect();
+      const res = await patch({
+        line_group_policy: 'allowlist',
+        line_group_allowlist: ['Cf3a9', 'Re8f1'],
+        line_require_mention: true,
+      });
+      expect(res.status).toBe(200);
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(onDisk.agents[0].line).toMatchObject({
+        groupPolicy: 'allowlist',
+        groupAllowlist: ['Cf3a9', 'Re8f1'],
+        requireMention: true,
+      });
+      expect(configs.get(AGENT_ID)!.line!.groupPolicy).toBe('allowlist');
+      expect(configs.get(AGENT_ID)!.line!.requireMention).toBe(true);
+    });
+
+    it('exposes line_group_* + line_require_mention on GET /agents', async () => {
+      await connect();
+      await patch({ line_group_policy: 'open', line_group_allowlist: ['Cf3a9'], line_require_mention: false });
+      const res = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+      const agent = res.body.agents.find((a: { id: string }) => a.id === AGENT_ID);
+      expect(agent.line_group_policy).toBe('open');
+      expect(agent.line_group_allowlist).toEqual(['Cf3a9']);
+      expect(agent.line_require_mention).toBe(false);
+    });
+
+    it('returns null group policy + empty allowlist when unset', async () => {
+      await connect();
+      const res = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+      const agent = res.body.agents.find((a: { id: string }) => a.id === AGENT_ID);
+      expect(agent.line_group_policy).toBeNull();
+      expect(agent.line_group_allowlist).toEqual([]);
+      expect(agent.line_require_mention).toBeNull();
+    });
+
+    it('rejects an invalid group policy + a non-boolean requireMention', async () => {
+      await connect();
+      expect((await patch({ line_group_policy: 'nope' })).status).toBe(400);
+      expect((await patch({ line_require_mention: 'yes' })).status).toBe(400);
+      expect((await patch({ line_group_allowlist: ['Cok', 5] })).status).toBe(400);
+    });
+
+    it('drops a group from the knock list when added to the group allowlist', async () => {
+      await connect();
+      recordDeniedConversation(AGENT_ID, 'Cf3a9', 'group', 'Team', 1000);
+      recordDeniedConversation(AGENT_ID, 'Cother', 'group', 'Other', 1000);
+      const res = await patch({ line_group_policy: 'allowlist', line_group_allowlist: ['Cf3a9'] });
+      expect(res.status).toBe(200);
+      expect(getPendingSenders(AGENT_ID).map((s) => s.userId)).toEqual(['Cother']);
+    });
+  });
+});

--- a/tests/unit/builtin-commands.test.ts
+++ b/tests/unit/builtin-commands.test.ts
@@ -128,4 +128,23 @@ describe('isBuiltinCommand', () => {
       }
     });
   });
+
+  // ── LINE — regression for the empty-regex blocker (fixed 2026-06-23) ───────
+  // No BUILTIN_COMMANDS entry lists 'line', so buildRegex('line') had no parts.
+  // `new RegExp('')` matches EVERY string, which misrouted ALL LINE messages
+  // into the command handler — they never reached the agent. The guard returns
+  // /(?!)/ (matches nothing) instead. A channel with zero registered commands
+  // must treat ordinary text (and even slash-looking text) as NOT a command.
+  describe('line (no registered commands)', () => {
+    it('never treats a normal message as a command', () => {
+      expect(isBuiltinCommand('hi', 'line')).toBe(false);
+      expect(isBuiltinCommand('สวัสดี', 'line')).toBe(false);
+      expect(isBuiltinCommand('', 'line')).toBe(false);
+    });
+
+    it('does not match even telegram command syntax on the line channel', () => {
+      expect(isBuiltinCommand('/session', 'line')).toBe(false);
+      expect(isBuiltinCommand('/help', 'line')).toBe(false);
+    });
+  });
 });

--- a/tests/unit/line-access.test.ts
+++ b/tests/unit/line-access.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the LINE DM access gate (src/api/line-access.ts).
+ * Pure logic, no network. Closed-by-default posture (matches hermes/openclaw).
+ */
+import { isLineSenderAllowed, isLineConversationAllowed, resolveLineSource } from '../../src/api/line-access';
+
+const U = 'Ub3b856bfb309cf5717a305d0df1e846b';
+const G = 'Cf3a9c0000000000000000000000000000';
+const R = 'Re8f1d0000000000000000000000000000';
+
+describe('isLineSenderAllowed()', () => {
+  describe("policy 'open' → allow everyone", () => {
+    test('listed or not, always true', () => {
+      expect(isLineSenderAllowed('open', [], U)).toBe(true);
+      expect(isLineSenderAllowed('open', ['Uother'], U)).toBe(true);
+      expect(isLineSenderAllowed('open', undefined, U)).toBe(true);
+    });
+    test('even an empty userId passes (group source drops later in normalize)', () => {
+      expect(isLineSenderAllowed('open', [], '')).toBe(true);
+    });
+  });
+
+  describe("policy 'disabled' → deny everyone", () => {
+    test('always false, even if in the list', () => {
+      expect(isLineSenderAllowed('disabled', [U], U)).toBe(false);
+      expect(isLineSenderAllowed('disabled', [], U)).toBe(false);
+    });
+  });
+
+  describe("policy 'allowlist' → only listed senders", () => {
+    test('id in list → true', () => {
+      expect(isLineSenderAllowed('allowlist', [U, 'Uother'], U)).toBe(true);
+    });
+    test('id not in list → false', () => {
+      expect(isLineSenderAllowed('allowlist', ['Uother'], U)).toBe(false);
+    });
+    test('empty or undefined list → false', () => {
+      expect(isLineSenderAllowed('allowlist', [], U)).toBe(false);
+      expect(isLineSenderAllowed('allowlist', undefined, U)).toBe(false);
+    });
+  });
+
+  describe('policy undefined → closed default (allowlist semantics)', () => {
+    test('id in list → true', () => {
+      expect(isLineSenderAllowed(undefined, [U], U)).toBe(true);
+    });
+    test('id not in list / empty / undefined list → false', () => {
+      expect(isLineSenderAllowed(undefined, ['Uother'], U)).toBe(false);
+      expect(isLineSenderAllowed(undefined, [], U)).toBe(false);
+      expect(isLineSenderAllowed(undefined, undefined, U)).toBe(false);
+    });
+  });
+
+  describe('empty userId', () => {
+    test('false under closed/allowlist even if "" somehow in the list', () => {
+      expect(isLineSenderAllowed(undefined, [''], '')).toBe(false);
+      expect(isLineSenderAllowed('allowlist', [''], '')).toBe(false);
+    });
+  });
+
+  describe('case sensitivity (LINE userIds are case-sensitive)', () => {
+    test('different case → not a match', () => {
+      expect(isLineSenderAllowed('allowlist', [U.toUpperCase()], U)).toBe(false);
+      expect(isLineSenderAllowed('allowlist', [U.toLowerCase()], U)).toBe(false);
+    });
+  });
+});
+
+describe('resolveLineSource()', () => {
+  test('user → conversationId = senderId = userId', () => {
+    expect(resolveLineSource({ type: 'user', userId: U })).toEqual({
+      conversationId: U, senderId: U, kind: 'user',
+    });
+  });
+  test('group → conversationId = groupId, senderId = userId', () => {
+    expect(resolveLineSource({ type: 'group', groupId: G, userId: U })).toEqual({
+      conversationId: G, senderId: U, kind: 'group',
+    });
+  });
+  test('group without userId (no profile consent) → senderId empty', () => {
+    expect(resolveLineSource({ type: 'group', groupId: G })).toEqual({
+      conversationId: G, senderId: '', kind: 'group',
+    });
+  });
+  test('room → conversationId = roomId', () => {
+    expect(resolveLineSource({ type: 'room', roomId: R, userId: U })).toEqual({
+      conversationId: R, senderId: U, kind: 'room',
+    });
+  });
+  test('unknown / missing → other', () => {
+    expect(resolveLineSource(undefined).kind).toBe('other');
+    expect(resolveLineSource({ type: 'something' }).kind).toBe('other');
+  });
+});
+
+describe('isLineConversationAllowed()', () => {
+  test('user source uses dmPolicy/dmAllowlist (unchanged DM behavior)', () => {
+    expect(isLineConversationAllowed({ dmPolicy: 'open' }, { type: 'user', userId: U })).toBe(true);
+    expect(isLineConversationAllowed({ dmAllowlist: [U] }, { type: 'user', userId: U })).toBe(true);
+    expect(isLineConversationAllowed({}, { type: 'user', userId: U })).toBe(false); // closed default
+    expect(isLineConversationAllowed({ dmPolicy: 'disabled', dmAllowlist: [U] }, { type: 'user', userId: U })).toBe(false);
+  });
+  test('group source uses groupPolicy/groupAllowlist, NOT dm fields', () => {
+    expect(isLineConversationAllowed({ groupAllowlist: [G] }, { type: 'group', groupId: G, userId: U })).toBe(true);
+    expect(isLineConversationAllowed({ groupPolicy: 'open' }, { type: 'group', groupId: G })).toBe(true);
+    expect(isLineConversationAllowed({}, { type: 'group', groupId: G })).toBe(false); // closed default
+    expect(isLineConversationAllowed({ groupPolicy: 'disabled', groupAllowlist: [G] }, { type: 'group', groupId: G })).toBe(false);
+    // DM allowlist must NOT grant group access:
+    expect(isLineConversationAllowed({ dmPolicy: 'open' }, { type: 'group', groupId: G })).toBe(false);
+  });
+  test('room source gated on groupAllowlist (shared with groups)', () => {
+    expect(isLineConversationAllowed({ groupAllowlist: [R] }, { type: 'room', roomId: R })).toBe(true);
+    expect(isLineConversationAllowed({}, { type: 'room', roomId: R })).toBe(false);
+  });
+  test('unknown source kind → denied', () => {
+    expect(isLineConversationAllowed({ dmPolicy: 'open', groupPolicy: 'open' }, { type: 'x' })).toBe(false);
+  });
+});

--- a/tests/unit/line-mention.test.ts
+++ b/tests/unit/line-mention.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for the LINE bot-mention helper (src/api/line-mention.ts).
+ * Pure logic; @All never counts, native isSelf is the reliable signal.
+ */
+import { wasBotMentioned, hasNativeBotMention } from '../../src/api/line-mention';
+
+describe('wasBotMentioned()', () => {
+  test('native isSelf mention → true', () => {
+    const msg = {
+      type: 'text',
+      text: '@bot help',
+      mention: { mentionees: [{ type: 'user', isSelf: true }] },
+    };
+    expect(wasBotMentioned(msg)).toBe(true);
+    expect(hasNativeBotMention(msg)).toBe(true);
+  });
+
+  test('mention of another user (isSelf false) → false', () => {
+    const msg = {
+      type: 'text',
+      text: '@somchai hi',
+      mention: { mentionees: [{ type: 'user', isSelf: false }] },
+    };
+    expect(wasBotMentioned(msg)).toBe(false);
+  });
+
+  test('@All (type: all) does NOT count as a bot mention', () => {
+    const msg = { type: 'text', text: '@All meeting', mention: { mentionees: [{ type: 'all' }] } };
+    expect(wasBotMentioned(msg)).toBe(false);
+  });
+
+  test('bot mentioned among several mentionees → true', () => {
+    const msg = {
+      type: 'text',
+      text: '@somchai @bot',
+      mention: { mentionees: [{ type: 'user', isSelf: false }, { type: 'user', isSelf: true }] },
+    };
+    expect(wasBotMentioned(msg)).toBe(true);
+  });
+
+  test('no mention object → false', () => {
+    expect(wasBotMentioned({ type: 'text', text: 'hello' })).toBe(false);
+    expect(wasBotMentioned(undefined)).toBe(false);
+  });
+
+  test('typed @name in plain text (no native mention) does NOT count', () => {
+    // Only native isSelf mentions wake the bot; a typed name is let through silently.
+    expect(wasBotMentioned({ type: 'text', text: 'hey @Buddy can you help' })).toBe(false);
+  });
+});

--- a/tests/unit/line-pending-senders.test.ts
+++ b/tests/unit/line-pending-senders.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the LINE pending-senders store (src/api/line-pending-senders.ts).
+ * In-memory, deterministic via injected `now`.
+ */
+import {
+  recordDeniedSender,
+  recordDeniedConversation,
+  getPendingSenders,
+  getPendingSender,
+  clearPendingSender,
+  generatePairingCode,
+  _resetPendingSenders,
+  MAX_PENDING_PER_AGENT,
+} from '../../src/api/line-pending-senders';
+
+const A = 'getpod';
+
+describe('line pending store', () => {
+  beforeEach(() => _resetPendingSenders());
+
+  it('records a denied sender with display name', () => {
+    recordDeniedSender(A, 'Ualice', 'Alice', 1000);
+    const list = getPendingSenders(A);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ userId: 'Ualice', displayName: 'Alice', count: 1, firstSeen: 1000, lastSeen: 1000 });
+  });
+
+  it('dedups by userId: bumps count + lastSeen, backfills displayName', () => {
+    recordDeniedSender(A, 'Ualice', undefined, 1000);
+    recordDeniedSender(A, 'Ualice', 'Alice', 2000);
+    const list = getPendingSenders(A);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ count: 2, firstSeen: 1000, lastSeen: 2000, displayName: 'Alice' });
+  });
+
+  it('returns most-recent first', () => {
+    recordDeniedSender(A, 'Ua', 'A', 1000);
+    recordDeniedSender(A, 'Ub', 'B', 3000);
+    recordDeniedSender(A, 'Uc', 'C', 2000);
+    expect(getPendingSenders(A).map((s) => s.userId)).toEqual(['Ub', 'Uc', 'Ua']);
+  });
+
+  it('caps per agent, evicting the least-recently-seen', () => {
+    for (let i = 0; i < MAX_PENDING_PER_AGENT; i++) {
+      recordDeniedSender(A, `U${i}`, undefined, 1000 + i);
+    }
+    // U0 is oldest; adding one more evicts it
+    recordDeniedSender(A, 'Unew', undefined, 9999);
+    const ids = getPendingSenders(A).map((s) => s.userId);
+    expect(ids).toHaveLength(MAX_PENDING_PER_AGENT);
+    expect(ids).toContain('Unew');
+    expect(ids).not.toContain('U0');
+  });
+
+  it('isolates agents', () => {
+    recordDeniedSender('a1', 'Ux', undefined, 1);
+    recordDeniedSender('a2', 'Uy', undefined, 1);
+    expect(getPendingSenders('a1').map((s) => s.userId)).toEqual(['Ux']);
+    expect(getPendingSenders('a2').map((s) => s.userId)).toEqual(['Uy']);
+  });
+
+  it('clearPendingSender drops one user (e.g. after adding to allowlist)', () => {
+    recordDeniedSender(A, 'Ualice', undefined, 1);
+    recordDeniedSender(A, 'Ubob', undefined, 2);
+    clearPendingSender(A, 'Ualice');
+    expect(getPendingSenders(A).map((s) => s.userId)).toEqual(['Ubob']);
+  });
+
+  it('ignores empty agentId or userId', () => {
+    recordDeniedSender('', 'Ux');
+    recordDeniedSender(A, '');
+    expect(getPendingSenders(A)).toHaveLength(0);
+  });
+
+  describe('recordDeniedConversation (group/room)', () => {
+    it('records a group with kind + name', () => {
+      recordDeniedConversation(A, 'Cgroup1', 'group', 'Team Dev', 1000);
+      const list = getPendingSenders(A);
+      expect(list).toHaveLength(1);
+      expect(list[0]).toMatchObject({ userId: 'Cgroup1', displayName: 'Team Dev', kind: 'group', count: 1 });
+    });
+
+    it('records a room (no name) with kind room', () => {
+      recordDeniedConversation(A, 'Rroom1', 'room', undefined, 1000);
+      expect(getPendingSenders(A)[0]).toMatchObject({ userId: 'Rroom1', kind: 'room' });
+      expect(getPendingSenders(A)[0].displayName).toBeUndefined();
+    });
+
+    it('dedups a group by id, backfilling the name on a later resolve', () => {
+      recordDeniedConversation(A, 'Cg', 'group', undefined, 1000);
+      recordDeniedConversation(A, 'Cg', 'group', 'Family', 2000);
+      const list = getPendingSenders(A);
+      expect(list).toHaveLength(1);
+      expect(list[0]).toMatchObject({ count: 2, displayName: 'Family', kind: 'group' });
+    });
+
+    it('users and groups coexist in one knock list, tagged by kind', () => {
+      recordDeniedSender(A, 'Ualice', 'Alice', 1000);
+      recordDeniedConversation(A, 'Cteam', 'group', 'Team', 2000);
+      const byId = Object.fromEntries(getPendingSenders(A).map((s) => [s.userId, s.kind]));
+      expect(byId).toEqual({ Ualice: 'user', Cteam: 'group' });
+    });
+
+    it('clearPendingSender drops a group id too (after adding to groupAllowlist)', () => {
+      recordDeniedConversation(A, 'Cteam', 'group', 'Team', 1);
+      clearPendingSender(A, 'Cteam');
+      expect(getPendingSenders(A)).toHaveLength(0);
+    });
+  });
+
+  describe('pairing code', () => {
+    it('generatePairingCode is 6 uppercase hex', () => {
+      for (let i = 0; i < 50; i++) {
+        expect(generatePairingCode()).toMatch(/^[0-9A-F]{6}$/);
+      }
+    });
+
+    it('returns true (wasNew) on first contact, false on dedup', () => {
+      expect(recordDeniedSender(A, 'Ualice', undefined, 1000, 'ABC123')).toBe(true);
+      expect(recordDeniedSender(A, 'Ualice', undefined, 2000, 'ZZZ999')).toBe(false);
+    });
+
+    it('sets code on create and never overwrites it on dedup', () => {
+      recordDeniedSender(A, 'Ualice', undefined, 1000, 'ABC123');
+      recordDeniedSender(A, 'Ualice', 'Alice', 2000, 'ZZZ999');
+      expect(getPendingSender(A, 'Ualice')?.code).toBe('ABC123');
+    });
+
+    it('stores a code for group/room entries too', () => {
+      expect(recordDeniedConversation(A, 'Cteam', 'group', undefined, 1000, 'DEAD01')).toBe(true);
+      expect(getPendingSender(A, 'Cteam')?.code).toBe('DEAD01');
+    });
+
+    it('getPendingSender returns undefined for an unknown id', () => {
+      expect(getPendingSender(A, 'Unope')).toBeUndefined();
+    });
+
+    it('leaves code undefined when none is passed (pairing off)', () => {
+      recordDeniedSender(A, 'Ubob', 'Bob', 1000);
+      expect(getPendingSender(A, 'Ubob')?.code).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/line-reply-manager.test.ts
+++ b/tests/unit/line-reply-manager.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for LineReplyManager — the slow-LLM postback button state machine
+ * ported from hermes-agent. The LINE SDK client and logger are mocked; the
+ * slow-button timer is driven with jest fake timers.
+ */
+jest.mock('@line/bot-sdk', () => {
+  const replyMessage = jest.fn();
+  const pushMessage = jest.fn();
+  return {
+    messagingApi: {
+      MessagingApiClient: jest.fn(() => ({ replyMessage, pushMessage })),
+      __mock: { replyMessage, pushMessage },
+    },
+  };
+});
+jest.mock('../../src/logger', () => ({
+  createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+
+import { messagingApi } from '@line/bot-sdk';
+import { LineReplyManager } from '../../src/agent/line-reply-manager';
+
+const { replyMessage, pushMessage } = (messagingApi as any).__mock as {
+  replyMessage: jest.Mock;
+  pushMessage: jest.Mock;
+};
+
+const CHAT = 'U123';
+const THRESHOLD_S = 1; // → 1000ms timer
+
+/** Flush pending microtasks so awaited mock calls settle. */
+const tick = async () => {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+};
+
+function newManager() {
+  return new LineReplyManager({
+    agentId: 'getpod',
+    logDir: '/tmp',
+    accessToken: 'tok',
+    thresholdSeconds: THRESHOLD_S,
+  });
+}
+
+/** Pull the postback `data` JSON out of the most recent button reply. */
+function lastButtonData(): any {
+  const call = replyMessage.mock.calls.find(
+    ([req]) => req.messages?.[0]?.type === 'template',
+  );
+  return JSON.parse(call![0].messages[0].template.actions[0].data);
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  replyMessage.mockReset().mockResolvedValue({});
+  pushMessage.mockReset().mockResolvedValue({});
+});
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('LineReplyManager', () => {
+  test('1. fast answer → free reply, no button, no push', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    await m.onAnswer(CHAT, 'hello');
+    await tick();
+    expect(replyMessage).toHaveBeenCalledTimes(1);
+    expect(replyMessage.mock.calls[0][0]).toMatchObject({ replyToken: 'rt-1' });
+    expect(replyMessage.mock.calls[0][0].messages[0]).toEqual({ type: 'text', text: 'hello' });
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('2. slow answer → Template Buttons sent via reply token, then answer cached (no push)', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    // Button sent via the reply token.
+    expect(replyMessage).toHaveBeenCalledTimes(1);
+    const sent = replyMessage.mock.calls[0][0];
+    expect(sent.replyToken).toBe('rt-1');
+    expect(sent.messages[0].type).toBe('template');
+    expect(sent.messages[0].template.type).toBe('buttons');
+    expect(lastButtonData()).toMatchObject({ action: 'show_response' });
+    expect(lastButtonData().request_id).toBeTruthy();
+    // Answer arrives after the button → cached, nothing more sent.
+    await m.onAnswer(CHAT, 'the answer');
+    await tick();
+    expect(replyMessage).toHaveBeenCalledTimes(1); // still just the button
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('3. tap after ready → cached answer delivered free via fresh token', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    const data = lastButtonData();
+    await m.onAnswer(CHAT, 'the answer');
+    await tick();
+
+    const handled = await m.handlePostback(CHAT, 'rt-fresh', JSON.stringify(data));
+    await tick();
+    expect(handled).toBe(true);
+    const deliver = replyMessage.mock.calls.at(-1)![0];
+    expect(deliver.replyToken).toBe('rt-fresh');
+    expect(deliver.messages[0]).toEqual({ type: 'text', text: 'the answer' });
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('4. tap before ready → "still thinking", then next tap delivers', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    const data = lastButtonData();
+
+    // Tap while still PENDING.
+    await m.handlePostback(CHAT, 'rt-fresh1', JSON.stringify(data));
+    await tick();
+    const pendingReply = replyMessage.mock.calls.at(-1)![0];
+    expect(pendingReply.replyToken).toBe('rt-fresh1');
+    expect(pendingReply.messages[0].text).toMatch(/thinking/i);
+
+    // Answer arrives, then tap again → delivered.
+    await m.onAnswer(CHAT, 'final');
+    await m.handlePostback(CHAT, 'rt-fresh2', JSON.stringify(data));
+    await tick();
+    const deliver = replyMessage.mock.calls.at(-1)![0];
+    expect(deliver.replyToken).toBe('rt-fresh2');
+    expect(deliver.messages[0].text).toBe('final');
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('5. never taps → no push (answer waits in cache)', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    await m.onAnswer(CHAT, 'cached forever');
+    await tick();
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('6. rapid messages → only one button per chat', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    m.onInbound(CHAT, 'rt-2'); // second turn before first button consumed
+    jest.advanceTimersByTime(1000);
+    await tick();
+    const buttons = replyMessage.mock.calls.filter(([r]) => r.messages?.[0]?.type === 'template');
+    expect(buttons).toHaveLength(1); // one outstanding button per chat
+    m.disposeAll();
+  });
+
+  test('6b. consecutive slow turns: prior answered+untapped button does not swallow the 2nd answer', async () => {
+    const m = newManager();
+    // Turn 1: slow → button, answered (READY), never tapped.
+    m.onInbound(CHAT, 'rt-1');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    const data1 = lastButtonData();
+    await m.onAnswer(CHAT, 'answer-1');
+    await tick();
+
+    // Turn 2: new inbound supersedes the resolved button → fires its OWN button.
+    m.onInbound(CHAT, 'rt-2');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    const buttons = () =>
+      replyMessage.mock.calls.filter(([r]) => r.messages?.[0]?.type === 'template');
+    expect(buttons()).toHaveLength(2); // turn 2 got its own button (not blocked)
+    await m.onAnswer(CHAT, 'answer-2');
+    await tick();
+
+    // Old button still delivers turn-1's answer …
+    await m.handlePostback(CHAT, 'rt-fresh-1', JSON.stringify(data1));
+    await tick();
+    expect(replyMessage.mock.calls.at(-1)![0].messages[0].text).toBe('answer-1');
+    // … and the new button delivers turn-2's answer (would be lost before the fix).
+    const data2 = JSON.parse(buttons().at(-1)![0].messages[0].template.actions[0].data);
+    await m.handlePostback(CHAT, 'rt-fresh-2', JSON.stringify(data2));
+    await tick();
+    expect(replyMessage.mock.calls.at(-1)![0].messages[0].text).toBe('answer-2');
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('8b. interrupt AFTER answer cached → READY preserved, tap still delivers the answer', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    const data = lastButtonData();
+    await m.onAnswer(CHAT, 'real answer'); // READY
+    await tick();
+    // proc 'exit' fires after a normal answered turn → markInterrupted must NOT
+    // clobber a READY entry (this is the safety property the runner relies on).
+    m.markInterrupted(CHAT);
+    await m.handlePostback(CHAT, 'rt-fresh', JSON.stringify(data));
+    await tick();
+    expect(replyMessage.mock.calls.at(-1)![0].messages[0].text).toBe('real answer');
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('7. reply token rejected → push fallback (fast path)', async () => {
+    replyMessage.mockRejectedValueOnce(new Error('Invalid reply token'));
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    await m.onAnswer(CHAT, 'hello');
+    await tick();
+    expect(replyMessage).toHaveBeenCalledTimes(1);
+    expect(pushMessage).toHaveBeenCalledTimes(1);
+    expect(pushMessage.mock.calls[0][0]).toMatchObject({ to: CHAT });
+    m.disposeAll();
+  });
+
+  test('8. interrupted → tap returns the interrupted notice', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    jest.advanceTimersByTime(1000);
+    await tick();
+    const data = lastButtonData();
+    m.markInterrupted(CHAT);
+    await m.handlePostback(CHAT, 'rt-fresh', JSON.stringify(data));
+    await tick();
+    const reply = replyMessage.mock.calls.at(-1)![0];
+    expect(reply.messages[0].text).toMatch(/interrupted/i);
+    m.disposeAll();
+  });
+
+  test('9. double-fire (tool_use + result) → answer sent once', async () => {
+    const m = newManager();
+    m.onInbound(CHAT, 'rt-1');
+    await m.onAnswer(CHAT, 'hello');
+    await m.onAnswer(CHAT, 'hello'); // result fallback, same turn
+    await tick();
+    expect(replyMessage).toHaveBeenCalledTimes(1);
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('foreign postback (not ours) → returns false, nothing sent', async () => {
+    const m = newManager();
+    const handled = await m.handlePostback(CHAT, 'rt-x', JSON.stringify({ action: 'other' }));
+    expect(handled).toBe(false);
+    expect(replyMessage).not.toHaveBeenCalled();
+    expect(pushMessage).not.toHaveBeenCalled();
+    m.disposeAll();
+  });
+
+  test('non-JSON postback data → returns false', async () => {
+    const m = newManager();
+    expect(await m.handlePostback(CHAT, 'rt-x', 'not json')).toBe(false);
+    m.disposeAll();
+  });
+
+  describe('armButton:false (group/room — button disabled, answer still delivers)', () => {
+    test('no button fires even after the threshold elapses', async () => {
+      const m = newManager();
+      m.onInbound('G1', 'rt-g', { armButton: false });
+      jest.advanceTimersByTime(THRESHOLD_S * 1000 + 50);
+      await tick();
+      expect(replyMessage).not.toHaveBeenCalled();
+      m.disposeAll();
+    });
+
+    test('fast answer still delivers via the stashed reply token (free, plain text)', async () => {
+      const m = newManager();
+      m.onInbound('G1', 'rt-g', { armButton: false });
+      await m.onAnswer('G1', 'hi group');
+      await tick();
+      expect(replyMessage).toHaveBeenCalledTimes(1);
+      expect(replyMessage.mock.calls[0][0]).toMatchObject({ replyToken: 'rt-g' });
+      expect(replyMessage.mock.calls[0][0].messages[0].type).toBe('text');
+      m.disposeAll();
+    });
+
+    test('answer after the token expires falls back to push (to the group id)', async () => {
+      const m = newManager();
+      m.onInbound('G1', 'rt-g', { armButton: false });
+      jest.advanceTimersByTime(60_000); // let the reply-token TTL lapse
+      await m.onAnswer('G1', 'late answer');
+      await tick();
+      expect(pushMessage).toHaveBeenCalledTimes(1);
+      expect(pushMessage.mock.calls[0][0]).toMatchObject({ to: 'G1' });
+      m.disposeAll();
+    });
+  });
+});

--- a/tests/unit/line.test.ts
+++ b/tests/unit/line.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Unit tests for the LINE channel's pure logic:
+ *  - chunkText / batch  (mcp/tools/line/pure.ts)  — outbound splitting
+ *  - normalizeLineEvent (src/api/line-webhook-router.ts) — inbound parsing
+ *
+ * Signature validation is the SDK's own (validateSignature, HMAC-SHA256 +
+ * timing-safe compare) and is trusted here rather than re-tested. No network in
+ * this file.
+ */
+import {
+  chunkText,
+  batch,
+  planLineSend,
+  LINE_TEXT_LIMIT,
+  LINE_MAX_MESSAGES_PER_REQUEST,
+} from '../../mcp/tools/line/pure';
+import {
+  stripMarkdownPreservingUrls,
+  splitForLine,
+  LINE_SAFE_BUBBLE_CHARS,
+} from '../../src/agent/line-pure';
+import { normalizeLineEvent } from '../../src/api/line-webhook-router';
+import { LineModule } from '../../mcp/tools/line/module';
+
+describe('chunkText()', () => {
+  test('text <= limit → single chunk', () => {
+    expect(chunkText('hello', LINE_TEXT_LIMIT)).toEqual(['hello']);
+  });
+
+  test('empty string → single empty chunk (callers always have something to send)', () => {
+    expect(chunkText('', LINE_TEXT_LIMIT)).toEqual(['']);
+  });
+
+  test('text exactly at limit → single chunk', () => {
+    const text = 'a'.repeat(LINE_TEXT_LIMIT);
+    expect(chunkText(text, LINE_TEXT_LIMIT)).toEqual([text]);
+  });
+
+  test('text > limit → hard cut into <=limit pieces', () => {
+    const text = 'a'.repeat(LINE_TEXT_LIMIT + 50);
+    const out = chunkText(text, LINE_TEXT_LIMIT);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toHaveLength(LINE_TEXT_LIMIT);
+    expect(out[1]).toHaveLength(50);
+    expect(out.join('')).toBe(text);
+  });
+
+  test('prefers to break on a newline within the limit', () => {
+    const text = 'a'.repeat(10) + '\n' + 'b'.repeat(12);
+    const out = chunkText(text, 15);
+    expect(out[0]).toBe('a'.repeat(10)); // broke at the newline, not at char 15
+    expect(out[1]).toBe('b'.repeat(12)); // newline consumed, remainder fits
+  });
+
+  test('every chunk respects the limit', () => {
+    const text = 'x'.repeat(LINE_TEXT_LIMIT * 3 + 7);
+    for (const chunk of chunkText(text, LINE_TEXT_LIMIT)) {
+      expect(chunk.length).toBeLessThanOrEqual(LINE_TEXT_LIMIT);
+    }
+  });
+});
+
+describe('batch()', () => {
+  test('groups into batches of <= the per-request cap', () => {
+    const items = Array.from({ length: 12 }, (_, i) => i);
+    const groups = batch(items); // default = LINE_MAX_MESSAGES_PER_REQUEST (5)
+    expect(groups.map(g => g.length)).toEqual([5, 5, 2]);
+    expect(groups.flat()).toEqual(items);
+  });
+
+  test('fewer than the cap → single group', () => {
+    expect(batch([1, 2, 3])).toEqual([[1, 2, 3]]);
+  });
+
+  test('empty input → no groups', () => {
+    expect(batch([])).toEqual([]);
+  });
+
+  test('cap matches the documented LINE limit', () => {
+    expect(LINE_MAX_MESSAGES_PER_REQUEST).toBe(5);
+  });
+});
+
+describe('planLineSend()', () => {
+  test('no reply token → everything pushes (reply API unused)', () => {
+    const plan = planLineSend(['a', 'b', 'c'], false);
+    expect(plan.replyBatch).toBeNull();
+    expect(plan.pushBatches).toEqual([['a', 'b', 'c']]);
+  });
+
+  test('with reply token, single batch → reply only, no push', () => {
+    const plan = planLineSend(['a', 'b', 'c'], true);
+    expect(plan.replyBatch).toEqual(['a', 'b', 'c']);
+    expect(plan.pushBatches).toEqual([]);
+  });
+
+  test('with reply token, >1 batch → first batch replies (free), rest push', () => {
+    const chunks = Array.from({ length: 12 }, (_, i) => `m${i}`);
+    const plan = planLineSend(chunks, true);
+    expect(plan.replyBatch).toHaveLength(LINE_MAX_MESSAGES_PER_REQUEST); // 5
+    expect(plan.replyBatch).toEqual(chunks.slice(0, 5));
+    expect(plan.pushBatches.map((b) => b.length)).toEqual([5, 2]); // remaining 7
+    expect([...(plan.replyBatch ?? []), ...plan.pushBatches.flat()]).toEqual(chunks);
+  });
+
+  test('empty chunks → nothing to reply, no push batches', () => {
+    expect(planLineSend([], true)).toEqual({ replyBatch: null, pushBatches: [] });
+  });
+});
+
+describe('normalizeLineEvent()', () => {
+  const textEvent = (over: Record<string, unknown> = {}) =>
+    ({
+      type: 'message',
+      timestamp: 1700000000000,
+      replyToken: 'rt-123',
+      source: { type: 'user', userId: 'U123' },
+      message: { type: 'text', id: 'm1', text: 'สวัสดี' },
+      ...over,
+    }) as any;
+
+  test('1:1 text message → {content, meta}', () => {
+    const norm = normalizeLineEvent(textEvent());
+    expect(norm).not.toBeNull();
+    expect(norm!.content).toBe('สวัสดี');
+    expect(norm!.meta).toMatchObject({
+      source: 'line',
+      chat_id: 'U123',
+      user_id: 'U123',
+      user: 'U123',
+      message_id: 'm1',
+      reply_token: 'rt-123',
+    });
+    // epoch ms → ISO
+    expect(norm!.meta.ts).toBe(new Date(1700000000000).toISOString());
+  });
+
+  test('non-message event → null', () => {
+    expect(normalizeLineEvent(textEvent({ type: 'follow' }))).toBeNull();
+  });
+
+  test('image message → normalized with media_type=image and empty content', () => {
+    const norm = normalizeLineEvent(textEvent({ message: { type: 'image', id: 'i1' } }));
+    expect(norm).not.toBeNull();
+    expect(norm!.content).toBe('');
+    expect(norm!.meta.media_type).toBe('image');
+    expect(norm!.meta.message_id).toBe('i1');
+    expect(norm!.meta.chat_id).toBe('U123');
+    // reply_token still flows through so the agent can answer for free
+    expect(norm!.meta.reply_token).toBe('rt-123');
+  });
+
+  test('other media (e.g. sticker/video) → null (only text + image handled)', () => {
+    expect(
+      normalizeLineEvent(textEvent({ message: { type: 'sticker', id: 's1' } })),
+    ).toBeNull();
+    expect(
+      normalizeLineEvent(textEvent({ message: { type: 'video', id: 'v1' } })),
+    ).toBeNull();
+  });
+
+  test('group source → normalized; chat_id=groupId, user_id=sender, line_chat_type=group', () => {
+    const norm = normalizeLineEvent(
+      textEvent({ source: { type: 'group', groupId: 'G1', userId: 'U123' } }),
+    );
+    expect(norm).not.toBeNull();
+    expect(norm!.meta).toMatchObject({
+      chat_id: 'G1',
+      user_id: 'U123',
+      line_chat_type: 'group',
+      reply_token: 'rt-123',
+    });
+  });
+
+  test('group source without sender userId → user_id falls back to groupId', () => {
+    const norm = normalizeLineEvent(textEvent({ source: { type: 'group', groupId: 'G1' } }));
+    expect(norm).not.toBeNull();
+    expect(norm!.meta.chat_id).toBe('G1');
+    expect(norm!.meta.user_id).toBe('G1');
+    expect(norm!.meta.line_chat_type).toBe('group');
+  });
+
+  test('room source → normalized with line_chat_type=room, chat_id=roomId', () => {
+    const norm = normalizeLineEvent(
+      textEvent({ source: { type: 'room', roomId: 'R1', userId: 'U123' } }),
+    );
+    expect(norm).not.toBeNull();
+    expect(norm!.meta.chat_id).toBe('R1');
+    expect(norm!.meta.line_chat_type).toBe('room');
+  });
+
+  test('1:1 text carries line_chat_type=user', () => {
+    expect(normalizeLineEvent(textEvent())!.meta.line_chat_type).toBe('user');
+  });
+
+  test('group source without a groupId → null', () => {
+    expect(normalizeLineEvent(textEvent({ source: { type: 'group' } }))).toBeNull();
+  });
+
+  test('user source without userId → null', () => {
+    expect(
+      normalizeLineEvent(textEvent({ source: { type: 'user' } })),
+    ).toBeNull();
+  });
+
+  test('omits reply_token when the event has none', () => {
+    const norm = normalizeLineEvent(textEvent({ replyToken: undefined }));
+    expect(norm).not.toBeNull();
+    expect(norm!.meta.reply_token).toBeUndefined();
+  });
+});
+
+describe('stripMarkdownPreservingUrls()', () => {
+  test('empty/undefined passthrough', () => {
+    expect(stripMarkdownPreservingUrls('')).toBe('');
+  });
+
+  test('markdown link → "label (url)" so the URL stays tappable', () => {
+    expect(stripMarkdownPreservingUrls('see [docs](https://a.co/x) now')).toBe(
+      'see docs (https://a.co/x) now',
+    );
+  });
+
+  test('bare URL is left untouched', () => {
+    expect(stripMarkdownPreservingUrls('go https://a.co/x')).toBe('go https://a.co/x');
+  });
+
+  test('bold/italic/inline-code markers stripped, content kept', () => {
+    expect(stripMarkdownPreservingUrls('**bold** *it* `code`')).toBe('bold it code');
+  });
+
+  test('code fence: inner content kept, fences dropped', () => {
+    expect(stripMarkdownPreservingUrls('```js\nconst a=1;\n```')).toBe('const a=1;');
+  });
+
+  test('headings stripped, bullets normalized to •', () => {
+    expect(stripMarkdownPreservingUrls('# Title\n- one\n- two')).toBe('Title\n• one\n• two');
+  });
+});
+
+describe('splitForLine()', () => {
+  test('empty → no chunks', () => {
+    expect(splitForLine('')).toEqual([]);
+  });
+
+  test('short text → single chunk', () => {
+    expect(splitForLine('hello')).toEqual(['hello']);
+  });
+
+  test('text at the safe limit → single chunk', () => {
+    const text = 'a'.repeat(LINE_SAFE_BUBBLE_CHARS);
+    expect(splitForLine(text)).toEqual([text]);
+  });
+
+  test('prefers paragraph break within budget', () => {
+    const a = 'a'.repeat(40);
+    const b = 'b'.repeat(40);
+    const out = splitForLine(`${a}\n\n${b}`, 50);
+    expect(out[0]).toBe(a);
+    expect(out[1]).toBe(b);
+  });
+
+  test('never exceeds the 5-message budget; final chunk gets an ellipsis', () => {
+    const text = 'x'.repeat(LINE_SAFE_BUBBLE_CHARS * 10);
+    const out = splitForLine(text);
+    expect(out.length).toBeLessThanOrEqual(LINE_MAX_MESSAGES_PER_REQUEST);
+    expect(out[out.length - 1].endsWith('…')).toBe(true);
+  });
+});
+
+describe('LineModule line_reply refresh guard', () => {
+  const restore: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    restore.refresh = process.env.LINE_REPLY_REFRESH;
+    restore.token = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+  });
+  afterEach(() => {
+    if (restore.refresh === undefined) delete process.env.LINE_REPLY_REFRESH;
+    else process.env.LINE_REPLY_REFRESH = restore.refresh;
+    if (restore.token === undefined) delete process.env.LINE_CHANNEL_ACCESS_TOKEN;
+    else process.env.LINE_CHANNEL_ACCESS_TOKEN = restore.token;
+  });
+
+  test('LINE_REPLY_REFRESH=1 → no-op handed to gateway, no send attempted', async () => {
+    process.env.LINE_REPLY_REFRESH = '1';
+    delete process.env.LINE_CHANNEL_ACCESS_TOKEN; // guard must short-circuit before the token check
+    const mod = new LineModule();
+    const res = await mod.handleTool('line_reply', { chat_id: 'U123', text: 'hi' });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toMatch(/handed to gateway/i);
+  });
+
+  test('without refresh + no token → token error (proves the guard is what suppresses)', async () => {
+    delete process.env.LINE_REPLY_REFRESH;
+    delete process.env.LINE_CHANNEL_ACCESS_TOKEN;
+    const mod = new LineModule();
+    const res = await mod.handleTool('line_reply', { chat_id: 'U123', text: 'hi' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/missing LINE_CHANNEL_ACCESS_TOKEN/i);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,6 +527,13 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@line/bot-sdk@^11.0.2":
+  version "11.0.2"
+  resolved "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.0.2.tgz"
+  integrity sha512-Y2PCEIlKw5ytu56HhrZt0Wfb8ZxBjrpKTlsmaZ4nWkbHKV2F0T7ZpwFfT7FqXryyqOrl8+RdvFYBBXE4B464SA==
+  dependencies:
+    "@types/node" "^24.0.0"
+
 "@noble/hashes@^1.1.5":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
@@ -717,6 +724,13 @@
   dependencies:
     undici-types "~6.21.0"
 
+"@types/node@^24.0.0":
+  version "24.13.2"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz"
+  integrity sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==
+  dependencies:
+    undici-types "~7.18.0"
+
 "@types/qs@*":
   version "6.15.0"
   resolved "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz"
@@ -778,6 +792,13 @@
   version "0.2.6"
   resolved "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz"
   integrity sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==
+
+"@types/ws@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -3004,6 +3025,11 @@ undici-types@~6.21.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
+
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
@@ -3086,6 +3112,11 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+ws@^8.21.0:
+  version "8.21.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Summary

Adds **LINE** as a first-class chat channel for gateway agents, on par with Telegram and Discord. An agent with a `line` config block can receive LINE messages (1:1 and groups/rooms) and reply through the LINE Messaging API, with closed-by-default access control and a slow-response UX ported from hermes-agent.

## What's included

**Inbound** (`src/api/line-webhook-router.ts`)
- Webhook-only, mounted before `express.json()` so the raw body is available for `x-line-signature` HMAC validation (rejects forged POSTs with 401 before any processing).
- Normalizes LINE events into the existing `/channel` intake (same path Telegram uses). Text and image are handled; image bytes are fetched via the blob API into the agent's MediaStore.

**Outbound** (`mcp/tools/line/module.ts`, `src/agent/line-reply-manager.ts`)
- `line_reply` MCP tool: reply-token-first → push fallback (reply tokens are free, push is metered), Markdown-stripped and chunked to LINE's limits.
- Slow-LLM postback button: when a turn runs long, burn the reply token on a tappable Template button before it expires; tapping delivers the cached answer for free. Disabled in groups.

**Access control** (closed by default — `src/api/line-access.ts`)
- Tier 1 DM allowlist — `dmPolicy` (`open|allowlist|disabled`) + `dmAllowlist`.
- Tier 3 group/room allowlist — `groupPolicy` + `groupAllowlist`, with an `@mention` gate (`requireMention`; native `isSelf` mention only, `@All` never counts).
- Pairing: a one-time visual-match code replied to unknown senders (toggle, default on; free reply token only).
- Pending/knock list with best-effort display names so an admin can approve senders from the UI instead of grepping logs.

**Config** (`src/api/router.ts`)
- Per-agent over the agent API (token, secret, policies, pairing) — settable at runtime; the webhook reads live config per request.
- `config.template.json` documents a LINE-enabled agent by example.

## Test plan

- `tsc --noEmit` clean.
- Full jest suite green (run split to avoid OOM): unit **84 suites / 1673 tests**, integration **16 suites / 226 tests** = **1899 passing**, including:
  - `tests/unit/line-*.test.ts` — access gate, mention gate, pending senders, reply-manager state machine, pure chunking.
  - `tests/integration/line-config-to-chat.test.ts` — full "configure via PATCH → signed webhook → forwarded to agent" path against a mock LINE server.
  - `tests/unit/api-router-line.test.ts` — config API surface.
- The mock LINE base URL is injected via an explicit `createLineWebhookRouter(..., { apiBase })` option (not env), so there's no test-only seam in production code.

## Notes

- No secrets in the diff; LINE credentials are configured per-agent at runtime.
- Closed-by-default access is a deliberate posture: an existing LINE agent with no `dmPolicy`/`groupPolicy` stays silent until allowlisted (or set to `open`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
