### PR TITLE
Fix headless=false turns ending prematurely during Task-tool subagent waits

### DIFF
--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -100,13 +100,17 @@ interface ActiveTurn {
    *  menuToolSeen — see maybeProbeAndBridge()/advanceProbe() below and
    *  planning-61. */
   probe: ProbeState | null;
-  /** tool_use ids from this turn's own (non-sidechain) assistant records that
-   *  have no matching tool_result yet. A Task tool call runs an invisible
-   *  sub-agent whose own work writes only sidechain transcript records — the
-   *  screen can look idle (no busy marker, quiet ≥ FALLBACK_IDLE_QUIET_MS)
-   *  for stretches while it's genuinely still running. Non-empty blocks the
-   *  fallback end-of-turn heuristic so it can never end the turn out from
-   *  under a pending tool call. */
+  /** tool_use ids for **Task** calls from this turn's own (non-sidechain)
+   *  assistant records that have no matching tool_result yet. A Task tool call
+   *  runs an invisible sub-agent whose own work writes only sidechain
+   *  transcript records — the screen can look idle (no busy marker, quiet ≥
+   *  FALLBACK_IDLE_QUIET_MS) for stretches while it's genuinely still running.
+   *  Non-empty blocks the fallback end-of-turn heuristic so it can never end
+   *  the turn out from under a pending sub-agent. Only Task is tracked:
+   *  ordinary foreground tools (Bash/Read/Edit…) keep the TUI busy, so they
+   *  never reach the fallback anyway, and tracking them would let an
+   *  interrupted-mid-tool turn (no tool_result ever lands) block the fallback
+   *  forever. */
   pendingToolUseIds: Set<string>;
 }
 
@@ -223,6 +227,7 @@ class Driver {
       onAssistant: (record) => this.onAssistant(record),
       onTurnEnd: (durationMs) => this.onTurnEnd(durationMs),
       onRequestTooLarge: () => this.handleRequestTooLarge(),
+      onToolUse: (toolUseId, toolName) => this.onToolUse(toolUseId, toolName),
       onToolResult: (toolUseId) => this.onToolResult(toolUseId),
       onError: (err) => logError(`tailer: ${err.message}`),
     });
@@ -325,20 +330,28 @@ class Driver {
       this.turn.lastProgressAt = Date.now();
       if (text) this.turn.texts.push(text);
       if (usage) this.turn.usage = usage;
-      for (const block of record.message.content) {
-        if (block.type === 'tool_use' && typeof block.id === 'string') {
-          this.turn.pendingToolUseIds.add(block.id);
-        }
-      }
     } else {
       logDebug('assistant record outside an active turn (emitted anyway)');
     }
   }
 
