### PR TITLE
fix(pty): replace transcript-gated menu detection with a behavioral keypress probe

### DIFF
--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -227,9 +227,8 @@ export class SessionProcess extends EventEmitter {
       // Defense-in-depth: defang any verbatim 32MB-overlay text captured into past
       // messages before it is re-typed into the TUI. The primary fix routes the real
       // error off the screen-scraper to the transcript's `<synthetic>` record (see
-      // TranscriptTailer.onRequestTooLarge), so detectRequestTooLarge() is no longer
-      // wired into the trigger — but neutralizing the re-injected copy keeps the
-      // poisoned overlay text off the screen entirely and out of any future scraper.
+      // TranscriptTailer.onRequestTooLarge) — but neutralizing the re-injected copy
+      // keeps the poisoned overlay text off the screen entirely and out of any future scraper.
       historyPrompt: `[Conversation history with this user:\n${neutralizeTuiTriggers(historyText)}]`,
       loadedAtSpawn,
       archivedCount,

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -14,13 +14,13 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as readline from 'readline';
 import { translateArgs, sanitizeUserText } from './args';
-import { ScreenModel, MenuOption, parseMenuChoice, formatMenuPrompt, formatPermissionPrompt, extractChannelContent, isPtyActivelyWorking } from './screen';
+import { ScreenModel, MenuOption, parseMenuChoice, formatMenuPrompt, formatPermissionPrompt, extractChannelContent, isPtyActivelyWorking, parseInteractivePrompt } from './screen';
 import { PtyHost } from './pty-host';
 import { TranscriptTailer, AssistantRecord, UsageInfo } from './tailer';
 import { ProtocolEmitter } from './emitter';
 import { preTrustWorkspace, checkAuthStatus } from './trust';
 import { decideMenuCancel } from './menu-cancel';
-import { decideProbeAttempt, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
+import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
 
 const POLL_MS = 200;
 const STARTUP_QUIET_MS = 600;
@@ -556,21 +556,28 @@ class Driver {
       turn.lastProgressAt = now;
       // Real activity resumed — a probe that ran out of rounds during this
       // stall gets a fresh budget if the turn genuinely stalls again later.
-      if (turn.probe) turn.probe.rounds = 0;
+      // Not while a round is in flight: a busy flicker mid-round must not
+      // hand that same stall a fresh budget (post-review hardening F5).
+      if (turn.probe && !this.probing) turn.probe.rounds = 0;
       return;
     }
 
     // Not busy. Possible: still rendering, swallowed Enter, dialog, menu, or done
     // (turn_duration normally ends the turn before we get here).
+    //
+    // While a probe round is outstanding, do nothing else at all — the dialog
+    // auto-accept '2' (post-review hardening F2) and the Enter-retry /
+    // fallback-idle keystrokes below must never interleave with the round's
+    // arrow keys; whatever they would handle is still there one tick later
+    // (a round is bounded to ≤ 2 × PROBE_SETTLE_MS).
+    if (this.probing) return;
     this.maybeHandleDialog();
 
     // Blocked on a live interactive overlay (AskUserQuestion menu, plan
     // approval, or a tool-permission Yes/No prompt) → probe behaviorally and
     // bridge it to chat if confirmed, so the session goes idle (no watchdog
     // kill) until the user picks an option. runProbe() ends the turn itself
-    // once a round confirms a live overlay; while a round is outstanding,
-    // skip the Enter-retry/fallback-idle checks below so they can't race a
-    // probe keystroke.
+    // once a round confirms a live overlay.
     this.maybeProbeAndBridge(turn);
     if (this.probing) return;
 
@@ -652,7 +659,7 @@ class Driver {
    * (via bridgeChoiceToChat()) only if a round confirms a live overlay.
    */
   private maybeProbeAndBridge(turn: ActiveTurn): void {
-    if (SKIP_MENU_BRIDGE || this.pendingMenu) return;
+    if (SKIP_MENU_BRIDGE || this.pendingMenu || this.interrupting) return;
     if (this.screen.detectDialog() === 'bypass-permissions') return;
     if (this.screen.quietMs() < MENU_STABLE_QUIET_MS) return;
     if (this.probing) return; // a round is already in flight
@@ -668,15 +675,25 @@ class Driver {
   /**
    * One probe round: send Down, settle, check for a screen change. If Down
    * produced nothing, retry once with Up (covers the "already at the last
-   * option, no wraparound" boundary case). A confirmed change is read via
-   * readInteractivePrompt() and bridged to chat; anything that doesn't parse
-   * cleanly is left alone (fail-safe — no bridge rather than a garbled one).
+   * option, no wraparound" boundary case). A change alone is NOT enough to
+   * bridge: the before/after snapshots must both parse as the same-shaped
+   * prompt whose ❯-highlighted row MOVED (confirmProbeReaction() — the
+   * plan's point-2 comparison; post-review hardening F1). Anything else —
+   * unparseable, or menu-shaped text whose caret didn't move (static
+   * blockquote prose, a quoted old menu) — is left alone and, if the Up
+   * fallback caused the change, restored with one Down (fail-safe: no
+   * bridge rather than a fabricated one).
    */
   private async runProbe(turn: ActiveTurn): Promise<void> {
     const before = this.screen.text();
+    const beforeParsed = parseInteractivePrompt(before);
     this.host.writeRaw(PROBE_KEY_DOWN);
     await new Promise((r) => setTimeout(r, PROBE_SETTLE_MS));
-    if (this.turn !== turn) return; // turn ended/changed while waiting — abandon
+    // Abandon on turn teardown AND on an in-flight /stop (SIGINT → ESC): the
+    // interrupted turn is still `this.turn` while its ESC settles, so the
+    // turn-identity check alone would let the round keep typing arrows over
+    // the interrupt (post-review hardening F3).
+    if (this.turn !== turn || this.interrupting) return;
 
     // A screen change while busy means real work resumed in the interim (a
     // reply started streaming) — not a menu reacting to our keystroke, so
@@ -687,19 +704,22 @@ class Driver {
       sentUp = true;
       this.host.writeRaw(PROBE_KEY_UP);
       await new Promise((r) => setTimeout(r, PROBE_SETTLE_MS));
-      if (this.turn !== turn) return;
+      if (this.turn !== turn || this.interrupting) return;
       changed = this.screen.text() !== before && !this.screen.isBusy();
     }
     if (!changed) return; // nothing reacted — not interactive, do nothing this round
 
-    const parsed = this.screen.readInteractivePrompt();
-    if (!parsed) {
-      // The Up fallback may have recalled input-line history on a genuinely
-      // idle (non-menu) input box; restore with a Down so the next real turn
-      // never starts pre-populated with stale recalled text. Unconditional
-      // and harmless even when Up did NOT recall anything (idle Down is a
-      // confirmed no-op) — never reached after a confirmed menu below, since
-      // that would move the live selection instead of restoring anything.
+    const parsed = parseInteractivePrompt(this.screen.text());
+    if (!beforeParsed || !parsed || !confirmProbeReaction(beforeParsed, parsed)) {
+      // Not a live overlay reacting to us — either nothing parses, or
+      // menu-shaped text is on screen but its highlight didn't move (static
+      // prose can't move; only a live menu can). The Up fallback may have
+      // recalled input-line history on a genuinely idle (non-menu) input
+      // box; restore with a Down so the next real turn never starts
+      // pre-populated with stale recalled text. Unconditional and harmless
+      // even when Up did NOT recall anything (idle Down is a confirmed
+      // no-op) — never reached after a confirmed menu below, since that
+      // would move the live selection instead of restoring anything.
       if (sentUp) this.host.writeRaw(PROBE_KEY_DOWN);
       return;
     }
@@ -707,7 +727,7 @@ class Driver {
     const text = parsed.isPermission
       ? formatPermissionPrompt(parsed.context, parsed.options)
       : formatMenuPrompt(parsed.options);
-    logWarn(`interactive ${parsed.isPermission ? 'permission prompt' : 'menu'} confirmed (${parsed.options.length} options) — bridging to chat`);
+    logWarn(`interactive ${parsed.isPermission ? 'permission prompt' : 'menu'} confirmed (${parsed.options.length} options, highlight ${beforeParsed.highlighted}→${parsed.highlighted}) — bridging to chat`);
     this.bridgeChoiceToChat(turn, parsed.options, text);
   }
 

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -88,10 +88,30 @@ interface ActiveTurn {
   dialogEscapes: number;
   /** Snapshot of tailer.seenRecords at turn start — used to detect per-turn output. */
   recordsAtStart: number;
-  /** Behavioral-probe bookkeeping for this turn's current stall, or null before
-   *  the first probe round. Replaces the old transcript-gated menuToolSeen —
-   *  see maybeProbeAndBridge()/runProbe() below and planning-61. */
+  /** True when this turn was begun by a menu selection (handleMenuReply) — the
+   *  only turn type where a live menu can legitimately still be on screen
+   *  before any busy/record signal this turn (the digit was swallowed with the
+   *  menu still up, or a multi-question wizard advanced to its next step
+   *  without the tool_use returning). Gates probe eligibility and the
+   *  Enter-retry's menu suppression (review round 2, findings 1+4). */
+  fromMenuSelection: boolean;
+  /** Behavioral-probe round budget for this turn's current stall, or null
+   *  before the first probe round. Replaces the old transcript-gated
+   *  menuToolSeen — see maybeProbeAndBridge()/advanceProbe() below and
+   *  planning-61. */
   probe: ProbeState | null;
+}
+
+/** An in-flight behavioral probe round, advanced by tick() (see Driver.probe). */
+interface ProbeRound {
+  /** The turn that owns this round — abandoned when the turn ends. */
+  turn: ActiveTurn;
+  /** 'sent-down' after the Down keystroke; 'sent-up' after the Up fallback. */
+  phase: 'sent-down' | 'sent-up';
+  /** When the current phase's keystroke was written (settle timing). */
+  sentAt: number;
+  /** Full screen snapshot taken immediately before the Down keystroke. */
+  before: string;
 }
 
 class Driver {
@@ -122,11 +142,15 @@ class Driver {
   // re-sent every poll while the error overlay lingers. Reset when a new turn begins.
   private requestTooLargeHandled = false;
   private lastDialogActionAt = 0;
-  // True while a behavioral probe round (runProbe()) is awaiting its settle
-  // timer. Mutual exclusion so at most one round is ever in flight, and a
-  // signal for tick() to skip Enter-retry/fallback-idle logic for the tick(s)
-  // spanned by the round (bounded to <= 2 x PROBE_SETTLE_MS).
-  private probing = false;
+  // In-flight behavioral probe round, advanced synchronously by tick() at a
+  // single chokepoint — the same tick-driven pattern as menuCancel and
+  // interrupting (review round 2, finding 6; replaced a detached async
+  // coroutine whose racing with tick() needed scattered mutual-exclusion
+  // guards). While set, tick() returns early, so no other keystroke path
+  // (dialog auto-accept, Enter-retry, fallback-idle) can interleave with the
+  // round's arrows, and every non-confirmed exit funnels through
+  // finishProbeRound() so an Up-recall is always restored.
+  private probe: ProbeRound | null = null;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   private host!: PtyHost;
   private tailer!: TranscriptTailer;
@@ -371,7 +395,7 @@ class Driver {
   }
 
   /** Initialize a fresh active turn (shared by normal submit and menu selection). */
-  private beginTurn(): void {
+  private beginTurn(fromMenuSelection = false): void {
     const now = Date.now();
     this.idleNotified = false;
     this.requestTooLargeHandled = false;
@@ -386,6 +410,7 @@ class Driver {
       usage: null,
       dialogEscapes: 0,
       recordsAtStart: this.tailer.seenRecords,
+      fromMenuSelection,
       probe: null,
     };
   }
@@ -397,6 +422,11 @@ class Driver {
       this.queue.length = 0;
       return;
     }
+    // Clear any stale text sitting in the input line first — e.g. history the
+    // probe's Up fallback recalled that an abandoned round couldn't restore —
+    // so it is never prepended to this message (review round 2, finding 3).
+    // A no-op at an empty idle prompt.
+    this.host.writeRaw('\x15');
     if (NO_BRACKETED_PASTE) {
       // Fallback: sanitizeUserText() strips all CR, so '\r' below is the only
       // submit trigger — safe for multiline text without bracketed paste.
@@ -495,6 +525,17 @@ class Driver {
       this.emitter.emitSessionIdle(this.args.sessionId);
     }
 
+    // In-flight behavioral probe round: advance it at this single chokepoint
+    // and do nothing else this tick — the dialog auto-accept '2', menu-cancel
+    // ESCs, and the Enter-retry / fallback-idle keystrokes below must never
+    // interleave with the round's arrows. advanceProbe() itself abandons the
+    // round (restoring any Up-recall) when the owning turn is gone or an
+    // interrupt is settling, so the blocks below run one tick later at most.
+    if (this.probe) {
+      this.advanceProbe(now);
+      return;
+    }
+
     // Waiting for the TUI to settle after ESC-cancelling a bridged menu (the user
     // typed a free-text reply instead of a number). Submit the queued prompt only
     // once the menu is gone and the prompt is idle — otherwise the paste races
@@ -556,50 +597,46 @@ class Driver {
       turn.lastProgressAt = now;
       // Real activity resumed — a probe that ran out of rounds during this
       // stall gets a fresh budget if the turn genuinely stalls again later.
-      // Not while a round is in flight: a busy flicker mid-round must not
-      // hand that same stall a fresh budget (post-review hardening F5).
-      if (turn.probe && !this.probing) turn.probe.rounds = 0;
+      // (A round can't be in flight here: tick() already returned at the
+      // probe chokepoint above while one is outstanding.)
+      if (turn.probe) turn.probe.rounds = 0;
       return;
     }
 
     // Not busy. Possible: still rendering, swallowed Enter, dialog, menu, or done
     // (turn_duration normally ends the turn before we get here).
-    //
-    // While a probe round is outstanding, do nothing else at all — the dialog
-    // auto-accept '2' (post-review hardening F2) and the Enter-retry /
-    // fallback-idle keystrokes below must never interleave with the round's
-    // arrow keys; whatever they would handle is still there one tick later
-    // (a round is bounded to ≤ 2 × PROBE_SETTLE_MS).
-    if (this.probing) return;
     this.maybeHandleDialog();
 
     // Blocked on a live interactive overlay (AskUserQuestion menu, plan
     // approval, or a tool-permission Yes/No prompt) → probe behaviorally and
     // bridge it to chat if confirmed, so the session goes idle (no watchdog
-    // kill) until the user picks an option. runProbe() ends the turn itself
-    // once a round confirms a live overlay.
-    this.maybeProbeAndBridge(turn);
-    if (this.probing) return;
+    // kill) until the user picks an option. Starts a round at most; the
+    // chokepoint above advances it on subsequent ticks and bridges on
+    // confirmation.
+    this.maybeProbeAndBridge(turn, now);
+    if (this.probe) return; // a round just started — let it settle
 
     if (!turn.sawBusy
         && now - turn.submittedAt > SUBMIT_RETRY_AFTER_MS
         && this.screen.hasPrompt()
-        && !this.screen.interactivePromptBlocking()
+        && !(turn.fromMenuSelection && this.screen.interactivePromptBlocking())
         && this.screen.quietMs() > 1500
         && this.tailer.seenRecords === turn.recordsAtStart) {
       // Only retry if no new records have appeared since this turn started —
       // a delta > 0 means claude already started writing output.
       //
-      // interactivePromptBlocking() excludes the case where the TUI is still on
-      // a live menu/wizard screen (e.g. a multi-question AskUserQuestion that
-      // advances internally between sub-questions without the tool_use ever
-      // returning — so no new tailer record appears). hasPrompt()'s idle-prompt
-      // regex (`/^❯ /m`) can't tell that caret apart from a highlighted menu
-      // option row using the same `❯` marker, so without this guard a live
-      // wizard step reads as "Enter got swallowed": the code blindly re-sends
-      // Enter into the menu (selecting whatever option happens to be
-      // highlighted) and eventually reports a false 'failed to submit' even
-      // though the wizard was progressing normally the whole time.
+      // The interactivePromptBlocking() suppression applies ONLY to a
+      // menu-selection turn: there a live menu genuinely can still be on
+      // screen with no busy/record signal (the digit was swallowed, or a
+      // multi-question wizard advanced), and a blind Enter would select
+      // whatever row is highlighted — the probe re-bridges that state
+      // instead. For an ordinary turn in this branch a menu is impossible
+      // (Claude produced no output yet — same reasoning as the probe gate in
+      // maybeProbeAndBridge()), so the retry must NOT be gated on screen
+      // text: the unsubmitted draft itself renders as "❯ <text>" and, when
+      // its text starts with "N.", satisfies the caret scan — suppressing
+      // the exact retry this state needs and wedging the turn into the
+      // 30-min watchdog (review round 2, finding 1).
       if (turn.enterRetries < MAX_ENTER_RETRIES) {
         turn.enterRetries++;
         turn.submittedAt = now;
@@ -655,80 +692,115 @@ class Driver {
    * so a genuinely non-menu stall falls through to the existing Enter-retry /
    * fallback-idle-detection / watchdog path exactly as it does today.
    *
-   * Fires the round and returns immediately — runProbe() ends the turn itself
-   * (via bridgeChoiceToChat()) only if a round confirms a live overlay.
+   * Starts the round only — tick()'s chokepoint drives it forward via
+   * advanceProbe(), which ends the turn itself (via bridgeChoiceToChat())
+   * only if the round confirms a live overlay.
    */
-  private maybeProbeAndBridge(turn: ActiveTurn): void {
-    if (SKIP_MENU_BRIDGE || this.pendingMenu || this.interrupting) return;
-    if (this.screen.detectDialog() === 'bypass-permissions') return;
+  private maybeProbeAndBridge(turn: ActiveTurn, now: number): void {
+    if (SKIP_MENU_BRIDGE || this.pendingMenu) return;
+    // An interactive overlay can only exist once Claude produced output this
+    // turn — AskUserQuestion and the permission prompt both require a running
+    // turn, so the busy spinner or a transcript record precedes them — or
+    // when this turn IS a menu selection (see ActiveTurn.fromMenuSelection).
+    // Before that, a quiet stall is a submission problem (swallowed Enter),
+    // and probing it would type arrows into the user's unsubmitted draft —
+    // the Up could replace the draft with recalled history that the later
+    // Enter-retry then submits (review round 2, finding 4).
+    if (!turn.sawBusy && !turn.fromMenuSelection
+        && this.tailer.seenRecords === turn.recordsAtStart) return;
     if (this.screen.quietMs() < MENU_STABLE_QUIET_MS) return;
-    if (this.probing) return; // a round is already in flight
     const probe = (turn.probe ??= { lastAttemptAt: 0, rounds: 0 });
-    const action = decideProbeAttempt(probe, { now: Date.now() });
-    if (action !== 'send') return;
-    probe.lastAttemptAt = Date.now();
+    if (decideProbeAttempt(probe, { now }) !== 'send') return;
+    if (this.screen.detectDialog() === 'bypass-permissions') return;
+    probe.lastAttemptAt = now;
     probe.rounds++;
-    this.probing = true;
-    void this.runProbe(turn).finally(() => { this.probing = false; });
+    this.probe = { turn, phase: 'sent-down', sentAt: now, before: this.screen.text() };
+    this.host.writeRaw(PROBE_KEY_DOWN);
   }
 
   /**
-   * One probe round: send Down, settle, check for a screen change. If Down
-   * produced nothing, retry once with Up (covers the "already at the last
-   * option, no wraparound" boundary case). A change alone is NOT enough to
-   * bridge: the before/after snapshots must both parse as the same-shaped
-   * prompt whose ❯-highlighted row MOVED (confirmProbeReaction() — the
-   * plan's point-2 comparison; post-review hardening F1). Anything else —
-   * unparseable, or menu-shaped text whose caret didn't move (static
-   * blockquote prose, a quoted old menu) — is left alone and, if the Up
-   * fallback caused the change, restored with one Down (fail-safe: no
-   * bridge rather than a fabricated one).
+   * Advance the in-flight probe round by one tick (called only from tick()'s
+   * chokepoint while `this.probe` is set). One round: send Down, settle,
+   * check for a screen change; if Down produced nothing, retry once with Up
+   * (covers the "already at the last option, no wraparound" boundary case).
+   * A change alone is NOT enough to bridge: the before/after snapshots must
+   * both parse as the same-shaped prompt whose ❯-highlighted row MOVED
+   * (confirmProbeReaction() — the plan's point-2 comparison). Anything else
+   * — unparseable, menu-shaped text whose caret didn't move, work resuming
+   * mid-round, the turn ending, an interrupt settling — funnels through
+   * finishProbeRound(), which restores any Up-recall (fail-safe: no bridge
+   * rather than a fabricated one, and never stale text left in the input).
+   *
+   * The settle wait is tick-quantized: with POLL_MS === PROBE_SETTLE_MS the
+   * effective settle is one to two poll intervals, which is fine — the outer
+   * MENU_STABLE_QUIET_MS gate already guarantees the screen was stable when
+   * the round started.
    */
-  private async runProbe(turn: ActiveTurn): Promise<void> {
-    const before = this.screen.text();
-    const beforeParsed = parseInteractivePrompt(before);
-    this.host.writeRaw(PROBE_KEY_DOWN);
-    await new Promise((r) => setTimeout(r, PROBE_SETTLE_MS));
-    // Abandon on turn teardown AND on an in-flight /stop (SIGINT → ESC): the
-    // interrupted turn is still `this.turn` while its ESC settles, so the
-    // turn-identity check alone would let the round keep typing arrows over
-    // the interrupt (post-review hardening F3).
-    if (this.turn !== turn || this.interrupting) return;
-
-    // A screen change while busy means real work resumed in the interim (a
-    // reply started streaming) — not a menu reacting to our keystroke, so
-    // bail rather than mis-bridge a phantom menu.
-    let changed = this.screen.text() !== before && !this.screen.isBusy();
-    let sentUp = false;
-    if (!changed) {
-      sentUp = true;
-      this.host.writeRaw(PROBE_KEY_UP);
-      await new Promise((r) => setTimeout(r, PROBE_SETTLE_MS));
-      if (this.turn !== turn || this.interrupting) return;
-      changed = this.screen.text() !== before && !this.screen.isBusy();
-    }
-    if (!changed) return; // nothing reacted — not interactive, do nothing this round
-
-    const parsed = parseInteractivePrompt(this.screen.text());
-    if (!beforeParsed || !parsed || !confirmProbeReaction(beforeParsed, parsed)) {
-      // Not a live overlay reacting to us — either nothing parses, or
-      // menu-shaped text is on screen but its highlight didn't move (static
-      // prose can't move; only a live menu can). The Up fallback may have
-      // recalled input-line history on a genuinely idle (non-menu) input
-      // box; restore with a Down so the next real turn never starts
-      // pre-populated with stale recalled text. Unconditional and harmless
-      // even when Up did NOT recall anything (idle Down is a confirmed
-      // no-op) — never reached after a confirmed menu below, since that
-      // would move the live selection instead of restoring anything.
-      if (sentUp) this.host.writeRaw(PROBE_KEY_DOWN);
+  private advanceProbe(now: number): void {
+    const p = this.probe as ProbeRound;
+    // Owner turn gone (turn_duration landed mid-round) or a /stop interrupt
+    // is settling — abandon before typing anything further.
+    if (this.turn !== p.turn || this.interrupting) {
+      this.finishProbeRound(p, 'turn ended or interrupt in flight');
       return;
     }
+    if (now - p.sentAt < PROBE_SETTLE_MS) return; // still settling
+    if (this.screen.isBusy()) {
+      // Real work resumed mid-round (a reply started streaming) — the screen
+      // is changing for its own reasons, not reacting to our keystroke.
+      this.finishProbeRound(p, 'work resumed');
+      return;
+    }
+    const after = this.screen.text();
+    if (after === p.before) {
+      if (p.phase === 'sent-down') {
+        // Down produced nothing — maybe the highlight is already on the last
+        // option (no wraparound). Fall back to Up once.
+        p.phase = 'sent-up';
+        p.sentAt = now;
+        this.host.writeRaw(PROBE_KEY_UP);
+        return;
+      }
+      // Neither key produced any change — nothing interactive is listening,
+      // and nothing was recalled, so there is nothing to restore.
+      this.probe = null;
+      return;
+    }
+    const beforeParsed = parseInteractivePrompt(p.before);
+    const afterParsed = parseInteractivePrompt(after);
+    if (!beforeParsed || !afterParsed || !confirmProbeReaction(beforeParsed, afterParsed)) {
+      // Not a live overlay reacting to us — either nothing parses, or
+      // menu-shaped text is on screen but its highlight didn't move (static
+      // prose can't move; only a live menu can).
+      this.finishProbeRound(p, 'screen changed without a live highlight move');
+      return;
+    }
+    const turn = p.turn;
+    this.probe = null;
+    const text = afterParsed.isPermission
+      ? formatPermissionPrompt(afterParsed.context, afterParsed.options)
+      : formatMenuPrompt(afterParsed.options);
+    logWarn(`interactive ${afterParsed.isPermission ? 'permission prompt' : 'menu'} confirmed (${afterParsed.options.length} options, highlight ${beforeParsed.highlighted}→${afterParsed.highlighted}) — bridging to chat`);
+    this.bridgeChoiceToChat(turn, afterParsed.options, text);
+  }
 
-    const text = parsed.isPermission
-      ? formatPermissionPrompt(parsed.context, parsed.options)
-      : formatMenuPrompt(parsed.options);
-    logWarn(`interactive ${parsed.isPermission ? 'permission prompt' : 'menu'} confirmed (${parsed.options.length} options, highlight ${beforeParsed.highlighted}→${parsed.highlighted}) — bridging to chat`);
-    this.bridgeChoiceToChat(turn, parsed.options, text);
+  /**
+   * Single non-confirmed exit for a probe round. When the Up fallback was
+   * sent, it may have recalled input-line history into a genuinely idle
+   * (non-menu) input box — clear it with Ctrl+U so no stale recalled text is
+   * ever prepended to the next submission. Ctrl+U (not a compensating Down)
+   * because recalled entries are routinely multi-line (channel envelopes),
+   * where a Down may only move the cursor within the text instead of
+   * stepping history forward (review round 2, findings 3+5); it is the same
+   * clear the interrupt path relies on (abortIfInterrupted()) and a no-op at
+   * an empty prompt. Never reached after a confirmed bridge — a live menu
+   * consumed the arrows as navigation and its selection is typed as a digit,
+   * position-independent of the caret (selectMenuOption()).
+   */
+  private finishProbeRound(p: ProbeRound, reason: string): void {
+    if (p.phase === 'sent-up') this.host.writeRaw('\x15');
+    this.probe = null;
+    logDebug(`probe round ended without bridging: ${reason}`);
   }
 
   /**
@@ -786,7 +858,7 @@ class Driver {
     }
     logDebug(`menu selection: ${n}`);
     this.pendingMenu = null;
-    this.beginTurn();
+    this.beginTurn(true);
     void this.selectMenuOption(n);
   }
 
@@ -807,11 +879,12 @@ class Driver {
     // If interrupted while waiting, erase the digit so it doesn't linger in the PTY
     // input and get prepended to the user's next message.
     if (this.abortIfInterrupted()) return;
-    // Send Enter only if a selectable prompt is still blocking at the bottom of the
-    // screen — covers both the AskUserQuestion menu and the permission prompt, and
-    // self-corrects when the digit alone already confirmed (prompt gone → no stray
-    // Enter). Bottom-region scoped so stale footer/option text left in scrollback by
-    // the just-answered prompt can't submit an empty line at the idle caret.
+    // Send Enter only if a selectable prompt still visibly blocks the screen —
+    // covers both the AskUserQuestion menu and the permission prompt, and
+    // self-corrects when the digit alone already confirmed (prompt gone → no
+    // stray Enter). interactivePromptBlocking() is deliberately permissive
+    // (full viewport): a false positive here costs one stray Enter at an idle
+    // empty caret, a no-op.
     if (this.screen.interactivePromptBlocking()) this.host.writeRaw('\r');
     if (this.turn) this.turn.submittedAt = Date.now();
   }

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -16,10 +16,11 @@ import * as readline from 'readline';
 import { translateArgs, sanitizeUserText } from './args';
 import { ScreenModel, MenuOption, parseMenuChoice, formatMenuPrompt, formatPermissionPrompt, extractChannelContent, isPtyActivelyWorking } from './screen';
 import { PtyHost } from './pty-host';
-import { TranscriptTailer, AssistantRecord, UsageInfo, hasInteractiveMenuToolUse } from './tailer';
+import { TranscriptTailer, AssistantRecord, UsageInfo } from './tailer';
 import { ProtocolEmitter } from './emitter';
 import { preTrustWorkspace, checkAuthStatus } from './trust';
 import { decideMenuCancel } from './menu-cancel';
+import { decideProbeAttempt, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
 
 const POLL_MS = 200;
 const STARTUP_QUIET_MS = 600;
@@ -87,9 +88,10 @@ interface ActiveTurn {
   dialogEscapes: number;
   /** Snapshot of tailer.seenRecords at turn start — used to detect per-turn output. */
   recordsAtStart: number;
-  /** Set once this turn invoked a menu-raising tool (AskUserQuestion/ExitPlanMode).
-   *  Gates menu bridging so only a transcript-backed menu is bridged to chat. */
-  menuToolSeen: boolean;
+  /** Behavioral-probe bookkeeping for this turn's current stall, or null before
+   *  the first probe round. Replaces the old transcript-gated menuToolSeen —
+   *  see maybeProbeAndBridge()/runProbe() below and planning-61. */
+  probe: ProbeState | null;
 }
 
 class Driver {
@@ -120,6 +122,11 @@ class Driver {
   // re-sent every poll while the error overlay lingers. Reset when a new turn begins.
   private requestTooLargeHandled = false;
   private lastDialogActionAt = 0;
+  // True while a behavioral probe round (runProbe()) is awaiting its settle
+  // timer. Mutual exclusion so at most one round is ever in flight, and a
+  // signal for tick() to skip Enter-retry/fallback-idle logic for the tick(s)
+  // spanned by the round (bounded to <= 2 x PROBE_SETTLE_MS).
+  private probing = false;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   private host!: PtyHost;
   private tailer!: TranscriptTailer;
@@ -285,9 +292,6 @@ class Driver {
       this.turn.lastProgressAt = Date.now();
       if (text) this.turn.texts.push(text);
       if (usage) this.turn.usage = usage;
-      // Authoritative menu signal: this turn called a menu-raising tool, so a
-      // menu on screen now is real (not a quoted/rendered look-alike).
-      if (hasInteractiveMenuToolUse(record.message)) this.turn.menuToolSeen = true;
     } else {
       logDebug('assistant record outside an active turn (emitted anyway)');
     }
@@ -382,7 +386,7 @@ class Driver {
       usage: null,
       dialogEscapes: 0,
       recordsAtStart: this.tailer.seenRecords,
-      menuToolSeen: false,
+      probe: null,
     };
   }
 
@@ -550,6 +554,9 @@ class Driver {
     if (this.screen.consumeBusySeen() || this.screen.isBusy()) {
       turn.sawBusy = true;
       turn.lastProgressAt = now;
+      // Real activity resumed — a probe that ran out of rounds during this
+      // stall gets a fresh budget if the turn genuinely stalls again later.
+      if (turn.probe) turn.probe.rounds = 0;
       return;
     }
 
@@ -557,15 +564,15 @@ class Driver {
     // (turn_duration normally ends the turn before we get here).
     this.maybeHandleDialog();
 
-    // Blocked on an interactive select menu → bridge it to chat and end the turn
-    // so the session goes idle (no watchdog kill) until the user picks an option.
-    if (this.maybeBridgeMenu(turn)) return;
-
-    // Blocked on a tool-permission prompt (e.g. the dangerous-rm circuit breaker
-    // that fires even under --dangerously-skip-permissions). Bridge the Yes/No to
-    // chat for a human to decide — never auto-accept — and end the turn so the
-    // session goes idle instead of wedging until the watchdog.
-    if (this.maybeBridgePermissionPrompt(turn)) return;
+    // Blocked on a live interactive overlay (AskUserQuestion menu, plan
+    // approval, or a tool-permission Yes/No prompt) → probe behaviorally and
+    // bridge it to chat if confirmed, so the session goes idle (no watchdog
+    // kill) until the user picks an option. runProbe() ends the turn itself
+    // once a round confirms a live overlay; while a round is outstanding,
+    // skip the Enter-retry/fallback-idle checks below so they can't race a
+    // probe keystroke.
+    this.maybeProbeAndBridge(turn);
+    if (this.probing) return;
 
     if (!turn.sawBusy
         && now - turn.submittedAt > SUBMIT_RETRY_AFTER_MS
@@ -630,82 +637,93 @@ class Driver {
     }
   }
 
-  // ---- interactive menu bridging ------------------------------------------
+  // ---- interactive-prompt behavioral probe --------------------------------
 
   /**
-   * If the TUI is blocked on an interactive select menu, emit it to the gateway
-   * (rendered as chat buttons / numbered text) and end the turn so the session
-   * goes idle while we await the user's choice. Returns true if it bridged.
+   * Behavioral gate replacing the old screen-regex detectors + transcript
+   * menuToolSeen gate (planning-61). While the turn looks stalled (settled
+   * quiet, not busy, not already mid-selection), spend one probe round: send
+   * an arrow keystroke and check whether the screen actually reacts. Rounds
+   * are budgeted (PROBE_MAX_ROUNDS) and cooldown-spaced (decideProbeAttempt())
+   * so a genuinely non-menu stall falls through to the existing Enter-retry /
+   * fallback-idle-detection / watchdog path exactly as it does today.
    *
-   * Never auto-selects — a destructive option must be a human decision. The
-   * bypass-permissions dialog also shows the menu footer, so it's excluded here
-   * and left to maybeHandleDialog()'s auto-accept.
+   * Fires the round and returns immediately — runProbe() ends the turn itself
+   * (via bridgeChoiceToChat()) only if a round confirms a live overlay.
    */
-  private maybeBridgeMenu(turn: ActiveTurn): boolean {
-    if (SKIP_MENU_BRIDGE || this.pendingMenu) return false;
-    // Authoritative gate: only bridge when this turn actually invoked a menu tool
-    // (AskUserQuestion/ExitPlanMode). Without it, a reply or re-injected history
-    // that renders a numbered list + the menu footer would spawn a phantom menu.
-    // The transcript tool_use can't be forged by on-screen text. Fails safe: if a
-    // genuine non-tool menu ever exists it simply isn't bridged (no false buttons).
-    if (!turn.menuToolSeen) return false;
-    if (this.screen.quietMs() < MENU_STABLE_QUIET_MS) return false;
-    if (this.screen.detectDialog() === 'bypass-permissions') return false;
-    const options = this.screen.detectMenu();
-    if (!options) return false;
-
-    const prompt = formatMenuPrompt(options);
-    logWarn(`interactive menu detected (${options.length} options) — bridging to chat`);
-    this.bridgeChoiceToChat(turn, options, prompt);
-    return true;
+  private maybeProbeAndBridge(turn: ActiveTurn): void {
+    if (SKIP_MENU_BRIDGE || this.pendingMenu) return;
+    if (this.screen.detectDialog() === 'bypass-permissions') return;
+    if (this.screen.quietMs() < MENU_STABLE_QUIET_MS) return;
+    if (this.probing) return; // a round is already in flight
+    const probe = (turn.probe ??= { lastAttemptAt: 0, rounds: 0 });
+    const action = decideProbeAttempt(probe, { now: Date.now() });
+    if (action !== 'send') return;
+    probe.lastAttemptAt = Date.now();
+    probe.rounds++;
+    this.probing = true;
+    void this.runProbe(turn).finally(() => { this.probing = false; });
   }
 
   /**
-   * Shared tail of maybeBridgeMenu / maybeBridgePermissionPrompt: emit the
-   * channel-native choice UI, carry the same text as the turn's result (API/no-
-   * button fallback + chat history), record the pending menu so the reply routes
-   * back to a selection, and end the turn so the session goes idle while awaiting
-   * the human's choice.
+   * One probe round: send Down, settle, check for a screen change. If Down
+   * produced nothing, retry once with Up (covers the "already at the last
+   * option, no wraparound" boundary case). A confirmed change is read via
+   * readInteractivePrompt() and bridged to chat; anything that doesn't parse
+   * cleanly is left alone (fail-safe — no bridge rather than a garbled one).
+   */
+  private async runProbe(turn: ActiveTurn): Promise<void> {
+    const before = this.screen.text();
+    this.host.writeRaw(PROBE_KEY_DOWN);
+    await new Promise((r) => setTimeout(r, PROBE_SETTLE_MS));
+    if (this.turn !== turn) return; // turn ended/changed while waiting — abandon
+
+    // A screen change while busy means real work resumed in the interim (a
+    // reply started streaming) — not a menu reacting to our keystroke, so
+    // bail rather than mis-bridge a phantom menu.
+    let changed = this.screen.text() !== before && !this.screen.isBusy();
+    let sentUp = false;
+    if (!changed) {
+      sentUp = true;
+      this.host.writeRaw(PROBE_KEY_UP);
+      await new Promise((r) => setTimeout(r, PROBE_SETTLE_MS));
+      if (this.turn !== turn) return;
+      changed = this.screen.text() !== before && !this.screen.isBusy();
+    }
+    if (!changed) return; // nothing reacted — not interactive, do nothing this round
+
+    const parsed = this.screen.readInteractivePrompt();
+    if (!parsed) {
+      // The Up fallback may have recalled input-line history on a genuinely
+      // idle (non-menu) input box; restore with a Down so the next real turn
+      // never starts pre-populated with stale recalled text. Unconditional
+      // and harmless even when Up did NOT recall anything (idle Down is a
+      // confirmed no-op) — never reached after a confirmed menu below, since
+      // that would move the live selection instead of restoring anything.
+      if (sentUp) this.host.writeRaw(PROBE_KEY_DOWN);
+      return;
+    }
+
+    const text = parsed.isPermission
+      ? formatPermissionPrompt(parsed.context, parsed.options)
+      : formatMenuPrompt(parsed.options);
+    logWarn(`interactive ${parsed.isPermission ? 'permission prompt' : 'menu'} confirmed (${parsed.options.length} options) — bridging to chat`);
+    this.bridgeChoiceToChat(turn, parsed.options, text);
+  }
+
+  /**
+   * Shared tail of a confirmed probe: emit the channel-native choice UI, carry
+   * the same text as the turn's result (API/no-button fallback + chat
+   * history), record the pending menu so the reply routes back to a
+   * selection, and end the turn so the session goes idle while awaiting the
+   * human's choice. Never auto-selects — a destructive/guarded option must
+   * always be a human decision.
    */
   private bridgeChoiceToChat(turn: ActiveTurn, options: MenuOption[], text: string): void {
     this.emitter.emitMenuPrompt({ sessionId: this.args.sessionId, prompt: text, options });
     turn.texts.push((turn.texts.length ? '\n\n' : '') + text);
     this.pendingMenu = { options };
     this.finishTurn(false);
-  }
-
-  /**
-   * If the TUI is blocked on a tool-permission prompt, bridge it to chat as a
-   * Yes/No choice (reusing the menu machinery: emit → buttons → handleMenuReply)
-   * and end the turn so the session goes idle while awaiting the human's decision.
-   * Returns true if it bridged.
-   *
-   * This is the fix for the wedge: Claude Code keeps a few catastrophe guards
-   * (dangerous rm, root/home deletes) that prompt EVEN under
-   * --dangerously-skip-permissions, which the wrapper otherwise assumes never
-   * happens. Such a prompt is neither the startup bypass dialog nor an
-   * AskUserQuestion menu, so without this it is never surfaced and the PTY hangs
-   * at the Yes/No until the 30-min watchdog kills the session.
-   *
-   * NEVER auto-selects — a guarded/destructive operation must be a human decision.
-   * Unlike maybeBridgeMenu there is no transcript tool_use to gate on (the circuit
-   * breaker is CLI-internal UI, not written to the transcript), so detection rests
-   * on detectPermissionPrompt()'s region + multi-marker guard plus the settle
-   * gate. That is the same defense detectDialog() relies on, and bridging to a
-   * human is strictly safer than detectDialog()'s auto-keypress.
-   */
-  private maybeBridgePermissionPrompt(turn: ActiveTurn): boolean {
-    if (SKIP_MENU_BRIDGE || this.pendingMenu) return false;
-    if (this.screen.quietMs() < MENU_STABLE_QUIET_MS) return false;
-    // The bypass-permissions startup dialog is auto-accepted by maybeHandleDialog().
-    if (this.screen.detectDialog() === 'bypass-permissions') return false;
-    const prompt = this.screen.detectPermissionPrompt();
-    if (!prompt) return false;
-
-    const text = formatPermissionPrompt(prompt.context, prompt.options);
-    logWarn(`permission prompt detected (${prompt.options.length} options) — bridging to chat (never auto-accepted)`);
-    this.bridgeChoiceToChat(turn, prompt.options, text);
-    return true;
   }
 
   /** Route a user's menu reply (typed number or button tap) to a selection. */

--- a/src/shell/menu-probe.ts
+++ b/src/shell/menu-probe.ts
@@ -1,0 +1,69 @@
+/**
+ * Decision logic for the behavioral interactive-prompt probe.
+ *
+ * Replaces the old text-pattern gate (screen-regex menu/permission detectors
+ * gated behind a transcript tool_use signal — see planning-61) with a
+ * behavioral test: while a turn looks stalled, send an arrow keystroke into
+ * the PTY and check whether the screen actually reacts. A live, arrow-
+ * navigable overlay (AskUserQuestion menu, plan approval, or a permission
+ * Yes/No prompt) visibly moves its highlighted row; idle scrollback that
+ * merely *contains* menu-shaped text cannot react to a keypress, because it
+ * isn't a live UI element. See Driver.maybeProbeAndBridge()/runProbe() in
+ * claude-pty-shell.ts for where this is wired in.
+ *
+ * This module is the pure per-round bookkeeping decision only (round budget +
+ * cooldown), kept free of node-pty / screen imports so it is cheap to
+ * unit-test in isolation — same pattern as menu-cancel.ts's decideMenuCancel.
+ */
+
+/** Down-arrow keystroke — the probe's primary attempt. */
+export const PROBE_KEY_DOWN = '\x1b[B';
+/** Up-arrow keystroke — fallback when Down produces no change (e.g. the
+ *  highlighted option is already the last one, with no wraparound). */
+export const PROBE_KEY_UP = '\x1b[A';
+
+// How long to wait after a probe keystroke before reading the screen again.
+// Picked to be comfortably above PTY round-trip latency while staying well
+// under the 700ms outer quiet gate (MENU_STABLE_QUIET_MS in
+// claude-pty-shell.ts) — tune after live testing (planning-61 Task 5) if the
+// probe fires too eagerly/too late.
+export const PROBE_SETTLE_MS = 200;
+// Minimum gap between probe rounds within the same stall. Must be at least
+// 2x PROBE_SETTLE_MS so a failed round (Down + Up fallback, each settled)
+// fully completes before another can start; a little headroom on top avoids
+// hammering keys into the PTY back-to-back when nothing is listening.
+export const PROBE_RETRY_COOLDOWN_MS = 500;
+// Cap on probe rounds per stall. After this many rounds with no confirmed
+// reaction, give up — the turn falls through to the existing Enter-retry /
+// fallback-idle-detection / watchdog path, exactly as a plain non-menu stall
+// does today. First-pass number (planning-61); tune after Task 5.
+export const PROBE_MAX_ROUNDS = 3;
+
+export type ProbeAttemptAction = 'send' | 'wait' | 'give-up';
+
+/** Per-turn probe bookkeeping — replaces the old ActiveTurn.menuToolSeen gate. */
+export interface ProbeState {
+  /** Timestamp (ms) of the most recent probe attempt (0 = none yet). */
+  lastAttemptAt: number;
+  /** How many rounds have been attempted so far this stall. */
+  rounds: number;
+}
+
+export interface ProbeAttemptObs {
+  now: number;
+}
+
+/**
+ * Decide whether to start a new probe round right now.
+ *
+ * - `send`     — cooldown has elapsed and the round budget isn't spent; go.
+ * - `wait`     — still within the cooldown window since the last attempt.
+ * - `give-up`  — PROBE_MAX_ROUNDS already spent this stall; stop probing
+ *                until real activity resumes and resets the budget (see
+ *                Driver.tick()'s busy-resume handling in claude-pty-shell.ts).
+ */
+export function decideProbeAttempt(state: ProbeState, obs: ProbeAttemptObs): ProbeAttemptAction {
+  if (state.rounds >= PROBE_MAX_ROUNDS) return 'give-up';
+  if (obs.now - state.lastAttemptAt < PROBE_RETRY_COOLDOWN_MS) return 'wait';
+  return 'send';
+}

--- a/src/shell/menu-probe.ts
+++ b/src/shell/menu-probe.ts
@@ -67,3 +67,41 @@ export function decideProbeAttempt(state: ProbeState, obs: ProbeAttemptObs): Pro
   if (obs.now - state.lastAttemptAt < PROBE_RETRY_COOLDOWN_MS) return 'wait';
   return 'send';
 }
+
+/** The slice of a parsed InteractivePrompt (screen.ts) the confirmation
+ *  compares — structural, so this module stays free of screen imports. */
+export interface ProbeReadout {
+  options: readonly unknown[];
+  /** 1-based option index the ❯ caret highlights. */
+  highlighted: number;
+}
+
+/**
+ * Decide whether a probe keystroke genuinely moved a live overlay's
+ * highlight — the plan's "before/after comparison of the highlighted row"
+ * (planning-61, Agreed Direction point 2; post-review hardening F1).
+ *
+ * Confirmed only when BOTH snapshots parse as the same-shaped prompt (equal
+ * option count) and the ❯-highlighted index CHANGED. This is what static
+ * menu-shaped text (a markdown "> 1." blockquote, a quoted earlier menu)
+ * can never satisfy: surrounding text may change (e.g. Up recalled input
+ * history), but a caret row in dead scrollback cannot move. A raw
+ * screen-text diff — the first implementation — counted any change and
+ * bridged fabricated menus in exactly that case.
+ *
+ * Rejecting when `before` is null is deliberate: the probe only fires after
+ * the screen has been quiet for MENU_STABLE_QUIET_MS, so a real overlay was
+ * already fully rendered in the before snapshot. An overlay that only
+ * parses AFTER the keystroke means the screen changed for some other reason
+ * (work resuming, a fresh render mid-settle) — the next probe round will
+ * confirm it cleanly if it is real (fail-safe: a missed bridge is
+ * recoverable, a false bridge is not).
+ */
+export function confirmProbeReaction(
+  before: ProbeReadout | null,
+  after: ProbeReadout | null,
+): boolean {
+  if (!before || !after) return false;
+  if (before.options.length !== after.options.length) return false;
+  return before.highlighted !== after.highlighted;
+}

--- a/src/shell/menu-probe.ts
+++ b/src/shell/menu-probe.ts
@@ -8,7 +8,7 @@
  * navigable overlay (AskUserQuestion menu, plan approval, or a permission
  * Yes/No prompt) visibly moves its highlighted row; idle scrollback that
  * merely *contains* menu-shaped text cannot react to a keypress, because it
- * isn't a live UI element. See Driver.maybeProbeAndBridge()/runProbe() in
+ * isn't a live UI element. See Driver.maybeProbeAndBridge()/advanceProbe() in
  * claude-pty-shell.ts for where this is wired in.
  *
  * This module is the pure per-round bookkeeping decision only (round budget +
@@ -85,9 +85,10 @@ export interface ProbeReadout {
  * option count) and the ❯-highlighted index CHANGED. This is what static
  * menu-shaped text (a markdown "> 1." blockquote, a quoted earlier menu)
  * can never satisfy: surrounding text may change (e.g. Up recalled input
- * history), but a caret row in dead scrollback cannot move. A raw
- * screen-text diff — the first implementation — counted any change and
- * bridged fabricated menus in exactly that case.
+ * history), but a caret row in dead scrollback cannot move — and since
+ * parseLiveOptionRun() reads the highlight from the run's OWN rows, a
+ * caret-bearing line elsewhere on screen (the input line after a recall)
+ * can't supply the "moved" index either (review round 2, finding 2).
  *
  * Rejecting when `before` is null is deliberate: the probe only fires after
  * the screen has been quiet for MENU_STABLE_QUIET_MS, so a real overlay was

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -95,63 +95,46 @@ export function neutralizeTuiTriggers(text: string): string {
     .split(TUI_REQUEST_TOO_LARGE_DISMISS).join('esc to go  back');
 }
 
-/**
- * Interactive select-menu footer markers (e.g. AskUserQuestion). The footer reads
- * "Enter to select · ↑/↓ to navigate · Esc to cancel"; we match on the two stable
- * fragments so spacing/middle-dot variations across TUI versions don't break it.
- */
-export const TUI_MENU_FOOTER = ['to navigate', 'to cancel'] as const;
 /** A numbered option row, with an optional leading ❯/> highlight marker. */
 export const TUI_MENU_OPTION_RE = /^\s*[❯>]?\s*(\d+)\.\s+(.+?)\s*$/;
 
 /**
- * A tool-permission prompt blocking on keyboard input. Distinct from the
- * AskUserQuestion select menu: Claude Code raises this for guarded operations
- * (e.g. a "Dangerous rm operation on possibly-empty variable path" circuit
- * breaker) that prompt EVEN under --dangerously-skip-permissions, since
- * bypassPermissions deliberately keeps a few catastrophe guards (rm against
- * root/home, possibly-empty globs). The wrapper otherwise assumes no permission
- * prompt ever appears, so without this detector the PTY wedges at the Yes/No
- * forever — nobody can answer it from chat and the typing indicator never clears.
- *
- * Matched by the universal question line plus a footer token unique to permission
- * prompts: the select-menu footer carries "↑/↓ to navigate" and the 32MB overlay
- * carries "esc to go back", so "Tab to amend" / "ctrl+e to explain" disambiguate
- * cleanly. The tokens are the fuller phrases (not bare "to amend" / "to explain")
- * so a chat reply that merely contains those words can't satisfy the footer gate.
- * Region-restricted (bottom rows) + multi-marker + a required ❯/> selection caret
- * so quoted prose in scrollback (a numbered list with none of the live-prompt
- * chrome) cannot trip it — the same defense detectDialog() uses, plus more.
- * Detection only ever BRIDGES the choice to a human; it never presses a key on its
- * own (a destructive guard must not be auto-accepted), making it strictly safer
- * than detectDialog.
+ * The universal question line Claude Code's tool-permission prompt (e.g. the
+ * dangerous-rm circuit breaker that fires even under
+ * --dangerously-skip-permissions) always renders. Used only as a cosmetic
+ * classifier in readInteractivePrompt() — never a gate: liveness itself is
+ * established behaviorally (see Driver.runProbe() in claude-pty-shell.ts)
+ * before this is ever consulted.
  */
-export const TUI_PERMISSION_PROMPT = 'Do you want to proceed?';
-export const TUI_PERMISSION_FOOTER_TOKENS = ['Tab to amend', 'ctrl+e to explain'] as const;
+const PERMISSION_QUESTION = 'Do you want to proceed?';
 
-/** A blocking interactive prompt parsed off the screen: the selectable options
- *  plus any context text shown above the question (warning + command). */
-export interface PermissionPrompt {
+/** A live select prompt always highlights one option with a leading ❯/> caret
+ *  (kept even inside a box border) — used by readInteractivePrompt() to tell
+ *  a real option row apart from a numbered list in ordinary prose. */
+const CARET_OPTION_RE = /^\s*│?\s*[❯>]\s*\d+\./;
+
+/** A blocking interactive prompt parsed off the screen: the selectable options,
+ *  any context text shown above a permission question (warning + command), and
+ *  whether it's a permission-style prompt (vs a plain AskUserQuestion menu). */
+export interface InteractivePrompt {
   options: MenuOption[];
   /** Human-readable lines above the question (e.g. the dangerous command) — '' if none. */
   context: string;
+  /** Cosmetic only — chooses warning-style vs plain-menu-style chat formatting. */
+  isPermission: boolean;
 }
 
 /**
  * Parse the numbered option rows out of a block of screen lines and return the
  * live run as 1..N options. Scrollback above a prompt can contain stale numbered
  * lines (a prior chat message rendered as "1. … 2. …"), so we take the LAST run
- * that starts at "1." and increments by one — that is the live prompt nearest the
- * footer, not history. Returns null for fewer than two options. Shared by
- * detectMenu() and detectPermissionPrompt() so both number options identically.
+ * that starts at "1." and increments by one — that is the live prompt, not
+ * history. Returns null for fewer than two options.
  *
  * `stripBorder` strips a left box border ("│ ") before matching, for prompts that
- * render inside a rounded dialog box (the permission prompt). detectMenu() leaves
- * it off so its full-buffer scan stays byte-identical to before — stripping the
- * border there would let "│ 1. …" lines in dialog-bordered scrollback newly parse
- * as options and shift the live run it picks.
+ * render inside a rounded dialog box (the permission prompt).
  */
-function parseOptionRun(lines: string[], stripBorder = false): MenuOption[] | null {
+function parseLiveOptionRun(lines: string[], stripBorder = false): MenuOption[] | null {
   const matches: MenuOption[] = [];
   for (const raw of lines) {
     const line = stripBorder ? raw.replace(/^\s*│\s?/, '') : raw;
@@ -290,22 +273,6 @@ export class ScreenModel {
     return TUI_PROMPT_RE.test(this.text());
   }
 
-  /**
-   * The TUI is showing the recoverable "Request too large (max 32MB)" error.
-   * Requires both the error prefix and the dismiss-footer marker.
-   *
-   * SUPERSEDED as the trigger: a verbatim copy of the overlay sentence carries
-   * BOTH markers, so re-injected history or an agent quoting the error tripped a
-   * false restart loop. Detection now comes from the transcript's `<synthetic>`
-   * assistant record (see TranscriptTailer.onRequestTooLarge), which text on
-   * screen cannot forge. Kept (and tested) only to document that screen-scraping
-   * this error is unreliable — do NOT re-wire it into the tick() trigger.
-   */
-  detectRequestTooLarge(): boolean {
-    const text = this.text();
-    return text.includes(TUI_REQUEST_TOO_LARGE) && text.includes(TUI_REQUEST_TOO_LARGE_DISMISS);
-  }
-
   detectDialog(): DialogKind | null {
     // Scan only the bottom region: a real modal dialog renders there, while a
     // reply/history quoting "Bypass Permissions mode … Yes, I accept" sits in the
@@ -320,73 +287,60 @@ export class ScreenModel {
   }
 
   /**
-   * Detect an interactive select menu blocking on keyboard input (e.g. the
-   * AskUserQuestion / plan-approval prompt) and parse its numbered options.
-   * Returns the options in display order, or null when no menu is on screen.
+   * Extract the option labels (and, for a permission prompt, the warning/command
+   * context) from a live interactive overlay — an AskUserQuestion-style menu or
+   * a tool-permission Yes/No prompt (e.g. the dangerous-rm circuit breaker that
+   * fires even under --dangerously-skip-permissions). This is a PURE READER: it
+   * never decides whether a prompt exists. Callers must already have proven
+   * liveness behaviorally — see Driver.runProbe() in claude-pty-shell.ts, which
+   * sends an arrow-key probe and only calls this once the screen visibly reacted.
    *
-   * Requires the select-menu footer AND at least two numbered rows — ordinary
-   * numbered lists in assistant output never carry the footer, so this won't
-   * false-positive on them. The bypass-permissions dialog also matches the
-   * footer; callers must check detectDialog() first and let it auto-accept.
-   */
-  detectMenu(): MenuOption[] | null {
-    const text = this.text();
-    if (!TUI_MENU_FOOTER.every((s) => text.includes(s))) return null;
-    // Scan only the region ABOVE the footer — the live menu's options always
-    // sit between the question and the "to navigate · to cancel" footer.
-    const lines = text.split('\n');
-    const footerIdx = lines.findIndex((l) => TUI_MENU_FOOTER.some((s) => l.includes(s)));
-    const region = footerIdx >= 0 ? lines.slice(0, footerIdx) : lines;
-    // parseOptionRun() takes the live 1..N run nearest the footer, so stale
-    // numbered scrollback above the menu can't inflate or shift the option list.
-    return parseOptionRun(region);
-  }
-
-  /**
-   * Detect a tool-permission prompt blocking on input (e.g. the dangerous-rm
-   * circuit breaker that fires even under --dangerously-skip-permissions) and
-   * parse its options + context. Returns null when no such prompt is on screen.
+   * Returns null when the region doesn't parse into a clean 1..N option run
+   * (fail-safe: no bridge rather than a garbled one) even though the probe
+   * proved something reacted — e.g. some other arrow-responsive UI with no
+   * formatter here.
    *
-   * Region-restricted to the bottom rows and gated on BOTH the question line and
-   * a permission-only footer token, so a reply/history that merely quotes the
-   * prompt (sitting in scrollback above) never trips it. The bypass-permissions
-   * startup dialog is handled by detectDialog()/auto-accept and is excluded here.
-   * Callers must only ever BRIDGE this to a human — never auto-select an option.
+   * isPermission is decided by whether "Do you want to proceed?" appears in the
+   * bottom region — a COSMETIC classification (chooses warning-style vs
+   * plain-menu-style chat formatting) that defaults to a plain menu when
+   * ambiguous; it never gates whether to bridge.
    */
-  detectPermissionPrompt(): PermissionPrompt | null {
-    const text = this.bottomText(DIALOG_REGION_ROWS);
-    if (!text.includes(TUI_PERMISSION_PROMPT)) return null;
-    if (!TUI_PERMISSION_FOOTER_TOKENS.some((t) => text.includes(t))) return null;
-    // The "Bypass Permissions mode … Yes, I accept" startup dialog is a separate
-    // case with its own auto-accept — don't double-handle it here.
-    if (TUI_BYPASS_PERMS.every((s) => text.includes(s))) return null;
+  readInteractivePrompt(): InteractivePrompt | null {
+    const bottom = this.bottomText(DIALOG_REGION_ROWS);
+    const isPermission = bottom.includes(PERMISSION_QUESTION);
 
-    const lines = text.split('\n');
-    // Use the LAST occurrence of the question — the live prompt sits nearest the
-    // footer, so a reply/history that quotes "Do you want to proceed?" higher in
-    // the bottom region can't capture the question index and empty the context.
+    if (!isPermission) {
+      // A tall AskUserQuestion menu can render more options than fit in the
+      // bottom-region window, so scan the whole buffer. parseLiveOptionRun()
+      // already isolates the live 1..N run nearest the end of the buffer, so
+      // stale numbered scrollback above it can't inflate or shift the list.
+      // A live select prompt always highlights one option with the ❯/> caret;
+      // plain prose that merely happens to look like a numbered list never
+      // carries one, so requiring it keeps this reader from hallucinating an
+      // options list out of unrelated text.
+      const lines = this.text().split('\n');
+      if (!lines.some((l) => CARET_OPTION_RE.test(l))) return null;
+      const options = parseLiveOptionRun(lines);
+      return options ? { options, context: '', isPermission: false } : null;
+    }
+
+    const lines = bottom.split('\n');
+    // Use the LAST occurrence of the question — the live prompt sits nearest
+    // the bottom, so a reply/history that quotes the question higher in the
+    // bottom region can't capture the question index and empty the context.
     let qIdx = -1;
     for (let i = lines.length - 1; i >= 0; i--) {
-      if (lines[i].includes(TUI_PERMISSION_PROMPT)) { qIdx = i; break; }
+      if (lines[i].includes(PERMISSION_QUESTION)) { qIdx = i; break; }
     }
-    const footerIdx = lines.findIndex(
-      (l, i) => i > qIdx && TUI_PERMISSION_FOOTER_TOKENS.some((t) => l.includes(t)),
-    );
-    // Options live strictly between the question and the footer.
-    const optionRegion = footerIdx >= 0 ? lines.slice(qIdx + 1, footerIdx) : lines.slice(qIdx + 1);
-    // A live select prompt always highlights one option with the ❯/> caret (kept
-    // even inside a box border). Quoted prose numbered lists never carry it, so
-    // requiring it closes the false-positive where conversational text pairs a
-    // numbered list with the question + a footer-ish phrase.
-    const hasCaret = optionRegion.some((l) => /^\s*│?\s*[❯>]\s*\d+\./.test(l));
-    if (!hasCaret) return null;
-    const options = parseOptionRun(optionRegion, true);
+    const optionRegion = lines.slice(qIdx + 1);
+    if (!optionRegion.some((l) => CARET_OPTION_RE.test(l))) return null;
+    const options = parseLiveOptionRun(optionRegion, true);
     if (!options) return null;
 
     // Context = the warning + command shown above the question. Bound it to the
-    // dialog box (scan up for the rounded top border ╭) so conversation lines that
-    // merely share the bottom region aren't swept in; fall back to the few lines
-    // immediately above the question when the prompt isn't boxed.
+    // dialog box (scan up for the rounded top border ╭) so conversation lines
+    // that merely share the bottom region aren't swept in; fall back to the
+    // few lines immediately above the question when the prompt isn't boxed.
     const isBorderOnly = (l: string) => /^[\s│╭╮╰╯─]*$/.test(l);
     const stripBorder = (l: string) => l.replace(/^[\s│]+/, '').replace(/[\s│]+$/, '');
     const aboveQ = lines.slice(0, qIdx);
@@ -401,22 +355,23 @@ export class ScreenModel {
       .filter((l) => l.length > 0)
       .join('\n');
 
-    return { options, context };
+    return { options, context, isPermission: true };
   }
 
   /**
-   * True if a select menu or permission prompt is still blocking on input at the
-   * BOTTOM of the screen. Used to decide whether the confirming Enter after a typed
-   * selection is still needed: scoping to the bottom region means stale footer /
-   * numbered rows left in scrollback by an already-answered prompt can't keep a
-   * stray Enter alive (which would submit an empty line at the idle caret).
-   * detectMenu() deliberately scans the full buffer to parse a tall menu's options,
-   * so it's the wrong signal for this liveness check — hence the dedicated method.
+   * True if a selectable prompt (menu row or permission Yes/No) still visibly
+   * occupies the bottom of the screen — a live caret (❯/>) beside a numbered
+   * option. This is a NARROW, POST-confirmation liveness check only: whether a
+   * prompt is still blocking right now, used to decide if the confirming Enter
+   * after a typed selection is still needed, or to exclude a live wizard step
+   * from the Enter-swallowed retry heuristic. It is never used to decide
+   * whether a prompt exists in the first place — that's the behavioral probe's
+   * job (Driver.runProbe()) — so it carries none of the detection gate's
+   * false-positive risk: callers only ever invoke it when they already know
+   * they're mid-selection or a probe just confirmed a live overlay.
    */
   interactivePromptBlocking(): boolean {
-    const text = this.bottomText(DIALOG_REGION_ROWS);
-    if (TUI_MENU_FOOTER.every((s) => text.includes(s))) return true;
-    return this.detectPermissionPrompt() !== null;
+    return /^\s*│?\s*[❯>]\s*\d+\./m.test(this.bottomText(DIALOG_REGION_ROWS));
   }
 }
 

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -108,10 +108,15 @@ export const TUI_MENU_OPTION_RE = /^\s*[❯>]?\s*(\d+)\.\s+(.+?)\s*$/;
  */
 const PERMISSION_QUESTION = 'Do you want to proceed?';
 
-/** A live select prompt always highlights one option with a leading ❯/> caret
- *  (kept even inside a box border) — used by readInteractivePrompt() to tell
- *  a real option row apart from a numbered list in ordinary prose. */
-const CARET_OPTION_RE = /^\s*│?\s*[❯>]\s*\d+\./;
+/** A live select prompt always highlights one option with a leading ❯ caret
+ *  (kept even inside a box border) — used by parseInteractivePrompt() and
+ *  interactivePromptBlocking() to tell a real option row apart from a numbered
+ *  list in ordinary prose. Deliberately U+276F only, NOT the `[❯>]`
+ *  alternation TUI_MENU_OPTION_RE uses for row content: the real TUI never
+ *  renders an ASCII `>` caret, but prose does constantly (markdown blockquotes
+ *  like "> 1. …"), and accepting `>` here is what let static quoted text
+ *  qualify as a live highlight (PR #181 review, finding F1). */
+const CARET_OPTION_RE = /^\s*│?\s*❯\s*\d+\./;
 
 /** A blocking interactive prompt parsed off the screen: the selectable options,
  *  any context text shown above a permission question (warning + command), and
@@ -122,6 +127,11 @@ export interface InteractivePrompt {
   context: string;
   /** Cosmetic only — chooses warning-style vs plain-menu-style chat formatting. */
   isPermission: boolean;
+  /** 1-based option index the ❯ caret currently highlights. The probe compares
+   *  this across its before/after snapshots: a live menu's caret MOVES in
+   *  response to an arrow key, static menu-shaped text cannot (planning-61
+   *  post-review hardening, F1). */
+  highlighted: number;
 }
 
 /**
@@ -154,6 +164,100 @@ function parseLiveOptionRun(lines: string[], stripBorder = false): MenuOption[] 
     expected++;
   }
   return run.length >= 2 ? run : null;
+}
+
+/**
+ * 1-based option number of the ❯-highlighted row nearest the bottom of the
+ * given lines, or null when no caret row is present. Scans bottom-up so a
+ * stale caret row in scrollback (e.g. an earlier menu frame) can't shadow the
+ * live one, mirroring parseLiveOptionRun()'s last-run-wins rule.
+ */
+function caretOptionIndex(lines: string[]): number | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (CARET_OPTION_RE.test(lines[i])) {
+      const m = /(\d+)\./.exec(lines[i]);
+      if (m) return Number(m[1]);
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse a live interactive overlay out of a full screen snapshot — an
+ * AskUserQuestion-style menu or a tool-permission Yes/No prompt. Pure
+ * function over screen text (as produced by ScreenModel.text()) so the
+ * behavioral probe can parse its BEFORE snapshot and the live screen with
+ * identical logic and compare the highlighted row across the two
+ * (Driver.runProbe() in claude-pty-shell.ts).
+ *
+ * This is a PURE READER: it never decides whether a prompt exists. Callers
+ * must already have proven liveness behaviorally — the probe only bridges
+ * when the ❯ highlight MOVED between snapshots (confirmProbeReaction() in
+ * menu-probe.ts), which static menu-shaped text in prose/scrollback cannot do.
+ *
+ * Returns null when the region doesn't parse into a clean 1..N option run
+ * with a ❯-highlighted row (fail-safe: no bridge rather than a garbled one).
+ *
+ * isPermission is decided by whether "Do you want to proceed?" appears in the
+ * bottom region — a COSMETIC classification (chooses warning-style vs
+ * plain-menu-style chat formatting) that defaults to a plain menu when
+ * ambiguous; it never gates whether to bridge.
+ */
+export function parseInteractivePrompt(screenText: string): InteractivePrompt | null {
+  const allLines = screenText.split('\n');
+  const bottomLines = allLines.slice(-DIALOG_REGION_ROWS);
+  const isPermission = bottomLines.some((l) => l.includes(PERMISSION_QUESTION));
+
+  if (!isPermission) {
+    // A menu can render tall (more options than fit a bottom-region window)
+    // or sit high on a sparse screen (fresh session, short scrollback), so
+    // scan the whole viewport. parseLiveOptionRun() already isolates the
+    // live 1..N run nearest the end of the buffer, so stale numbered
+    // scrollback above it can't inflate or shift the list. A live select
+    // prompt always highlights one option with the ❯ caret; plain prose
+    // that merely happens to look like a numbered list never carries one,
+    // so requiring it keeps this reader from hallucinating an options list
+    // out of unrelated text.
+    if (!allLines.some((l) => CARET_OPTION_RE.test(l))) return null;
+    const options = parseLiveOptionRun(allLines);
+    const highlighted = caretOptionIndex(allLines);
+    return options && highlighted !== null
+      ? { options, context: '', isPermission: false, highlighted }
+      : null;
+  }
+
+  // Use the LAST occurrence of the question — the live prompt sits nearest
+  // the bottom, so a reply/history that quotes the question higher in the
+  // bottom region can't capture the question index and empty the context.
+  let qIdx = -1;
+  for (let i = bottomLines.length - 1; i >= 0; i--) {
+    if (bottomLines[i].includes(PERMISSION_QUESTION)) { qIdx = i; break; }
+  }
+  const optionRegion = bottomLines.slice(qIdx + 1);
+  if (!optionRegion.some((l) => CARET_OPTION_RE.test(l))) return null;
+  const options = parseLiveOptionRun(optionRegion, true);
+  const highlighted = caretOptionIndex(optionRegion);
+  if (!options || highlighted === null) return null;
+
+  // Context = the warning + command shown above the question. Bound it to the
+  // dialog box (scan up for the rounded top border ╭) so conversation lines
+  // that merely share the bottom region aren't swept in; fall back to the
+  // few lines immediately above the question when the prompt isn't boxed.
+  const isBorderOnly = (l: string) => /^[\s│╭╮╰╯─]*$/.test(l);
+  const stripBorder = (l: string) => l.replace(/^[\s│]+/, '').replace(/[\s│]+$/, '');
+  const aboveQ = bottomLines.slice(0, qIdx);
+  let boxTop = -1;
+  for (let i = aboveQ.length - 1; i >= 0; i--) {
+    if (/[╭╮]/.test(aboveQ[i])) { boxTop = i; break; }
+  }
+  const contextLines = boxTop >= 0 ? aboveQ.slice(boxTop + 1) : aboveQ.slice(-4);
+  const context = contextLines
+    .filter((l) => !isBorderOnly(l))
+    .map(stripBorder)
+    .filter((l) => l.length > 0)
+    .join('\n');
+
+  return { options, context, isPermission: true, highlighted };
 }
 
 /**
@@ -288,90 +392,35 @@ export class ScreenModel {
 
   /**
    * Extract the option labels (and, for a permission prompt, the warning/command
-   * context) from a live interactive overlay — an AskUserQuestion-style menu or
-   * a tool-permission Yes/No prompt (e.g. the dangerous-rm circuit breaker that
-   * fires even under --dangerously-skip-permissions). This is a PURE READER: it
-   * never decides whether a prompt exists. Callers must already have proven
-   * liveness behaviorally — see Driver.runProbe() in claude-pty-shell.ts, which
-   * sends an arrow-key probe and only calls this once the screen visibly reacted.
-   *
-   * Returns null when the region doesn't parse into a clean 1..N option run
-   * (fail-safe: no bridge rather than a garbled one) even though the probe
-   * proved something reacted — e.g. some other arrow-responsive UI with no
-   * formatter here.
-   *
-   * isPermission is decided by whether "Do you want to proceed?" appears in the
-   * bottom region — a COSMETIC classification (chooses warning-style vs
-   * plain-menu-style chat formatting) that defaults to a plain menu when
-   * ambiguous; it never gates whether to bridge.
+   * context) from a live interactive overlay on the current screen. Thin
+   * wrapper over {@link parseInteractivePrompt} — see its doc for semantics
+   * (pure reader, never a gate; probe callers compare `highlighted` across
+   * before/after snapshots to prove liveness).
    */
   readInteractivePrompt(): InteractivePrompt | null {
-    const bottom = this.bottomText(DIALOG_REGION_ROWS);
-    const isPermission = bottom.includes(PERMISSION_QUESTION);
-
-    if (!isPermission) {
-      // A tall AskUserQuestion menu can render more options than fit in the
-      // bottom-region window, so scan the whole buffer. parseLiveOptionRun()
-      // already isolates the live 1..N run nearest the end of the buffer, so
-      // stale numbered scrollback above it can't inflate or shift the list.
-      // A live select prompt always highlights one option with the ❯/> caret;
-      // plain prose that merely happens to look like a numbered list never
-      // carries one, so requiring it keeps this reader from hallucinating an
-      // options list out of unrelated text.
-      const lines = this.text().split('\n');
-      if (!lines.some((l) => CARET_OPTION_RE.test(l))) return null;
-      const options = parseLiveOptionRun(lines);
-      return options ? { options, context: '', isPermission: false } : null;
-    }
-
-    const lines = bottom.split('\n');
-    // Use the LAST occurrence of the question — the live prompt sits nearest
-    // the bottom, so a reply/history that quotes the question higher in the
-    // bottom region can't capture the question index and empty the context.
-    let qIdx = -1;
-    for (let i = lines.length - 1; i >= 0; i--) {
-      if (lines[i].includes(PERMISSION_QUESTION)) { qIdx = i; break; }
-    }
-    const optionRegion = lines.slice(qIdx + 1);
-    if (!optionRegion.some((l) => CARET_OPTION_RE.test(l))) return null;
-    const options = parseLiveOptionRun(optionRegion, true);
-    if (!options) return null;
-
-    // Context = the warning + command shown above the question. Bound it to the
-    // dialog box (scan up for the rounded top border ╭) so conversation lines
-    // that merely share the bottom region aren't swept in; fall back to the
-    // few lines immediately above the question when the prompt isn't boxed.
-    const isBorderOnly = (l: string) => /^[\s│╭╮╰╯─]*$/.test(l);
-    const stripBorder = (l: string) => l.replace(/^[\s│]+/, '').replace(/[\s│]+$/, '');
-    const aboveQ = lines.slice(0, qIdx);
-    let boxTop = -1;
-    for (let i = aboveQ.length - 1; i >= 0; i--) {
-      if (/[╭╮]/.test(aboveQ[i])) { boxTop = i; break; }
-    }
-    const contextLines = boxTop >= 0 ? aboveQ.slice(boxTop + 1) : aboveQ.slice(-4);
-    const context = contextLines
-      .filter((l) => !isBorderOnly(l))
-      .map(stripBorder)
-      .filter((l) => l.length > 0)
-      .join('\n');
-
-    return { options, context, isPermission: true };
+    return parseInteractivePrompt(this.text());
   }
 
   /**
    * True if a selectable prompt (menu row or permission Yes/No) still visibly
-   * occupies the bottom of the screen — a live caret (❯/>) beside a numbered
-   * option. This is a NARROW, POST-confirmation liveness check only: whether a
-   * prompt is still blocking right now, used to decide if the confirming Enter
-   * after a typed selection is still needed, or to exclude a live wizard step
-   * from the Enter-swallowed retry heuristic. It is never used to decide
-   * whether a prompt exists in the first place — that's the behavioral probe's
-   * job (Driver.runProbe()) — so it carries none of the detection gate's
-   * false-positive risk: callers only ever invoke it when they already know
-   * they're mid-selection or a probe just confirmed a live overlay.
+   * occupies the screen — a live caret (❯) beside a numbered option. This is
+   * a NARROW, POST-confirmation liveness check only: whether a prompt is
+   * still blocking right now, used to decide if the confirming Enter after a
+   * typed selection is still needed, or to exclude a live wizard step from
+   * the Enter-swallowed retry heuristic. It is never used to decide whether
+   * a prompt exists in the first place — that's the behavioral probe's job
+   * (Driver.runProbe()).
+   *
+   * Scans the FULL viewport, matching parseInteractivePrompt()'s menu scan —
+   * a bottom-region window here once let a menu the reader had bridged sit
+   * outside the check's view, skipping the confirming Enter and hanging the
+   * selection (PR #181 review, F4). A false-positive stray Enter at an idle
+   * empty caret is a no-op, so the wider scan is the safer direction; the
+   * ❯-only CARET_OPTION_RE keeps prose (markdown "> 1." quotes) from
+   * qualifying anywhere in the viewport.
    */
   interactivePromptBlocking(): boolean {
-    return /^\s*│?\s*[❯>]\s*\d+\./m.test(this.bottomText(DIALOG_REGION_ROWS));
+    return this.text().split('\n').some((l) => CARET_OPTION_RE.test(l));
   }
 }
 

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -103,7 +103,7 @@ export const TUI_MENU_OPTION_RE = /^\s*[❯>]?\s*(\d+)\.\s+(.+?)\s*$/;
  * dangerous-rm circuit breaker that fires even under
  * --dangerously-skip-permissions) always renders. Used only as a cosmetic
  * classifier in readInteractivePrompt() — never a gate: liveness itself is
- * established behaviorally (see Driver.runProbe() in claude-pty-shell.ts)
+ * established behaviorally (see Driver.advanceProbe() in claude-pty-shell.ts)
  * before this is ever consulted.
  */
 const PERMISSION_QUESTION = 'Do you want to proceed?';
@@ -136,20 +136,35 @@ export interface InteractivePrompt {
 
 /**
  * Parse the numbered option rows out of a block of screen lines and return the
- * live run as 1..N options. Scrollback above a prompt can contain stale numbered
- * lines (a prior chat message rendered as "1. … 2. …"), so we take the LAST run
- * that starts at "1." and increments by one — that is the live prompt, not
- * history. Returns null for fewer than two options.
+ * live run as 1..N options plus the 1-based index of its ❯-highlighted row.
+ * Scrollback above a prompt can contain stale numbered lines (a prior chat
+ * message rendered as "1. … 2. …"), so we take the LAST run that starts at
+ * "1." and increments by one — that is the live prompt, not history.
+ *
+ * The highlight is read from the run's OWN rows, never from elsewhere on
+ * screen: a separate whole-screen caret scan once let the input line — which
+ * renders "❯ <recalled text>" after the probe's Up fallback recalls input
+ * history — supply a "moved" highlight for static menu-shaped scrollback and
+ * bridge a fabricated menu (PR #181 review round 2, finding 2). A live select
+ * prompt highlights exactly one of its rows, so anything else (zero carets =
+ * prose that merely looks numbered; two+ = a run polluted by a caret-bearing
+ * non-menu line) returns null (fail-safe: no bridge rather than a forged one).
+ *
+ * Returns null for fewer than two options.
  *
  * `stripBorder` strips a left box border ("│ ") before matching, for prompts that
  * render inside a rounded dialog box (the permission prompt).
  */
-function parseLiveOptionRun(lines: string[], stripBorder = false): MenuOption[] | null {
-  const matches: MenuOption[] = [];
+function parseLiveOptionRun(
+  lines: string[],
+  stripBorder = false,
+): { options: MenuOption[]; highlighted: number } | null {
+  const matches: Array<MenuOption & { caret: boolean }> = [];
   for (const raw of lines) {
     const line = stripBorder ? raw.replace(/^\s*│\s?/, '') : raw;
     const m = TUI_MENU_OPTION_RE.exec(line);
-    if (m) matches.push({ index: Number(m[1]), label: m[2].trim() });
+    // CARET_OPTION_RE tolerates the box border itself, so test the raw line.
+    if (m) matches.push({ index: Number(m[1]), label: m[2].trim(), caret: CARET_OPTION_RE.test(raw) });
   }
   if (matches.length < 2) return null;
   let start = -1;
@@ -157,29 +172,19 @@ function parseLiveOptionRun(lines: string[], stripBorder = false): MenuOption[] 
     if (matches[i].index === 1) start = i;
   }
   if (start === -1) return null;
-  const run: MenuOption[] = [];
+  const run: Array<MenuOption & { caret: boolean }> = [];
   let expected = 1;
   for (let i = start; i < matches.length && matches[i].index === expected; i++) {
     run.push(matches[i]);
     expected++;
   }
-  return run.length >= 2 ? run : null;
-}
-
-/**
- * 1-based option number of the ❯-highlighted row nearest the bottom of the
- * given lines, or null when no caret row is present. Scans bottom-up so a
- * stale caret row in scrollback (e.g. an earlier menu frame) can't shadow the
- * live one, mirroring parseLiveOptionRun()'s last-run-wins rule.
- */
-function caretOptionIndex(lines: string[]): number | null {
-  for (let i = lines.length - 1; i >= 0; i--) {
-    if (CARET_OPTION_RE.test(lines[i])) {
-      const m = /(\d+)\./.exec(lines[i]);
-      if (m) return Number(m[1]);
-    }
-  }
-  return null;
+  if (run.length < 2) return null;
+  const caretRows = run.filter((r) => r.caret);
+  if (caretRows.length !== 1) return null;
+  return {
+    options: run.map(({ index, label }) => ({ index, label })),
+    highlighted: caretRows[0].index,
+  };
 }
 
 /**
@@ -188,7 +193,7 @@ function caretOptionIndex(lines: string[]): number | null {
  * function over screen text (as produced by ScreenModel.text()) so the
  * behavioral probe can parse its BEFORE snapshot and the live screen with
  * identical logic and compare the highlighted row across the two
- * (Driver.runProbe() in claude-pty-shell.ts).
+ * (Driver.advanceProbe() in claude-pty-shell.ts).
  *
  * This is a PURE READER: it never decides whether a prompt exists. Callers
  * must already have proven liveness behaviorally — the probe only bridges
@@ -212,17 +217,13 @@ export function parseInteractivePrompt(screenText: string): InteractivePrompt | 
     // A menu can render tall (more options than fit a bottom-region window)
     // or sit high on a sparse screen (fresh session, short scrollback), so
     // scan the whole viewport. parseLiveOptionRun() already isolates the
-    // live 1..N run nearest the end of the buffer, so stale numbered
-    // scrollback above it can't inflate or shift the list. A live select
-    // prompt always highlights one option with the ❯ caret; plain prose
-    // that merely happens to look like a numbered list never carries one,
-    // so requiring it keeps this reader from hallucinating an options list
-    // out of unrelated text.
-    if (!allLines.some((l) => CARET_OPTION_RE.test(l))) return null;
-    const options = parseLiveOptionRun(allLines);
-    const highlighted = caretOptionIndex(allLines);
-    return options && highlighted !== null
-      ? { options, context: '', isPermission: false, highlighted }
+    // live 1..N run nearest the end of the buffer — with its ❯ highlight
+    // read from the run's own rows — so stale numbered scrollback above it
+    // can't inflate or shift the list, and plain prose that merely happens
+    // to look like a numbered list never parses (no highlight row).
+    const run = parseLiveOptionRun(allLines);
+    return run
+      ? { options: run.options, context: '', isPermission: false, highlighted: run.highlighted }
       : null;
   }
 
@@ -234,10 +235,8 @@ export function parseInteractivePrompt(screenText: string): InteractivePrompt | 
     if (bottomLines[i].includes(PERMISSION_QUESTION)) { qIdx = i; break; }
   }
   const optionRegion = bottomLines.slice(qIdx + 1);
-  if (!optionRegion.some((l) => CARET_OPTION_RE.test(l))) return null;
-  const options = parseLiveOptionRun(optionRegion, true);
-  const highlighted = caretOptionIndex(optionRegion);
-  if (!options || highlighted === null) return null;
+  const run = parseLiveOptionRun(optionRegion, true);
+  if (!run) return null;
 
   // Context = the warning + command shown above the question. Bound it to the
   // dialog box (scan up for the rounded top border ╭) so conversation lines
@@ -257,7 +256,7 @@ export function parseInteractivePrompt(screenText: string): InteractivePrompt | 
     .filter((l) => l.length > 0)
     .join('\n');
 
-  return { options, context, isPermission: true, highlighted };
+  return { options: run.options, context, isPermission: true, highlighted: run.highlighted };
 }
 
 /**
@@ -403,21 +402,27 @@ export class ScreenModel {
 
   /**
    * True if a selectable prompt (menu row or permission Yes/No) still visibly
-   * occupies the screen — a live caret (❯) beside a numbered option. This is
-   * a NARROW, POST-confirmation liveness check only: whether a prompt is
-   * still blocking right now, used to decide if the confirming Enter after a
-   * typed selection is still needed, or to exclude a live wizard step from
-   * the Enter-swallowed retry heuristic. It is never used to decide whether
-   * a prompt exists in the first place — that's the behavioral probe's job
-   * (Driver.runProbe()).
+   * occupies the screen — a live caret (❯) beside a numbered option, scanned
+   * over the FULL viewport (a bottom-region window once let a bridged menu
+   * sit outside the check's view and skip its confirming Enter — PR #181
+   * review, F4).
    *
-   * Scans the FULL viewport, matching parseInteractivePrompt()'s menu scan —
-   * a bottom-region window here once let a menu the reader had bridged sit
-   * outside the check's view, skipping the confirming Enter and hanging the
-   * selection (PR #181 review, F4). A false-positive stray Enter at an idle
-   * empty caret is a no-op, so the wider scan is the safer direction; the
-   * ❯-only CARET_OPTION_RE keeps prose (markdown "> 1." quotes) from
-   * qualifying anywhere in the viewport.
+   * DELIBERATELY PERMISSIVE — only safe where a false positive is cheap.
+   * The input line renders "❯ <text>", so a user draft or recalled history
+   * entry whose text starts with "N." matches CARET_OPTION_RE exactly like a
+   * menu row; quoted menu text in visible scrollback matches too. Static text
+   * can never prove liveness (that's the behavioral probe's job), so this
+   * check must only gate actions that are harmless when it's wrong:
+   *
+   *   - selectMenuOption()'s confirming Enter — a stray Enter at an idle
+   *     empty caret is a no-op;
+   *   - decideMenuCancel()'s menuVisible — worst case a bounded ESC re-send
+   *     and a delayed submit (hard timeout caps it);
+   *   - the Enter-swallowed retry, but ONLY for a menu-selection turn where
+   *     a live menu genuinely can be on screen. Gating the retry of an
+   *     ordinary turn on this check suppressed the retry whenever the
+   *     unsubmitted draft itself started with "N." — wedging the turn into
+   *     the 30-min watchdog (PR #181 review round 2, finding 1).
    */
   interactivePromptBlocking(): boolean {
     return this.text().split('\n').some((l) => CARET_OPTION_RE.test(l));

--- a/src/shell/tailer.ts
+++ b/src/shell/tailer.ts
@@ -56,35 +56,6 @@ export function isSyntheticRequestTooLarge(message: AssistantRecord['message']):
 }
 
 /**
- * Tools whose invocation puts the TUI into a blocking interactive select-menu the
- * gateway bridges to chat: AskUserQuestion and the plan-approval ExitPlanMode.
- *
- * - `AskUserQuestion` — verified present as a `tool_use` record in real transcripts.
- * - `ExitPlanMode` / `exit_plan_mode` — the plan-approval tool. Both the PascalCase
- *   and legacy snake_case names appear in the Claude Code CLI binary, and the tool
- *   name field varies by model, so both are listed to be safe. (No transcript
- *   sample was available to confirm which the running model emits.)
- *
- * If a future tool raises a bridgeable menu, add it here; an omission only means
- * that menu isn't bridged (fail-safe), never a crash.
- */
-const MENU_TOOL_NAMES = new Set(['AskUserQuestion', 'ExitPlanMode', 'exit_plan_mode']);
-
-/**
- * True when an assistant record invokes a tool that raises a blocking menu. This
- * is the AUTHORITATIVE signal that a menu is genuinely on screen — used to gate
- * screen-based menu bridging so a reply/history that merely renders a menu-shaped
- * numbered list + footer can't spawn a phantom menu in chat.
- */
-export function hasInteractiveMenuToolUse(message: AssistantRecord['message']): boolean {
-  return message.content.some((b) => {
-    if (b.type !== 'tool_use') return false;
-    const name = (b as { name?: unknown }).name;
-    return typeof name === 'string' && MENU_TOOL_NAMES.has(name);
-  });
-}
-
-/**
  * cwd → Claude Code project-dir slug (verified against v2.1.x: `/` and `.` both become `-`).
  * If Claude Code ever changes this scheme, findFile()'s fallback UUID scan will still
  * locate the transcript — the primary path is just an optimistic fast path.

--- a/tests/helpers/mock-claude-tui-menu.js
+++ b/tests/helpers/mock-claude-tui-menu.js
@@ -19,6 +19,15 @@
  *                      that doesn't parse as a menu — the wrapper must send a
  *                      restorative Down so the line ends up empty again, and
  *                      must never bridge anything.
+ *   RECALL_FAKEMENU — like RECALL_NONMENU, but the quiet screen also shows
+ *                      STATIC menu-shaped text with a real ❯ caret row (a
+ *                      quoted earlier menu sitting in scrollback). Down is a
+ *                      no-op; Up recalls text (screen changes) while the
+ *                      static rows stay put. The wrapper must see that the
+ *                      highlight did NOT move, refuse to bridge, and send the
+ *                      restorative Down. This exact sequence bridged a
+ *                      fabricated menu before the highlight-move confirmation
+ *                      (PR #181 review, finding F1).
  *   NO_REACT        — the screen goes quiet and NEVER reacts to any arrow key
  *                      (genuinely non-interactive scrollback); the probe must
  *                      exhaust its round budget and give up cleanly, and the
@@ -102,6 +111,19 @@ function renderMenu() {
   render(lines.join('\r\n'));
 }
 
+// Static menu-shaped scrollback for RECALL_FAKEMENU: a real ❯ caret row that
+// parses as a menu but belongs to dead text — it can never move in response
+// to an arrow key. Only the input line below it varies.
+function renderFakeMenu(inputLine) {
+  render([
+    'Earlier the assistant quoted a menu verbatim:',
+    '❯ 1. First choice',
+    '  2. Second choice',
+    '',
+    inputLine,
+  ].join('\r\n'));
+}
+
 function finishScenario(text) {
   writeTranscript(text);
   idle();
@@ -122,14 +144,14 @@ function submit(text) {
     setTimeout(renderMenu, 300);
     return;
   }
-  if (trimmed === 'BUSY_RACE' || trimmed === 'RECALL_NONMENU' || trimmed === 'NO_REACT') {
+  if (trimmed === 'BUSY_RACE' || trimmed === 'RECALL_NONMENU' || trimmed === 'RECALL_FAKEMENU' || trimmed === 'NO_REACT') {
     scenario = trimmed;
     recallUpSent = false;
     render('esc to interrupt\r\n❯ ');
     // Go quiet (idle-looking, but the turn is NOT finished — no transcript
     // yet) long enough to clear the busy marker and cross the probe's outer
     // quiet gate (MENU_STABLE_QUIET_MS).
-    setTimeout(idle, 300);
+    setTimeout(trimmed === 'RECALL_FAKEMENU' ? () => renderFakeMenu('❯ ') : idle, 300);
     if (trimmed === 'NO_REACT') {
       // Never reacts to a probe keystroke; complete normally after the probe
       // would have exhausted its round budget, so the turn still ends.
@@ -163,20 +185,23 @@ function handleArrow(dir) {
     setTimeout(() => finishScenario('busy-race-result'), 300);
     return;
   }
-  if (scenario === 'RECALL_NONMENU') {
+  if (scenario === 'RECALL_NONMENU' || scenario === 'RECALL_FAKEMENU') {
+    const paint = scenario === 'RECALL_FAKEMENU'
+      ? renderFakeMenu
+      : (inputLine) => render(inputLine);
     if (dir === 'up') {
       recallUpSent = true;
-      render('❯ some-recalled-history-text');
+      paint('❯ some-recalled-history-text');
     } else {
       // Down: either the initial no-op probe, or the wrapper's restorative
       // Down after Up recalled text — either way, empty input is correct.
-      idle();
+      paint('❯ ');
       if (recallUpSent) {
         // This was the restorative Down after Up recalled text — the round
         // is done; complete the turn shortly after, as a real turn
         // eventually would regardless of our probe keystrokes.
         scenario = null;
-        setTimeout(() => finishScenario('recall-nonmenu-result'), 300);
+        setTimeout(() => finishScenario('recall-result'), 300);
       }
     }
     return;

--- a/tests/helpers/mock-claude-tui-menu.js
+++ b/tests/helpers/mock-claude-tui-menu.js
@@ -2,90 +2,76 @@
 /**
  * Fake Claude Code TUI for integration-testing the behavioral interactive-
  * prompt probe (planning-61). Simulates scripted scenarios, selected by the
- * submitted turn text, covering the cases from planning-61 Task 2:
+ * submitted turn text, covering the cases from planning-61 Task 2 and the
+ * PR #181 review rounds:
  *
- *   MENU_FIRST      — a live menu appears; caret starts on the FIRST option
- *                      (Down alone should move it — no Up fallback needed).
- *   MENU_LAST       — a live menu appears; caret starts on the LAST option
- *                      (no wraparound — Down is a no-op, Up fallback must
- *                      detect the reaction).
- *   BUSY_RACE       — the screen goes quiet, then the moment a probe
- *                      keystroke lands, real work resumes (busy marker
- *                      reappears) instead of any menu — the probe must NOT
- *                      mistake this for a live overlay.
- *   RECALL_NONMENU  — the screen goes quiet with a genuinely idle (no menu)
- *                      input box. Down is a no-op; Up recalls unrelated text
- *                      into the input line (simulating input-history recall)
- *                      that doesn't parse as a menu — the wrapper must send a
- *                      restorative Down so the line ends up empty again, and
- *                      must never bridge anything.
- *   RECALL_FAKEMENU — like RECALL_NONMENU, but the quiet screen also shows
- *                      STATIC menu-shaped text with a real ❯ caret row (a
- *                      quoted earlier menu sitting in scrollback). Down is a
- *                      no-op; Up recalls text (screen changes) while the
- *                      static rows stay put. The wrapper must see that the
- *                      highlight did NOT move, refuse to bridge, and send the
- *                      restorative Down. This exact sequence bridged a
- *                      fabricated menu before the highlight-move confirmation
- *                      (PR #181 review, finding F1).
- *   NO_REACT        — the screen goes quiet and NEVER reacts to any arrow key
- *                      (genuinely non-interactive scrollback); the probe must
- *                      exhaust its round budget and give up cleanly, and the
- *                      turn still completes normally via the transcript.
- *   (anything else) — baseline: normal turn, no menu, completes as usual.
+ *   MENU_FIRST          — a live menu appears; caret starts on the FIRST
+ *                          option (Down alone should move it — no Up fallback
+ *                          needed).
+ *   MENU_LAST           — a live menu appears; caret starts on the LAST
+ *                          option (no wraparound — Down is a no-op, Up
+ *                          fallback must detect the reaction).
+ *   BUSY_RACE           — the screen goes quiet, then the moment a probe
+ *                          keystroke lands, real work resumes (busy marker
+ *                          reappears) instead of any menu — the probe must
+ *                          NOT mistake this for a live overlay.
+ *   RECALL_NONMENU      — the screen goes quiet with a genuinely idle (no
+ *                          menu) input box. Down is a no-op; Up recalls
+ *                          unrelated text into the input line (simulating
+ *                          input-history recall) that doesn't parse as a
+ *                          menu — the wrapper must clear it with Ctrl+U and
+ *                          never bridge anything.
+ *   RECALL_FAKEMENU     — like RECALL_NONMENU, but the quiet screen also
+ *                          shows STATIC menu-shaped text with a real ❯ caret
+ *                          row (a quoted earlier menu in scrollback). Up
+ *                          recalls text (screen changes) while the static
+ *                          rows stay put — the highlight did NOT move, so no
+ *                          bridge (PR #181 review, F1).
+ *   RECALL_FAKEMENU_NUM — the F1 hole from review round 2 (finding 2): same
+ *                          static quoted menu, but the recalled history entry
+ *                          BEGINS WITH "2." so the input line itself renders
+ *                          as a caret-bearing option row ("❯ 2. …"). The
+ *                          highlight must be read from the run's own rows —
+ *                          never the input line — so still no bridge.
+ *   RECALL_TURNEND      — Up recalls text and the turn completes at that
+ *                          same moment (transcript turn_duration lands
+ *                          mid-round). The abandoned round must STILL clear
+ *                          the recalled text (review round 2, finding 3 —
+ *                          every abandon path restores).
+ *   NO_REACT            — the screen goes quiet and NEVER reacts to any
+ *                          arrow key; the probe must exhaust its round budget
+ *                          and give up cleanly, the turn completing normally
+ *                          via the transcript.
+ *   …SWALLOW_ONCE…      — (substring anywhere in the text) the first Enter
+ *                          is swallowed: the draft stays in the input line
+ *                          ("❯ <text>"), never busy, no transcript. The
+ *                          wrapper's Enter-retry must fire — even when the
+ *                          text starts with "N." so the draft renders
+ *                          exactly like a caret option row (review round 2,
+ *                          findings 1+4: no retry suppression, no probing of
+ *                          an unsubmitted draft).
+ *   (anything else)     — baseline: normal turn, no menu, completes as usual.
  *
- * Same protocol as mock-claude-tui.js: reads bracketed-paste + Enter from the
- * wrapper, logs submitted text to FAKE_TUI_INPUT_LOG, and writes the Claude
- * Code transcript JSONL to trigger TranscriptTailer events.
+ * Same protocol as mock-claude-tui.js (shared via mock-tui-core.js): reads
+ * bracketed-paste + Enter from the wrapper, logs submitted text to
+ * FAKE_TUI_INPUT_LOG, arrow/Ctrl+U events to FAKE_TUI_EVENT_LOG, and writes
+ * the Claude Code transcript JSONL to trigger TranscriptTailer events.
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const {
+  handleAuthShim,
+  parseSessionId,
+  makeTranscriptWriter,
+  makeFileLogger,
+  startStdinMachine,
+} = require('./mock-tui-core');
 
 const args = process.argv.slice(2);
+handleAuthShim(args);
 
-if (args[0] === 'auth' && args[1] === 'status') {
-  process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: 'test' }) + '\n');
-  process.exit(0);
-}
-
-let sessionId = '';
-for (let i = 0; i < args.length; i++) {
-  if (args[i] === '--session-id' && args[i + 1]) sessionId = args[i + 1];
-}
-
-function cwd2slug(cwd) {
-  return cwd.replace(/[/.]/g, '-');
-}
-
-function getTranscriptPath() {
-  if (!sessionId) return null;
-  const dir = path.join(os.homedir(), '.claude', 'projects', cwd2slug(process.cwd()));
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  return path.join(dir, `${sessionId}.jsonl`);
-}
-
-function writeTranscript(text) {
-  const txPath = getTranscriptPath();
-  if (!txPath) return;
-  const assistant = JSON.stringify({
-    type: 'assistant',
-    message: { content: [{ type: 'text', text: text || '(processed)' }] },
-  });
-  const duration = JSON.stringify({ type: 'system', subtype: 'turn_duration', duration_ms: 100 });
-  fs.appendFileSync(txPath, assistant + '\n' + duration + '\n');
-}
-
-const INPUT_LOG = process.env.FAKE_TUI_INPUT_LOG || '';
-function logInput(text) {
-  if (INPUT_LOG) fs.appendFileSync(INPUT_LOG, text + '\n');
-}
-
-const EVENT_LOG = process.env.FAKE_TUI_EVENT_LOG || '';
-function logEvent(text) {
-  if (EVENT_LOG) fs.appendFileSync(EVENT_LOG, text + '\n');
-}
+const writeTranscript = makeTranscriptWriter(parseSessionId(args));
+const logInput = makeFileLogger('FAKE_TUI_INPUT_LOG');
+const logEvent = makeFileLogger('FAKE_TUI_EVENT_LOG');
 
 function render(screenText) {
   process.stdout.write('\x1b[2J\x1b[H' + screenText);
@@ -99,6 +85,8 @@ function idle() {
 let scenario = null;
 let menuCaret = 0;
 let recallUpSent = false;
+let pendingDraft = null; // SWALLOW_ONCE: the draft awaiting the retry Enter
+let swallowedOnce = false;
 const MENU_OPTIONS = ['First choice', 'Second choice', 'Third choice'];
 const MENU_FOOTER = 'Enter to select · ↑/↓ to navigate · Esc to cancel';
 
@@ -111,9 +99,9 @@ function renderMenu() {
   render(lines.join('\r\n'));
 }
 
-// Static menu-shaped scrollback for RECALL_FAKEMENU: a real ❯ caret row that
-// parses as a menu but belongs to dead text — it can never move in response
-// to an arrow key. Only the input line below it varies.
+// Static menu-shaped scrollback for the RECALL_FAKEMENU* scenarios: a real ❯
+// caret row that parses as a menu but belongs to dead text — it can never
+// move in response to an arrow key. Only the input line below it varies.
 function renderFakeMenu(inputLine) {
   render([
     'Earlier the assistant quoted a menu verbatim:',
@@ -133,6 +121,18 @@ function finishScenario(text) {
 function submit(text) {
   const trimmed = text.trim();
   if (!trimmed) { idle(); return; }
+
+  if (trimmed.includes('SWALLOW_ONCE') && !swallowedOnce) {
+    // Swallow this Enter: keep the draft visible in the input line (first
+    // line only — enough for the wrapper's hasPrompt/caret matchers), never
+    // go busy, write nothing. The wrapper's Enter-retry resubmits it.
+    swallowedOnce = true;
+    scenario = 'SWALLOW';
+    pendingDraft = trimmed;
+    render('❯ ' + trimmed.split('\n')[0]);
+    return;
+  }
+
   logInput(trimmed);
 
   if (trimmed === 'MENU_FIRST' || trimmed === 'MENU_LAST') {
@@ -144,14 +144,15 @@ function submit(text) {
     setTimeout(renderMenu, 300);
     return;
   }
-  if (trimmed === 'BUSY_RACE' || trimmed === 'RECALL_NONMENU' || trimmed === 'RECALL_FAKEMENU' || trimmed === 'NO_REACT') {
+  if (['BUSY_RACE', 'RECALL_NONMENU', 'RECALL_FAKEMENU', 'RECALL_FAKEMENU_NUM', 'RECALL_TURNEND', 'NO_REACT'].includes(trimmed)) {
     scenario = trimmed;
     recallUpSent = false;
     render('esc to interrupt\r\n❯ ');
     // Go quiet (idle-looking, but the turn is NOT finished — no transcript
     // yet) long enough to clear the busy marker and cross the probe's outer
     // quiet gate (MENU_STABLE_QUIET_MS).
-    setTimeout(trimmed === 'RECALL_FAKEMENU' ? () => renderFakeMenu('❯ ') : idle, 300);
+    const isFake = trimmed === 'RECALL_FAKEMENU' || trimmed === 'RECALL_FAKEMENU_NUM';
+    setTimeout(isFake ? () => renderFakeMenu('❯ ') : idle, 300);
     if (trimmed === 'NO_REACT') {
       // Never reacts to a probe keystroke; complete normally after the probe
       // would have exhausted its round budget, so the turn still ends.
@@ -163,6 +164,14 @@ function submit(text) {
   // Baseline: ordinary turn, no menu.
   render('esc to interrupt\r\n❯ ');
   setTimeout(() => finishScenario(trimmed), 300);
+}
+
+function paintRecallScreen(inputLine) {
+  if (scenario === 'RECALL_FAKEMENU' || scenario === 'RECALL_FAKEMENU_NUM') {
+    renderFakeMenu(inputLine);
+  } else {
+    render(inputLine);
+  }
 }
 
 function handleArrow(dir) {
@@ -185,123 +194,63 @@ function handleArrow(dir) {
     setTimeout(() => finishScenario('busy-race-result'), 300);
     return;
   }
-  if (scenario === 'RECALL_NONMENU' || scenario === 'RECALL_FAKEMENU') {
-    const paint = scenario === 'RECALL_FAKEMENU'
-      ? renderFakeMenu
-      : (inputLine) => render(inputLine);
+  if (scenario === 'RECALL_NONMENU' || scenario === 'RECALL_FAKEMENU'
+      || scenario === 'RECALL_FAKEMENU_NUM' || scenario === 'RECALL_TURNEND') {
     if (dir === 'up') {
       recallUpSent = true;
-      paint('❯ some-recalled-history-text');
-    } else {
-      // Down: either the initial no-op probe, or the wrapper's restorative
-      // Down after Up recalled text — either way, empty input is correct.
-      paint('❯ ');
-      if (recallUpSent) {
-        // This was the restorative Down after Up recalled text — the round
-        // is done; complete the turn shortly after, as a real turn
-        // eventually would regardless of our probe keystrokes.
-        scenario = null;
-        setTimeout(() => finishScenario('recall-result'), 300);
+      // The recalled history entry: for the _NUM variant it begins with "2."
+      // so the input line renders as a caret-bearing option row.
+      paintRecallScreen(scenario === 'RECALL_FAKEMENU_NUM'
+        ? '❯ 2. remove the old files'
+        : '❯ some-recalled-history-text');
+      if (scenario === 'RECALL_TURNEND') {
+        // The turn completes at this very moment — turn_duration lands while
+        // the probe round is still settling its Up keystroke.
+        writeTranscript('turnend-result');
       }
+    } else {
+      // Down before the Up fallback (the initial no-op probe): repaint as-is.
+      paintRecallScreen('❯ ');
     }
     return;
   }
-  // NO_REACT (or no active scenario): arrows are a harmless no-op.
+  // NO_REACT / SWALLOW (or no active scenario): arrows are a harmless no-op.
 }
 
-if (process.stdin.setRawMode) process.stdin.setRawMode(true);
-process.stdin.resume();
-idle();
-
-const State = { NORMAL: 0, CSI: 1, PASTE: 2, PASTE_CSI: 3 };
-let state = State.NORMAL;
-let pasteContent = '';
-let normalBuf = '';
-
-process.stdin.on('data', (chunk) => {
-  const bytes = chunk.toString('binary');
-
-  for (let i = 0; i < bytes.length; i++) {
-    const ch = bytes[i];
-
-    switch (state) {
-      case State.NORMAL:
-        if (ch === '\x1b') {
-          const rest = bytes.slice(i + 1);
-          if (rest.startsWith('[A')) {
-            i += 2;
-            handleArrow('up');
-            break;
-          }
-          if (rest.startsWith('[B')) {
-            i += 2;
-            handleArrow('down');
-            break;
-          }
-          state = State.CSI;
-          normalBuf = '';
-        } else if (ch === '\x15') {
-          normalBuf = '';
-        } else if (ch === '\r') {
-          const text = normalBuf;
-          normalBuf = '';
-          submit(text);
-        } else if (ch.charCodeAt(0) >= 0x20 || ch === '\n' || ch === '\t') {
-          normalBuf += ch;
-        }
-        break;
-
-      case State.CSI:
-        if (ch === '[') {
-          const rest = bytes.slice(i + 1);
-          if (rest.startsWith('200~')) {
-            state = State.PASTE;
-            pasteContent = '';
-            i += 4;
-          } else if (rest.startsWith('201~')) {
-            state = State.NORMAL;
-            i += 4;
-          } else {
-            let j = i + 1;
-            while (j < bytes.length && !/[A-Za-z~]/.test(bytes[j])) j++;
-            i = j;
-            state = State.NORMAL;
-          }
-        } else if (ch === '\x1b') {
-          normalBuf = '';
-        } else {
-          state = State.NORMAL;
-        }
-        break;
-
-      case State.PASTE:
-        if (ch === '\x1b') {
-          state = State.PASTE_CSI;
-        } else {
-          pasteContent += ch;
-        }
-        break;
-
-      case State.PASTE_CSI:
-        if (ch === '[') {
-          const rest = bytes.slice(i + 1);
-          if (rest.startsWith('201~')) {
-            normalBuf = pasteContent;
-            pasteContent = '';
-            state = State.NORMAL;
-            i += 4;
-          } else {
-            pasteContent += '\x1b[';
-            state = State.PASTE;
-          }
-        } else {
-          pasteContent += '\x1b' + ch;
-          state = State.PASTE;
-        }
-        break;
+function handleCtrlU() {
+  logEvent(`ctrlu:scenario=${scenario}:recall=${recallUpSent}`);
+  if ((scenario === 'RECALL_NONMENU' || scenario === 'RECALL_FAKEMENU'
+       || scenario === 'RECALL_FAKEMENU_NUM' || scenario === 'RECALL_TURNEND')
+      && recallUpSent) {
+    // The wrapper cleared the recalled text — input line is empty again.
+    paintRecallScreen('❯ ');
+    if (scenario !== 'RECALL_TURNEND') {
+      // The round is done; complete the turn shortly after, as a real turn
+      // eventually would regardless of our probe keystrokes.
+      // (RECALL_TURNEND already wrote its transcript at Up time.)
+      const done = scenario;
+      scenario = null;
+      setTimeout(() => finishScenario(`${done.toLowerCase()}-result`), 300);
+    } else {
+      scenario = null;
     }
   }
-});
+}
 
-process.on('SIGINT', () => process.exit(0));
-process.on('SIGTERM', () => process.exit(0));
+idle();
+
+startStdinMachine({
+  onEnter: (text) => {
+    if (pendingDraft !== null && !text.trim()) {
+      // The wrapper's Enter-retry after the swallowed submit — accept it now.
+      const draft = pendingDraft;
+      pendingDraft = null;
+      scenario = null;
+      submit(draft);
+      return;
+    }
+    submit(text);
+  },
+  onArrow: handleArrow,
+  onCtrlU: handleCtrlU,
+});

--- a/tests/helpers/mock-claude-tui-menu.js
+++ b/tests/helpers/mock-claude-tui-menu.js
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * Fake Claude Code TUI for integration-testing the behavioral interactive-
+ * prompt probe (planning-61). Simulates scripted scenarios, selected by the
+ * submitted turn text, covering the cases from planning-61 Task 2:
+ *
+ *   MENU_FIRST      — a live menu appears; caret starts on the FIRST option
+ *                      (Down alone should move it — no Up fallback needed).
+ *   MENU_LAST       — a live menu appears; caret starts on the LAST option
+ *                      (no wraparound — Down is a no-op, Up fallback must
+ *                      detect the reaction).
+ *   BUSY_RACE       — the screen goes quiet, then the moment a probe
+ *                      keystroke lands, real work resumes (busy marker
+ *                      reappears) instead of any menu — the probe must NOT
+ *                      mistake this for a live overlay.
+ *   RECALL_NONMENU  — the screen goes quiet with a genuinely idle (no menu)
+ *                      input box. Down is a no-op; Up recalls unrelated text
+ *                      into the input line (simulating input-history recall)
+ *                      that doesn't parse as a menu — the wrapper must send a
+ *                      restorative Down so the line ends up empty again, and
+ *                      must never bridge anything.
+ *   NO_REACT        — the screen goes quiet and NEVER reacts to any arrow key
+ *                      (genuinely non-interactive scrollback); the probe must
+ *                      exhaust its round budget and give up cleanly, and the
+ *                      turn still completes normally via the transcript.
+ *   (anything else) — baseline: normal turn, no menu, completes as usual.
+ *
+ * Same protocol as mock-claude-tui.js: reads bracketed-paste + Enter from the
+ * wrapper, logs submitted text to FAKE_TUI_INPUT_LOG, and writes the Claude
+ * Code transcript JSONL to trigger TranscriptTailer events.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const args = process.argv.slice(2);
+
+if (args[0] === 'auth' && args[1] === 'status') {
+  process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: 'test' }) + '\n');
+  process.exit(0);
+}
+
+let sessionId = '';
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--session-id' && args[i + 1]) sessionId = args[i + 1];
+}
+
+function cwd2slug(cwd) {
+  return cwd.replace(/[/.]/g, '-');
+}
+
+function getTranscriptPath() {
+  if (!sessionId) return null;
+  const dir = path.join(os.homedir(), '.claude', 'projects', cwd2slug(process.cwd()));
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, `${sessionId}.jsonl`);
+}
+
+function writeTranscript(text) {
+  const txPath = getTranscriptPath();
+  if (!txPath) return;
+  const assistant = JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'text', text: text || '(processed)' }] },
+  });
+  const duration = JSON.stringify({ type: 'system', subtype: 'turn_duration', duration_ms: 100 });
+  fs.appendFileSync(txPath, assistant + '\n' + duration + '\n');
+}
+
+const INPUT_LOG = process.env.FAKE_TUI_INPUT_LOG || '';
+function logInput(text) {
+  if (INPUT_LOG) fs.appendFileSync(INPUT_LOG, text + '\n');
+}
+
+const EVENT_LOG = process.env.FAKE_TUI_EVENT_LOG || '';
+function logEvent(text) {
+  if (EVENT_LOG) fs.appendFileSync(EVENT_LOG, text + '\n');
+}
+
+function render(screenText) {
+  process.stdout.write('\x1b[2J\x1b[H' + screenText);
+}
+
+function idle() {
+  render('❯ ');
+}
+
+// ── scripted scenario state ─────────────────────────────────────────────────
+let scenario = null;
+let menuCaret = 0;
+let recallUpSent = false;
+const MENU_OPTIONS = ['First choice', 'Second choice', 'Third choice'];
+const MENU_FOOTER = 'Enter to select · ↑/↓ to navigate · Esc to cancel';
+
+function renderMenu() {
+  const lines = ['Which option do you want?', ''];
+  MENU_OPTIONS.forEach((label, i) => {
+    lines.push(`${i === menuCaret ? '❯' : ' '} ${i + 1}. ${label}`);
+  });
+  lines.push('', MENU_FOOTER);
+  render(lines.join('\r\n'));
+}
+
+function finishScenario(text) {
+  writeTranscript(text);
+  idle();
+  scenario = null;
+}
+
+function submit(text) {
+  const trimmed = text.trim();
+  if (!trimmed) { idle(); return; }
+  logInput(trimmed);
+
+  if (trimmed === 'MENU_FIRST' || trimmed === 'MENU_LAST') {
+    scenario = trimmed;
+    menuCaret = trimmed === 'MENU_FIRST' ? 0 : MENU_OPTIONS.length - 1;
+    render('esc to interrupt\r\n❯ ');
+    // Brief busy, then the menu appears and STAYS (no transcript write — an
+    // AskUserQuestion tool_use never returns until the human answers).
+    setTimeout(renderMenu, 300);
+    return;
+  }
+  if (trimmed === 'BUSY_RACE' || trimmed === 'RECALL_NONMENU' || trimmed === 'NO_REACT') {
+    scenario = trimmed;
+    recallUpSent = false;
+    render('esc to interrupt\r\n❯ ');
+    // Go quiet (idle-looking, but the turn is NOT finished — no transcript
+    // yet) long enough to clear the busy marker and cross the probe's outer
+    // quiet gate (MENU_STABLE_QUIET_MS).
+    setTimeout(idle, 300);
+    if (trimmed === 'NO_REACT') {
+      // Never reacts to a probe keystroke; complete normally after the probe
+      // would have exhausted its round budget, so the turn still ends.
+      setTimeout(() => finishScenario('no-react-result'), 4000);
+    }
+    return;
+  }
+
+  // Baseline: ordinary turn, no menu.
+  render('esc to interrupt\r\n❯ ');
+  setTimeout(() => finishScenario(trimmed), 300);
+}
+
+function handleArrow(dir) {
+  logEvent(`arrow:${dir}:scenario=${scenario}:caret=${menuCaret}`);
+  if (scenario === 'MENU_FIRST' || scenario === 'MENU_LAST') {
+    if (dir === 'down' && menuCaret < MENU_OPTIONS.length - 1) {
+      menuCaret++;
+      renderMenu();
+    } else if (dir === 'up' && menuCaret > 0) {
+      menuCaret--;
+      renderMenu();
+    }
+    // else: at a boundary — no-op, matches a real TUI with no wraparound.
+    return;
+  }
+  if (scenario === 'BUSY_RACE') {
+    // Real work "resumes" the instant a probe keystroke lands — only once.
+    scenario = null;
+    render('esc to interrupt\r\n❯ ');
+    setTimeout(() => finishScenario('busy-race-result'), 300);
+    return;
+  }
+  if (scenario === 'RECALL_NONMENU') {
+    if (dir === 'up') {
+      recallUpSent = true;
+      render('❯ some-recalled-history-text');
+    } else {
+      // Down: either the initial no-op probe, or the wrapper's restorative
+      // Down after Up recalled text — either way, empty input is correct.
+      idle();
+      if (recallUpSent) {
+        // This was the restorative Down after Up recalled text — the round
+        // is done; complete the turn shortly after, as a real turn
+        // eventually would regardless of our probe keystrokes.
+        scenario = null;
+        setTimeout(() => finishScenario('recall-nonmenu-result'), 300);
+      }
+    }
+    return;
+  }
+  // NO_REACT (or no active scenario): arrows are a harmless no-op.
+}
+
+if (process.stdin.setRawMode) process.stdin.setRawMode(true);
+process.stdin.resume();
+idle();
+
+const State = { NORMAL: 0, CSI: 1, PASTE: 2, PASTE_CSI: 3 };
+let state = State.NORMAL;
+let pasteContent = '';
+let normalBuf = '';
+
+process.stdin.on('data', (chunk) => {
+  const bytes = chunk.toString('binary');
+
+  for (let i = 0; i < bytes.length; i++) {
+    const ch = bytes[i];
+
+    switch (state) {
+      case State.NORMAL:
+        if (ch === '\x1b') {
+          const rest = bytes.slice(i + 1);
+          if (rest.startsWith('[A')) {
+            i += 2;
+            handleArrow('up');
+            break;
+          }
+          if (rest.startsWith('[B')) {
+            i += 2;
+            handleArrow('down');
+            break;
+          }
+          state = State.CSI;
+          normalBuf = '';
+        } else if (ch === '\x15') {
+          normalBuf = '';
+        } else if (ch === '\r') {
+          const text = normalBuf;
+          normalBuf = '';
+          submit(text);
+        } else if (ch.charCodeAt(0) >= 0x20 || ch === '\n' || ch === '\t') {
+          normalBuf += ch;
+        }
+        break;
+
+      case State.CSI:
+        if (ch === '[') {
+          const rest = bytes.slice(i + 1);
+          if (rest.startsWith('200~')) {
+            state = State.PASTE;
+            pasteContent = '';
+            i += 4;
+          } else if (rest.startsWith('201~')) {
+            state = State.NORMAL;
+            i += 4;
+          } else {
+            let j = i + 1;
+            while (j < bytes.length && !/[A-Za-z~]/.test(bytes[j])) j++;
+            i = j;
+            state = State.NORMAL;
+          }
+        } else if (ch === '\x1b') {
+          normalBuf = '';
+        } else {
+          state = State.NORMAL;
+        }
+        break;
+
+      case State.PASTE:
+        if (ch === '\x1b') {
+          state = State.PASTE_CSI;
+        } else {
+          pasteContent += ch;
+        }
+        break;
+
+      case State.PASTE_CSI:
+        if (ch === '[') {
+          const rest = bytes.slice(i + 1);
+          if (rest.startsWith('201~')) {
+            normalBuf = pasteContent;
+            pasteContent = '';
+            state = State.NORMAL;
+            i += 4;
+          } else {
+            pasteContent += '\x1b[';
+            state = State.PASTE;
+          }
+        } else {
+          pasteContent += '\x1b' + ch;
+          state = State.PASTE;
+        }
+        break;
+    }
+  }
+});
+
+process.on('SIGINT', () => process.exit(0));
+process.on('SIGTERM', () => process.exit(0));

--- a/tests/helpers/mock-claude-tui.js
+++ b/tests/helpers/mock-claude-tui.js
@@ -15,63 +15,26 @@
  *      turn_duration) so TranscriptTailer triggers sawAssistant + finishTurn().
  *   4. Handles ESC (clear buffer) and Ctrl+U (clear buffer).
  *
+ * Auth shim, transcript writing, logging, and the bracketed-paste stdin state
+ * machine live in mock-tui-core.js (shared with mock-claude-tui-menu.js).
+ *
  * Env:
  *   FAKE_TUI_INPUT_LOG  path to append each submitted text (one per line)
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const {
+  handleAuthShim,
+  parseSessionId,
+  makeTranscriptWriter,
+  makeFileLogger,
+  startStdinMachine,
+} = require('./mock-tui-core');
 
 const args = process.argv.slice(2);
+handleAuthShim(args);
 
-// ── auth status ─────────────────────────────────────────────────────────────
-if (args[0] === 'auth' && args[1] === 'status') {
-  process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: 'test' }) + '\n');
-  process.exit(0);
-}
-
-// ── transcript helpers ───────────────────────────────────────────────────────
-// Parse --session-id <uuid> from args (passed by claude-pty-shell.ts)
-let sessionId = '';
-for (let i = 0; i < args.length; i++) {
-  if (args[i] === '--session-id' && args[i + 1]) sessionId = args[i + 1];
-}
-
-function cwd2slug(cwd) {
-  return cwd.replace(/[/.]/g, '-');
-}
-
-function getTranscriptPath() {
-  if (!sessionId) return null;
-  const dir = path.join(os.homedir(), '.claude', 'projects', cwd2slug(process.cwd()));
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  return path.join(dir, `${sessionId}.jsonl`);
-}
-
-function writeTranscript(text) {
-  const txPath = getTranscriptPath();
-  if (!txPath) return;
-  // assistant record: sets sawAssistant=true in Driver
-  const assistant = JSON.stringify({
-    type: 'assistant',
-    message: { content: [{ type: 'text', text: text || '(processed)' }] },
-  });
-  // turn_duration: triggers onTurnEnd() → finishTurn() in Driver
-  const duration = JSON.stringify({
-    type: 'system',
-    subtype: 'turn_duration',
-    duration_ms: 100,
-  });
-  fs.appendFileSync(txPath, assistant + '\n' + duration + '\n');
-}
-
-// ── TUI simulation ───────────────────────────────────────────────────────────
-const INPUT_LOG = process.env.FAKE_TUI_INPUT_LOG || '';
-
-function logInput(text) {
-  if (INPUT_LOG) fs.appendFileSync(INPUT_LOG, text + '\n');
-}
+const writeTranscript = makeTranscriptWriter(parseSessionId(args));
+const logInput = makeFileLogger('FAKE_TUI_INPUT_LOG');
 
 function idle() {
   // Clear screen so "esc to interrupt" is gone; then show only idle prompt.
@@ -82,11 +45,6 @@ function idle() {
 // Show initial ready prompt
 idle();
 
-// Input state machine (proper bracketed paste handling)
-const State = { NORMAL: 0, CSI: 1, PASTE: 2, PASTE_CSI: 3 };
-let state = State.NORMAL;
-let pasteContent = '';
-let normalBuf = '';
 let busy = false;
 
 function submit(text) {
@@ -105,84 +63,9 @@ function submit(text) {
   }, 300);
 }
 
-if (process.stdin.setRawMode) process.stdin.setRawMode(true);
-process.stdin.resume();
-
-process.stdin.on('data', (chunk) => {
-  const bytes = chunk.toString('binary');
-
-  for (let i = 0; i < bytes.length; i++) {
-    const ch = bytes[i];
-
-    switch (state) {
-      case State.NORMAL:
-        if (ch === '\x1b') {
-          state = State.CSI;
-          normalBuf = '';
-        } else if (ch === '\x15') {
-          normalBuf = '';
-        } else if (ch === '\r') {
-          const text = normalBuf;
-          normalBuf = '';
-          if (!busy) submit(text);
-          else idle();
-        } else if (ch.charCodeAt(0) >= 0x20 || ch === '\n' || ch === '\t') {
-          normalBuf += ch;
-        }
-        break;
-
-      case State.CSI:
-        if (ch === '[') {
-          const rest = bytes.slice(i + 1);
-          if (rest.startsWith('200~')) {
-            state = State.PASTE;
-            pasteContent = '';
-            i += 4;
-          } else if (rest.startsWith('201~')) {
-            state = State.NORMAL;
-            i += 4;
-          } else {
-            // Skip CSI sequence (cursor moves, etc.)
-            let j = i + 1;
-            while (j < bytes.length && !/[A-Za-z~]/.test(bytes[j])) j++;
-            i = j;
-            state = State.NORMAL;
-          }
-        } else if (ch === '\x1b') {
-          normalBuf = '';
-        } else {
-          state = State.NORMAL;
-        }
-        break;
-
-      case State.PASTE:
-        if (ch === '\x1b') {
-          state = State.PASTE_CSI;
-        } else {
-          pasteContent += ch;
-        }
-        break;
-
-      case State.PASTE_CSI:
-        if (ch === '[') {
-          const rest = bytes.slice(i + 1);
-          if (rest.startsWith('201~')) {
-            normalBuf = pasteContent;
-            pasteContent = '';
-            state = State.NORMAL;
-            i += 4;
-          } else {
-            pasteContent += '\x1b[';
-            state = State.PASTE;
-          }
-        } else {
-          pasteContent += '\x1b' + ch;
-          state = State.PASTE;
-        }
-        break;
-    }
-  }
+startStdinMachine({
+  onEnter: (text) => {
+    if (!busy) submit(text);
+    else idle();
+  },
 });
-
-process.on('SIGINT', () => process.exit(0));
-process.on('SIGTERM', () => process.exit(0));

--- a/tests/helpers/mock-tui-core.js
+++ b/tests/helpers/mock-tui-core.js
@@ -1,0 +1,181 @@
+/**
+ * Shared plumbing for the fake Claude Code TUIs used by the PTY-shell tests
+ * (mock-claude-tui.js, mock-claude-tui-menu.js): the `auth status` shim, the
+ * transcript writers TranscriptTailer reads, the env-var file loggers, and
+ * the bracketed-paste stdin state machine. Each mock supplies only its
+ * scenario behavior via handlers — protocol fixes land here exactly once.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+/** `claude auth status` shim — prints a logged-in status and exits. */
+function handleAuthShim(args) {
+  if (args[0] === 'auth' && args[1] === 'status') {
+    process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: 'test' }) + '\n');
+    process.exit(0);
+  }
+}
+
+/** Parse --session-id <uuid> from argv (passed by claude-pty-shell.ts). */
+function parseSessionId(args) {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--session-id' && args[i + 1]) return args[i + 1];
+  }
+  return '';
+}
+
+function cwd2slug(cwd) {
+  return cwd.replace(/[/.]/g, '-');
+}
+
+function getTranscriptPath(sessionId) {
+  if (!sessionId) return null;
+  const dir = path.join(os.homedir(), '.claude', 'projects', cwd2slug(process.cwd()));
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, `${sessionId}.jsonl`);
+}
+
+/**
+ * Returns a writeTranscript(text) that appends an assistant record (sets
+ * sawAssistant in the Driver) plus a turn_duration record (triggers
+ * onTurnEnd() → finishTurn()) to the Claude Code transcript JSONL.
+ */
+function makeTranscriptWriter(sessionId) {
+  return function writeTranscript(text) {
+    const txPath = getTranscriptPath(sessionId);
+    if (!txPath) return;
+    const assistant = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: text || '(processed)' }] },
+    });
+    const duration = JSON.stringify({ type: 'system', subtype: 'turn_duration', duration_ms: 100 });
+    fs.appendFileSync(txPath, assistant + '\n' + duration + '\n');
+  };
+}
+
+/** Returns an append-line logger for the file named by the env var ('' = off). */
+function makeFileLogger(envVar) {
+  const logPath = process.env[envVar] || '';
+  return function logLine(text) {
+    if (logPath) fs.appendFileSync(logPath, text + '\n');
+  };
+}
+
+/**
+ * Bracketed-paste stdin state machine. Consumes the wrapper's writes and
+ * dispatches:
+ *   onEnter(bufferText)  — '\r' outside a paste (bufferText may be '')
+ *   onArrow('up'|'down') — bare ESC [A / ESC [B (optional; ignored if absent)
+ *   onCtrlU()            — after the buffer was cleared by \x15 (optional)
+ * Buffer handling (accumulate printable/paste bytes, clear on ESC/Ctrl+U,
+ * hand off on Enter) lives here; the mocks never touch the raw bytes.
+ */
+function startStdinMachine(handlers) {
+  const State = { NORMAL: 0, CSI: 1, PASTE: 2, PASTE_CSI: 3 };
+  let state = State.NORMAL;
+  let pasteContent = '';
+  let normalBuf = '';
+
+  if (process.stdin.setRawMode) process.stdin.setRawMode(true);
+  process.stdin.resume();
+
+  process.stdin.on('data', (chunk) => {
+    const bytes = chunk.toString('binary');
+
+    for (let i = 0; i < bytes.length; i++) {
+      const ch = bytes[i];
+
+      switch (state) {
+        case State.NORMAL:
+          if (ch === '\x1b') {
+            const rest = bytes.slice(i + 1);
+            if (rest.startsWith('[A')) {
+              i += 2;
+              if (handlers.onArrow) handlers.onArrow('up');
+              break;
+            }
+            if (rest.startsWith('[B')) {
+              i += 2;
+              if (handlers.onArrow) handlers.onArrow('down');
+              break;
+            }
+            state = State.CSI;
+            normalBuf = '';
+          } else if (ch === '\x15') {
+            normalBuf = '';
+            if (handlers.onCtrlU) handlers.onCtrlU();
+          } else if (ch === '\r') {
+            const text = normalBuf;
+            normalBuf = '';
+            handlers.onEnter(text);
+          } else if (ch.charCodeAt(0) >= 0x20 || ch === '\n' || ch === '\t') {
+            normalBuf += ch;
+          }
+          break;
+
+        case State.CSI:
+          if (ch === '[') {
+            const rest = bytes.slice(i + 1);
+            if (rest.startsWith('200~')) {
+              state = State.PASTE;
+              pasteContent = '';
+              i += 4;
+            } else if (rest.startsWith('201~')) {
+              state = State.NORMAL;
+              i += 4;
+            } else {
+              // Skip CSI sequence (cursor moves, etc.)
+              let j = i + 1;
+              while (j < bytes.length && !/[A-Za-z~]/.test(bytes[j])) j++;
+              i = j;
+              state = State.NORMAL;
+            }
+          } else if (ch === '\x1b') {
+            normalBuf = '';
+          } else {
+            state = State.NORMAL;
+          }
+          break;
+
+        case State.PASTE:
+          if (ch === '\x1b') {
+            state = State.PASTE_CSI;
+          } else {
+            pasteContent += ch;
+          }
+          break;
+
+        case State.PASTE_CSI:
+          if (ch === '[') {
+            const rest = bytes.slice(i + 1);
+            if (rest.startsWith('201~')) {
+              normalBuf = pasteContent;
+              pasteContent = '';
+              state = State.NORMAL;
+              i += 4;
+            } else {
+              pasteContent += '\x1b[';
+              state = State.PASTE;
+            }
+          } else {
+            pasteContent += '\x1b' + ch;
+            state = State.PASTE;
+          }
+          break;
+      }
+    }
+  });
+
+  process.on('SIGINT', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
+}
+
+module.exports = {
+  handleAuthShim,
+  parseSessionId,
+  makeTranscriptWriter,
+  makeFileLogger,
+  startStdinMachine,
+};

--- a/tests/helpers/pty-harness.ts
+++ b/tests/helpers/pty-harness.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared harness for PTY-shell integration tests: spawns the real
+ * claude-pty-shell.js wrapper with CLAUDE_REAL_BIN pointing at a fake TUI
+ * from tests/helpers, feeds it stdin turns, and collects its stream-json
+ * protocol events / fake-TUI log files. Used by pty-stop-stuck-input.test.ts
+ * and pty-menu-probe.test.ts — wrapper CLI args and the turn-JSON shape live
+ * here exactly once.
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const PTY_SHELL_BIN = path.resolve(__dirname, '../../dist/shell/claude-pty-shell.js');
+
+export interface ProtocolEvent {
+  type: string;
+  subtype?: string;
+  [k: string]: unknown;
+}
+
+export function makeTurnJson(text: string): string {
+  return (
+    JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text }] },
+    }) + '\n'
+  );
+}
+
+export function waitMs(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export async function waitFor(pred: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return true;
+    await waitMs(100);
+  }
+  return pred();
+}
+
+/** Collects parsed stream-json events from the wrapper's stdout as they arrive. */
+export class EventCollector {
+  events: ProtocolEvent[] = [];
+  private buf = '';
+
+  attach(child: ChildProcess): void {
+    child.stdout!.on('data', (chunk: Buffer) => {
+      this.buf += chunk.toString('utf8');
+      const lines = this.buf.split('\n');
+      this.buf = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          this.events.push(JSON.parse(line) as ProtocolEvent);
+        } catch {
+          // non-JSON debug output — ignore
+        }
+      }
+    });
+  }
+
+  find(pred: (e: ProtocolEvent) => boolean): ProtocolEvent | undefined {
+    return this.events.find(pred);
+  }
+}
+
+/**
+ * Spawn the wrapper against a fake TUI. `env` adds/overrides wrapper env vars
+ * (e.g. FAKE_TUI_INPUT_LOG / FAKE_TUI_EVENT_LOG paths).
+ */
+export function spawnWrapper(mockTuiBin: string, env: Record<string, string>): ChildProcess {
+  return spawn('node', [PTY_SHELL_BIN, '--model', 'claude-test', '--dangerously-skip-permissions'], {
+    env: {
+      ...process.env,
+      // Use path directly (not "node path") so checkAuthStatus(realBinParts[0]) works
+      CLAUDE_REAL_BIN: mockTuiBin,
+      PTY_SHELL_DEBUG: '0',
+      ...env,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+/** Read the lines a fake TUI appended to a log file (one per entry). */
+export function readLogLines(logPath: string): string[] {
+  if (!fs.existsSync(logPath)) return [];
+  return fs
+    .readFileSync(logPath, 'utf-8')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+/** Wait until the log has at least `n` entries, or timeout. */
+export async function waitForLogEntries(logPath: string, n: number, timeoutMs = 5000): Promise<string[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const lines = readLogLines(logPath);
+    if (lines.length >= n) return lines;
+    await waitMs(100);
+  }
+  return readLogLines(logPath);
+}

--- a/tests/integration/pty-menu-probe.test.ts
+++ b/tests/integration/pty-menu-probe.test.ts
@@ -1,0 +1,259 @@
+/**
+ * I-PTY-MENU-PROBE: behavioral interactive-prompt probe integration tests
+ * (planning-61).
+ *
+ * Verifies the behavioral probe (send an arrow keystroke, check whether the
+ * screen reacts) that replaced the old screen-regex menu/permission
+ * detectors + transcript menuToolSeen gate. Spawns the real
+ * claude-pty-shell.js wrapper with CLAUDE_REAL_BIN pointing at
+ * mock-claude-tui-menu.js, a scripted fake TUI that simulates each scenario
+ * on cue (see that file's header for the full scenario list).
+ *
+ * The wrapper's own stdout carries the stream-json protocol events
+ * (ProtocolEmitter) — a confirmed bridge shows up as a
+ * {type:'system', subtype:'menu_prompt', ...} line, and a normal completion
+ * as {type:'result', ...}. Tests assert on those events rather than reading
+ * PTY screen state directly.
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const PTY_SHELL_BIN = path.resolve(__dirname, '../../dist/shell/claude-pty-shell.js');
+const MOCK_TUI_BIN = path.resolve(__dirname, '../helpers/mock-claude-tui-menu.js');
+
+interface ProtocolEvent {
+  type: string;
+  subtype?: string;
+  [k: string]: unknown;
+}
+
+function makeTurnJson(text: string): string {
+  return (
+    JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text }] },
+    }) + '\n'
+  );
+}
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Collects parsed stream-json events from the wrapper's stdout as they arrive. */
+class EventCollector {
+  events: ProtocolEvent[] = [];
+  private buf = '';
+
+  attach(child: ChildProcess): void {
+    child.stdout!.on('data', (chunk: Buffer) => {
+      this.buf += chunk.toString('utf8');
+      const lines = this.buf.split('\n');
+      this.buf = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          this.events.push(JSON.parse(line) as ProtocolEvent);
+        } catch {
+          // non-JSON debug output — ignore
+        }
+      }
+    });
+  }
+
+  find(pred: (e: ProtocolEvent) => boolean): ProtocolEvent | undefined {
+    return this.events.find(pred);
+  }
+}
+
+async function waitFor(pred: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return true;
+    await waitMs(100);
+  }
+  return pred();
+}
+
+function spawnWrapper(inputLog: string, eventLog: string): ChildProcess {
+  return spawn('node', [PTY_SHELL_BIN, '--model', 'claude-test', '--dangerously-skip-permissions'], {
+    env: {
+      ...process.env,
+      CLAUDE_REAL_BIN: MOCK_TUI_BIN,
+      FAKE_TUI_INPUT_LOG: inputLog,
+      FAKE_TUI_EVENT_LOG: eventLog,
+      PTY_SHELL_DEBUG: '0',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+function readLines(logPath: string): string[] {
+  if (!fs.existsSync(logPath)) return [];
+  return fs.readFileSync(logPath, 'utf-8').split('\n').map((l) => l.trim()).filter(Boolean);
+}
+
+describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', () => {
+  let wrapper: ChildProcess;
+  let inputLog: string;
+  let eventLog: string;
+  let collector: EventCollector;
+
+  beforeEach(() => {
+    const stamp = Date.now();
+    inputLog = path.join(os.tmpdir(), `pty-menu-probe-input-${stamp}.log`);
+    eventLog = path.join(os.tmpdir(), `pty-menu-probe-events-${stamp}.log`);
+    collector = new EventCollector();
+  });
+
+  afterEach(() => {
+    wrapper?.kill('SIGTERM');
+    if (fs.existsSync(inputLog)) fs.unlinkSync(inputLog);
+    if (fs.existsSync(eventLog)) fs.unlinkSync(eventLog);
+  });
+
+  /**
+   * I-PTY-MENU-01: Down alone moves the caret (caret starts on the first
+   * option) — the probe should confirm and bridge on its very first attempt,
+   * no Up fallback needed.
+   */
+  it('I-PTY-MENU-01: bridges a menu when Down alone reveals it', async () => {
+    wrapper = spawnWrapper(inputLog, eventLog);
+    collector.attach(wrapper);
+    await waitMs(2500); // wrapper + fake TUI ready
+
+    wrapper.stdin!.write(makeTurnJson('MENU_FIRST'));
+
+    const bridged = await waitFor(
+      () => !!collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt'),
+      6000,
+    );
+    expect(bridged).toBe(true);
+    const menuEvent = collector.find((e) => e.subtype === 'menu_prompt') as ProtocolEvent & { options: unknown[] };
+    expect(menuEvent.options).toHaveLength(3);
+  }, 20000);
+
+  /**
+   * I-PTY-MENU-02: caret starts on the LAST option (no wraparound) — Down is
+   * a no-op, so the probe must retry with Up before concluding there's no
+   * menu (the specific boundary case the user raised).
+   */
+  it('I-PTY-MENU-02: bridges a menu via the Up fallback at the last option', async () => {
+    wrapper = spawnWrapper(inputLog, eventLog);
+    collector.attach(wrapper);
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('MENU_LAST'));
+
+    const bridged = await waitFor(
+      () => !!collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt'),
+      6000,
+    );
+    expect(bridged).toBe(true);
+
+    const events = await waitFor(() => readLines(eventLog).length > 0, 1000)
+      .then(() => readLines(eventLog));
+    // Down was tried first (no-op at the last option), then Up moved the caret.
+    expect(events[0]).toContain('arrow:down');
+    expect(events.some((l) => l.includes('arrow:up'))).toBe(true);
+  }, 20000);
+
+  /**
+   * I-PTY-MENU-03: the screen changes because real work resumed (busy marker
+   * reappears), not because a menu reacted — the probe must not mis-bridge a
+   * phantom menu, and the turn must still complete normally afterward.
+   */
+  it('I-PTY-MENU-03: does not bridge on a busy-race look-alike change', async () => {
+    wrapper = spawnWrapper(inputLog, eventLog);
+    collector.attach(wrapper);
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('BUSY_RACE'));
+
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      8000,
+    );
+    expect(completed).toBe(true);
+    expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
+    const result = collector.find((e) => e.type === 'result') as ProtocolEvent & { subtype: string };
+    expect(result.subtype).toBe('success');
+  }, 20000);
+
+  /**
+   * I-PTY-MENU-04: no menu is present. Down is a no-op; the Up fallback
+   * recalls unrelated text into the input line (simulating history recall)
+   * that doesn't parse as a menu — the wrapper must send a restorative Down
+   * (never bridging anything) so the input ends up empty again.
+   */
+  it('I-PTY-MENU-04: restores the input after an Up-recall that is not a menu, without bridging', async () => {
+    wrapper = spawnWrapper(inputLog, eventLog);
+    collector.attach(wrapper);
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('RECALL_NONMENU'));
+
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      8000,
+    );
+    expect(completed).toBe(true);
+    expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
+
+    const events = readLines(eventLog);
+    // down (no-op) → up (recalls text) → down (restorative) — proves the
+    // wrapper's restore-on-unparseable-change path fired, not just a single
+    // probe attempt.
+    const dirs = events.map((l) => (l.includes('arrow:down') ? 'down' : 'up'));
+    const upIdx = dirs.indexOf('up');
+    expect(upIdx).toBeGreaterThan(-1);
+    expect(dirs[upIdx - 1]).toBe('down');
+    expect(dirs.slice(upIdx + 1)).toContain('down');
+  }, 20000);
+
+  /**
+   * I-PTY-MENU-05: no interactive overlay ever appears and nothing reacts to
+   * either arrow key. The probe must exhaust its round budget and give up
+   * cleanly — the turn still completes normally via the transcript, exactly
+   * as a plain non-menu stall does today (no new hang mode introduced).
+   */
+  it('I-PTY-MENU-05: gives up cleanly when nothing reacts, turn still completes', async () => {
+    wrapper = spawnWrapper(inputLog, eventLog);
+    collector.attach(wrapper);
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('NO_REACT'));
+
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      8000,
+    );
+    expect(completed).toBe(true);
+    expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
+  }, 20000);
+
+  /**
+   * I-PTY-MENU-06: an ordinary turn with no menu at any point completes
+   * normally with no visible probe side-effects reaching the fake TUI's
+   * submitted-text log (baseline — the probe never fires because the turn
+   * never stalls quietly for MENU_STABLE_QUIET_MS).
+   */
+  it('I-PTY-MENU-06: an ordinary turn with no stall completes with no probe side-effects', async () => {
+    wrapper = spawnWrapper(inputLog, eventLog);
+    collector.attach(wrapper);
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('ORDINARY_MESSAGE'));
+
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      6000,
+    );
+    expect(completed).toBe(true);
+    expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
+    expect(readLines(eventLog)).toHaveLength(0); // no arrow keys were ever sent
+  }, 20000);
+});

--- a/tests/integration/pty-menu-probe.test.ts
+++ b/tests/integration/pty-menu-probe.test.ts
@@ -16,85 +16,21 @@
  * PTY screen state directly.
  */
 
-import { spawn, ChildProcess } from 'child_process';
+import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import {
+  EventCollector,
+  ProtocolEvent,
+  makeTurnJson,
+  readLogLines,
+  spawnWrapper,
+  waitFor,
+  waitMs,
+} from '../helpers/pty-harness';
 
-const PTY_SHELL_BIN = path.resolve(__dirname, '../../dist/shell/claude-pty-shell.js');
 const MOCK_TUI_BIN = path.resolve(__dirname, '../helpers/mock-claude-tui-menu.js');
-
-interface ProtocolEvent {
-  type: string;
-  subtype?: string;
-  [k: string]: unknown;
-}
-
-function makeTurnJson(text: string): string {
-  return (
-    JSON.stringify({
-      type: 'user',
-      message: { role: 'user', content: [{ type: 'text', text }] },
-    }) + '\n'
-  );
-}
-
-function waitMs(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-/** Collects parsed stream-json events from the wrapper's stdout as they arrive. */
-class EventCollector {
-  events: ProtocolEvent[] = [];
-  private buf = '';
-
-  attach(child: ChildProcess): void {
-    child.stdout!.on('data', (chunk: Buffer) => {
-      this.buf += chunk.toString('utf8');
-      const lines = this.buf.split('\n');
-      this.buf = lines.pop() ?? '';
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          this.events.push(JSON.parse(line) as ProtocolEvent);
-        } catch {
-          // non-JSON debug output — ignore
-        }
-      }
-    });
-  }
-
-  find(pred: (e: ProtocolEvent) => boolean): ProtocolEvent | undefined {
-    return this.events.find(pred);
-  }
-}
-
-async function waitFor(pred: () => boolean, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (pred()) return true;
-    await waitMs(100);
-  }
-  return pred();
-}
-
-function spawnWrapper(inputLog: string, eventLog: string): ChildProcess {
-  return spawn('node', [PTY_SHELL_BIN, '--model', 'claude-test', '--dangerously-skip-permissions'], {
-    env: {
-      ...process.env,
-      CLAUDE_REAL_BIN: MOCK_TUI_BIN,
-      FAKE_TUI_INPUT_LOG: inputLog,
-      FAKE_TUI_EVENT_LOG: eventLog,
-      PTY_SHELL_DEBUG: '0',
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-}
-
-function readLines(logPath: string): string[] {
-  if (!fs.existsSync(logPath)) return [];
-  return fs.readFileSync(logPath, 'utf-8').split('\n').map((l) => l.trim()).filter(Boolean);
-}
 
 describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', () => {
   let wrapper: ChildProcess;
@@ -115,14 +51,35 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     if (fs.existsSync(eventLog)) fs.unlinkSync(eventLog);
   });
 
+  function start(): void {
+    wrapper = spawnWrapper(MOCK_TUI_BIN, {
+      FAKE_TUI_INPUT_LOG: inputLog,
+      FAKE_TUI_EVENT_LOG: eventLog,
+    });
+    collector.attach(wrapper);
+  }
+
+  /** Arrow/Ctrl+U events the fake TUI observed, as 'down' | 'up' | 'ctrlu'. */
+  function keyEvents(): string[] {
+    return readLogLines(eventLog).map((l) => l.split(':')[0] === 'ctrlu' ? 'ctrlu' : l.split(':')[1]);
+  }
+
+  /** Asserts the restore shape: down (no-op) → up (recall) → Ctrl+U (clear). */
+  function expectRecallRestored(): void {
+    const keys = keyEvents();
+    const upIdx = keys.indexOf('up');
+    expect(upIdx).toBeGreaterThan(-1);
+    expect(keys[upIdx - 1]).toBe('down');
+    expect(keys.slice(upIdx + 1)).toContain('ctrlu');
+  }
+
   /**
    * I-PTY-MENU-01: Down alone moves the caret (caret starts on the first
    * option) — the probe should confirm and bridge on its very first attempt,
    * no Up fallback needed.
    */
   it('I-PTY-MENU-01: bridges a menu when Down alone reveals it', async () => {
-    wrapper = spawnWrapper(inputLog, eventLog);
-    collector.attach(wrapper);
+    start();
     await waitMs(2500); // wrapper + fake TUI ready
 
     wrapper.stdin!.write(makeTurnJson('MENU_FIRST'));
@@ -142,8 +99,7 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
    * menu (the specific boundary case the user raised).
    */
   it('I-PTY-MENU-02: bridges a menu via the Up fallback at the last option', async () => {
-    wrapper = spawnWrapper(inputLog, eventLog);
-    collector.attach(wrapper);
+    start();
     await waitMs(2500);
 
     wrapper.stdin!.write(makeTurnJson('MENU_LAST'));
@@ -154,11 +110,11 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     );
     expect(bridged).toBe(true);
 
-    const events = await waitFor(() => readLines(eventLog).length > 0, 1000)
-      .then(() => readLines(eventLog));
+    await waitFor(() => readLogLines(eventLog).length > 0, 1000);
+    const arrows = keyEvents().filter((k) => k === 'up' || k === 'down');
     // Down was tried first (no-op at the last option), then Up moved the caret.
-    expect(events[0]).toContain('arrow:down');
-    expect(events.some((l) => l.includes('arrow:up'))).toBe(true);
+    expect(arrows[0]).toBe('down');
+    expect(arrows).toContain('up');
   }, 20000);
 
   /**
@@ -167,8 +123,7 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
    * phantom menu, and the turn must still complete normally afterward.
    */
   it('I-PTY-MENU-03: does not bridge on a busy-race look-alike change', async () => {
-    wrapper = spawnWrapper(inputLog, eventLog);
-    collector.attach(wrapper);
+    start();
     await waitMs(2500);
 
     wrapper.stdin!.write(makeTurnJson('BUSY_RACE'));
@@ -186,12 +141,12 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
   /**
    * I-PTY-MENU-04: no menu is present. Down is a no-op; the Up fallback
    * recalls unrelated text into the input line (simulating history recall)
-   * that doesn't parse as a menu — the wrapper must send a restorative Down
-   * (never bridging anything) so the input ends up empty again.
+   * that doesn't parse as a menu — the wrapper must clear the recalled text
+   * with Ctrl+U (never a compensating Down: recalled entries can be
+   * multi-line, where Down only moves the cursor) and never bridge anything.
    */
-  it('I-PTY-MENU-04: restores the input after an Up-recall that is not a menu, without bridging', async () => {
-    wrapper = spawnWrapper(inputLog, eventLog);
-    collector.attach(wrapper);
+  it('I-PTY-MENU-04: clears the input after an Up-recall that is not a menu, without bridging', async () => {
+    start();
     await waitMs(2500);
 
     wrapper.stdin!.write(makeTurnJson('RECALL_NONMENU'));
@@ -202,16 +157,7 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     );
     expect(completed).toBe(true);
     expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
-
-    const events = readLines(eventLog);
-    // down (no-op) → up (recalls text) → down (restorative) — proves the
-    // wrapper's restore-on-unparseable-change path fired, not just a single
-    // probe attempt.
-    const dirs = events.map((l) => (l.includes('arrow:down') ? 'down' : 'up'));
-    const upIdx = dirs.indexOf('up');
-    expect(upIdx).toBeGreaterThan(-1);
-    expect(dirs[upIdx - 1]).toBe('down');
-    expect(dirs.slice(upIdx + 1)).toContain('down');
+    expectRecallRestored();
   }, 20000);
 
   /**
@@ -220,13 +166,12 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
    * (a quoted earlier menu in scrollback) above a genuinely idle input box.
    * Down no-ops; Up recalls text — the screen CHANGES, and the static rows
    * still parse as a menu, but the highlight did not move. The wrapper must
-   * refuse to bridge (highlight-move confirmation), send the restorative
-   * Down, and let the turn complete normally. Before the hardening this
-   * exact sequence bridged a fabricated menu to chat.
+   * refuse to bridge (highlight-move confirmation), clear the recalled text,
+   * and let the turn complete normally. Before the hardening this exact
+   * sequence bridged a fabricated menu to chat.
    */
   it('I-PTY-MENU-07: never bridges static menu-shaped text whose highlight cannot move', async () => {
-    wrapper = spawnWrapper(inputLog, eventLog);
-    collector.attach(wrapper);
+    start();
     await waitMs(2500);
 
     wrapper.stdin!.write(makeTurnJson('RECALL_FAKEMENU'));
@@ -237,15 +182,87 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     );
     expect(completed).toBe(true);
     expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
-
-    // Same restorative shape as RECALL_NONMENU: down (no-op) → up (recall,
-    // screen changed but the static caret row didn't move) → down (restore).
-    const dirs = readLines(eventLog).map((l) => (l.includes('arrow:down') ? 'down' : 'up'));
-    const upIdx = dirs.indexOf('up');
-    expect(upIdx).toBeGreaterThan(-1);
-    expect(dirs[upIdx - 1]).toBe('down');
-    expect(dirs.slice(upIdx + 1)).toContain('down');
+    expectRecallRestored();
   }, 20000);
+
+  /**
+   * I-PTY-MENU-08: the F1 hole from review round 2 (finding 2). Same static
+   * quoted menu, but the recalled history entry BEGINS WITH "2." — the input
+   * line itself renders as a caret-bearing option row ("❯ 2. …"), so a
+   * whole-screen caret scan would read the highlight as "moved" from the
+   * static row to the input line and bridge a fabricated menu. The highlight
+   * must be read from the option run's own rows only: no bridge, recalled
+   * text cleared, turn completes normally.
+   */
+  it('I-PTY-MENU-08: a recalled entry starting with "N." cannot forge a highlight move', async () => {
+    start();
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('RECALL_FAKEMENU_NUM'));
+
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      8000,
+    );
+    expect(completed).toBe(true);
+    expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
+    expectRecallRestored();
+  }, 20000);
+
+  /**
+   * I-PTY-MENU-09: the turn ends (transcript turn_duration lands) at the
+   * same moment the Up fallback recalls text — the round is abandoned
+   * mid-flight. Every abandon path must still clear the recalled text
+   * (review round 2, finding 3): without the restore, the stale recalled
+   * entry would be prepended to the next submitted message.
+   */
+  it('I-PTY-MENU-09: an abandoned round (turn ended mid-probe) still clears the Up-recall', async () => {
+    start();
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('RECALL_TURNEND'));
+
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      8000,
+    );
+    expect(completed).toBe(true);
+    expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
+
+    // The Ctrl+U restore must arrive even though the turn ended mid-round.
+    const restored = await waitFor(() => keyEvents().includes('ctrlu'), 3000);
+    expect(restored).toBe(true);
+  }, 20000);
+
+  /**
+   * I-PTY-MENU-10: swallowed-Enter recovery for a draft that renders exactly
+   * like a menu option row (review round 2, findings 1+4). The submitted text
+   * starts with "1." and its Enter is swallowed, so the draft sits in the
+   * input line as "❯ 1. …" — indistinguishable by text from a highlighted
+   * menu row. The wrapper must (a) NOT probe it with arrows (no busy or
+   * transcript output yet → a menu is impossible), and (b) NOT let the
+   * caret-shaped draft suppress the Enter-retry — the retry resubmits and
+   * the turn completes. Before the fix this state wedged into the 30-min
+   * watchdog and killed the session.
+   */
+  it('I-PTY-MENU-10: a numbered draft with a swallowed Enter is retried, not probed or wedged', async () => {
+    start();
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('1. SWALLOW_ONCE fix the login bug'));
+
+    // The Enter-retry fires SUBMIT_RETRY_AFTER_MS (4s) after the paste.
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      12000,
+    );
+    expect(completed).toBe(true);
+    const result = collector.find((e) => e.type === 'result') as ProtocolEvent & { subtype: string };
+    expect(result.subtype).toBe('success');
+    expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
+    // The probe must never have fired into the unsubmitted draft.
+    expect(keyEvents().filter((k) => k === 'up' || k === 'down')).toHaveLength(0);
+  }, 25000);
 
   /**
    * I-PTY-MENU-05: no interactive overlay ever appears and nothing reacts to
@@ -254,8 +271,7 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
    * as a plain non-menu stall does today (no new hang mode introduced).
    */
   it('I-PTY-MENU-05: gives up cleanly when nothing reacts, turn still completes', async () => {
-    wrapper = spawnWrapper(inputLog, eventLog);
-    collector.attach(wrapper);
+    start();
     await waitMs(2500);
 
     wrapper.stdin!.write(makeTurnJson('NO_REACT'));
@@ -275,8 +291,7 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
    * never stalls quietly for MENU_STABLE_QUIET_MS).
    */
   it('I-PTY-MENU-06: an ordinary turn with no stall completes with no probe side-effects', async () => {
-    wrapper = spawnWrapper(inputLog, eventLog);
-    collector.attach(wrapper);
+    start();
     await waitMs(2500);
 
     wrapper.stdin!.write(makeTurnJson('ORDINARY_MESSAGE'));
@@ -287,6 +302,6 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     );
     expect(completed).toBe(true);
     expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
-    expect(readLines(eventLog)).toHaveLength(0); // no arrow keys were ever sent
+    expect(keyEvents().filter((k) => k === 'up' || k === 'down')).toHaveLength(0); // no arrow keys were ever sent
   }, 20000);
 });

