### PR TITLE
Fix flaky tests: poll instead of fixed sleeps, cap Jest maxWorkers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   testPathIgnorePatterns: ['/node_modules/', '<rootDir>/tests/e2e/'],
   forceExit: true,
   testTimeout: 30000,
+  maxWorkers: '50%',
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
       tsconfig: {

--- a/tests/helpers/wait-for.ts
+++ b/tests/helpers/wait-for.ts
@@ -1,0 +1,28 @@
+/**
+ * Generic condition poller for async tests. Prefer this over a fixed
+ * `setTimeout` sleep + direct assertion — a fixed sleep either wastes time
+ * (waiting longer than needed) or is too short under load (flaky failures
+ * unrelated to the code under test).
+ */
+
+export function waitMs(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Polls `pred` every `intervalMs` until it returns true or `timeoutMs`
+ * elapses. Resolves to the final result of `pred()` either way — callers
+ * that want a hard failure on timeout should assert on the return value.
+ */
+export async function waitFor(
+  pred: () => boolean,
+  timeoutMs: number,
+  intervalMs = 100,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return true;
+    await waitMs(intervalMs);
+  }
+  return pred();
+}

--- a/tests/integration/line-config-to-chat.test.ts
+++ b/tests/integration/line-config-to-chat.test.ts
@@ -29,6 +29,7 @@ import { createWebhooksRouter } from '../../src/api/webhooks-router';
 import { getPendingSenders, _resetPendingSenders } from '../../src/api/line-pending-senders';
 import { AgentConfig, ApiKey } from '../../src/types';
 import type { AgentRunner } from '../../src/agent/runner';
+import { waitFor } from '../helpers/wait-for';
 
 const AGENT_ID = 'baerbel';
 const ADMIN = { Authorization: 'Bearer sk-admin' };
@@ -158,7 +159,7 @@ describe('LINE: getpod config → chat (inbound) integration', () => {
     expect(ok.status).toBe(200);
 
     // Intake forwarded to the agent's /channel (async after ack).
-    await new Promise((r) => setTimeout(r, 300));
+    await waitFor(() => intake.length >= 1, 5000);
     expect(intake).toHaveLength(1);
     const post = intake[0] as { content: string; meta: Record<string, string> };
     expect(post.content).toBe('สวัสดีจาก LINE');
@@ -232,7 +233,7 @@ describe('LINE: getpod config → chat (inbound) integration', () => {
       expect(res.status).toBe(200); // webhook is always ack'd
 
       // Async gate work settles: not forwarded, but recorded on the knock list.
-      await new Promise((r) => setTimeout(r, 300));
+      await waitFor(() => getPendingSenders(AGENT_ID).some((s) => s.userId === KNOCKER_ID), 5000);
       expect(intake).toHaveLength(0);
       expect(getPendingSenders(AGENT_ID).map((s) => s.userId)).toContain(KNOCKER_ID);
     } finally {

--- a/tests/integration/phase-manual.test.ts
+++ b/tests/integration/phase-manual.test.ts
@@ -895,13 +895,21 @@ const noopLogger = {
  * - extends EventEmitter so `on('output', cb)` and `removeListener` work
  * - exposes `isRunning()` returning true
  */
-function makeMockRunner(): EventEmitter & { sendMessage: jest.Mock; isRunning: () => boolean } {
+function makeMockRunner(): EventEmitter & {
+  sendMessage: jest.Mock;
+  isRunning: () => boolean;
+  getSessionsSummary: () => ReturnType<AgentRunner['getSessionsSummary']>;
+} {
   const emitter = new EventEmitter() as EventEmitter & {
     sendMessage: jest.Mock;
     isRunning: () => boolean;
+    getSessionsSummary: () => ReturnType<AgentRunner['getSessionsSummary']>;
   };
   emitter.sendMessage = jest.fn();
   emitter.isRunning = () => true;
+  // GET /status (gateway-router.ts) calls this unconditionally to build the
+  // per-agent sessions list — without it the route throws and returns 500.
+  emitter.getSessionsSummary = () => [];
   return emitter;
 }
 
@@ -1629,7 +1637,7 @@ describe('Phase 4: watchWorkspace', () => {
 
     try {
       // Give the watcher time to initialise
-      await new Promise((r) => setTimeout(r, 100));
+      await handle.ready;
 
       // Modify a file in the workspace
       fs.writeFileSync(path.join(ws, 'agent.md'), '# Agent\nUpdated content.', 'utf-8');
@@ -1653,7 +1661,7 @@ describe('Phase 4: watchWorkspace', () => {
     });
 
     // Give watcher time to initialise then immediately close it
-    await new Promise((r) => setTimeout(r, 100));
+    await handle.ready;
     handle.close();
 
     // Give close time to take effect

--- a/tests/integration/telegram-plugin-process.test.ts
+++ b/tests/integration/telegram-plugin-process.test.ts
@@ -264,7 +264,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     // MCP handshake
     const initResponse = mcp.wait<any>(
       m => (m as any).id === 1 && (m as any).result?.serverInfo !== undefined,
-      10000,
+      20000,
     )
     writeMcp(proc, {
       jsonrpc: '2.0',
@@ -280,8 +280,8 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     writeMcp(proc, { jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
 
     // Wait for bot to start polling (getMe is a reliable signal)
-    await mock.waitForCall('getMe', 0, 10000)
-  }, 30000)
+    await mock.waitForCall('getMe', 0, 20000)
+  }, 45000)
 
   afterAll(async () => {
     try { proc?.kill('SIGTERM') } catch {}
@@ -293,7 +293,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
 
   test('tools/list returns reply, react, download_attachment, edit_message', async () => {
     const id = nextId()
-    const res = mcp.wait<any>(m => (m as any).id === id && (m as any).result?.tools, 5000)
+    const res = mcp.wait<any>(m => (m as any).id === id && (m as any).result?.tools, 15000)
     writeMcp(proc, { jsonrpc: '2.0', id, method: 'tools/list', params: {} })
     const result = await res
     const names: string[] = result.result.tools.map((t: any) => t.name)
@@ -301,7 +301,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     expect(names).toContain('react')
     expect(names).toContain('download_attachment')
     expect(names).toContain('edit_message')
-  }, 10000)
+  }, 20000)
 
   // ── test 2 ──────────────────────────────────────────────────────────────
 
@@ -321,7 +321,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     })
 
     // Typing indicator must arrive on Telegram API
-    const typingCall = await mock.waitForCall('sendChatAction', t0, 10000)
+    const typingCall = await mock.waitForCall('sendChatAction', t0, 20000)
     expect(typingCall.body['action']).toBe('typing')
     expect(String(typingCall.body['chat_id'])).toBe(USER_ID)
 
@@ -329,12 +329,12 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     const notification = await mcp.wait<any>(
       m => (m as any).method === 'notifications/claude/channel' &&
            (m as any).params?.meta?.chat_id === USER_ID,
-      10000,
+      20000,
     )
     expect(notification.params.content).toBe('hello plugin')
     expect(notification.params.meta.user).toBe('tester')
     expect(notification.params.meta.message_id).toBe('42')
-  }, 15000)
+  }, 30000)
 
   // ── test 3 ──────────────────────────────────────────────────────────────
 
@@ -342,7 +342,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     const t0 = Date.now()
     const id = nextId()
 
-    const res = mcp.wait<any>(m => (m as any).id === id && (m as any).result, 8000)
+    const res = mcp.wait<any>(m => (m as any).id === id && (m as any).result, 20000)
     writeMcp(proc, {
       jsonrpc: '2.0',
       id,
@@ -357,10 +357,10 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     expect(result.result.isError).toBeFalsy()
     expect(result.result.content[0].text).toMatch(/sent/)
 
-    const sendCall = await mock.waitForCall('sendMessage', t0, 5000)
+    const sendCall = await mock.waitForCall('sendMessage', t0, 20000)
     expect(String(sendCall.body['chat_id'])).toBe(USER_ID)
     expect(sendCall.body['text']).toBe('hello from jest test')
-  }, 15000)
+  }, 30000)
 
   // ── test 4 ──────────────────────────────────────────────────────────────
 
@@ -368,7 +368,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     const t0 = Date.now()
     const id = nextId()
 
-    const res = mcp.wait<any>(m => (m as any).id === id && (m as any).result, 5000)
+    const res = mcp.wait<any>(m => (m as any).id === id && (m as any).result, 20000)
     writeMcp(proc, {
       jsonrpc: '2.0',
       id,
@@ -388,7 +388,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     const stray = mock.calls.find(c => c.method === 'sendMessage' && c.ts >= t0 &&
       String(c.body['chat_id']) === '999888777')
     expect(stray).toBeUndefined()
-  }, 10000)
+  }, 30000)
 
   // ── test 5 ──────────────────────────────────────────────────────────────
 
