### PR TITLE
feat(webhooks): unified /webhooks/:app ingress dispatcher

### DIFF
--- a/API.md
+++ b/API.md
@@ -1040,7 +1040,7 @@ response.
 
 | Status | When |
 |--------|------|
-| 401 | Missing/invalid `x-line-signature`, or no `channelSecret` configured for the resolved agent |
+| 401 | Missing or invalid `x-line-signature` (the resolved agent always has `channelSecret` set — see the 404 row below) |
 | 404 | No LINE-enabled agent found — no agent has `line.channelSecret` set, or the given `:agentId` doesn't |
 
 **Access control:** DMs and groups/rooms are closed by default (`dmPolicy` /

--- a/API.md
+++ b/API.md
@@ -68,6 +68,15 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 | `GET` | `/api/v1/agents/:agentId/telegram/allowlist` | Admin | List allowlisted users |
 | `DELETE` | `/api/v1/agents/:agentId/telegram/allow/:userId` | Admin | Remove a user from the allowlist |
 
+### Public Webhook Ingress
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/webhooks/:app` | None (self-authenticating) | Provider URL-verification probe |
+| `GET` | `/webhooks/:app/:agentId` | None (self-authenticating) | Provider URL-verification probe, agent-scoped |
+| `POST` | `/webhooks/:app` | None (self-authenticating) | Inbound webhook delivery — first agent with `:app` configured |
+| `POST` | `/webhooks/:app/:agentId` | None (self-authenticating) | Inbound webhook delivery — specific agent |
+
 ### Skill API
 
 | Method | Path | Auth | Description |
@@ -963,6 +972,81 @@ curl -X POST \
 > - `session_id` is optional — omit for a stateless one-shot call
 > - Sessions idle-timeout after `idleTimeoutMinutes` (default 30 min); history is restored automatically on next message
 > - Error 409 = session is currently processing a request — wait and retry
+
+---
+
+## Public Webhook Ingress
+
+All external, unauthenticated webhooks (LINE today; more apps can be added later) enter
+through a single dispatcher route `/webhooks/:app/:agentId?`, routed to a per-app handler
+by the `:app` path segment.
+
+**This zone bypasses the gateway's API-key auth entirely** — it is mounted outside the
+`/api` routers, before `express.json()`, so each handler gets the raw request bytes it
+needs for its own signature validation. There is no ambient auth: every app handler
+(e.g. LINE's `x-line-signature` HMAC check) **must authenticate its own requests** as its
+first step.
+
+Request bodies on this route are capped at 256KB (pre-auth cap, applies to every app).
+An unknown `:app` returns `404`:
+
+```bash
+curl http://localhost:10850/webhooks/nope
+```
+
+```json
+{ "error": "unknown webhook app: nope" }
+```
+
+### LINE (`app: "line"`)
+
+**Setup:** configure `line.channelSecret` + `line.channelAccessToken` for an agent via
+`PATCH /api/v1/agents/:agentId` (see Agent API above), then point the LINE Developer
+Console's webhook URL at:
+
+```
+https://<your-gateway-host>/webhooks/line/<agentId>
+```
+
+`<agentId>` may be omitted — the dispatcher then falls back to the first agent with
+`line.channelSecret` set — but an explicit ID is recommended once more than one agent has
+LINE configured.
+
+**Verification (`GET`):** LINE's Console "Verify" button sends a GET (or empty POST); the
+handler answers unconditionally:
+
+```json
+{ "ok": true }
+```
+
+**Inbound delivery (`POST`):** the request must carry a valid `x-line-signature` header
+(HMAC-SHA256 of the raw body, keyed by `channelSecret`, base64-encoded).
+
+```bash
+BODY='{"events":[{"type":"message","message":{"type":"text","id":"1","text":"hi"},"source":{"type":"user","userId":"Uxxxx"},"replyToken":"xxx","timestamp":1234567890}]}'
+SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "<CHANNEL_SECRET>" -binary | base64)
+curl -X POST http://localhost:10850/webhooks/line/<agentId> \
+  -H "Content-Type: application/json" \
+  -H "x-line-signature: $SIG" \
+  -d "$BODY"
+```
+
+Text and image messages from allowed 1:1/group/room sources are normalized and forwarded
+to the agent's `/channel` intake (the same path Telegram uses). The request is
+acknowledged (`200 {"ok":true}`) **before** event processing, so LINE never sees a slow
+response.
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 401 | Missing/invalid `x-line-signature`, or no `channelSecret` configured for the resolved agent |
+| 404 | No LINE-enabled agent found — no agent has `line.channelSecret` set, or the given `:agentId` doesn't |
+
+**Access control:** DMs and groups/rooms are closed by default (`dmPolicy` /
+`groupPolicy` allowlist, per agent config); a denied sender receives a one-time pairing
+code (via LINE reply) to share with the admin, who approves it the same way as Telegram
+pairing.
 
 ---
 

--- a/scripts/mock-line-webhook.ts
+++ b/scripts/mock-line-webhook.ts
@@ -8,14 +8,14 @@
  *
  * Env overrides:
  *   LINE_CHANNEL_SECRET   (required) the agent's channel secret used to sign
- *   LINE_WEBHOOK_URL      target route (default http://localhost:3021/line/webhook)
+ *   LINE_WEBHOOK_URL      target route (default http://localhost:3021/webhooks/line)
  *   LINE_MOCK_USER_ID     sender userId (default Umock00000000000000000000000000)
  */
 import { createHmac } from 'node:crypto';
 
 const text = process.argv.slice(2).join(' ') || 'hello from mock-line-webhook';
 const secret = process.env.LINE_CHANNEL_SECRET ?? '';
-const url = process.env.LINE_WEBHOOK_URL ?? 'http://localhost:3021/line/webhook';
+const url = process.env.LINE_WEBHOOK_URL ?? 'http://localhost:3021/webhooks/line';
 const userId = process.env.LINE_MOCK_USER_ID ?? 'Umock00000000000000000000000000';
 
 if (!secret) {

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -19,7 +19,7 @@ import { createCronRouter } from './cron-router';
 import { createWorkspaceRouter } from './workspace-router';
 import { createSkillsRouter } from './skills-router';
 import { createPackagesRouter } from './packages';
-import { createLineWebhookRouter } from './line-webhook-router';
+import { createWebhooksRouter } from './webhooks-router';
 import { AppsRegistry } from '../apps/registry';
 import { AppInstaller } from '../apps/installer';
 import { RegistryClient } from '../apps/registry-client';
@@ -200,10 +200,13 @@ export class GatewayRouter {
     if (process.env.DEV_MODE) {
       process.stderr.write('[gateway] DEV_MODE=1 active — module cache busted on every /dashboard request. Never enable in production.\n');
     }
-    // LINE webhook MUST be mounted before express.json() — it needs the raw
-    // request bytes for x-line-signature validation (it uses its own express.raw).
+    // Public webhook ingress (LINE + future apps) MUST be mounted before
+    // express.json() — each app handler needs the raw request bytes for its own
+    // signature validation. This whole /webhooks zone bypasses API-key auth;
+    // every app authenticates itself (see webhooks-router.ts).
     this.app.use(
-      createLineWebhookRouter(this.agents, this.gatewayConfig?.gateway?.logDir ?? '/tmp'),
+      '/webhooks',
+      createWebhooksRouter(this.agents, this.gatewayConfig?.gateway?.logDir ?? '/tmp'),
     );
 
     this.app.use(express.json());

--- a/src/api/line-webhook-router.ts
+++ b/src/api/line-webhook-router.ts
@@ -1,15 +1,17 @@
 /**
- * LINE inbound webhook route (openclaw-style: LINE is webhook-only, no polling).
+ * LINE inbound webhook handler (openclaw-style: LINE is webhook-only, no polling).
  *
- * Mounted on the gateway's Express app BEFORE express.json() so the raw request
- * bytes are available for signature validation (LINE signs the raw body; a
- * re-serialized parsed body would not match).
+ * Exposed as a WebhookAppHandler ({ verify, handlePost }) wired into the unified
+ * `/webhooks/:app` dispatcher (see webhooks-router.ts) under app "line". The
+ * dispatcher mounts BEFORE express.json() and applies express.raw, so the raw
+ * request bytes are available for signature validation (LINE signs the raw body;
+ * a re-serialized parsed body would not match).
  *
  * Flow: verify x-line-signature → 200 → for each text message from a 1:1 user,
  * show a loading animation and forward a normalized {content, meta} to the
  * target agent's existing /channel callback (the same intake Telegram uses).
  */
-import express, { Router, type Request, type Response } from 'express';
+import { type Request, type Response } from 'express';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -28,9 +30,8 @@ import {
   generatePairingCode,
 } from './line-pending-senders';
 import { wasBotMentioned, type LineMessageLike } from './line-mention';
+import type { WebhookAppHandler } from './webhooks-router';
 
-const DEFAULT_WEBHOOK_PATH = '/line/webhook';
-const MAX_BODY_BYTES = 256 * 1024; // pre-auth body cap
 const LOADING_SECONDS = 20; // 5..60, multiple of 5; 1:1 chats only
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024; // matches MediaStore.maxUploadBytes
 
@@ -204,14 +205,12 @@ export interface LineWebhookOptions {
   dataApiBase?: string;
 }
 
-export function createLineWebhookRouter(
+export function createLineWebhookHandler(
   agents: Map<string, AgentRunner>,
   logDir: string,
   opts: LineWebhookOptions = {},
-): Router {
-  const router = Router();
+): WebhookAppHandler {
   const logger = createLogger('line-webhook', logDir);
-  const rawBody = express.raw({ type: '*/*', limit: MAX_BODY_BYTES });
 
   // LINE webhook URL verification (Console "Verify" sends a GET / empty POST).
   const handleGet = (_req: Request, res: Response): void => {
@@ -413,10 +412,5 @@ export function createLineWebhookRouter(
     }
   };
 
-  router.get(DEFAULT_WEBHOOK_PATH, handleGet);
-  router.get(`${DEFAULT_WEBHOOK_PATH}/:agentId`, handleGet);
-  router.post(DEFAULT_WEBHOOK_PATH, rawBody, (req, res) => void handlePost(req, res));
-  router.post(`${DEFAULT_WEBHOOK_PATH}/:agentId`, rawBody, (req, res) => void handlePost(req, res));
-
-  return router;
+  return { verify: handleGet, handlePost };
 }

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -526,7 +526,7 @@ export function createApiRouter(
         telegram_dm_policy: cfg.telegram?.botToken ? readTelegramAccess(id).dmPolicy : null,
         line_connected: !!cfg.line?.channelSecret,
         line_token_preview: cfg.line?.channelAccessToken ? maskToken(cfg.line.channelAccessToken) : null,
-        line_webhook_path: cfg.line?.channelSecret ? `/line/webhook/${id}` : null,
+        line_webhook_path: cfg.line?.channelSecret ? `/webhooks/line/${id}` : null,
         // DM access (Tier 1). Stored directly in the line config (no separate
         // access file like Telegram). `dmPolicy` absent ⇒ closed/allowlist
         // semantics at runtime; surface the raw value (null when unset) so the
@@ -1387,7 +1387,7 @@ export function createApiRouter(
         telegram_dm_policy: cfg.telegram?.botToken ? readTelegramAccess(agentId).dmPolicy : null,
         line_connected: !!cfg.line?.channelSecret,
         line_token_preview: cfg.line?.channelAccessToken ? maskToken(cfg.line.channelAccessToken) : null,
-        line_webhook_path: cfg.line?.channelSecret ? `/line/webhook/${agentId}` : null,
+        line_webhook_path: cfg.line?.channelSecret ? `/webhooks/line/${agentId}` : null,
       },
     });
   });

--- a/src/api/webhooks-router.ts
+++ b/src/api/webhooks-router.ts
@@ -50,9 +50,14 @@ export function createWebhooksRouter(
   };
 
   const resolve = (req: Request, res: Response): WebhookAppHandler | null => {
-    const handler = handlers[req.params.app];
+    const app = req.params.app;
+    // Object.prototype.hasOwnProperty guards against `app` being a prototype-chain
+    // key (e.g. "__proto__", "constructor", "toString") — those resolve `handlers[app]`
+    // to a truthy non-handler object, which would bypass the 404 below and then throw
+    // on the missing verify/handlePost call.
+    const handler = Object.prototype.hasOwnProperty.call(handlers, app) ? handlers[app] : undefined;
     if (!handler) {
-      res.status(404).json({ error: `unknown webhook app: ${req.params.app}` });
+      res.status(404).json({ error: `unknown webhook app: ${app}` });
       return null;
     }
     return handler;

--- a/src/api/webhooks-router.ts
+++ b/src/api/webhooks-router.ts
@@ -1,0 +1,76 @@
+/**
+ * Unified public webhook ingress.
+ *
+ * All external, unauthenticated webhooks (LINE today; more later) enter through a
+ * single route `/webhooks/:app/:agentId?` and are dispatched to a per-app handler
+ * by the `:app` path segment. Mounted BEFORE express.json() so each handler sees
+ * the raw request bytes it needs for signature validation.
+ *
+ * The whole `/webhooks/*` zone bypasses the gateway's API-key auth (it is mounted
+ * outside the /api routers, exactly like the old LINE mount) AND Traefik's
+ * ForwardAuth (a single `/gateway/webhooks` bypass router upstream). Therefore
+ * EVERY app handler MUST authenticate its own requests (e.g. LINE's HMAC
+ * signature) as its first step — there is no ambient auth on this path.
+ *
+ * Adding a new webhook app = register one entry in `handlers` below; no Traefik or
+ * getpod change is needed once the `/gateway/webhooks` ingress exists.
+ */
+import express, { Router, type Request, type Response } from 'express';
+import type { AgentRunner } from '../agent/runner';
+import { createLineWebhookHandler, type LineWebhookOptions } from './line-webhook-router';
+
+const MAX_BODY_BYTES = 256 * 1024; // pre-auth body cap
+
+/**
+ * A per-app webhook handler. `verify` answers provider URL-verification probes
+ * (GET / empty POST); `handlePost` processes a signed inbound POST. Each handler
+ * is responsible for authenticating the request itself.
+ */
+export interface WebhookAppHandler {
+  verify(req: Request, res: Response): void;
+  handlePost(req: Request, res: Response): Promise<void>;
+}
+
+/**
+ * Options forwarded to app handlers. Only LINE has options today (test-only base
+ * URL overrides); generalize to a per-app map when a second app needs its own.
+ */
+export type WebhooksOptions = LineWebhookOptions;
+
+export function createWebhooksRouter(
+  agents: Map<string, AgentRunner>,
+  logDir: string,
+  opts: WebhooksOptions = {},
+): Router {
+  const router = Router();
+  const rawBody = express.raw({ type: '*/*', limit: MAX_BODY_BYTES });
+
+  const handlers: Record<string, WebhookAppHandler> = {
+    line: createLineWebhookHandler(agents, logDir, opts),
+  };
+
+  const resolve = (req: Request, res: Response): WebhookAppHandler | null => {
+    const handler = handlers[req.params.app];
+    if (!handler) {
+      res.status(404).json({ error: `unknown webhook app: ${req.params.app}` });
+      return null;
+    }
+    return handler;
+  };
+
+  const dispatchGet = (req: Request, res: Response): void => {
+    const handler = resolve(req, res);
+    if (handler) handler.verify(req, res);
+  };
+  const dispatchPost = (req: Request, res: Response): void => {
+    const handler = resolve(req, res);
+    if (handler) void handler.handlePost(req, res);
+  };
+
+  router.get('/:app', dispatchGet);
+  router.get('/:app/:agentId', dispatchGet);
+  router.post('/:app', rawBody, dispatchPost);
+  router.post('/:app/:agentId', rawBody, dispatchPost);
+
+  return router;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,10 +32,6 @@ export interface AgentConfig {
   line?: {
     channelAccessToken: string;
     channelSecret: string;
-    /** default true when the block is present */
-    enabled?: boolean;
-    /** default "/line/webhook" */
-    webhookPath?: string;
     /**
      * Slow-LLM postback button (ported from hermes-agent). Seconds to wait for
      * the agent's answer before burning the reply token to send a tappable

--- a/tests/integration/line-config-to-chat.test.ts
+++ b/tests/integration/line-config-to-chat.test.ts
@@ -6,7 +6,7 @@
  *   1. PATCH /api/v1/agents/:id with line_channel_access_token + line_channel_secret
  *      (exactly what getpod's LINE card sends) writes AgentConfig.line and syncs
  *      the runner via updateAgentConfig().
- *   2. A signed LINE webhook to /line/webhook/:id is then accepted using THOSE
+ *   2. A signed LINE webhook to /webhooks/line/:id is then accepted using THOSE
  *      just-configured credentials and the message is forwarded to the agent's
  *      /channel intake.
  *   3. Clearing the credentials via PATCH makes the same webhook fail (404 — no
@@ -24,10 +24,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { createApiRouter } from '../../src/api/router';
-import {
-  createLineWebhookRouter,
-  type LineWebhookOptions,
-} from '../../src/api/line-webhook-router';
+import { type LineWebhookOptions } from '../../src/api/line-webhook-router';
+import { createWebhooksRouter } from '../../src/api/webhooks-router';
 import { getPendingSenders, _resetPendingSenders } from '../../src/api/line-pending-senders';
 import { AgentConfig, ApiKey } from '../../src/types';
 import type { AgentRunner } from '../../src/agent/runner';
@@ -103,7 +101,7 @@ describe('LINE: getpod config → chat (inbound) integration', () => {
   function buildApp(lineOpts: LineWebhookOptions = {}): express.Express {
     const app = express();
     // LINE webhook must be mounted before express.json() (raw body for signature).
-    app.use(createLineWebhookRouter(runners, tmpDir, lineOpts));
+    app.use('/webhooks', createWebhooksRouter(runners, tmpDir, lineOpts));
     app.use(express.json());
     const apiKeys: ApiKey[] = [{ key: 'sk-admin', agents: '*', admin: true }];
     app.use('/api', createApiRouter(runners, configs, apiKeys, configPath));
@@ -126,7 +124,7 @@ describe('LINE: getpod config → chat (inbound) integration', () => {
     const sig = crypto.createHmac('sha256', SECRET).update(raw).digest('base64');
     return supertest
       .default(app)
-      .post(`/line/webhook/${AGENT_ID}`)
+      .post(`/webhooks/line/${AGENT_ID}`)
       .set('Content-Type', 'application/json')
       .set('x-line-signature', sig)
       .send(raw);
@@ -153,7 +151,7 @@ describe('LINE: getpod config → chat (inbound) integration', () => {
       });
     expect(patch.status).toBe(200);
     expect(patch.body.agent.line_connected).toBe(true);
-    expect(patch.body.agent.line_webhook_path).toBe(`/line/webhook/${AGENT_ID}`);
+    expect(patch.body.agent.line_webhook_path).toBe(`/webhooks/line/${AGENT_ID}`);
 
     // Now the same signed webhook is accepted with the configured secret.
     const ok = await signedWebhook(app, 'สวัสดีจาก LINE');
@@ -180,7 +178,7 @@ describe('LINE: getpod config → chat (inbound) integration', () => {
     const raw = JSON.stringify({ events: [] });
     const res = await supertest
       .default(app)
-      .post(`/line/webhook/${AGENT_ID}`)
+      .post(`/webhooks/line/${AGENT_ID}`)
       .set('Content-Type', 'application/json')
       .set('x-line-signature', 'not-a-valid-signature')
       .send(raw);
@@ -227,7 +225,7 @@ describe('LINE: getpod config → chat (inbound) integration', () => {
       const sig = crypto.createHmac('sha256', SECRET).update(raw).digest('base64');
       const res = await supertest
         .default(app)
-        .post(`/line/webhook/${AGENT_ID}`)
+        .post(`/webhooks/line/${AGENT_ID}`)
         .set('Content-Type', 'application/json')
         .set('x-line-signature', sig)
         .send(raw);

--- a/tests/unit/api-router-line.test.ts
+++ b/tests/unit/api-router-line.test.ts
@@ -87,7 +87,7 @@ describe('LINE channel management API', () => {
     });
     expect(res.status).toBe(200);
     expect(res.body.agent.line_connected).toBe(true);
-    expect(res.body.agent.line_webhook_path).toBe(`/line/webhook/${AGENT_ID}`);
+    expect(res.body.agent.line_webhook_path).toBe(`/webhooks/line/${AGENT_ID}`);
     expect(res.body.agent.line_token_preview).toBeTruthy();
     expect(res.body.agent.line_token_preview).not.toContain(VALID_AT); // masked
 
@@ -137,7 +137,7 @@ describe('LINE channel management API', () => {
     expect(res.status).toBe(200);
     const agent = res.body.agents.find((a: { id: string }) => a.id === AGENT_ID);
     expect(agent.line_connected).toBe(true);
-    expect(agent.line_webhook_path).toBe(`/line/webhook/${AGENT_ID}`);
+    expect(agent.line_webhook_path).toBe(`/webhooks/line/${AGENT_ID}`);
     expect(agent.line_token_preview).toBeTruthy();
   });
 

--- a/tests/unit/webhooks-router.test.ts
+++ b/tests/unit/webhooks-router.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit: the unified /webhooks/:app dispatcher. Verifies app routing (known vs
+ * unknown app) and that a known app reaches its handler. The LINE app's full
+ * inbound pipeline is covered by tests/integration/line-config-to-chat.test.ts.
+ */
+import express from 'express';
+import * as supertest from 'supertest';
+import type { AgentRunner } from '../../src/agent/runner';
+import { createWebhooksRouter } from '../../src/api/webhooks-router';
+
+function makeApp(): express.Express {
+  const app = express();
+  const agents = new Map<string, AgentRunner>();
+  app.use('/webhooks', createWebhooksRouter(agents, '/tmp'));
+  return app;
+}
+
+describe('webhooks dispatcher', () => {
+  it('routes GET /webhooks/line to the LINE verify handler (200 ok)', async () => {
+    const res = await supertest.default(makeApp()).get('/webhooks/line');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('404s an unknown app on GET', async () => {
+    const res = await supertest.default(makeApp()).get('/webhooks/nope');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('unknown webhook app');
+  });
+
+  it('404s an unknown app on POST', async () => {
+    const res = await supertest.default(makeApp())
+      .post('/webhooks/nope')
+      .set('Content-Type', 'application/json')
+      .send({ hello: 'world' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('nope');
+  });
+
+  it('dispatches POST /webhooks/line to the LINE handler (404 when no LINE agent)', async () => {
+    const res = await supertest.default(makeApp())
+      .post('/webhooks/line')
+      .set('Content-Type', 'application/json')
+      .send({ events: [] });
+    // Reaches the LINE handler, which resolves no LINE-enabled agent.
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('no LINE-enabled agent');
+  });
+});

--- a/tests/unit/webhooks-router.test.ts
+++ b/tests/unit/webhooks-router.test.ts
@@ -46,4 +46,26 @@ describe('webhooks dispatcher', () => {
     expect(res.status).toBe(404);
     expect(res.body.error).toContain('no LINE-enabled agent');
   });
+
+  // `app` is attacker-controlled (`:app` path segment, no auth on this zone). A
+  // plain-object lookup with no own-property guard would resolve these to a
+  // truthy prototype-chain value instead of undefined, bypassing the 404 below
+  // and crashing on the missing verify()/handlePost() call.
+  it.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty'])(
+    '404s the reserved prototype-chain key "%s" instead of crashing',
+    async (app) => {
+      const res = await supertest.default(makeApp()).get(`/webhooks/${app}`);
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain('unknown webhook app');
+    },
+  );
+
+  it('404s "__proto__" on POST too', async () => {
+    const res = await supertest.default(makeApp())
+      .post('/webhooks/__proto__')
+      .set('Content-Type', 'application/json')
+      .send({ hello: 'world' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('unknown webhook app');
+  });
 });


### PR DESCRIPTION
## Summary

Serve all external, unauthenticated webhooks through a single `/webhooks/:app/:agentId` route, dispatched to a per-app handler by the `:app` path segment. Mounted **before** `express.json()` so each handler gets the raw request bytes it needs for signature validation; the whole `/webhooks` zone bypasses API-key auth, so every app authenticates its own requests (LINE HMAC unchanged).

## Changes

- **New `src/api/webhooks-router.ts`**: `createWebhooksRouter` + `WebhookAppHandler` interface + handler registry `{line}`; unknown app → 404. Owns the raw-body cap for the zone.
- **`line-webhook-router.ts`**: `createLineWebhookRouter` → `createLineWebhookHandler` returning `{verify, handlePost}`; drops its own route registration and the raw-body/path constants (moved to the dispatcher). Inbound pipeline unchanged.
- **`gateway-router.ts`**: mount `createWebhooksRouter` at `/webhooks`.
- **`router.ts`**: `line_webhook_path` → `/webhooks/line/<id>`.
- **`scripts/mock-line-webhook.ts`**: default URL → `/webhooks/line`.
- **tests**: new webhooks-router dispatcher unit test; LINE path updates in the integration + api-router tests.
- **fix**: `resolve()` now guards the `handlers` lookup with `hasOwnProperty` so a prototype-chain `:app` value (`__proto__`, `constructor`, `toString`) 404s cleanly instead of bypassing the check and throwing.

## Scope

2 commits, 9 files (+186 −39). Based on current upstream `main` (`861742c`).

Companion to Crown-Labs/getpod#1486 (Traefik `/gateway/webhooks` ingress).