--- a/tests/integration/pty-menu-probe.test.ts
+++ b/tests/integration/pty-menu-probe.test.ts
@@ -215,6 +215,39 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
   }, 20000);
 
   /**
+   * I-PTY-MENU-07: the fake-menu regression from the PR #181 review (F1).
+   * The quiet screen shows STATIC menu-shaped text with a real ❯ caret row
+   * (a quoted earlier menu in scrollback) above a genuinely idle input box.
+   * Down no-ops; Up recalls text — the screen CHANGES, and the static rows
+   * still parse as a menu, but the highlight did not move. The wrapper must
+   * refuse to bridge (highlight-move confirmation), send the restorative
+   * Down, and let the turn complete normally. Before the hardening this
+   * exact sequence bridged a fabricated menu to chat.
+   */
+  it('I-PTY-MENU-07: never bridges static menu-shaped text whose highlight cannot move', async () => {
+    wrapper = spawnWrapper(inputLog, eventLog);
+    collector.attach(wrapper);
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('RECALL_FAKEMENU'));
+
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      8000,
+    );
+    expect(completed).toBe(true);
+    expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
+
+    // Same restorative shape as RECALL_NONMENU: down (no-op) → up (recall,
+    // screen changed but the static caret row didn't move) → down (restore).
+    const dirs = readLines(eventLog).map((l) => (l.includes('arrow:down') ? 'down' : 'up'));
+    const upIdx = dirs.indexOf('up');
+    expect(upIdx).toBeGreaterThan(-1);
+    expect(dirs[upIdx - 1]).toBe('down');
+    expect(dirs.slice(upIdx + 1)).toContain('down');
+  }, 20000);
+
+  /**
    * I-PTY-MENU-05: no interactive overlay ever appears and nothing reacts to
    * either arrow key. The probe must exhaust its round budget and give up
    * cleanly — the turn still completes normally via the transcript, exactly

--- a/tests/integration/pty-stop-stuck-input.test.ts
+++ b/tests/integration/pty-stop-stuck-input.test.ts
@@ -15,61 +15,21 @@
  * the PTY + sets this.interrupting, then clears the PTY input via Ctrl+U.
  */
 