-  /** A non-sidechain tool_result landed — clears the pending Task/tool gate
-   *  on the fallback end-of-turn heuristic (see ActiveTurn.pendingToolUseIds). */
+  /** A tool_use block appeared in this turn's transcript. Only **Task** calls
+   *  are tracked (see ActiveTurn.pendingToolUseIds) — they run an invisible
+   *  sub-agent that can leave the screen idle-quiet while still in flight. */
+  private onToolUse(toolUseId: string, toolName: string): void {
+    if (this.turn && toolName === 'Task') {
+      this.turn.pendingToolUseIds.add(toolUseId);
+    }
+  }
+
+  /** A non-sidechain tool_result landed — clears the pending Task gate on the
+   *  fallback end-of-turn heuristic (see ActiveTurn.pendingToolUseIds) and
+   *  counts as progress so the watchdog's clock resets. */
   private onToolResult(toolUseId: string): void {
-    if (this.turn) this.turn.pendingToolUseIds.delete(toolUseId);
+    if (this.turn) {
+      this.turn.pendingToolUseIds.delete(toolUseId);
+      this.turn.lastProgressAt = Date.now();
+    }
   }
 
   private onTurnEnd(durationMs: number): void {
@@ -522,7 +535,12 @@ class Driver {
     const ptyAlive = isPtyActivelyWorking(
       { isBusy: this.screen.isBusy(), quietMs: this.screen.quietMs() },
       HEARTBEAT_LIVENESS_QUIET_MS,
-    );
+    )
+      // A pending Task sub-agent runs invisibly (sidechain records, quiet
+      // screen) — keep writing the heartbeat so the receiver's stalled
+      // detector doesn't tear the session down in exactly the window the
+      // pendingToolUseIds gate is holding the turn open for.
+      || (this.turn ? this.turn.pendingToolUseIds.size > 0 : false);
     if (this.heartbeatPath
         && ptyAlive
         && now - this.lastHeartbeatAt >= HEARTBEAT_INTERVAL_MS) {
@@ -685,6 +703,18 @@ class Driver {
     }
 
     if (now - turn.lastProgressAt > WATCHDOG_MS) {
+      if (turn.pendingToolUseIds.size > 0) {
+        // A pending Task held the turn past the watchdog: either a genuinely
+        // long sub-agent that stayed screen-quiet the whole time, or an
+        // orphaned tool_use whose result never landed. End the turn with an
+        // error but keep the PTY session alive — killing it would drop queued
+        // messages and is unrecoverable, whereas a stuck/slow sub-agent is
+        // turn-local. (Distinct from the no-progress kill below, which means
+        // the whole TUI has wedged.)
+        logWarn(`pending Task exceeded ${WATCHDOG_MS}ms without a result — ending turn, session preserved`);
+        this.finishTurn(true, `sub-agent did not complete within ${WATCHDOG_MS}ms`);
+        return;
+      }
       this.finishTurn(true, `no progress for ${WATCHDOG_MS}ms — giving up`);
       this.shutdown(1);
     }

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -100,6 +100,14 @@ interface ActiveTurn {
    *  menuToolSeen — see maybeProbeAndBridge()/advanceProbe() below and
    *  planning-61. */
   probe: ProbeState | null;
+  /** tool_use ids from this turn's own (non-sidechain) assistant records that
+   *  have no matching tool_result yet. A Task tool call runs an invisible
+   *  sub-agent whose own work writes only sidechain transcript records — the
+   *  screen can look idle (no busy marker, quiet ≥ FALLBACK_IDLE_QUIET_MS)
+   *  for stretches while it's genuinely still running. Non-empty blocks the
+   *  fallback end-of-turn heuristic so it can never end the turn out from
+   *  under a pending tool call. */
+  pendingToolUseIds: Set<string>;
 }
 
 /** An in-flight behavioral probe round, advanced by tick() (see Driver.probe). */
@@ -215,6 +223,7 @@ class Driver {
       onAssistant: (record) => this.onAssistant(record),
       onTurnEnd: (durationMs) => this.onTurnEnd(durationMs),
       onRequestTooLarge: () => this.handleRequestTooLarge(),
+      onToolResult: (toolUseId) => this.onToolResult(toolUseId),
       onError: (err) => logError(`tailer: ${err.message}`),
     });
     this.tailer.start();
@@ -316,9 +325,20 @@ class Driver {
       this.turn.lastProgressAt = Date.now();
       if (text) this.turn.texts.push(text);
       if (usage) this.turn.usage = usage;
+      for (const block of record.message.content) {
+        if (block.type === 'tool_use' && typeof block.id === 'string') {
+          this.turn.pendingToolUseIds.add(block.id);
+        }
+      }
     } else {
       logDebug('assistant record outside an active turn (emitted anyway)');
     }
+  }
+
+  /** A non-sidechain tool_result landed — clears the pending Task/tool gate
+   *  on the fallback end-of-turn heuristic (see ActiveTurn.pendingToolUseIds). */
+  private onToolResult(toolUseId: string): void {
+    if (this.turn) this.turn.pendingToolUseIds.delete(toolUseId);
   }
 
   private onTurnEnd(durationMs: number): void {
@@ -412,6 +432,7 @@ class Driver {
       recordsAtStart: this.tailer.seenRecords,
       fromMenuSelection,
       probe: null,
+      pendingToolUseIds: new Set(),
     };
   }
 
