### PR TITLE
feat(models): add Fable 5 (1M) model entry

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -10,14 +10,15 @@
       "claude.dangerouslySkipPermissions"
     ]
   },
-  "configVersion": "1.0.10",
+  "configVersion": "1.0.11",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "models": [
-      { "id": "claude-fable-5",            "label": "Fable 5",          "alias": "fable",       "contextWindow": 1000000 },
+      { "id": "claude-fable-5[1m]",        "label": "Fable 5 (1M)",     "alias": "fable[1m]",   "contextWindow": 1000000 },
       { "id": "claude-opus-4-8[1m]",       "label": "Opus 4.8 (1M)",    "alias": "opus[1m]",    "contextWindow": 1000000 },
       { "id": "claude-sonnet-5[1m]",       "label": "Sonnet 5 (1M)",    "alias": "sonnet[1m]",  "contextWindow": 1000000 },
+      { "id": "claude-fable-5",            "label": "Fable 5",          "alias": "fable",       "contextWindow": 200000 },
       { "id": "claude-opus-4-8",           "label": "Opus 4.8",         "alias": "opus",        "contextWindow": 200000 },
       { "id": "claude-opus-4-6",           "label": "Opus 4.6",         "alias": "opus46",      "contextWindow": 200000 },
       { "id": "claude-sonnet-5",           "label": "Sonnet 5",         "alias": "sonnet",      "contextWindow": 200000 },

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -710,9 +710,10 @@ const BOT_COMMANDS = [
 
 // Available AI models for /models command
 const AVAILABLE_MODELS = [
-  { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable' },
+  { id: 'claude-fable-5[1m]',        label: 'Fable 5 (1M)',     alias: 'fable[1m]' },
   { id: 'claude-opus-4-8[1m]',       label: 'Opus 4.8 (1M)',    alias: 'opus[1m]' },
   { id: 'claude-sonnet-5[1m]',       label: 'Sonnet 5 (1M)',    alias: 'sonnet[1m]' },
+  { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable' },
   { id: 'claude-opus-4-8',           label: 'Opus 4.8',         alias: 'opus' },
   { id: 'claude-opus-4-6',           label: 'Opus 4.6',         alias: 'opus46' },
   { id: 'claude-sonnet-5',           label: 'Sonnet 5',         alias: 'sonnet' },

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -38,9 +38,10 @@ const TOO_LARGE_HISTORY_LADDER: readonly number[] = [MAX_HISTORY_MESSAGES, 40, 3
 export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
 export const DEFAULT_MODELS: ModelConfig[] = [
-  { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable',       contextWindow: 1000000 },
+  { id: 'claude-fable-5[1m]',        label: 'Fable 5 (1M)',     alias: 'fable[1m]',   contextWindow: 1000000 },
   { id: 'claude-opus-4-8[1m]',       label: 'Opus 4.8 (1M)',    alias: 'opus[1m]',    contextWindow: 1000000 },
   { id: 'claude-sonnet-5[1m]',       label: 'Sonnet 5 (1M)',    alias: 'sonnet[1m]',  contextWindow: 1000000 },
+  { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable',       contextWindow: 200000 },
   { id: 'claude-opus-4-8',           label: 'Opus 4.8',         alias: 'opus',        contextWindow: 200000 },
   { id: 'claude-opus-4-6',           label: 'Opus 4.6',         alias: 'opus46',      contextWindow: 200000 },
   { id: 'claude-sonnet-5',           label: 'Sonnet 5',         alias: 'sonnet',      contextWindow: 200000 },


### PR DESCRIPTION
## What

Adds `claude-fable-5[1m]` (Fable 5 (1M), alias `fable[1m]`, 1M context window) to all three model lists, and aligns plain `claude-fable-5` with the 200k group, matching the existing opus/sonnet plain-vs-`[1m]` scheme:

- **config.template.json** — new 1M entry at the top of `gateway.models`; plain fable moved to 200k. `configVersion` bumped **1.0.10 → 1.0.11** so the startup migrator (`migrateModels`) auto-merges the new entry into existing user configs.
- **`DEFAULT_MODELS`** (`src/agent/runner.ts`) — in-code fallback mirrored to the template.
- **`AVAILABLE_MODELS`** (`mcp/tools/telegram/receiver-server.ts`) — Telegram `/models` keyboard fallback mirrored (Discord has no hardcoded list; it uses `get_models` only).

## Migration side effect (intentional)

On the next gateway restart the migrator also syncs existing entries by id, so a live config's plain `claude-fable-5` at 1,000,000 will be updated to 200,000. Agents that should keep the 1M window must switch their model to `claude-fable-5[1m]`.

## Verification

- `tsc --noEmit` clean in both the root and `mcp/` workspaces
- No tests pin the fable entries; `migrateModels` add/update behavior is already covered by `tests/unit/config-migrator.test.ts`
- Web UI model badge matches `/fable/i`, so the `[1m]` id gets the Fable badge automatically
- PTY backend passes `[1m]` model ids through verbatim (same as the existing `claude-opus-4-8[1m]` / `claude-sonnet-5[1m]` entries in production use)