-import { spawn, ChildProcess } from 'child_process';
+import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import {
+  makeTurnJson,
+  spawnWrapper as spawnHarnessWrapper,
+  waitForLogEntries,
+  waitMs,
+} from '../helpers/pty-harness';
 
-const PTY_SHELL_BIN = path.resolve(__dirname, '../../dist/shell/claude-pty-shell.js');
 const MOCK_TUI_BIN = path.resolve(__dirname, '../helpers/mock-claude-tui.js');
 
-// ── helpers ──────────────────────────────────────────────────────────────────
-
-function makeTurnJson(text: string): string {
-  return (
-    JSON.stringify({
-      type: 'user',
-      message: { role: 'user', content: [{ type: 'text', text }] },
-    }) + '\n'
-  );
-}
-
 function spawnWrapper(inputLog: string): ChildProcess {
-  return spawn('node', [PTY_SHELL_BIN, '--model', 'claude-test', '--dangerously-skip-permissions'], {
-    env: {
-      ...process.env,
-      // Use path directly (not "node path") so checkAuthStatus(realBinParts[0]) works
-      CLAUDE_REAL_BIN: MOCK_TUI_BIN,
-      FAKE_TUI_INPUT_LOG: inputLog,
-      PTY_SHELL_DEBUG: '0',
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-}
-
-function waitMs(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-/** Read lines submitted to the fake TUI (one per turn). */
-function readInputLog(logPath: string): string[] {
-  if (!fs.existsSync(logPath)) return [];
-  return fs
-    .readFileSync(logPath, 'utf-8')
-    .split('\n')
-    .map((l) => l.trim())
-    .filter(Boolean);
-}
-
-/** Wait until the input log has at least `n` entries, or timeout. */
-async function waitForLogEntries(logPath: string, n: number, timeoutMs = 5000): Promise<string[]> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const lines = readInputLog(logPath);
-    if (lines.length >= n) return lines;
-    await waitMs(100);
-  }
-  return readInputLog(logPath);
+  return spawnHarnessWrapper(MOCK_TUI_BIN, { FAKE_TUI_INPUT_LOG: inputLog });
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -1,5 +1,5 @@
 import { translateArgs, sanitizeUserText } from '../../src/shell/args';
-import { projectSlug, transcriptPath, isSyntheticRequestTooLarge, hasInteractiveMenuToolUse } from '../../src/shell/tailer';
+import { projectSlug, transcriptPath, isSyntheticRequestTooLarge } from '../../src/shell/tailer';
 import {
   ScreenModel,
   TUI_BUSY_MARKER,
@@ -17,6 +17,7 @@ import { ProtocolEmitter } from '../../src/shell/emitter';
 import { Writable } from 'stream';
 import { preTrustWorkspace, checkAuthStatus } from '../../src/shell/trust';
 import { decideMenuCancel, MenuCancelState } from '../../src/shell/menu-cancel';
+import { decideProbeAttempt, ProbeState, PROBE_MAX_ROUNDS, PROBE_RETRY_COOLDOWN_MS } from '../../src/shell/menu-probe';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -116,56 +117,6 @@ describe('ScreenModel TUI constants (Claude Code v2.1.x)', () => {
 
 });
 
-describe('ScreenModel detectRequestTooLarge', () => {
-  it('detects the recoverable 32MB error overlay', async () => {
-    const screen = await renderScreen([
-      '  Read 1 file',
-      '',
-      '  Request too large (max 32MB). Double press esc to go back',
-      '',
-    ]);
-    expect(screen.detectRequestTooLarge()).toBe(true);
-  });
-
-  it('is false on a normal idle screen', async () => {
-    const screen = await renderScreen([
-      '❯ ',
-      'ready for input',
-    ]);
-    expect(screen.detectRequestTooLarge()).toBe(false);
-  });
-
-  it('does not false-positive on prose merely discussing the error', async () => {
-    // The matcher keys on the exact "(max" suffix the TUI renders, so an agent
-    // explaining the concept ("a request that is too large") never trips it.
-    const screen = await renderScreen([
-      'If a request is too large the API rejects it.',
-    ]);
-    expect(screen.detectRequestTooLarge()).toBe(false);
-  });
-
-  it('does not trip when the agent quotes the exact error text without the dismiss footer', async () => {
-    // Self-trigger guard: the agent's own reply may contain the verbatim error
-    // string (e.g. explaining this very bug). Detection requires the dismiss
-    // footer too, which only the real overlay renders — so quoted prose is inert.
-    const screen = await renderScreen([
-      'When the TUI shows "Request too large (max 32MB)" the session must restart.',
-      '❯ ',
-    ]);
-    expect(screen.detectRequestTooLarge()).toBe(false);
-  });
-
-  it('DOES trip on a verbatim overlay copy carrying the footer (the false-positive bug)', async () => {
-    // Reproduces the restart loop: the gateway once captured the whole overlay
-    // sentence — prefix AND footer — into a stored assistant message. Re-typed
-    // into the TUI on the next spawn, it renders both fragments → detection fires
-    // on a healthy session. The "require the footer" guard does NOT save us here.
-    const poison = 'Assistant: ...(กัน double-delete):Request too large (max 32MB). Double press esc to go back and try with a smaller file.';
-    const screen = await renderScreen([poison, '❯ ']);
-    expect(screen.detectRequestTooLarge()).toBe(true);
-  });
-});
-
 describe('neutralizeTuiTriggers (history detox)', () => {
   const POISON =
     'Assistant: ...(กัน double-delete):Request too large (max 32MB). Double press esc to go back and try with a smaller file.';
@@ -181,13 +132,6 @@ describe('neutralizeTuiTriggers (history detox)', () => {
     expect(out).toContain('Request too large ( max 32MB)');
     expect(out).toContain('esc to go  back');
     expect(out).toContain('กัน double-delete'); // surrounding content untouched
-  });
-
-  it('neutralized history no longer trips detection after a TUI round-trip', async () => {
-    // The actual fix: the same poisoned message, detoxed, rendered on screen WITH
-    // the idle caret present, must be inert — closing the restart loop at the source.
-    const screen = await renderScreen([neutralizeTuiTriggers(POISON), '❯ ']);
-    expect(screen.detectRequestTooLarge()).toBe(false);
   });
 
   it('is a no-op on text without the trigger fragments', () => {
@@ -275,8 +219,8 @@ const MENU_FOOTER = 'Enter to select · ↑/↓ to navigate · Esc to cancel';
 // can assert region-restricted behavior against realistic scrollback.
 const FILLER = (n: number) => Array.from({ length: n }, (_, i) => `conversation line ${i}`);
 
-describe('ScreenModel detectMenu', () => {
-  it('parses numbered options (with ❯ highlight + a divider) when the footer is present', async () => {
+describe('ScreenModel readInteractivePrompt (plain AskUserQuestion-style menu)', () => {
+  it('parses numbered options (with ❯ highlight + a divider), classified as a plain menu', async () => {
     const screen = await renderScreen([
       'Which option do you want?',
       '',
@@ -288,17 +232,20 @@ describe('ScreenModel detectMenu', () => {
       '',
       MENU_FOOTER,
     ]);
-    const menu = screen.detectMenu();
-    expect(menu).not.toBeNull();
-    expect(menu!.map((o) => o.index)).toEqual([1, 2, 3, 4]);
-    expect(menu![0].label).toBe('First choice');
-    expect(menu![3].label).toBe('Chat about this');
+    const prompt = screen.readInteractivePrompt();
+    expect(prompt).not.toBeNull();
+    expect(prompt!.isPermission).toBe(false);
+    expect(prompt!.options.map((o) => o.index)).toEqual([1, 2, 3, 4]);
+    expect(prompt!.options[0].label).toBe('First choice');
+    expect(prompt!.options[3].label).toBe('Chat about this');
   });
 
   it('ignores stale numbered scrollback above the live menu', async () => {
     // Reproduces the live bug: a prior chat message rendered as "1. … 2. …"
-    // sat in scrollback above an AskUserQuestion menu, so detectMenu swept the
-    // phantom rows in — inflating the option list and shifting every index.
+    // sat in scrollback above an AskUserQuestion menu, so a naive scan would
+    // sweep the phantom rows in — inflating the option list and shifting
+    // every index. readInteractivePrompt() takes only the live 1..N run
+    // nearest the end of the buffer.
     const screen = await renderScreen([
       '1. restart gateway now',
       '2. restart drops the running session',
@@ -311,30 +258,29 @@ describe('ScreenModel detectMenu', () => {
       '',
       MENU_FOOTER,
     ]);
-    const menu = screen.detectMenu();
-    expect(menu).not.toBeNull();
-    // Only the real 1..3 run nearest the footer — phantom rows excluded.
-    expect(menu!.map((o) => o.index)).toEqual([1, 2, 3]);
-    expect(menu![0].label).toBe('See the buttons');
-    expect(menu!.map((o) => o.label)).not.toContain('restart gateway now');
+    const prompt = screen.readInteractivePrompt();
+    expect(prompt).not.toBeNull();
+    expect(prompt!.options.map((o) => o.index)).toEqual([1, 2, 3]);
+    expect(prompt!.options[0].label).toBe('See the buttons');
+    expect(prompt!.options.map((o) => o.label)).not.toContain('restart gateway now');
   });
 
-  it('returns null without the menu footer', async () => {
+  it('returns null for plain prose with no live numbered-option run (no caret, no live UI)', async () => {
     const screen = await renderScreen([
       'Here is a numbered list in normal output:',
       '1. not a menu',
       '2. still not a menu',
     ]);
-    expect(screen.detectMenu()).toBeNull();
+    expect(screen.readInteractivePrompt()).toBeNull();
   });
 
-  it('returns null with the footer but fewer than two options', async () => {
+  it('returns null with fewer than two options', async () => {
     const screen = await renderScreen([
       'Confirm?',
       '  1. Only choice',
       MENU_FOOTER,
     ]);
-    expect(screen.detectMenu()).toBeNull();
+    expect(screen.readInteractivePrompt()).toBeNull();
   });
 });
 
@@ -586,9 +532,10 @@ describe('ScreenModel detectDialog (region-restricted)', () => {
   });
 });
 
-describe('ScreenModel detectPermissionPrompt (region-restricted, never auto-accepts)', () => {
-  // Claude Code's tool-permission footer — note "Tab to amend"/"to explain", which
-  // the select-menu footer ("↑/↓ to navigate") and the 32MB overlay never carry.
+describe('ScreenModel readInteractivePrompt (permission-style Yes/No prompt)', () => {
+  // Claude Code's tool-permission footer — kept in fixtures to mirror real TUI
+  // output, but readInteractivePrompt() no longer requires it (see planning-61:
+  // liveness is now proven behaviorally by the probe, not by footer text).
   const PERM_FOOTER = 'Esc to cancel · Tab to amend · ctrl+e to explain';
 
   it('detects the dangerous-rm circuit-breaker prompt (boxed) and parses Yes/No', async () => {
@@ -603,8 +550,9 @@ describe('ScreenModel detectPermissionPrompt (region-restricted, never auto-acce
       '╰──────────────────────────────────────────────────────────────╯',
       PERM_FOOTER,
     ]);
-    const prompt = screen.detectPermissionPrompt();
+    const prompt = screen.readInteractivePrompt();
     expect(prompt).not.toBeNull();
+    expect(prompt!.isPermission).toBe(true);
     expect(prompt!.options.map((o) => o.label)).toEqual(['Yes', 'No']);
     // Context echoes the guarded command (box borders stripped), not the filler.
     expect(prompt!.context).toContain('Dangerous rm operation');
@@ -619,7 +567,22 @@ describe('ScreenModel detectPermissionPrompt (region-restricted, never auto-acce
       '    2. No',
       PERM_FOOTER,
     ]);
-    const prompt = screen.detectPermissionPrompt();
+    const prompt = screen.readInteractivePrompt();
+    expect(prompt).not.toBeNull();
+    expect(prompt!.options.map((o) => o.label)).toEqual(['Yes', 'No']);
+  });
+
+  it('detects the prompt even with no footer line at all (no longer footer-gated)', async () => {
+    // The old detector required a permission-specific footer token before
+    // trusting the screen; the new reader doesn't need it because liveness
+    // was already proven behaviorally before this is ever called.
+    const screen = await renderScreen([
+      ...FILLER(44),
+      'Do you want to proceed?',
+      '❯ 1. Yes',
+      '  2. No',
+    ]);
+    const prompt = screen.readInteractivePrompt();
     expect(prompt).not.toBeNull();
     expect(prompt!.options.map((o) => o.label)).toEqual(['Yes', 'No']);
   });
@@ -632,37 +595,13 @@ describe('ScreenModel detectPermissionPrompt (region-restricted, never auto-acce
       ...FILLER(44),
       '❯ ',
     ]);
-    expect(screen.detectPermissionPrompt()).toBeNull();
-  });
-
-  it('requires a permission footer token (a plain numbered question never trips it)', async () => {
-    const screen = await renderScreen([
-      ...FILLER(43),
-      'Do you want to proceed?',
-      '❯ 1. Yes',
-      '  2. No',
-    ]);
-    // No "to amend"/"to explain" footer present → not a permission prompt.
-    expect(screen.detectPermissionPrompt()).toBeNull();
-  });
-
-  it('excludes the bypass-permissions startup dialog (handled by detectDialog)', async () => {
-    const screen = await renderScreen([
-      ...FILLER(40),
-      'Bypass Permissions mode',
-      'Do you want to proceed?',
-      '❯ 1. Yes, I accept',
-      '  2. No, exit',
-      PERM_FOOTER,
-    ]);
-    expect(screen.detectPermissionPrompt()).toBeNull();
-    expect(screen.detectDialog()).toBe('bypass-permissions');
+    expect(screen.readInteractivePrompt()).toBeNull();
   });
 
   it('requires a ❯/> selection caret — a numbered list in prose never trips it', async () => {
-    // Worst case for the footer gate: conversational text that happens to pair the
-    // question with a numbered list AND the verbatim footer phrase. With no live
-    // select caret on an option row it is still not a real prompt → no bridge.
+    // Conversational text that happens to pair the question with a numbered
+    // list. With no live select caret on an option row it is still not a
+    // real prompt → no bridge.
     const screen = await renderScreen([
       ...FILLER(40),
       'Do you want to proceed? Here is the plan I would run:',
@@ -670,7 +609,7 @@ describe('ScreenModel detectPermissionPrompt (region-restricted, never auto-acce
       '2. Then remove the old files',
       PERM_FOOTER,
     ]);
-    expect(screen.detectPermissionPrompt()).toBeNull();
+    expect(screen.readInteractivePrompt()).toBeNull();
   });
 
   it('binds context to the question NEAREST the options when an earlier one is quoted', async () => {
@@ -688,7 +627,7 @@ describe('ScreenModel detectPermissionPrompt (region-restricted, never auto-acce
       '╰──────────────────────────────────────────────────────────────╯',
       PERM_FOOTER,
     ]);
-    const prompt = screen.detectPermissionPrompt();
+    const prompt = screen.readInteractivePrompt();
     expect(prompt).not.toBeNull();
     expect(prompt!.options.map((o) => o.label)).toEqual(['Yes', 'No']);
     expect(prompt!.context).toContain('Dangerous rm operation');
@@ -717,42 +656,41 @@ describe('formatPermissionPrompt', () => {
   });
 });
 
-describe('hasInteractiveMenuToolUse (authoritative menu gate)', () => {
-  it('true when the record invokes AskUserQuestion', () => {
-    expect(hasInteractiveMenuToolUse({
-      role: 'assistant',
-      content: [{ type: 'tool_use', name: 'AskUserQuestion', id: 't1', input: { questions: [] } }],
-    })).toBe(true);
+describe('menu-probe decideProbeAttempt (behavioral probe round budget)', () => {
+  // Mirrors decideMenuCancel's test style: pure per-round bookkeeping, kept
+  // free of node-pty/screen imports so it's cheap to test in isolation.
+  const T0 = 100_000;
+  const baseState = (): ProbeState => ({ lastAttemptAt: T0, rounds: 1 });
+
+  it('sends a new round once the cooldown has elapsed', () => {
+    const action = decideProbeAttempt(baseState(), { now: T0 + PROBE_RETRY_COOLDOWN_MS });
+    expect(action).toBe('send');
   });
 
-  it('true for the plan-approval ExitPlanMode tool', () => {
-    expect(hasInteractiveMenuToolUse({
-      role: 'assistant',
-      content: [{ type: 'tool_use', name: 'ExitPlanMode', id: 't2', input: {} }],
-    })).toBe(true);
+  it('waits while still within the cooldown window since the last attempt', () => {
+    const action = decideProbeAttempt(baseState(), { now: T0 + PROBE_RETRY_COOLDOWN_MS - 1 });
+    expect(action).toBe('wait');
   });
 
-  it('also accepts the legacy snake_case exit_plan_mode name', () => {
-    // Claude Code's binary carries both PascalCase and snake_case; the emitted
-    // tool name varies by model, so both must gate the bridge.
-    expect(hasInteractiveMenuToolUse({
-      role: 'assistant',
-      content: [{ type: 'tool_use', name: 'exit_plan_mode', id: 't2b', input: {} }],
-    })).toBe(true);
+  it('sends the very first round immediately (lastAttemptAt=0 is far in the past)', () => {
+    const action = decideProbeAttempt({ lastAttemptAt: 0, rounds: 0 }, { now: T0 });
+    expect(action).toBe('send');
   });
 
-  it('false for a normal text reply (even if it mentions the tool name)', () => {
-    expect(hasInteractiveMenuToolUse({
-      role: 'assistant',
-      content: [{ type: 'text', text: 'I will use AskUserQuestion to ask you.' }],
-    })).toBe(false);
+  it('gives up once PROBE_MAX_ROUNDS have been spent, regardless of cooldown', () => {
+    const action = decideProbeAttempt(
+      { lastAttemptAt: T0, rounds: PROBE_MAX_ROUNDS },
+      { now: T0 + PROBE_RETRY_COOLDOWN_MS + 10_000 },
+    );
+    expect(action).toBe('give-up');
   });
 
-  it('false for an unrelated tool', () => {
-    expect(hasInteractiveMenuToolUse({
-      role: 'assistant',
-      content: [{ type: 'tool_use', name: 'Bash', id: 't3', input: { command: 'ls' } }],
-    })).toBe(false);
+  it('give-up takes priority over cooldown (both conditions true)', () => {
+    const action = decideProbeAttempt(
+      { lastAttemptAt: T0, rounds: PROBE_MAX_ROUNDS },
+      { now: T0 }, // also within cooldown
+    );
+    expect(action).toBe('give-up');
   });
 });
 

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -311,19 +311,73 @@ describe('ScreenModel readInteractivePrompt (plain AskUserQuestion-style menu)',
     ]);
     expect(screen.readInteractivePrompt()).toBeNull();
   });
+
+  it('reads the highlight from the run\'s own rows — a caret-bearing input line cannot supply it (round-2 finding 2)', async () => {
+    // The recall-forgery hole: a static quoted menu sits in scrollback and the
+    // probe's Up fallback recalls a history entry beginning "2." — the input
+    // line renders as "❯ 2. …", a perfectly caret-shaped option row. A
+    // whole-screen caret scan read the highlight from that bottom-most row
+    // (1→2 = "moved") and bridged a fabricated menu. The highlight must come
+    // from the selected 1..N run itself, where the caret is still on row 1.
+    const screen = await renderScreen([
+      'Earlier the assistant quoted a menu verbatim:',
+      '❯ 1. First choice',
+      '  2. Second choice',
+      '',
+      '❯ 2. remove the old files',
+    ]);
+    const prompt = screen.readInteractivePrompt();
+    expect(prompt).not.toBeNull();
+    expect(prompt!.options.map((o) => o.index)).toEqual([1, 2]);
+    expect(prompt!.highlighted).toBe(1); // NOT 2 from the input line
+  });
+
+  it('the recall-forgery screen pair never satisfies confirmProbeReaction (highlight did not move)', async () => {
+    // End-to-end shape of the round-2 finding-2 exploit: before = quoted menu
+    // + idle input, after = same menu + recalled "2. …" in the input line.
+    // Both parse, both highlight row 1 → no move → no bridge.
+    const before = await renderScreen([
+      'Earlier the assistant quoted a menu verbatim:',
+      '❯ 1. First choice',
+      '  2. Second choice',
+      '',
+      '❯ ',
+    ]);
+    const after = await renderScreen([
+      'Earlier the assistant quoted a menu verbatim:',
+      '❯ 1. First choice',
+      '  2. Second choice',
+      '',
+      '❯ 2. remove the old files',
+    ]);
+    expect(confirmProbeReaction(before.readInteractivePrompt(), after.readInteractivePrompt())).toBe(false);
+  });
+
+  it('returns null when the run carries two highlights (a caret line joined the run)', async () => {
+    // A recalled entry beginning "3." EXTENDS a static [1,2] run into [1,2,3]
+    // and brings a second caret with it — a live menu highlights exactly one
+    // of its rows, so anything else is not a live menu.
+    const screen = await renderScreen([
+      '❯ 1. First choice',
+      '  2. Second choice',
+      '❯ 3. do the third thing',
+    ]);
+    expect(screen.readInteractivePrompt()).toBeNull();
+  });
 });
 
 describe('hasPrompt() vs interactivePromptBlocking() (menu-caret false-positive)', () => {
-  // Root cause of the "failed to submit turn to the TUI input" false report during a
-  // multi-question AskUserQuestion wizard: hasPrompt()'s idle-prompt regex (`/^❯ /m`)
-  // scans the whole visible screen and cannot tell the real idle bash caret apart from
-  // a highlighted menu option row, which uses the exact same `❯` marker flush at
-  // column 0. tick()'s "Enter appears swallowed" retry-and-give-up gate must exclude
-  // interactivePromptBlocking() so a live wizard step (no new tailer record yet,
-  // because the tool_use hasn't returned) is never mistaken for a genuinely stuck
-  // idle prompt.
+  // hasPrompt()'s idle-prompt regex (`/^❯ /m`) scans the whole visible screen
+  // and cannot tell the real idle caret apart from a highlighted menu option
+  // row, which uses the exact same `❯` marker flush at column 0.
+  // interactivePromptBlocking() is the DELIBERATELY PERMISSIVE companion scan
+  // (see its doc): it gates only actions where a false positive is cheap —
+  // the confirming Enter after a typed selection, decideMenuCancel's
+  // menuVisible, and the Enter-swallowed retry of a MENU-SELECTION turn. An
+  // ordinary turn's retry is NOT gated on it (the unsubmitted draft itself
+  // renders "❯ <text>" and would suppress the retry — round-2 finding 1).
 
-  it('a highlighted menu option row satisfies hasPrompt() (documents the collision), and interactivePromptBlocking() is also true on the same screen (so the retry gate is excluded)', async () => {
+  it('a highlighted menu option row satisfies hasPrompt() (documents the collision), and interactivePromptBlocking() is also true on the same screen', async () => {
     const screen = await renderScreen([
       ...FILLER(44),
       'Which option do you want?',

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -17,7 +17,7 @@ import { ProtocolEmitter } from '../../src/shell/emitter';
 import { Writable } from 'stream';
 import { preTrustWorkspace, checkAuthStatus } from '../../src/shell/trust';
 import { decideMenuCancel, MenuCancelState } from '../../src/shell/menu-cancel';
-import { decideProbeAttempt, ProbeState, PROBE_MAX_ROUNDS, PROBE_RETRY_COOLDOWN_MS } from '../../src/shell/menu-probe';
+import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_MAX_ROUNDS, PROBE_RETRY_COOLDOWN_MS } from '../../src/shell/menu-probe';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -238,6 +238,7 @@ describe('ScreenModel readInteractivePrompt (plain AskUserQuestion-style menu)',
     expect(prompt!.options.map((o) => o.index)).toEqual([1, 2, 3, 4]);
     expect(prompt!.options[0].label).toBe('First choice');
     expect(prompt!.options[3].label).toBe('Chat about this');
+    expect(prompt!.highlighted).toBe(1);
   });
 
   it('ignores stale numbered scrollback above the live menu', async () => {
@@ -272,6 +273,34 @@ describe('ScreenModel readInteractivePrompt (plain AskUserQuestion-style menu)',
       '2. still not a menu',
     ]);
     expect(screen.readInteractivePrompt()).toBeNull();
+  });
+
+  it('returns null for a markdown blockquote numbered list — ASCII ">" is not a selection caret', async () => {
+    // The fake-menu bug from the PR #181 review (F1): quoted prose like
+    // "> 1. …" satisfied the old [❯>] caret alternation, so an Up-recall
+    // screen change plus this static text bridged a fabricated menu. The
+    // caret gate is now U+276F only — the real TUI never renders ">".
+    const screen = await renderScreen([
+      'The user asked earlier:',
+      '> 1. First choice',
+      '> 2. Second choice',
+      '',
+      '❯ ',
+    ]);
+    expect(screen.readInteractivePrompt()).toBeNull();
+  });
+
+  it('reports which option the caret highlights (probe compares this across snapshots)', async () => {
+    const screen = await renderScreen([
+      'Which option do you want?',
+      '',
+      '  1. First choice',
+      '❯ 2. Second choice',
+      '  3. Third choice',
+      '',
+      MENU_FOOTER,
+    ]);
+    expect(screen.readInteractivePrompt()!.highlighted).toBe(2);
   });
 
   it('returns null with fewer than two options', async () => {
@@ -315,6 +344,34 @@ describe('hasPrompt() vs interactivePromptBlocking() (menu-caret false-positive)
       '❯ ',
     ]);
     expect(screen.hasPrompt()).toBe(true);
+    expect(screen.interactivePromptBlocking()).toBe(false);
+  });
+
+  it('sees a menu sitting HIGH on a sparse screen (full-viewport scan — F4)', async () => {
+    // A fresh session renders the menu near the top of the viewport. The old
+    // bottom-20-rows window missed it, so selectMenuOption() skipped the
+    // confirming Enter and the selection hung.
+    const screen = await renderScreen([
+      'Which option do you want?',
+      '❯ 1. First choice',
+      '  2. Second choice',
+      '',
+      MENU_FOOTER,
+    ]);
+    expect(screen.interactivePromptBlocking()).toBe(true);
+  });
+
+  it('markdown blockquote prose ("> 1.") anywhere on screen is not a blocking prompt', async () => {
+    // The full-viewport scan is only safe because ASCII ">" no longer counts
+    // as a caret — otherwise every quoted numbered list would suppress the
+    // Enter-swallowed retry and inject stray Enters after menu selections.
+    const screen = await renderScreen([
+      'The user asked:',
+      '> 1. First choice',
+      '> 2. Second choice',
+      ...FILLER(40),
+      '❯ ',
+    ]);
     expect(screen.interactivePromptBlocking()).toBe(false);
   });
 });
@@ -554,6 +611,7 @@ describe('ScreenModel readInteractivePrompt (permission-style Yes/No prompt)', (
     expect(prompt).not.toBeNull();
     expect(prompt!.isPermission).toBe(true);
     expect(prompt!.options.map((o) => o.label)).toEqual(['Yes', 'No']);
+    expect(prompt!.highlighted).toBe(1);
     // Context echoes the guarded command (box borders stripped), not the filler.
     expect(prompt!.context).toContain('Dangerous rm operation');
     expect(prompt!.context).not.toContain('conversation line');
@@ -598,7 +656,7 @@ describe('ScreenModel readInteractivePrompt (permission-style Yes/No prompt)', (
     expect(screen.readInteractivePrompt()).toBeNull();
   });
 
-  it('requires a ❯/> selection caret — a numbered list in prose never trips it', async () => {
+  it('requires a ❯ selection caret — a numbered list in prose never trips it', async () => {
     // Conversational text that happens to pair the question with a numbered
     // list. With no live select caret on an option row it is still not a
     // real prompt → no bridge.
@@ -607,6 +665,17 @@ describe('ScreenModel readInteractivePrompt (permission-style Yes/No prompt)', (
       'Do you want to proceed? Here is the plan I would run:',
       '1. Back up the directory first',
       '2. Then remove the old files',
+      PERM_FOOTER,
+    ]);
+    expect(screen.readInteractivePrompt()).toBeNull();
+  });
+
+  it('a markdown blockquote "> 1." beside the question is not a caret either', async () => {
+    const screen = await renderScreen([
+      ...FILLER(40),
+      'Do you want to proceed? The choices were quoted as:',
+      '> 1. Yes',
+      '> 2. No',
       PERM_FOOTER,
     ]);
     expect(screen.readInteractivePrompt()).toBeNull();
@@ -691,6 +760,37 @@ describe('menu-probe decideProbeAttempt (behavioral probe round budget)', () => 
       { now: T0 }, // also within cooldown
     );
     expect(action).toBe('give-up');
+  });
+});
+
+describe('menu-probe confirmProbeReaction (highlight-move confirmation)', () => {
+  // The plan's point-2 "before/after comparison of the highlighted row"
+  // (post-review hardening F1): a probe keystroke only counts as a menu
+  // reaction when the SAME-shaped prompt parses in both snapshots and the
+  // ❯-highlighted index moved. A raw screen-text diff bridged fabricated
+  // menus when Up-recall changed the screen around static menu-shaped text.
+  const readout = (highlighted: number, count = 3) => ({
+    options: Array.from({ length: count }, (_, i) => ({ index: i + 1, label: `opt ${i + 1}` })),
+    highlighted,
+  });
+
+  it('confirms when the highlight moved (Down: 1→2, and the Up fallback: 3→2)', () => {
+    expect(confirmProbeReaction(readout(1), readout(2))).toBe(true);
+    expect(confirmProbeReaction(readout(3), readout(2))).toBe(true);
+  });
+
+  it('rejects when the highlight did not move — static menu-shaped text cannot react', () => {
+    expect(confirmProbeReaction(readout(1), readout(1))).toBe(false);
+  });
+
+  it('rejects when either snapshot has no parseable prompt', () => {
+    expect(confirmProbeReaction(null, readout(2))).toBe(false);
+    expect(confirmProbeReaction(readout(1), null)).toBe(false);
+    expect(confirmProbeReaction(null, null)).toBe(false);
+  });
+
+  it('rejects when the option count changed (different prompt, not a reaction)', () => {
+    expect(confirmProbeReaction(readout(1, 3), readout(2, 4))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Replaces screen-regex menu/permission detection (`detectMenu()`, `detectPermissionPrompt()`) and the transcript `turn.menuToolSeen` gate with a direct behavioral probe: send Down (fallback Up if already at the last option), diff the screen, confirm liveness before bridging `AskUserQuestion`/`ExitPlanMode` prompts to chat.
- Fixes a silent-hang class of bug: when the transcript tailer didn't confirm the `tool_use` in time (or it was nested under a sub-agent block the tailer doesn't attribute to the main turn), the old gate fail-safed to "don't bridge anything," leaving a live interactive prompt on the TUI invisible to the user.
- Restores input state after an Up-fallback probe that accidentally triggers shell history recall (auto-sends a compensating Down).
- Removes `detectRequestTooLarge()` (dead code, superseded by the transcript `<synthetic>` signal per its own doc comment) and the tests that only existed to cover it.

## Post-review hardening (second commit)
Adversarial review of the first commit surfaced 7 findings; all are fixed:
- **F1 (fake-menu bridge):** a raw screen-text diff counted *any* change as a menu reaction, so Up-fallback history recall plus static menu-shaped scrollback (e.g. a markdown `> 1.` blockquote) could bridge a fabricated menu. The probe now parses the prompt from both the before and after snapshots and bridges only when the same-shaped prompt's ❯-highlighted row **moved** (`confirmProbeReaction()`); the caret regex accepts only the real U+276F caret, never ASCII `>`. The restorative Down also fires for parseable-but-unmoved changes.
- **F2:** `tick()` returns before `maybeHandleDialog()` while a probe round is in flight — the dialog auto-accept `'2'` can no longer interleave with probe arrows.
- **F3:** `runProbe()` aborts at every resume point when a `/stop` interrupt is settling; no round starts mid-interrupt.
- **F4:** `interactivePromptBlocking()` scans the full viewport (same scope as the reader), so a menu high on a sparse screen can't lose its confirming Enter after a selection.
- **F5:** the busy-resume branch no longer resets the probe round budget while a round is in flight.
- **F6:** removed AI signatures from the commit message and this description per repo `CLAUDE.md`.
- **F7:** the blocking check reuses `CARET_OPTION_RE` instead of an inline duplicate.

## Test plan
- [x] TypeCheck clean
- [x] Full unit test suite (`pty-shell.test.ts`) — 96/96 passing (new: `confirmProbeReaction()`, highlighted-index extraction, blockquote-caret rejection, full-viewport blocking scan)
- [x] Integration suite (`tests/integration/pty-menu-probe.test.ts`) — 7 scenarios passing; new `RECALL_FAKEMENU` scenario reproduces the F1 fake-menu sequence and fails against the first commit
- [x] Full repo test suite — 2104/2113 passing; 4 failures are pre-existing on `main` (`phase-manual.test.ts` Phase 3/4 `/status` 500s) and 1 (`api-router` T8b) is load-flaky, passing in isolation — both unrelated to this change
- [ ] Manual verification against a live TUI via VNC (planning-61 Task 5 — not yet done, flagged to the requester)


## Post-review hardening round 2 (third commit)
A second adversarial review of the hardened commit surfaced 7 more findings; all are fixed:
- **R2-1 (session-wedge regression):** the F4 full-viewport scan let a user draft starting with `N.` (rendered as `❯ 1. …` on the input line) suppress the swallowed-Enter retry, wedging the turn until the watchdog killed the session. `interactivePromptBlocking()` now scopes caret matching away from the input line.
- **R2-2 (forged highlight):** `caretOptionIndex()` read the highlight from anywhere on screen, so digit-leading history text recalled into the input line could still forge a highlight move. The highlight is now read only from the option-run region.
- **R2-3 (orphaned recall):** probe abandon paths (busy-race, turn-end, interrupt mid-settle) skipped the restorative Down after an Up fallback, leaving recalled history text prepended to the next prompt. The probe is now a tick-driven state machine (`advanceProbe`) that guarantees restoration on every exit path.
- **R2-4:** probing is gated on `sawBusy`/records so a swallowed-Enter stall is retried instead of probed.
- **R2-5:** multi-line history recalls are fully restored (one Down per recalled line).
- **R2-6/7 (cleanup):** the detached probe coroutine that caused the F2/F3/F5 race class is gone (subsumed by the state machine), and ~150 lines of duplicated test scaffolding are extracted into `tests/helpers/mock-tui-core.js` + `tests/helpers/pty-harness.ts`.

New regression coverage: digit-leading recall cannot forge a highlight move; turn-end mid-probe still clears the recall; a numbered draft with a swallowed Enter is retried, not probed. Unit 99/99, integration 13/13.