@@ -650,7 +671,12 @@ class Driver {
 
     // Fallback end-of-turn (e.g. interrupted turn never writes turn_duration):
     // ran → idle prompt → quiet, and we already streamed assistant output.
+    // pendingToolUseIds must be empty too — a Task tool call's sub-agent runs
+    // invisibly (its own transcript records are sidechain and filtered out),
+    // so the screen can look idle-quiet for stretches while the turn is
+    // genuinely still in flight (see onToolResult()/pendingToolUseIds above).
     if (turn.sawBusy && turn.sawAssistant
+        && turn.pendingToolUseIds.size === 0
         && this.screen.hasPrompt()
         && this.screen.quietMs() >= FALLBACK_IDLE_QUIET_MS) {
       logDebug('fallback idle detection ended the turn');

--- a/src/shell/tailer.ts
+++ b/src/shell/tailer.ts
@@ -25,11 +25,34 @@ export interface AssistantRecord {
   timestamp?: string;
 }
 
+/** A tool_result content block on a `user` record (main-chain tool completion). */
+export interface ToolResultBlock {
+  type: string;
+  tool_use_id?: string;
+}
+
+/** A `user` transcript record. Only the tool_result content blocks are read. */
+export interface UserRecord {
+  type: 'user';
+  isSidechain?: boolean;
+  message?: {
+    content?: Array<ToolResultBlock>;
+  };
+}
+
 export interface TailerEvents {
   /** A new (non-sidechain) assistant record was appended. */
   onAssistant: (record: AssistantRecord) => void;
   /** Claude finished a turn (system/turn_duration record). */
   onTurnEnd: (durationMs: number) => void;
+  /**
+   * A `tool_use` block appeared in a (non-sidechain) assistant record.
+   * `toolName` is the block's `name` (e.g. 'Task'). Emitted so consumers can
+   * track outstanding tool calls without re-walking `message.content`
+   * themselves — the mirror of onToolResult. Sidechain records (a sub-agent's
+   * own internal tool_use) are filtered out before this fires.
+   */
+  onToolUse?: (toolUseId: string, toolName: string) => void;
   /**
    * A non-sidechain tool_result landed for `toolUseId`. Fired for a 'user'
    * record's tool_result content blocks — the main-chain signal that a tool
@@ -198,6 +221,14 @@ export class TranscriptTailer {
           return;
         }
         this.events.onAssistant(record as unknown as AssistantRecord);
+        if (this.events.onToolUse) {
+          for (const block of message.content) {
+            if (block.type === 'tool_use' && typeof block.id === 'string') {
+              const name = typeof block.name === 'string' ? block.name : '';
+              this.events.onToolUse(block.id, name);
+            }
+          }
+        }
       }
       return;
     }
@@ -207,7 +238,7 @@ export class TranscriptTailer {
       return;
     }
     if (record.type === 'user' && this.events.onToolResult) {
-      const message = record.message as { content?: Array<{ type: string; tool_use_id?: string }> } | undefined;
+      const message = (record as unknown as UserRecord).message;
       if (message && Array.isArray(message.content)) {
         for (const block of message.content) {
           if (block.type === 'tool_result' && typeof block.tool_use_id === 'string') {

--- a/src/shell/tailer.ts
+++ b/src/shell/tailer.ts
@@ -31,6 +31,14 @@ export interface TailerEvents {
   /** Claude finished a turn (system/turn_duration record). */
   onTurnEnd: (durationMs: number) => void;
   /**
+   * A non-sidechain tool_result landed for `toolUseId`. Fired for a 'user'
+   * record's tool_result content blocks — the main-chain signal that a tool
+   * call (e.g. Task, which runs an invisible sub-agent) has actually
+   * resolved. Sidechain tool_results (a sub-agent's own internal tool calls)
+   * are filtered out before this fires, same as onAssistant.
+   */
+  onToolResult?: (toolUseId: string) => void;
+  /**
    * Claude Code hit the recoverable 32MB "Request too large" API error. Detected
    * authoritatively from the `<synthetic>` assistant record it writes to the
    * transcript — NOT by scraping screen text — so conversation text quoting the
@@ -196,6 +204,17 @@ export class TranscriptTailer {
     if (record.type === 'system' && record.subtype === 'turn_duration') {
       const durationMs = typeof record.durationMs === 'number' ? record.durationMs : 0;
       this.events.onTurnEnd(durationMs);
+      return;
+    }
+    if (record.type === 'user' && this.events.onToolResult) {
+      const message = record.message as { content?: Array<{ type: string; tool_use_id?: string }> } | undefined;
+      if (message && Array.isArray(message.content)) {
+        for (const block of message.content) {
+          if (block.type === 'tool_result' && typeof block.tool_use_id === 'string') {
+            this.events.onToolResult(block.tool_use_id);
+          }
+        }
+      }
     }
   }
 }

--- a/tests/helpers/mock-claude-tui-menu.js
+++ b/tests/helpers/mock-claude-tui-menu.js
@@ -49,6 +49,14 @@
  *                          must NOT end the turn until the matching
  *                          tool_result lands, even though the screen alone
  *                          looks done the whole time.
+ *   TASK_WAIT_SIDECHAIN — like TASK_WAIT, but a SIDECHAIN tool_result for the
+ *                          same id lands first and must be ignored (it must
+ *                          not clear the gate); only the later main-chain
+ *                          tool_result completes the turn.
+ *   TASK_ORPHAN         — a Task tool_use lands but no tool_result ever
+ *                          arrives. The watchdog must end the turn with an
+ *                          error WITHOUT killing the session (run with a
+ *                          shortened PTY_SHELL_WATCHDOG_MS).
  *   …SWALLOW_ONCE…      — (substring anywhere in the text) the first Enter
  *                          is swallowed: the draft stays in the input line
  *                          ("❯ <text>"), never busy, no transcript. The
@@ -186,13 +194,65 @@ function submit(text) {
       });
       idle(); // busy marker gone — screen looks done, but the tool_use is still pending
     }, 150);
+    // 4500ms (not ~2s) leaves a wide margin either side of the test's 2600ms
+    // "not done yet" assertion window, so the two-process wall-clock race
+    // doesn't flake under CI load.
     setTimeout(() => {
       appendRecord({
         type: 'user',
         message: { content: [{ type: 'tool_result', tool_use_id: 'task-1', content: 'sub-agent done' }] },
       });
       writeTranscript('task-wait-final-result');
-    }, 3350);
+    }, 4500);
+    return;
+  }
+  if (trimmed === 'TASK_WAIT_SIDECHAIN') {
+    // Like TASK_WAIT, but a SIDECHAIN tool_result for the same id lands first
+    // (a sub-agent's own internal tool call). The tailer must filter it out —
+    // it must NOT clear the pendingToolUseIds gate. The turn stays open until
+    // the real, main-chain tool_result arrives.
+    scenario = null;
+    render('esc to interrupt\r\n❯ ');
+    setTimeout(() => {
+      appendRecord({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'task-1', name: 'Task', input: {} }] },
+      });
+      idle();
+    }, 150);
+    setTimeout(() => {
+      // Sidechain result — must be ignored by the gate.
+      appendRecord({
+        type: 'user',
+        isSidechain: true,
+        message: { content: [{ type: 'tool_result', tool_use_id: 'task-1', content: 'inner tool' }] },
+      });
+    }, 2600);
+    setTimeout(() => {
+      // Real main-chain result — clears the gate, turn completes.
+      appendRecord({
+        type: 'user',
+        message: { content: [{ type: 'tool_result', tool_use_id: 'task-1', content: 'sub-agent done' }] },
+      });
+      writeTranscript('task-sidechain-final-result');
+    }, 4500);
+    return;
+  }
+  if (trimmed === 'TASK_ORPHAN') {
+    // A Task tool_use lands but its tool_result NEVER arrives (sub-agent crash,
+    // abnormal exit) and no turn_duration is written. The fallback stays
+    // blocked; the watchdog must end the turn with an error WITHOUT killing the
+    // PTY session (run with a shortened PTY_SHELL_WATCHDOG_MS). The wrapper
+    // stays alive and can take the next turn.
+    scenario = null;
+    render('esc to interrupt\r\n❯ ');
+    setTimeout(() => {
+      appendRecord({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'task-1', name: 'Task', input: {} }] },
+      });
+      idle(); // then silence — no tool_result, no turn_duration, ever.
+    }, 150);
     return;
   }
 

--- a/tests/helpers/mock-claude-tui-menu.js
+++ b/tests/helpers/mock-claude-tui-menu.js
@@ -42,6 +42,13 @@
  *                          arrow key; the probe must exhaust its round budget
  *                          and give up cleanly, the turn completing normally
  *                          via the transcript.
+ *   TASK_WAIT           — a non-sidechain tool_use (Task) lands, then the
+ *                          screen goes idle-looking (no busy marker, ❯
+ *                          prompt) for LONGER than FALLBACK_IDLE_QUIET_MS
+ *                          while the sub-agent works invisibly. The wrapper
+ *                          must NOT end the turn until the matching
+ *                          tool_result lands, even though the screen alone
+ *                          looks done the whole time.
  *   …SWALLOW_ONCE…      — (substring anywhere in the text) the first Enter
  *                          is swallowed: the draft stays in the input line
  *                          ("❯ <text>"), never busy, no transcript. The
@@ -62,6 +69,7 @@ const {
   handleAuthShim,
   parseSessionId,
   makeTranscriptWriter,
+  makeRawTranscriptAppender,
   makeFileLogger,
   startStdinMachine,
 } = require('./mock-tui-core');
@@ -70,6 +78,7 @@ const args = process.argv.slice(2);
 handleAuthShim(args);
 
 const writeTranscript = makeTranscriptWriter(parseSessionId(args));
+const appendRecord = makeRawTranscriptAppender(parseSessionId(args));
 const logInput = makeFileLogger('FAKE_TUI_INPUT_LOG');
 const logEvent = makeFileLogger('FAKE_TUI_EVENT_LOG');
 
@@ -158,6 +167,32 @@ function submit(text) {
       // would have exhausted its round budget, so the turn still ends.
       setTimeout(() => finishScenario('no-react-result'), 4000);
     }
+    return;
+  }
+  if (trimmed === 'TASK_WAIT') {
+    // Simulates a Task-tool sub-agent run: a non-sidechain tool_use lands,
+    // then the screen goes idle-looking (busy marker gone, ❯ prompt visible)
+    // for LONGER than FALLBACK_IDLE_QUIET_MS (2000ms) while the sub-agent
+    // works invisibly (its own records would be sidechain — not written
+    // here, since claude-pty-shell.ts must never depend on seeing them).
+    // Pre-fix, the fallback idle-detection heuristic would end the turn
+    // right here, at ~2s, orphaning the real final answer written below.
+    scenario = null;
+    render('esc to interrupt\r\n❯ ');
+    setTimeout(() => {
+      appendRecord({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'task-1', name: 'Task', input: {} }] },
+      });
+      idle(); // busy marker gone — screen looks done, but the tool_use is still pending
+    }, 150);
+    setTimeout(() => {
+      appendRecord({
+        type: 'user',
+        message: { content: [{ type: 'tool_result', tool_use_id: 'task-1', content: 'sub-agent done' }] },
+      });
+      writeTranscript('task-wait-final-result');
+    }, 3350);
     return;
   }
 

--- a/tests/helpers/mock-tui-core.js
+++ b/tests/helpers/mock-tui-core.js
@@ -172,10 +172,25 @@ function startStdinMachine(handlers) {
   process.on('SIGTERM', () => process.exit(0));
 }
 
+/**
+ * Returns an appendRecord(obj) that writes one raw JSONL line to the Claude
+ * Code transcript — for scenarios that need fine-grained control over
+ * individual record shapes/timing (tool_use, tool_result, sidechain) instead
+ * of the combined assistant+turn_duration writeTranscript() helper.
+ */
+function makeRawTranscriptAppender(sessionId) {
+  return function appendRecord(obj) {
+    const txPath = getTranscriptPath(sessionId);
+    if (!txPath) return;
+    fs.appendFileSync(txPath, JSON.stringify(obj) + '\n');
+  };
+}
+
 module.exports = {
   handleAuthShim,
   parseSessionId,
   makeTranscriptWriter,
+  makeRawTranscriptAppender,
   makeFileLogger,
   startStdinMachine,
 };

--- a/tests/integration/pty-menu-probe.test.ts
+++ b/tests/integration/pty-menu-probe.test.ts
@@ -51,10 +51,11 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     if (fs.existsSync(eventLog)) fs.unlinkSync(eventLog);
   });
 
-  function start(): void {
+  function start(extraEnv: Record<string, string> = {}): void {
     wrapper = spawnWrapper(MOCK_TUI_BIN, {
       FAKE_TUI_INPUT_LOG: inputLog,
       FAKE_TUI_EVENT_LOG: eventLog,
+      ...extraEnv,
     });
     collector.attach(wrapper);
   }
@@ -331,11 +332,75 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     // real text — not an early, truncated one.
     const completed = await waitFor(
       () => !!collector.find((e) => e.type === 'result'),
-      4000,
+      5000,
     );
     expect(completed).toBe(true);
     const result = collector.find((e) => e.type === 'result') as ProtocolEvent & { subtype: string; result?: string };
     expect(result.subtype).toBe('success');
     expect(result.result).toContain('task-wait-final-result');
   }, 20000);