@@ -422,5 +422,5 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
                   m.params?.meta?.chat_id === String(unknownId)
     )
     expect(notifForStranger).toBeUndefined()
-  }, 10000)
+  }, 15000)
 })

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -469,7 +469,7 @@ services:
       expect(started).toBe(6); // every app was started
       expect(maxInFlight).toBeLessThanOrEqual(4); // never exceeded the cap
       expect(maxInFlight).toBeGreaterThan(1); // and it actually parallelised
-    });
+    }, 60000);
   });
 
   // ─── GitHub URL install — validation ─────────────────────────────────────

--- a/tests/unit/command-endpoint.test.ts
+++ b/tests/unit/command-endpoint.test.ts
@@ -2,13 +2,11 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { waitFor } from '../helpers/wait-for';
 
 async function pollUntil(condition: () => boolean, intervalMs = 50, timeoutMs = 8000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!condition()) {
-    if (Date.now() >= deadline) throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-    await new Promise(r => setTimeout(r, intervalMs));
-  }
+  const ok = await waitFor(condition, timeoutMs, intervalMs);
+  if (!ok) throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
 }
 
 // ── Mock child_process ────────────────────────────────────────────────────────

--- a/tests/unit/command-endpoint.test.ts
+++ b/tests/unit/command-endpoint.test.ts
@@ -203,7 +203,7 @@ describe('AgentRunner /command endpoint', () => {
 
     // Create a session first
     await sendChannelPost(port, 'chat123', 'hello');
-    await new Promise(r => setTimeout(r, 100));
+    await pollUntil(() => getSessions(runner).has('chat123'));
 
     const { data } = await sendCommand(port, {
       command: 'set_model',
@@ -255,7 +255,7 @@ describe('AgentRunner /command endpoint', () => {
 
     // Create a session by sending a message
     await sendChannelPost(port, 'chat123', 'hello');
-    await new Promise(r => setTimeout(r, 100));
+    await pollUntil(() => getSessions(runner).has('chat123'));
 
     const sessions = getSessions(runner);
     expect(sessions.size).toBeGreaterThanOrEqual(1);
@@ -288,7 +288,7 @@ describe('AgentRunner /command endpoint', () => {
 
     // Create a session by sending a message, then let it stop
     await sendChannelPost(port, 'chat123', 'hello');
-    await new Promise(r => setTimeout(r, 100));
+    await pollUntil(() => getSessions(runner).has('chat123'));
 
     const { data } = await sendCommand(port, {
       command: 'set_model',
@@ -319,7 +319,7 @@ describe('AgentRunner /command endpoint', () => {
 
     // Create a session
     await sendChannelPost(port, 'chat123', 'hello');
-    await new Promise(r => setTimeout(r, 100));
+    await pollUntil(() => getSessions(runner).has('chat123'));
 
     const sessions = getSessions(runner);
     expect(sessions.has('chat123')).toBe(true);
@@ -418,8 +418,11 @@ describe('SessionProcess restart watcher notify payload', () => {
     currentSp = sp;
     await sp.start();
 
-    // Give chokidar time to initialize the watcher
-    await new Promise(r => setTimeout(r, 1000));
+    // Give chokidar time to initialize the watcher (SessionProcess uses a raw
+    // chokidar.watch() with no .ready-equivalent exposed to tests, so this is
+    // a plain timeout bump, not a poll — same fixed-delay-arm-race caveat as
+    // the fs-watcher tests, just without an observable "ready" signal here).
+    await new Promise(r => setTimeout(r, 2500));
 
     // Write restart signal with notify payload
     const signalPath = path.join(stateDir, 'restart-chat123');
@@ -468,8 +471,11 @@ describe('SessionProcess restart watcher notify payload', () => {
     currentSp = sp;
     await sp.start();
 
-    // Give chokidar time to initialize the watcher
-    await new Promise(r => setTimeout(r, 1000));
+    // Give chokidar time to initialize the watcher (SessionProcess uses a raw
+    // chokidar.watch() with no .ready-equivalent exposed to tests, so this is
+    // a plain timeout bump, not a poll — same fixed-delay-arm-race caveat as
+    // the fs-watcher tests, just without an observable "ready" signal here).
+    await new Promise(r => setTimeout(r, 2500));
 
     // Write empty restart signal (self-restart)
     const signalPath = path.join(stateDir, 'restart-chat456');

--- a/tests/unit/session-commands.test.ts
+++ b/tests/unit/session-commands.test.ts
@@ -10,6 +10,7 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { waitFor } from '../helpers/wait-for';
 
 // ── Mock child_process ────────────────────────────────────────────────────────
 
@@ -135,6 +136,10 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
     return content.text as string;
   }
 
+  async function waitForForward(): Promise<void> {
+    await waitFor(() => fs.existsSync(getForwardFile()), 8000);
+  }
+
   async function setupSession(lastInputTokens: number): Promise<void> {
     // Manually write the session index and set lastInputTokens (used for context % display)
     const agentsBaseDir = path.resolve(agentConfig.workspace, '..', '..');
@@ -180,7 +185,7 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, '/session');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     const text = getForwardText();
     expect(text).toContain('Context: 40%');
@@ -195,7 +200,7 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, '/session');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     const text = getForwardText();
     expect(text).toContain('Context: 0%');
@@ -213,7 +218,7 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, '/session');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     const text = getForwardText();
     expect(text).toContain('Near limit');
@@ -229,7 +234,7 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, '/session');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     const text = getForwardText();
     expect(text).toContain('Near limit');
@@ -244,7 +249,7 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, '/session');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     const text = getForwardText();
     expect(text).toContain('Context: 65%');
@@ -262,7 +267,7 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, '/session');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     const text = getForwardText();
     expect(text).toContain('Test Session');
@@ -311,6 +316,21 @@ describe('AgentRunner — /stop command', () => {
     return session!.process!;
   }
 
+  async function waitForForward(): Promise<void> {
+    await waitFor(() => fs.existsSync(getForwardFile()), 8000);
+  }
+
+  async function waitForSubprocess(): Promise<void> {
+    await waitFor(() => !!getActiveSession()?.process, 8000);
+  }
+
+  async function waitForStdinWrite(): Promise<void> {
+    await waitFor(() => {
+      const proc = getActiveSession()?.process;
+      return !!proc?.stdin && (proc.stdin.write as jest.Mock).mock.calls.length > 0;
+    }, 8000);
+  }
+
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-stop-'));
     const workspace = path.join(tmpDir, 'agents', 'test-agent', 'workspace');
@@ -334,7 +354,7 @@ describe('AgentRunner — /stop command', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, '/stop');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     expect(getForwardText()).toBe('No turn in progress.');
   }, 15000);
@@ -348,14 +368,14 @@ describe('AgentRunner — /stop command', () => {
     // Spawn a session with a regular message — handler sets processing=true,
     // but we manually clear it to simulate an idle session.
     await postChannelMessage(port, chatId, 'hello');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForSubprocess();
     const subprocess = getSessionSubprocess();
     getActiveSession()!.setProcessing(false);
 
     try { fs.rmSync(getForwardFile(), { force: true }); } catch {}
 
     await postChannelMessage(port, chatId, '/stop');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     expect(getForwardText()).toBe('No turn in progress.');
     expect(subprocess.kill).not.toHaveBeenCalledWith('SIGINT');
@@ -368,7 +388,7 @@ describe('AgentRunner — /stop command', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, 'long task');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForSubprocess();
     const subprocess = getSessionSubprocess();
     // Simulate an in-flight turn
     getActiveSession()!.setProcessing(true);
@@ -376,7 +396,7 @@ describe('AgentRunner — /stop command', () => {
     try { fs.rmSync(getForwardFile(), { force: true }); } catch {}
 
     await postChannelMessage(port, chatId, '/stop');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     expect(getForwardText()).toBe('Stopped.');
     expect(subprocess.kill).toHaveBeenCalledWith('SIGINT');
@@ -389,14 +409,14 @@ describe('AgentRunner — /stop command', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, 'hello');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForSubprocess();
     const subprocess = getSessionSubprocess();
     getActiveSession()!.setProcessing(true);
 
     const writesBefore = (subprocess.stdin!.write as jest.Mock).mock.calls.length;
 
     await postChannelMessage(port, chatId, '/stop');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForForward();
 
     const writesAfter = (subprocess.stdin!.write as jest.Mock).mock.calls.length;
     expect(writesAfter).toBe(writesBefore);
@@ -409,7 +429,7 @@ describe('AgentRunner — /stop command', () => {
 
     const port = getCallbackPort(runner);
     await postChannelMessage(port, chatId, '/stopwatch');
-    await new Promise(r => setTimeout(r, 300));
+    await waitForStdinWrite();
 
     const subprocess = getSessionSubprocess();
     const stdinWrites = (subprocess.stdin!.write as jest.Mock).mock.calls;

--- a/tests/unit/skills-watcher.test.ts
+++ b/tests/unit/skills-watcher.test.ts
@@ -117,10 +117,11 @@ describe('Skill File Watcher', () => {
 
   test('W4: debounces multiple rapid changes into fewer calls', async () => {
     let callCount = 0;
+    const debounceMs = 200;
     const watcher = watchSkills({
       dirs: [skillsDir],
       onChange: () => { callCount++; },
-      debounceMs: 200,
+      debounceMs,
       chokidarOpts: TEST_CHOKIDAR_OPTS,
     });
 
@@ -130,9 +131,11 @@ describe('Skill File Watcher', () => {
       writeSkillFile(`rapid-${i}`);
     }
 
-    // Wait for at least one call, then let debounce settle before asserting max
+    // Wait for at least one call, then let the debounce window fully settle
+    // before asserting the upper bound — scaled off debounceMs rather than a
+    // hardcoded constant, so it doesn't go stale if debounceMs changes.
     await pollUntil(() => callCount >= 1);
-    await new Promise((r) => setTimeout(r, 400));
+    await new Promise((r) => setTimeout(r, debounceMs * 2));
 
     await watcher.close();
     expect(callCount).toBeGreaterThanOrEqual(1);

--- a/tests/unit/watch-factory.test.ts
+++ b/tests/unit/watch-factory.test.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { createWatcher } from '../../src/watch/factory';
+import { waitFor } from '../helpers/wait-for';
 
 let tmpDir: string;
 
@@ -32,9 +33,9 @@ describe('createWatcher', () => {
       onChange: () => { count++; },
     });
 
-    await new Promise(r => setTimeout(r, 150));
+    await handle.ready;
     fs.writeFileSync(path.join(tmpDir, 'new.md'), 'hello');
-    await new Promise(r => setTimeout(r, 300));
+    await waitFor(() => count >= 1, 5000);
 
     await handle.close();
     expect(count).toBeGreaterThanOrEqual(1);
@@ -51,9 +52,9 @@ describe('createWatcher', () => {
       onChange: () => { count++; },
     });
 
-    await new Promise(r => setTimeout(r, 150));
+    await handle.ready;
     fs.writeFileSync(filePath, 'updated');
-    await new Promise(r => setTimeout(r, 300));
+    await waitFor(() => count >= 1, 5000);
 
     await handle.close();
     expect(count).toBeGreaterThanOrEqual(1);
@@ -70,9 +71,9 @@ describe('createWatcher', () => {
       onChange: () => { count++; },
     });
 
-    await new Promise(r => setTimeout(r, 150));
+    await handle.ready;
     fs.rmSync(filePath);
-    await new Promise(r => setTimeout(r, 300));
+    await waitFor(() => count >= 1, 5000);
 
     await handle.close();
     expect(count).toBeGreaterThanOrEqual(1);
@@ -80,17 +81,21 @@ describe('createWatcher', () => {
 
   test('WF4: debounces rapid changes into fewer calls', async () => {
     let count = 0;
+    const debounceMs = 200;
     const handle = createWatcher({
       paths: [path.join(tmpDir, '*.md')],
-      debounceMs: 200,
+      debounceMs,
       onChange: () => { count++; },
     });
 
-    await new Promise(r => setTimeout(r, 150));
+    await handle.ready;
     for (let i = 0; i < 5; i++) {
       fs.writeFileSync(path.join(tmpDir, `rapid-${i}.md`), 'x');
     }
-    await new Promise(r => setTimeout(r, 800));
+    await waitFor(() => count >= 1, 5000);
+    // Let the debounce window fully settle before asserting the upper bound —
+    // scaled off the configured debounceMs rather than a hardcoded constant.
+    await new Promise(r => setTimeout(r, debounceMs * 4));
 
     await handle.close();
     expect(count).toBeGreaterThanOrEqual(1);
@@ -105,7 +110,7 @@ describe('createWatcher', () => {
       onChange: () => { count++; },
     });
 
-    await new Promise(r => setTimeout(r, 150));
+    await handle.ready;
     await handle.close();
 
     // Write after close — should NOT trigger onChange
@@ -123,10 +128,10 @@ describe('createWatcher', () => {
       onChange: (changed) => { batches.push(changed.map(p => path.basename(p))); },
     });
 
-    await new Promise(r => setTimeout(r, 150));
+    await handle.ready;
     fs.writeFileSync(path.join(tmpDir, 'a.md'), 'x');
     fs.writeFileSync(path.join(tmpDir, 'b.md'), 'y');
-    await new Promise(r => setTimeout(r, 600));
+    await waitFor(() => batches.length >= 1, 5000);
 
     await handle.close();
     expect(batches.length).toBeGreaterThanOrEqual(1);
@@ -144,9 +149,9 @@ describe('createWatcher', () => {
       onChange: () => {},
     });
 
-    await new Promise(r => setTimeout(r, 150));
+    await handle.ready;
     fs.writeFileSync(path.join(tmpDir, 'hello.md'), 'x');
-    await new Promise(r => setTimeout(r, 300));
+    await waitFor(() => seen.includes('hello.md'), 5000);
 
     await handle.close();
     expect(seen).toContain('hello.md');

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -8,6 +8,7 @@ import {
   AGENT_WRITABLE_FILES,
   MissingRequiredFileError,
 } from '../../src/agent/workspace-loader';
+import { waitFor } from '../helpers/wait-for';
 
 const FIXTURES = path.join(__dirname, '../fixtures/workspaces');
 
@@ -259,13 +260,15 @@ describe('workspace-loader', () => {
 
       try {
         // Wait for watcher to initialize
-        await new Promise((r) => setTimeout(r, 500));
+        await handle.ready;
 
         // Write a lowercase soul.md — watcher should auto-rename it
         fs.writeFileSync(path.join(tmpDir, 'soul.md'), '# Soul\nContent');
 
-        // Wait for debounce + rename (300ms debounce + generous buffer for loaded CI)
-        await new Promise((r) => setTimeout(r, 3000));
+        // The rename happens synchronously in onAddSync (before the debounce),
+        // but onChange/changeCount only fires after the debounce timer — poll
+        // on changeCount, not on SOUL.md's existence, or this resolves too early.
+        await waitFor(() => changeCount > 0, 5000);
 
         // onChange should have fired
         expect(changeCount).toBeGreaterThan(0);
@@ -306,9 +309,9 @@ describe('workspace-loader', () => {
       const handle = watchWorkspace(tmpDir, (changed) => { batches.push(changed); });
 
       try {
-        await new Promise((r) => setTimeout(r, 500));
+        await handle.ready;
         fs.writeFileSync(path.join(tmpDir, 'MEMORY.md'), 'updated by agent');
-        await new Promise((r) => setTimeout(r, 1500));
+        await waitFor(() => batches.flat().includes('MEMORY.md'), 5000);
 
         const all = batches.flat();
         expect(all).toContain('MEMORY.md');
@@ -342,17 +345,19 @@ describe('workspace-loader', () => {
       const handle = watchWorkspace(tmpDir, (changed) => { batches.push(changed); });
 
       try {
-        await new Promise((r) => setTimeout(r, 600));
+        await handle.ready;
 
         // Churn deep inside .telegram-state — must be invisible to the watcher.
         fs.writeFileSync(path.join(typingDir, 'chat.json'), 'updated');
         fs.writeFileSync(path.join(typingDir, 'new.json'), 'new');
+        // Absence assertion — no observable positive condition to poll for,
+        // so this stays a fixed wait (safe direction: only risk is a false pass).
         await new Promise((r) => setTimeout(r, 1200));
         expect(batches.flat()).toHaveLength(0);
 
         // Sanity: top-level *.md still fires, so the watcher is alive.
         fs.writeFileSync(path.join(tmpDir, 'MEMORY.md'), 'top-level change');
-        await new Promise((r) => setTimeout(r, 1500));
+        await waitFor(() => batches.flat().includes('MEMORY.md'), 5000);
         expect(batches.flat()).toContain('MEMORY.md');
       } finally {
         handle.close();
@@ -377,16 +382,18 @@ describe('workspace-loader', () => {
       const handle = watchWorkspace(tmpDir, (changed) => { batches.push(changed); });
 
       try {
-        await new Promise((r) => setTimeout(r, 600));
+        await handle.ready;
 
         // A top-level dotfile that the *.md glob matches — must be ignored.
         fs.writeFileSync(path.join(tmpDir, '.scratch.md'), 'noise');
+        // Absence assertion — no observable positive condition to poll for,
+        // so this stays a fixed wait (safe direction: only risk is a false pass).
         await new Promise((r) => setTimeout(r, 1000));
         expect(batches.flat()).toHaveLength(0);
 
         // Sanity: a normal top-level *.md still fires.
         fs.writeFileSync(path.join(tmpDir, 'USER.md'), 'real change');
-        await new Promise((r) => setTimeout(r, 1500));
+        await waitFor(() => batches.flat().includes('USER.md'), 5000);
         expect(batches.flat()).toContain('USER.md');
       } finally {
         handle.close();


### PR DESCRIPTION
## Summary
- Fixed-timeout sleeps in fs-watcher, session-commands, and telegram-plugin tests raced against real async work under CI's variable CPU load, causing intermittent failures unrelated to any code regression.
- Added a small, dependency-free `waitFor(predicate, timeoutMs)` poll helper (`tests/helpers/wait-for.ts`) and replaced fixed sleeps with `await handle.ready` (where available) or condition polling in `watch-factory.test.ts`, `skills-watcher.test.ts`, `workspace-loader.test.ts`, `phase-manual.test.ts`, `line-config-to-chat.test.ts`, `session-commands.test.ts`, and `command-endpoint.test.ts`.
- Also addressed a separate class of flakiness surfaced while validating this fix under full-suite load: too-tight per-test timeouts in `telegram-plugin-process.test.ts` and `installer.test.ts` that were correct in isolation but tripped under CPU contention with the full suite running. Bumped those timeouts and capped `jest.config.js` `maxWorkers` to `50%` to reduce contention.
- Two intentional exceptions kept as fixed sleeps in `workspace-loader.test.ts` (absence assertions with no positive condition to poll for — documented inline) and `command-endpoint.test.ts` (raw `chokidar.watch()` restart-signal tests with no `.ready`-equivalent exposed — timeout bumped instead of converted to a poll, documented inline).

Closes #189

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Targeted suites (`watch-factory`, `skills-watcher`, `workspace-loader`, `session-commands`, `command-endpoint`, `telegram-plugin-process`, `installer`, `phase-manual`, `line-config-to-chat`) pass individually
- [x] Full unit suite (`npm run test`) green across multiple repeated runs, including with `maxWorkers` capped
- [x] No behavior changes to `src/watch/factory.ts` or `src/skills/watcher.ts` — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)