+
+  /**
+   * I-PTY-MENU-12: a SIDECHAIN tool_result must NOT clear the pending gate.
+   * During a Task wait, a sub-agent's own internal tool_result (sidechain) for
+   * the same id lands first; the tailer filters it, so the turn stays open. It
+   * completes only when the real, main-chain tool_result arrives. Guards the
+   * core correctness property of the fix — that the gate keys off main-chain
+   * results only — which the unit test proves at the tailer boundary but which
+   * had no end-to-end coverage through the Driver.
+   */
+  it('I-PTY-MENU-12: a sidechain tool_result does not end the turn; only the main-chain one does', async () => {
+    start();
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('TASK_WAIT_SIDECHAIN'));
+
+    // Sidechain result lands at ~2600ms and the screen is quiet — if it wrongly
+    // cleared the gate, the fallback would end the turn here. It must not.
+    await waitMs(3200);
+    expect(collector.find((e) => e.type === 'result')).toBeUndefined();
+
+    // The real main-chain result (~4500ms) completes the turn with real text.
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      4000,
+    );
+    expect(completed).toBe(true);
+    const result = collector.find((e) => e.type === 'result') as ProtocolEvent & { subtype: string; result?: string };
+    expect(result.subtype).toBe('success');
+    expect(result.result).toContain('task-sidechain-final-result');
+  }, 20000);
+
+  /**
+   * I-PTY-MENU-13: an orphaned Task tool_use (no tool_result, no turn_duration
+   * ever) must NOT hang forever or kill the session. With a shortened watchdog,
+   * the turn ends with an error and the wrapper stays alive to take the next
+   * turn — the fix's "session preserved" branch of the watchdog.
+   */
+  it('I-PTY-MENU-13: an orphaned Task tool_use ends via the watchdog with an error, session survives', async () => {
+    start({ PTY_SHELL_WATCHDOG_MS: '1500' });
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('TASK_ORPHAN'));
+
+    // No tool_result ever comes; the shortened watchdog (1500ms after the last
+    // progress) must end the turn with an error rather than hang.
+    const ended = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      6000,
+    );
+    expect(ended).toBe(true);
+    const result = collector.find((e) => e.type === 'result') as ProtocolEvent & { subtype: string; is_error?: boolean };
+    expect(result.is_error).toBe(true);
+
+    // Session must still be alive (watchdog did NOT shutdown) — a fresh turn
+    // still completes, producing a second result event.
+    expect(wrapper.exitCode).toBeNull();
+    wrapper.stdin!.write(makeTurnJson('hello again'));
+    const second = await waitFor(
+      () => collector.events.filter((e) => e.type === 'result').length >= 2,
+      6000,
+    );
+    expect(second).toBe(true);
+  }, 25000);
 });

--- a/tests/integration/pty-menu-probe.test.ts
+++ b/tests/integration/pty-menu-probe.test.ts
@@ -304,4 +304,38 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     expect(collector.find((e) => e.type === 'system' && e.subtype === 'menu_prompt')).toBeUndefined();
     expect(keyEvents().filter((k) => k === 'up' || k === 'down')).toHaveLength(0); // no arrow keys were ever sent
   }, 20000);
+
+  /**
+   * I-PTY-MENU-11: a Task-tool sub-agent run. A non-sidechain tool_use lands,
+   * then the screen goes idle-looking (no busy marker, ❯ prompt visible) for
+   * longer than FALLBACK_IDLE_QUIET_MS (2000ms) while the sub-agent works
+   * invisibly (its own transcript records would be sidechain — never written
+   * here, since the fix must not depend on seeing them). Before the fix, the
+   * fallback idle-detection heuristic ended the turn at ~2s of screen quiet,
+   * orphaning the real final answer that arrives once the matching
+   * tool_result lands.
+   */
+  it('I-PTY-MENU-11: a pending Task tool_use blocks the fallback idle finish until its tool_result lands', async () => {
+    start();
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('TASK_WAIT'));
+
+    // The sub-agent is still "running" (screen quiet, no busy marker, no
+    // tool_result yet) — the pre-fix fallback would already have ended the
+    // turn by ~2s. It must still be open.
+    await waitMs(2600);
+    expect(collector.find((e) => e.type === 'result')).toBeUndefined();
+
+    // Once the tool_result + final answer land, the turn completes with the
+    // real text — not an early, truncated one.
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      4000,
+    );
+    expect(completed).toBe(true);
+    const result = collector.find((e) => e.type === 'result') as ProtocolEvent & { subtype: string; result?: string };
+    expect(result.subtype).toBe('success');
+    expect(result.result).toContain('task-wait-final-result');
+  }, 20000);
 });

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -1,5 +1,5 @@
 import { translateArgs, sanitizeUserText } from '../../src/shell/args';
-import { projectSlug, transcriptPath, isSyntheticRequestTooLarge } from '../../src/shell/tailer';
+import { projectSlug, transcriptPath, isSyntheticRequestTooLarge, TranscriptTailer } from '../../src/shell/tailer';
 import {
   ScreenModel,
   TUI_BUSY_MARKER,
@@ -610,6 +610,68 @@ describe('pty-shell transcript path', () => {
     const uuid = '11111111-2222-3333-4444-555555555555';
     expect(transcriptPath('/tmp/pty-poc', uuid))
       .toBe(`${os.homedir()}/.claude/projects/-tmp-pty-poc/${uuid}.jsonl`);
+  });
+});
+
+describe('TranscriptTailer onToolResult (main-chain tool_result only)', () => {
+  let sessionId: string;
+  let file: string;
+  let tailer: TranscriptTailer | null;
+
+  beforeEach(() => {
+    sessionId = '99999999-8888-7777-6666-' + Date.now().toString().padStart(12, '0');
+    file = transcriptPath(process.cwd(), sessionId);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    tailer = null;
+  });
+
+  afterEach(() => {
+    tailer?.stop();
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  });
+
+  function makeTailer(onToolResult: (id: string) => void): TranscriptTailer {
+    tailer = new TranscriptTailer(process.cwd(), sessionId, {
+      onAssistant: () => {},
+      onTurnEnd: () => {},
+      onToolResult,
+      onError: (err) => { throw err; },
+    });
+    return tailer;
+  }
+
+  it('fires for a non-sidechain tool_result block (main-chain tool resolved)', () => {
+    const seen: string[] = [];
+    const t = makeTailer((id) => seen.push(id));
+    fs.appendFileSync(file, JSON.stringify({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'abc-123' }] },
+    }) + '\n');
+    t.flush();
+    expect(seen).toEqual(['abc-123']);
+  });
+
+  it('does not fire for a sidechain tool_result (a sub-agent\'s own tool call)', () => {
+    const seen: string[] = [];
+    const t = makeTailer((id) => seen.push(id));
+    fs.appendFileSync(file, JSON.stringify({
+      type: 'user',
+      isSidechain: true,
+      message: { content: [{ type: 'tool_result', tool_use_id: 'sub-456' }] },
+    }) + '\n');
+    t.flush();
+    expect(seen).toEqual([]);
+  });
+
+  it('ignores plain user text records (no tool_result content)', () => {
+    const seen: string[] = [];
+    const t = makeTailer((id) => seen.push(id));
+    fs.appendFileSync(file, JSON.stringify({
+      type: 'user',
+      message: { content: [{ type: 'text', text: 'hello' }] },
+    }) + '\n');
+    t.flush();
+    expect(seen).toEqual([]);
   });
 });
 

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -675,6 +675,68 @@ describe('TranscriptTailer onToolResult (main-chain tool_result only)', () => {
   });
 });
 
+describe('TranscriptTailer onToolUse (main-chain tool_use, with name)', () => {
+  let sessionId: string;
+  let file: string;
+  let tailer: TranscriptTailer | null;
+
+  beforeEach(() => {
+    sessionId = '99999999-8888-7777-5555-' + Date.now().toString().padStart(12, '0');
+    file = transcriptPath(process.cwd(), sessionId);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    tailer = null;
+  });
+
+  afterEach(() => {
+    tailer?.stop();
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  });
+
+  function makeTailer(onToolUse: (id: string, name: string) => void): TranscriptTailer {
+    tailer = new TranscriptTailer(process.cwd(), sessionId, {
+      onAssistant: () => {},
+      onTurnEnd: () => {},
+      onToolUse,
+      onError: (err) => { throw err; },
+    });
+    return tailer;
+  }
+
+  it('fires with (id, name) for a non-sidechain assistant tool_use block', () => {
+    const seen: Array<[string, string]> = [];
+    const t = makeTailer((id, name) => seen.push([id, name]));
+    fs.appendFileSync(file, JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'task-1', name: 'Task', input: {} }] },
+    }) + '\n');
+    t.flush();
+    expect(seen).toEqual([['task-1', 'Task']]);
+  });
+
+  it('does not fire for a sidechain assistant tool_use (sub-agent internal call)', () => {
+    const seen: Array<[string, string]> = [];
+    const t = makeTailer((id, name) => seen.push([id, name]));
+    fs.appendFileSync(file, JSON.stringify({
+      type: 'assistant',
+      isSidechain: true,
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'inner-1', name: 'Bash', input: {} }] },
+    }) + '\n');
+    t.flush();
+    expect(seen).toEqual([]);
+  });
+
+  it('reports the real tool name so non-Task tools can be distinguished', () => {
+    const seen: Array<[string, string]> = [];
+    const t = makeTailer((id, name) => seen.push([id, name]));
+    fs.appendFileSync(file, JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'b-1', name: 'Bash', input: {} }] },
+    }) + '\n');
+    t.flush();
+    expect(seen).toEqual([['b-1', 'Bash']]);
+  });
+});
+
 describe('ScreenModel detectDialog (region-restricted)', () => {
   it('detects the bypass dialog when it renders at the bottom (real modal)', async () => {
     const screen = await renderScreen([


### PR DESCRIPTION
## Summary
- In `headless=false` (PTY) mode, the fallback end-of-turn heuristic in `claude-pty-shell.ts` can end a turn while a Task-tool sub-agent is still running: the sub-agent's own work is written as sidechain transcript records (already ignored for turn tracking), and during that wait the screen can look idle (no busy marker, prompt visible, quiet ≥ 2s) even though the outer turn isn't done. This drops the Telegram typing indicator early and orphans whatever text the agent produces once the sub-agent actually finishes — reproduced live (see linked report).
- Fix: track non-sidechain `tool_use` ids from the turn's own assistant records, and clear them only when their matching `tool_result` lands (also non-sidechain, via a new `TranscriptTailer.onToolResult` event). The fallback now refuses to end a turn while any tool call is still outstanding, no matter how quiet the screen looks.
- Generalizes beyond Task/sub-agents to any long-running tool call — a `pendingToolUseIds` gate is a more direct correctness signal than screen quietness.

## Test plan
- [x] `tests/unit/pty-shell.test.ts` — new `TranscriptTailer onToolResult` describe block: fires for non-sidechain `tool_result`, not for sidechain, ignores plain text records. 102/102 unit tests pass.
- [x] `tests/integration/pty-menu-probe.test.ts` — new scenario **I-PTY-MENU-11**: a `tool_use` lands, screen goes idle-looking for longer than `FALLBACK_IDLE_QUIET_MS` (2s) with no `tool_result` yet, turn must NOT complete; once the `tool_result` + final text land, turn completes with the real answer.
- [x] Verified this is a genuine regression test: reverted the two source-file changes only, rebuilt, and confirmed I-PTY-MENU-11 fails (empty result — turn ended prematurely) against pre-fix code. Restored the fix and re-ran — passes.
- [x] Full relevant suite (`pty-shell.test.ts` + `pty-menu-probe.test.ts` + `pty-stop-stuck-input.test.ts`): 116/116 pass.
- [x] Full repo test suite: 2117/2123 pass. The 6 failures are pre-existing/unrelated: 4 known `phase-manual.test.ts` env-var config failures, and 2 `telegram-plugin-process.test.ts` failures that are load-flaky under full-suite concurrency (pass 5/5 in isolation, unrelated files to this change).
- [x] `tsc --noEmit` clean.