### PR TITLE
[Bug] wrap-shell: fix Telegram delivery, menu question context, and autonomous-wake forwarding

### DIFF
--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -28,7 +28,7 @@ import { randomBytes } from 'crypto'
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, rmSync, statSync, renameSync, realpathSync, chmodSync, existsSync } from 'fs'
 import { homedir } from 'os'
 import { join, extname, sep } from 'path'
-import { createWorkingStateManager } from './typing'
+import { createWorkingStateManager, drainOrphanForwards } from './typing'
 import { initDedupDir, isDuplicate as _isDuplicate, pruneDedup as _pruneDedup } from './dedup'
 import { hasMarkdown, toTelegramHtml } from './pure'
 
@@ -1756,6 +1756,21 @@ if (RECEIVER_MODE) {
     }
   }
   setInterval(drainMenuFiles, 1000).unref()
+
+  // Orphan auto-forward delivery: an autonomous wake writes .forward with no
+  // typing loop running, so stop() never drains it. The Discord receiver
+  // already drains .forward from a standalone poller; this mirrors it.
+  // Core logic (skip typing-active chats, remove-before-send, .replied dedup)
+  // lives in typing.ts drainOrphanForwards — unit-tested there.
+  function drainForwardFiles(): void {
+    drainOrphanForwards(
+      TYPING_DIR,
+      typingManager.states,
+      { sendMessage: (cid, t, opts) => bot.api.sendMessage(cid, t, opts) },
+      { existsSync, rmSync, readFileSync, readdirSync },
+    )
+  }
+  setInterval(drainForwardFiles, 1000).unref()
 
   void (async () => {
     for (let attempt = 1; ; attempt++) {

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -34,7 +34,8 @@ const BALANCED_TAGS = ['b', 'i', 'code', 'pre', 'a'] as const
  */
 export function openTagStack(html: string): string[] {
   const stack: string[] = []
-  const re = /<(\/?)([a-z]+)((?:\s[^>]*)?)>/g
+  // Attribute part tolerates '>' inside quoted values (<a href="a>b">).
+  const re = /<(\/?)([a-z]+)((?:\s(?:"[^"]*"|[^>])*)?)>/g
   let m: RegExpExecArray | null
   while ((m = re.exec(html)) !== null) {
     const closing = m[1] === '/'
@@ -74,27 +75,53 @@ export function chunkText(text: string, limit = TELEGRAM_MAX_CHARS, htmlSafe = f
   const out: string[] = []
   let rest = text
   const effLimit = htmlSafe ? limit - HTML_BALANCE_HEADROOM : limit
+  // If cut lands inside an open tag (<...>), move cut to before the '<'
+  const avoidMidTag = (cut: number): number => {
+    const tagStart = rest.lastIndexOf('<', cut)
+    const tagEnd = rest.lastIndexOf('>', cut)
+    return tagStart > tagEnd ? tagStart : cut
+  }
+  const closersFor = (open: string[]): string =>
+    open.map((t) => `</${/^<([a-z]+)/.exec(t)![1]}>`).reverse().join('')
+  // Cut at `cut`, balancing tags across the boundary when htmlSafe.
+  const splitAt = (cut: number): { head: string; tail: string } => {
+    let head = rest.slice(0, cut)
+    let tail = rest.slice(cut).replace(/^\n+/, '')
+    if (htmlSafe) {
+      const open = openTagStack(head)
+      if (open.length) {
+        head += closersFor(open)
+        tail = open.join('') + tail
+      }
+    }
+    return { head, tail }
+  }
   while (rest.length > effLimit) {
     const para = rest.lastIndexOf('\n\n', effLimit)
     const line = rest.lastIndexOf('\n', effLimit)
     const space = rest.lastIndexOf(' ', effLimit)
     let cut = para > effLimit / 2 ? para : line > effLimit / 2 ? line : space > 0 ? space : effLimit
-    if (htmlSafe) {
-      // If cut lands inside an open tag (<...>), move cut to before the '<'
-      const tagStart = rest.lastIndexOf('<', cut)
-      const tagEnd = rest.lastIndexOf('>', cut)
-      if (tagStart > tagEnd) cut = tagStart
-    }
-    let head = rest.slice(0, cut)
-    rest = rest.slice(cut).replace(/^\n+/, '')
-    if (htmlSafe) {
-      const open = openTagStack(head)
-      if (open.length) {
-        head += open.map((t) => `</${/^<([a-z]+)/.exec(t)![1]}>`).reverse().join('')
-        rest = open.join('') + rest
+    if (htmlSafe) cut = avoidMidTag(cut)
+    let { head, tail } = splitAt(cut)
+    // Forward-progress guard: when the chosen boundary sits right after an
+    // opening tag (e.g. "<b> " + one unbroken >limit token), the reopened tag
+    // prefix can re-add as much as the cut removed and `rest` never shrinks —
+    // an infinite loop that would hang the whole receiver. Retry with a hard
+    // cut at effLimit; if even that cannot shrink (degenerate tag-heavy input,
+    // e.g. a single huge <a href>), emit the remainder as one oversized chunk
+    // and stop — Telegram rejects it and the plain-text retry rescues the
+    // content, which beats hanging the process.
+    if (tail.length >= rest.length) {
+      cut = htmlSafe ? avoidMidTag(effLimit) : effLimit
+      ;({ head, tail } = splitAt(cut))
+      if (tail.length >= rest.length) {
+        out.push(rest)
+        rest = ''
+        break
       }
     }
     out.push(head)
+    rest = tail
   }
   if (rest) out.push(rest)
   return out

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -16,27 +16,85 @@
 export const TELEGRAM_MAX_CHARS = 4096
 
 /**
+ * Telegram rejects a message whose HTML entities are unbalanced, so a chunk cut
+ * that falls inside a <pre><code>…</code></pre> block must close the open tags
+ * at the end of the chunk and reopen them at the start of the next one.
+ * Reserve room for that worst-case suffix (</a></code></pre></b></i>) plus the
+ * mirrored reopening prefix so balancing never pushes a chunk past the limit.
+ */
+const HTML_BALANCE_HEADROOM = 64
+
+/** Tags toTelegramHtml() emits — the only ones balancing needs to understand. */
+const BALANCED_TAGS = ['b', 'i', 'code', 'pre', 'a'] as const
+
+/**
+ * Scan an HTML fragment (as produced by toTelegramHtml — no attributes except
+ * <a href>, no self-closing forms) and return the stack of tags still open at
+ * the end, as full opening-tag strings in opening order.
+ */
+export function openTagStack(html: string): string[] {
+  const stack: string[] = []
+  const re = /<(\/?)([a-z]+)((?:\s[^>]*)?)>/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(html)) !== null) {
+    const closing = m[1] === '/'
+    const name = m[2]
+    if (!(BALANCED_TAGS as readonly string[]).includes(name)) continue
+    if (closing) {
+      // toTelegramHtml emits well-nested pairs, so the match is always the top.
+      const top = stack.length - 1
+      if (top >= 0 && /^<([a-z]+)/.exec(stack[top])?.[1] === name) stack.pop()
+    } else {
+      stack.push(`<${name}${m[3] ?? ''}>`)
+    }
+  }
+  return stack
+}
+
+/** Strip Telegram-HTML tags and unescape entities → plain-text equivalent. */
+export function htmlToPlain(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, '')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+}
+
+/**
  * Split text into chunks that fit within Telegram's message size limit.
  * Prefers paragraph → line → space boundaries over hard cuts.
- * When htmlSafe=true, avoids cutting inside an HTML tag (e.g. <code>, <b>).
+ * When htmlSafe=true, avoids cutting inside an HTML tag (e.g. <code>, <b>) AND
+ * keeps every chunk entity-balanced: tags left open at a cut are closed at the
+ * chunk's end and reopened at the next chunk's start, so no chunk is ever
+ * rejected by Telegram's HTML parser for an unclosed <pre>/<code>/<b>.
  */
 export function chunkText(text: string, limit = TELEGRAM_MAX_CHARS, htmlSafe = false): string[] {
   if (text.length <= limit) return [text]
   const out: string[] = []
   let rest = text
-  while (rest.length > limit) {
-    const para = rest.lastIndexOf('\n\n', limit)
-    const line = rest.lastIndexOf('\n', limit)
-    const space = rest.lastIndexOf(' ', limit)
-    let cut = para > limit / 2 ? para : line > limit / 2 ? line : space > 0 ? space : limit
+  const effLimit = htmlSafe ? limit - HTML_BALANCE_HEADROOM : limit
+  while (rest.length > effLimit) {
+    const para = rest.lastIndexOf('\n\n', effLimit)
+    const line = rest.lastIndexOf('\n', effLimit)
+    const space = rest.lastIndexOf(' ', effLimit)
+    let cut = para > effLimit / 2 ? para : line > effLimit / 2 ? line : space > 0 ? space : effLimit
     if (htmlSafe) {
       // If cut lands inside an open tag (<...>), move cut to before the '<'
       const tagStart = rest.lastIndexOf('<', cut)
       const tagEnd = rest.lastIndexOf('>', cut)
       if (tagStart > tagEnd) cut = tagStart
     }
-    out.push(rest.slice(0, cut))
+    let head = rest.slice(0, cut)
     rest = rest.slice(cut).replace(/^\n+/, '')
+    if (htmlSafe) {
+      const open = openTagStack(head)
+      if (open.length) {
+        head += open.map((t) => `</${/^<([a-z]+)/.exec(t)![1]}>`).reverse().join('')
+        rest = open.join('') + rest
+      }
+    }
+    out.push(head)
   }
   if (rest) out.push(rest)
   return out
@@ -109,6 +167,101 @@ export interface FsApi {
   rmSync(path: string, opts: { force: boolean }): void
   readFileSync(path: string, enc: BufferEncoding): string
   statSync(path: string): { mtimeMs: number }
+}
+
+/**
+ * Deliver auto-forwarded turn text to a chat, never silently dropping content.
+ * Each chunk that fails as HTML (e.g. Telegram rejects an entity the balancer
+ * didn't anticipate) is retried as plain text — the user always gets the words,
+ * worst case without formatting. The generic "could not be delivered" notice is
+ * a last resort reserved for chunks that fail even as plain text (network/API
+ * outage), and is sent at most once.
+ */
+export async function deliverForwardText(
+  botApi: Pick<BotApi, 'sendMessage'>,
+  chatId: string,
+  forwardText: string,
+  parseMode: 'HTML' | undefined,
+): Promise<void> {
+  const msgOpts = parseMode ? { parse_mode: parseMode } : {}
+  const chunks = chunkText(forwardText, TELEGRAM_MAX_CHARS, parseMode === 'HTML')
+  let deliveryFailed = false
+  for (const part of chunks) {
+    try {
+      await botApi.sendMessage(chatId, part, msgOpts)
+    } catch {
+      const plain = parseMode === 'HTML' ? htmlToPlain(part) : part
+      try {
+        await botApi.sendMessage(chatId, plain)
+      } catch {
+        deliveryFailed = true
+        break
+      }
+    }
+  }
+  if (deliveryFailed) {
+    await botApi.sendMessage(
+      chatId,
+      '⚠️ Claude responded but the message could not be delivered. Please try asking again.',
+    ).catch(() => {})
+  }
+}
+
+/**
+ * Orphan auto-forward delivery (one poll pass). The typing-loop teardown
+ * (stop()) normally drains `<chatId>.forward`, but a forward can be written
+ * with NO typing loop running at all: an autonomous wake (a background Task
+ * finished and Claude continued on its own — e.g. writing up a plan) has no
+ * inbound message, so nothing ever started typing and stop() never runs.
+ * Without this drain that text sits on disk forever and the user sees a
+ * silent chat. Chats with a live typing state are skipped — stop() owns
+ * their delivery (including the .replied dedup) and draining them here
+ * would double-send.
+ */
+export function drainOrphanForwards(
+  typingDir: string,
+  activeChatIds: { has(chatId: string): boolean },
+  botApi: Pick<BotApi, 'sendMessage'>,
+  fsApi: Pick<FsApi, 'existsSync' | 'rmSync' | 'readFileSync'> & { readdirSync(path: string): string[] },
+): void {
+  let files: string[]
+  try {
+    files = fsApi.readdirSync(typingDir)
+  } catch {
+    return
+  }
+  for (const name of files) {
+    if (!name.endsWith('.forward')) continue
+    const chatId = name.slice(0, -'.forward'.length)
+    if (activeChatIds.has(chatId)) continue
+    const forwardPath = `${typingDir}/${name}`
+    let raw: string
+    try {
+      raw = fsApi.readFileSync(forwardPath, 'utf8').trim()
+    } catch {
+      fsApi.rmSync(forwardPath, { force: true })
+      continue
+    }
+    // Remove BEFORE sending so a slow/failing send can't double-deliver.
+    fsApi.rmSync(forwardPath, { force: true })
+    // Mirror stop()'s dedup: a lingering .replied with no typing state means
+    // the agent already sent this turn's text via the reply tool.
+    const repliedPath = `${typingDir}/${chatId}.replied`
+    if (fsApi.existsSync(repliedPath)) {
+      fsApi.rmSync(repliedPath, { force: true })
+      continue
+    }
+    let text = raw
+    let parseMode: 'HTML' | undefined
+    try {
+      const parsed = JSON.parse(raw) as { text: string; format: string }
+      text = parsed.text
+      parseMode = parsed.format === 'html' ? 'HTML' : undefined
+    } catch {
+      // Old format: plain text
+    }
+    if (text) void deliverForwardText(botApi, chatId, text, parseMode)
+  }
 }
 
 export function createWorkingStateManager(
@@ -191,23 +344,7 @@ export function createWorkingStateManager(
         // Skip if the reply tool already sent a message (agent already replied)
         const alreadyReplied = fsApi.existsSync(repliedPath)
         if (!alreadyReplied && forwardText) {
-          const msgOpts = parseMode ? { parse_mode: parseMode } : {}
-          const chunks = chunkText(forwardText, TELEGRAM_MAX_CHARS, parseMode === 'HTML')
-          let deliveryFailed = false
-          for (const part of chunks) {
-            try {
-              await botApi.sendMessage(chatId, part, msgOpts)
-            } catch {
-              deliveryFailed = true
-              break
-            }
-          }
-          if (deliveryFailed) {
-            await botApi.sendMessage(
-              chatId,
-              '⚠️ Claude responded but the message could not be delivered. Please try asking again.',
-            ).catch(() => {})
-          }
+          await deliverForwardText(botApi, chatId, forwardText, parseMode)
         }
       } catch {}
       fsApi.rmSync(forwardPath, { force: true })

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -846,6 +846,7 @@ export class AgentRunner extends EventEmitter {
       // Set when an interactive-menu prompt was rendered to the channel this turn,
       // so the result's plain-text auto-forward is skipped (no duplicate message).
       let menuSentThisTurn = false;
+      let menuPromptTextThisTurn = '';
       let typingDoneTimer: ReturnType<typeof setTimeout> | null = null;
       const TYPING_DONE_DELAY_MS = 3000;
       const replyToolName =
@@ -921,6 +922,7 @@ export class AgentRunner extends EventEmitter {
             if (promptText && options.length) {
               this.writeMenuForward(mapKey, promptText, options);
               menuSentThisTurn = true;
+              menuPromptTextThisTurn = promptText;
               // Persist the question to chat history so it's visible in the transcript.
               const channelSrc = this.channelSourceMap.get(mapKey) ?? 'telegram';
               this.historyDb.insertMessage({
@@ -994,10 +996,24 @@ export class AgentRunner extends EventEmitter {
               this.tooLargeRecoveries.delete(mapKey);
               this.tooLargeExhausted.delete(mapKey);
             }
-            // Skip when a menu was rendered to buttons this turn — the result
-            // text is the same numbered list and would duplicate the menu message.
-            if (!isSocketError && !isRequestTooLarge && resultText.trim() && !proc.queryMode && !replyCalled && !isThinkingCorruption && !menuSentThisTurn) {
-              const text = resultText.trim();
+            // When a menu was rendered to buttons this turn, the wrapper appends
+            // the same menu text to the turn's result — strip that suffix so it
+            // isn't duplicated, but DO forward any assistant prose that preceded
+            // the menu (a plan write-up or analysis the user needs in order to
+            // answer the question; previously the whole result was dropped).
+            let forwardableText = resultText.trim();
+            if (menuSentThisTurn && menuPromptTextThisTurn) {
+              const menuIdx = forwardableText.lastIndexOf(menuPromptTextThisTurn.trim());
+              if (menuIdx !== -1) {
+                forwardableText = forwardableText.slice(0, menuIdx).trim();
+              } else {
+                // Menu text not embedded verbatim — keep the old suppression
+                // rather than risk double-posting the option list.
+                forwardableText = '';
+              }
+            }
+            if (!isSocketError && !isRequestTooLarge && forwardableText && !proc.queryMode && !replyCalled && !isThinkingCorruption) {
+              const text = forwardableText;
               const channelSrcForResult = this.channelSourceMap.get(mapKey) ?? 'telegram';
               // Persist assistant reply to permanent history DB
               this.historyDb.insertMessage({
@@ -1022,6 +1038,7 @@ export class AgentRunner extends EventEmitter {
             replyCalled = false; // reset for next turn
             replyToolUseId = null;
             menuSentThisTurn = false;
+            menuPromptTextThisTurn = '';
             // In pty-shell mode, a `result` fires after every Claude API sub-turn
             // (there can be many per user message, separated by tool-call gaps of
             // arbitrary length). Starting the typing-done timer here would stop

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -342,7 +342,7 @@ class Driver {
     })) {
       logWarn('assistant record with no active turn and a working screen — adopting autonomous wake as a turn');
       this.beginTurn();
-      const turn = this.turn as unknown as ActiveTurn;
+      const turn = this.turn!;
       // Mark as already-submitted, already-busy: the Enter-retry path must
       // never type into a turn we didn't submit, and the probe/fallback-idle
       // paths require sawBusy to engage.

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -20,6 +20,7 @@ import { TranscriptTailer, AssistantRecord, UsageInfo } from './tailer';
 import { ProtocolEmitter } from './emitter';
 import { preTrustWorkspace, checkAuthStatus } from './trust';
 import { decideMenuCancel } from './menu-cancel';
+import { shouldAdoptOrphanWake } from './orphan-wake';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
 
 const POLL_MS = 200;
@@ -325,6 +326,29 @@ class Driver {
     // New output = activity: re-arm idle reconciliation so a fresh session_idle is
     // emitted once Claude settles, even if this record arrived outside a tracked turn.
     this.idleNotified = false;
+    // Claude can start a turn on its own — a background Task's completion
+    // notification re-invokes it with no user message and thus no ActiveTurn.
+    // Adopt the wake as a synthetic turn so the existing machinery (result
+    // forwarding, probe → menu bridge, watchdog) all applies. Gate reasoning
+    // lives with the pure function in orphan-wake.ts.
+    if (shouldAdoptOrphanWake({
+      hasTurn: this.turn !== null,
+      exiting: this.exiting,
+      interrupting: this.interrupting !== null,
+      menuCancelActive: this.menuCancel !== null,
+      pendingMenu: this.pendingMenu !== null,
+      screenBusy: this.screen.isBusy(),
+      screenHasPrompt: this.screen.hasPrompt(),
+    })) {
+      logWarn('assistant record with no active turn and a working screen — adopting autonomous wake as a turn');
+      this.beginTurn();
+      const turn = this.turn as unknown as ActiveTurn;
+      // Mark as already-submitted, already-busy: the Enter-retry path must
+      // never type into a turn we didn't submit, and the probe/fallback-idle
+      // paths require sawBusy to engage.
+      turn.submittedAt = Date.now();
+      turn.sawBusy = true;
+    }
     if (this.turn) {
       this.turn.sawAssistant = true;
       this.turn.lastProgressAt = Date.now();
@@ -835,7 +859,7 @@ class Driver {
     this.probe = null;
     const text = afterParsed.isPermission
       ? formatPermissionPrompt(afterParsed.context, afterParsed.options)
-      : formatMenuPrompt(afterParsed.options);
+      : formatMenuPrompt(afterParsed.options, afterParsed.context);
     logWarn(`interactive ${afterParsed.isPermission ? 'permission prompt' : 'menu'} confirmed (${afterParsed.options.length} options, highlight ${beforeParsed.highlighted}→${afterParsed.highlighted}) — bridging to chat`);
     this.bridgeChoiceToChat(turn, afterParsed.options, text);
   }

--- a/src/shell/orphan-wake.ts
+++ b/src/shell/orphan-wake.ts
@@ -1,0 +1,43 @@
+/**
+ * Orphan-wake adoption gate (Bug 3 — planning: autonomous wake loses output).
+ *
+ * Claude can start a turn on its own: a background Task's completion
+ * notification re-invokes it with no user message, so the wrapper has no
+ * ActiveTurn. Without a turn, tick() skips ALL end-of-turn and menu-bridge
+ * handling — streamed text is never forwarded to the channel, and an
+ * interactive overlay the wake ends on (plan approval / AskUserQuestion)
+ * blocks the session silently forever.
+ *
+ * The fix adopts such a wake as a synthetic turn, but only when it is safe:
+ * the screen must actually be working (busy, or the idle input prompt is
+ * gone). A straggler assistant record flushed just after finishTurn() — with
+ * the idle prompt back on screen — must NOT fabricate a turn, or stale text
+ * would be re-forwarded. Kept as a pure function so the gate is unit-testable
+ * without spawning a PTY.
+ */
+
+export interface OrphanWakeObs {
+  /** An ActiveTurn already exists — normal flow, nothing to adopt. */
+  hasTurn: boolean;
+  /** Wrapper is shutting down. */
+  exiting: boolean;
+  /** ESC interrupt in flight (/stop) — the wake is being cancelled, not started. */
+  interrupting: boolean;
+  /** Menu-cancel settle in flight — screen state is mid-transition. */
+  menuCancelActive: boolean;
+  /** A bridged menu is already awaiting the user's button answer. */
+  pendingMenu: boolean;
+  /** screen.isBusy() — the "esc to interrupt" busy marker is visible. */
+  screenBusy: boolean;
+  /** screen.hasPrompt() — the idle input caret is parked on screen. */
+  screenHasPrompt: boolean;
+}
+
+/** True when an assistant record with no ActiveTurn should be adopted as an
+ *  autonomous-wake turn (see module doc for the safety reasoning). */
+export function shouldAdoptOrphanWake(obs: OrphanWakeObs): boolean {
+  if (obs.hasTurn || obs.exiting || obs.interrupting || obs.menuCancelActive || obs.pendingMenu) {
+    return false;
+  }
+  return obs.screenBusy || !obs.screenHasPrompt;
+}

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -158,13 +158,14 @@ export interface InteractivePrompt {
 function parseLiveOptionRun(
   lines: string[],
   stripBorder = false,
-): { options: MenuOption[]; highlighted: number } | null {
-  const matches: Array<MenuOption & { caret: boolean }> = [];
-  for (const raw of lines) {
+): { options: MenuOption[]; highlighted: number; startLine: number } | null {
+  const matches: Array<MenuOption & { caret: boolean; lineIdx: number }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
     const line = stripBorder ? raw.replace(/^\s*│\s?/, '') : raw;
     const m = TUI_MENU_OPTION_RE.exec(line);
     // CARET_OPTION_RE tolerates the box border itself, so test the raw line.
-    if (m) matches.push({ index: Number(m[1]), label: m[2].trim(), caret: CARET_OPTION_RE.test(raw) });
+    if (m) matches.push({ index: Number(m[1]), label: m[2].trim(), caret: CARET_OPTION_RE.test(raw), lineIdx: i });
   }
   if (matches.length < 2) return null;
   let start = -1;
@@ -172,7 +173,7 @@ function parseLiveOptionRun(
     if (matches[i].index === 1) start = i;
   }
   if (start === -1) return null;
-  const run: Array<MenuOption & { caret: boolean }> = [];
+  const run: Array<MenuOption & { caret: boolean; lineIdx: number }> = [];
   let expected = 1;
   for (let i = start; i < matches.length && matches[i].index === expected; i++) {
     run.push(matches[i]);
@@ -184,7 +185,47 @@ function parseLiveOptionRun(
   return {
     options: run.map(({ index, label }) => ({ index, label })),
     highlighted: caretRows[0].index,
+    startLine: run[0].lineIdx,
   };
+}
+
+/**
+ * Bounds for the question/context text captured above a plain (non-permission)
+ * menu's option run. The question the user must answer sits directly above the
+ * options (AskUserQuestion header + question, or plan approval's "Would you
+ * like to proceed?" + plan tail), so we scan upward a bounded number of lines
+ * and keep the tail nearest the options when the cap trims anything.
+ */
+const MENU_CONTEXT_MAX_LINES = 12;
+const MENU_CONTEXT_MAX_CHARS = 1200;
+
+/**
+ * Collect the human-readable lines above a menu's option run — the question
+ * being asked. Scans upward from the run, stops at the question box's top
+ * border (╭/╮) when the menu renders boxed, and is line/char-capped so an
+ * unboxed menu (plan approval) carries the nearest prose (the proceed question
+ * plus the plan's tail) without dumping the whole screen into chat.
+ */
+function extractMenuContext(lines: string[], runStart: number): string {
+  const isBorderOnly = (l: string) => /^[\s│╭╮╰╯─]*$/.test(l);
+  const stripBorder = (l: string) => l.replace(/^[\s│]+/, '').replace(/[\s│]+$/, '');
+  const collected: string[] = [];
+  for (let i = runStart - 1; i >= 0 && collected.length < MENU_CONTEXT_MAX_LINES; i--) {
+    const raw = lines[i];
+    if (/[╭╮]/.test(raw)) break; // top border of the question box
+    if (isBorderOnly(raw)) {
+      // Preserve one blank as a paragraph separator, never leading blanks.
+      if (collected.length > 0 && collected[0] !== '') collected.unshift('');
+      continue;
+    }
+    collected.unshift(stripBorder(raw));
+  }
+  let context = collected.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+  if (context.length > MENU_CONTEXT_MAX_CHARS) {
+    // Keep the tail — the lines nearest the options are the question itself.
+    context = '…' + context.slice(-MENU_CONTEXT_MAX_CHARS);
+  }
+  return context;
 }
 
 /**
@@ -223,7 +264,12 @@ export function parseInteractivePrompt(screenText: string): InteractivePrompt | 
     // to look like a numbered list never parses (no highlight row).
     const run = parseLiveOptionRun(allLines);
     return run
-      ? { options: run.options, context: '', isPermission: false, highlighted: run.highlighted }
+      ? {
+          options: run.options,
+          context: extractMenuContext(allLines, run.startLine),
+          isPermission: false,
+          highlighted: run.highlighted,
+        }
       : null;
   }
 
@@ -285,10 +331,13 @@ export function extractChannelContent(text: string): string {
   return m[1].replace(/<replied\b[^>]*>[\s\S]*?<\/replied>/g, '').trim();
 }
 
-/** Build the chat-facing menu prompt (also the API/number fallback text). */
-export function formatMenuPrompt(options: MenuOption[]): string {
+/** Build the chat-facing menu prompt (also the API/number fallback text).
+ *  `context` is the question text captured above the option run — without it
+ *  the user sees a bare option list with no idea what is being asked. */
+export function formatMenuPrompt(options: MenuOption[], context = ''): string {
   const lines = options.map((o, i) => `${i + 1}. ${o.label}`).join('\n');
-  return `🔢 Choose an option — tap a button below, or reply with the number:\n\n${lines}`;
+  const ctx = context.trim() ? `❓ ${context.trim()}\n\n` : '';
+  return `${ctx}🔢 Choose an option — tap a button below, or reply with the number:\n\n${lines}`;
 }
 
 /**

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -2125,6 +2125,99 @@ describe('AgentRunner — session command routing', () => {
     // spawn should NOT have been called for a session command
     expect(spawnCountAfter).toBe(spawnCountBefore);
   }, 15000);
+
+  // -------------------------------------------------------------------------
+  // U14: menu_prompt + result — prose preceding the menu is forwarded, the
+  // duplicated menu text suffix is stripped (previously the whole result was
+  // dropped, losing plan/analysis text the user needed to answer the menu).
+  // -------------------------------------------------------------------------
+  it('U14: result prose before a bridged menu is forwarded with the menu suffix stripped', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    const chatId = 'chat:menu-strip';
+    await postChannelMessage(port, chatId, 'plan something');
+    await waitForSession(runner, chatId);
+    const session = getSessions(runner).get(chatId)!;
+
+    const menuText = '🔢 Choose an option — tap a button below.\n1. Yes\n2. No';
+    session.emit('output', JSON.stringify({
+      type: 'system',
+      subtype: 'menu_prompt',
+      prompt: menuText,
+      options: [{ label: 'Yes' }, { label: 'No' }],
+    }));
+    // Menu bridged to buttons via the .menu file
+    const menuFile = path.join(getTypingDir(), `${chatId}.menu`);
+    expect(fs.existsSync(menuFile)).toBe(true);
+    const menu = JSON.parse(fs.readFileSync(menuFile, 'utf8'));
+    expect(menu.text).toBe(menuText);
+    expect(menu.options).toHaveLength(2);
+
+    const prose = 'Here is the detailed plan.\nStep 1 does X, step 2 does Y.';
+    session.emit('output', JSON.stringify({
+      type: 'result',
+      is_error: false,
+      result: `${prose}\n\n${menuText}`,
+    }));
+    await new Promise(r => setTimeout(r, 100));
+
+    const forwardFile = path.join(getTypingDir(), `${chatId}.forward`);
+    expect(fs.existsSync(forwardFile)).toBe(true);
+    const forward = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    expect(forward.text).toContain('Here is the detailed plan.');
+    expect(forward.text).not.toContain('Choose an option');
+  }, 15000);
+
+  it('U14b: result that is only the menu text produces no forward (no duplicate)', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    const chatId = 'chat:menu-only';
+    await postChannelMessage(port, chatId, 'ask me');
+    await waitForSession(runner, chatId);
+    const session = getSessions(runner).get(chatId)!;
+
+    const menuText = '🔢 Choose an option\n1. A\n2. B';
+    session.emit('output', JSON.stringify({
+      type: 'system',
+      subtype: 'menu_prompt',
+      prompt: menuText,
+      options: [{ label: 'A' }, { label: 'B' }],
+    }));
+    session.emit('output', JSON.stringify({ type: 'result', is_error: false, result: menuText }));
+    await new Promise(r => setTimeout(r, 100));
+
+    expect(fs.existsSync(path.join(getTypingDir(), `${chatId}.forward`))).toBe(false);
+  }, 15000);
+
+  it('U14c: menu text not embedded verbatim in result — forward suppressed (no double post)', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    const chatId = 'chat:menu-reworded';
+    await postChannelMessage(port, chatId, 'ask me');
+    await waitForSession(runner, chatId);
+    const session = getSessions(runner).get(chatId)!;
+
+    session.emit('output', JSON.stringify({
+      type: 'system',
+      subtype: 'menu_prompt',
+      prompt: '🔢 Choose an option\n1. A\n2. B',
+      options: [{ label: 'A' }, { label: 'B' }],
+    }));
+    session.emit('output', JSON.stringify({
+      type: 'result',
+      is_error: false,
+      result: 'Reworded output listing 1. A and 2. B differently',
+    }));
+    await new Promise(r => setTimeout(r, 100));
+
+    expect(fs.existsSync(path.join(getTypingDir(), `${chatId}.forward`))).toBe(false);
+  }, 15000);
 });
 
 // ── Restart-before-turn tests (US-003) ───────────────────────────────────────

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -18,6 +18,7 @@ import { Writable } from 'stream';
 import { preTrustWorkspace, checkAuthStatus } from '../../src/shell/trust';
 import { decideMenuCancel, MenuCancelState } from '../../src/shell/menu-cancel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_MAX_ROUNDS, PROBE_RETRY_COOLDOWN_MS } from '../../src/shell/menu-probe';
+import { shouldAdoptOrphanWake, OrphanWakeObs } from '../../src/shell/orphan-wake';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -364,6 +365,84 @@ describe('ScreenModel readInteractivePrompt (plain AskUserQuestion-style menu)',
     ]);
     expect(screen.readInteractivePrompt()).toBeNull();
   });
+
+  it('captures the question text above the options as context (bug: bare "Choose an option" in chat)', async () => {
+    // Without the context, the bridged Telegram message is an option list
+    // with no question — the user cannot tell what is being asked.
+    const screen = await renderScreen([
+      'Scope of the PR',
+      '',
+      'Should the fix cover only the 3 failing suites, or the whole repo?',
+      '',
+      '❯ 1. Only the 3 suites',
+      '  2. Whole-repo sweep',
+      '  3. Chat about this',
+      '',
+      MENU_FOOTER,
+    ]);
+    const prompt = screen.readInteractivePrompt();
+    expect(prompt).not.toBeNull();
+    expect(prompt!.context).toContain('Scope of the PR');
+    expect(prompt!.context).toContain('whole repo?');
+    // The footer/options themselves are not part of the context.
+    expect(prompt!.context).not.toContain('1. Only the 3 suites');
+  });
+
+  it('bounds the context at the question box top border', async () => {
+    // The question header can render inside a rounded box above the option
+    // rows — the border marks where the question starts, so scrollback above
+    // it must not leak into the context.
+    const screen = await renderScreen([
+      'unrelated earlier conversation output',
+      '╭──────────────────────────────╮',
+      '│ Pick a database              │',
+      '╰──────────────────────────────╯',
+      '❯ 1. Postgres',
+      '  2. SQLite',
+      '',
+      MENU_FOOTER,
+    ]);
+    const prompt = screen.readInteractivePrompt();
+    expect(prompt).not.toBeNull();
+    expect(prompt!.context).toContain('Pick a database');
+    expect(prompt!.context).not.toContain('unrelated earlier conversation');
+  });
+
+  it('plan-approval shape: proceed question and plan tail become the context', async () => {
+    // The plan-mode approval prompt is unboxed: prose (the plan) ends with
+    // "Would you like to proceed?" directly above the option run.
+    const screen = await renderScreen([
+      'Here is Claude\'s plan:',
+      'Fix the flaky sleeps in the three failing suites.',
+      '',
+      'Would you like to proceed?',
+      '',
+      '❯ 1. Yes, and bypass permissions',
+      '  2. Yes, manually approve edits',
+      '  3. Tell Claude what to change',
+      '',
+      MENU_FOOTER,
+    ]);
+    const prompt = screen.readInteractivePrompt();
+    expect(prompt).not.toBeNull();
+    expect(prompt!.context).toContain('Would you like to proceed?');
+    expect(prompt!.context).toContain('flaky sleeps');
+  });
+
+  it('caps oversized context, keeping the tail nearest the options', async () => {
+    const longLines = Array.from({ length: 12 }, (_, i) => `plan detail line ${i} ${'x'.repeat(150)}`);
+    const screen = await renderScreen([
+      ...longLines,
+      'Would you like to proceed?',
+      '❯ 1. Yes',
+      '  2. No',
+      MENU_FOOTER,
+    ]);
+    const prompt = screen.readInteractivePrompt();
+    expect(prompt).not.toBeNull();
+    expect(prompt!.context.length).toBeLessThanOrEqual(1201); // cap + leading ellipsis
+    expect(prompt!.context).toContain('Would you like to proceed?'); // tail survives
+  });
 });
 
 describe('hasPrompt() vs interactivePromptBlocking() (menu-caret false-positive)', () => {
@@ -478,6 +557,21 @@ describe('formatMenuPrompt', () => {
     expect(text).toContain('1. Alpha');
     expect(text).toContain('2. Beta');
     expect(text.toLowerCase()).toContain('reply with the number');
+  });
+
+  it('leads with the question context when provided', () => {
+    const text = formatMenuPrompt(
+      [{ index: 1, label: 'Alpha' }, { index: 2, label: 'Beta' }],
+      'Scope of the PR\n\nWhich scope should the fix cover?',
+    );
+    expect(text.indexOf('Scope of the PR')).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf('Scope of the PR')).toBeLessThan(text.indexOf('1. Alpha'));
+    expect(text).toContain('Which scope should the fix cover?');
+  });
+
+  it('omits the context block when empty (unchanged legacy shape)', () => {
+    const text = formatMenuPrompt([{ index: 1, label: 'Alpha' }, { index: 2, label: 'Beta' }], '');
+    expect(text.startsWith('🔢')).toBe(true);
   });
 });
 
@@ -1014,6 +1108,48 @@ describe('isSyntheticRequestTooLarge (authoritative 413 detection)', () => {
       model: '<synthetic>',
       content: [{ type: 'tool_use', id: 'x' }, { type: 'text', text: overlayText }],
     })).toBe(true);
+  });
+});
+
+describe('shouldAdoptOrphanWake (autonomous-wake turn adoption)', () => {
+  // Models Bug 3: a background Task's completion notification re-invokes
+  // Claude with no user message → assistant records stream in with no
+  // ActiveTurn → tick() skips result forwarding and menu bridging, so a plan
+  // approval / AskUserQuestion the wake ends on blocks the session silently.
+  const baseObs = (over: Partial<OrphanWakeObs> = {}): OrphanWakeObs => ({
+    hasTurn: false,
+    exiting: false,
+    interrupting: false,
+    menuCancelActive: false,
+    pendingMenu: false,
+    screenBusy: true,
+    screenHasPrompt: false,
+    ...over,
+  });
+
+  it('adopts the wake when there is no turn and the screen is busy', () => {
+    expect(shouldAdoptOrphanWake(baseObs())).toBe(true);
+  });
+
+  it('adopts the wake when not busy yet but the idle prompt is gone (turn just starting)', () => {
+    expect(shouldAdoptOrphanWake(baseObs({ screenBusy: false, screenHasPrompt: false }))).toBe(true);
+  });
+
+  it('does NOT adopt a straggler record flushed after finishTurn (idle prompt on screen)', () => {
+    // The safety gate: idle prompt back on screen means the turn already
+    // ended — fabricating a turn here would re-forward stale text.
+    expect(shouldAdoptOrphanWake(baseObs({ screenBusy: false, screenHasPrompt: true }))).toBe(false);
+  });
+
+  it('does NOT adopt when a turn already exists (normal flow)', () => {
+    expect(shouldAdoptOrphanWake(baseObs({ hasTurn: true }))).toBe(false);
+  });
+
+  it('does NOT adopt while exiting, interrupting, menu-cancelling, or a menu is pending', () => {
+    expect(shouldAdoptOrphanWake(baseObs({ exiting: true }))).toBe(false);
+    expect(shouldAdoptOrphanWake(baseObs({ interrupting: true }))).toBe(false);
+    expect(shouldAdoptOrphanWake(baseObs({ menuCancelActive: true }))).toBe(false);
+    expect(shouldAdoptOrphanWake(baseObs({ pendingMenu: true }))).toBe(false);
   });
 });
 

--- a/tests/unit/telegram-plugin/typing.test.ts
+++ b/tests/unit/telegram-plugin/typing.test.ts
@@ -7,6 +7,9 @@ import {
   createWorkingStateManager,
   parseStatusFile,
   chunkText,
+  openTagStack,
+  htmlToPlain,
+  drainOrphanForwards,
   TELEGRAM_MAX_CHARS,
   STATUS_MESSAGES,
   ERROR_MESSAGES,
@@ -822,10 +825,11 @@ describe('createWorkingStateManager', () => {
       expect(forwardCalls).toHaveLength(1)
     })
 
-    it('U-TY-11b: sends delivery-failure warning when sendMessage throws during auto-forward', async () => {
+    it('U-TY-11b: retries a failed chunk as plain text — content delivered, no generic warning', async () => {
       const bot = makeBotApi()
       const fsApi = makeFsApi()
-      // First call (the actual forward) throws; second call (the warning) succeeds
+      // First call (the forward) throws; the plain-text retry succeeds — the
+      // user gets the actual content, so the generic warning must NOT be sent.
       bot.sendMessage
         .mockRejectedValueOnce(new Error('network error'))
         .mockResolvedValue({ message_id: 200 })
@@ -839,21 +843,80 @@ describe('createWorkingStateManager', () => {
 
       await mgr.stop(CHAT_ID)
 
-      // Warning message must be sent to the same chatId
+      const contentCalls = bot.sendMessage.mock.calls.filter(
+        c => c[0] === CHAT_ID && c[1] === 'Hello from agent',
+      )
+      expect(contentCalls).toHaveLength(2) // failed attempt + successful retry
+
+      const warnCalls = bot.sendMessage.mock.calls.filter(
+        c => c[0] === CHAT_ID && typeof c[1] === 'string' && (c[1] as string).includes('could not be delivered'),
+      )
+      expect(warnCalls).toHaveLength(0)
+    })
+
+    it('U-TY-11b2: sends delivery-failure warning only when the plain-text retry also fails', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      // Forward attempt AND its plain retry both throw (real outage); the
+      // warning send succeeds.
+      bot.sendMessage
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValue({ message_id: 200 })
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+      fsApi._files.set(
+        `${TYPING_DIR}/${CHAT_ID}.forward`,
+        JSON.stringify({ text: 'Hello from agent', format: 'text' }),
+      )
+
+      await mgr.stop(CHAT_ID)
+
       const warnCalls = bot.sendMessage.mock.calls.filter(
         c => c[0] === CHAT_ID && typeof c[1] === 'string' && (c[1] as string).includes('could not be delivered'),
       )
       expect(warnCalls).toHaveLength(1)
     })
 
-    it('U-TY-11c: stops sending chunks and warns after first chunk fails (multi-chunk delivery)', async () => {
+    it('U-TY-11b3: HTML chunk rejected by Telegram falls back to stripped plain text', async () => {
       const bot = makeBotApi()
       const fsApi = makeFsApi()
-      // sendMessage: first forward chunk succeeds, second throws, warning succeeds
+      // HTML parse rejection on the formatted send; plain retry succeeds.
+      bot.sendMessage
+        .mockRejectedValueOnce(new Error("Bad Request: can't parse entities"))
+        .mockResolvedValue({ message_id: 200 })
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+      fsApi._files.set(
+        `${TYPING_DIR}/${CHAT_ID}.forward`,
+        JSON.stringify({ text: '<b>bold</b> and <code>x &lt; y</code>', format: 'html' }),
+      )
+
+      await mgr.stop(CHAT_ID)
+
+      // Plain retry: tags stripped, entities unescaped, no parse_mode.
+      const plainCalls = bot.sendMessage.mock.calls.filter(
+        c => c[0] === CHAT_ID && c[1] === 'bold and x < y',
+      )
+      expect(plainCalls).toHaveLength(1)
+      expect(plainCalls[0][2]).toBeUndefined()
+
+      const warnCalls = bot.sendMessage.mock.calls.filter(
+        c => c[0] === CHAT_ID && typeof c[1] === 'string' && (c[1] as string).includes('could not be delivered'),
+      )
+      expect(warnCalls).toHaveLength(0)
+    })
+
+    it('U-TY-11c: a mid-delivery chunk failure is retried as plain and later chunks still send', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      // chunk1 OK, chunk2 fails once (plain retry succeeds), no warning.
       bot.sendMessage
         .mockResolvedValueOnce({ message_id: 100 })   // first chunk OK
         .mockRejectedValueOnce(new Error('rate limit')) // second chunk fails
-        .mockResolvedValue({ message_id: 200 })         // warning fallback
+        .mockResolvedValue({ message_id: 200 })         // plain retry succeeds
 
       const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
       mgr.start(CHAT_ID)
@@ -868,16 +931,21 @@ describe('createWorkingStateManager', () => {
 
       await mgr.stop(CHAT_ID)
 
-      // Only 2 sendMessage calls: chunk1 + warning (chunk2 was aborted)
-      const forwardCalls = bot.sendMessage.mock.calls.filter(
+      const aCalls = bot.sendMessage.mock.calls.filter(
         c => c[0] === CHAT_ID && typeof c[1] === 'string' && (c[1] as string).startsWith('A'),
       )
-      expect(forwardCalls).toHaveLength(1)
+      expect(aCalls).toHaveLength(1)
+
+      // chunk2: the failed attempt + the successful plain retry
+      const bCalls = bot.sendMessage.mock.calls.filter(
+        c => c[0] === CHAT_ID && typeof c[1] === 'string' && (c[1] as string).startsWith('B'),
+      )
+      expect(bCalls).toHaveLength(2)
 
       const warnCalls = bot.sendMessage.mock.calls.filter(
         c => c[0] === CHAT_ID && typeof c[1] === 'string' && (c[1] as string).includes('could not be delivered'),
       )
-      expect(warnCalls).toHaveLength(1)
+      expect(warnCalls).toHaveLength(0)
     })
 
     it('U-TY-11d: does NOT send delivery-failure warning when sendMessage succeeds', async () => {
@@ -958,5 +1026,160 @@ describe('createWorkingStateManager', () => {
       const closeInFirst = (chunks[0].match(/>/g) ?? []).length
       expect(openInFirst).toBeGreaterThan(closeInFirst)
     })
+
+    it('U-TY-18: htmlSafe=true keeps every chunk entity-balanced across a <pre><code> block', () => {
+      // A code block far larger than the limit: the cut MUST land inside it,
+      // and each chunk must close what it opened and reopen in the next —
+      // this exact shape (long analysis + big code block) is what Telegram
+      // rejected with 400 and surfaced as "could not be delivered".
+      const code = 'line of code\n'.repeat(600) // ~7800 chars
+      const text = `<b>Analysis</b>\n<pre><code>${code}</code></pre>\ntail`
+      const chunks = chunkText(text, 4096, true)
+      expect(chunks.length).toBeGreaterThan(1)
+      for (const c of chunks) {
+        expect(c.length).toBeLessThanOrEqual(4096)
+        // Balanced per tag type: every <pre>/<code>/<b> has its close in-chunk.
+        for (const tag of ['pre', 'code', 'b']) {
+          const open = (c.match(new RegExp(`<${tag}>`, 'g')) ?? []).length
+          const close = (c.match(new RegExp(`</${tag}>`, 'g')) ?? []).length
+          expect(open).toBe(close)
+        }
+      }
+      // No content lost: stripping tags from all chunks reproduces the code body.
+      const combined = chunks.map(c => c.replace(/<[^>]+>/g, '')).join('')
+      expect(combined).toContain('line of code')
+      expect(combined.match(/line of code/g)).toHaveLength(600)
+    })
+
+    it('U-TY-19: openTagStack returns tags still open, in order', () => {
+      expect(openTagStack('<b>x</b>')).toEqual([])
+      expect(openTagStack('<pre><code>abc')).toEqual(['<pre>', '<code>'])
+      expect(openTagStack('<a href="https://x.y">link')).toEqual(['<a href="https://x.y">'])
+      // Escaped entities are not tags
+      expect(openTagStack('a &lt;b&gt; c')).toEqual([])
+    })
+
+    it('U-TY-20: htmlToPlain strips tags and unescapes entities', () => {
+      expect(htmlToPlain('<b>bold</b> <code>x &lt; y &amp;&amp; z &gt; w</code>')).toBe('bold x < y && z > w')
+    })
+  })
+})
+
+// ── drainOrphanForwards (autonomous-wake .forward delivery) ──────────────────
+
+describe('drainOrphanForwards', () => {
+  // Bug 3: an autonomous wake writes `<chatId>.forward` with no typing loop
+  // running, so stop() never drains it — without this poller the text sits on
+  // disk forever and the chat stays silent.
+
+  function makeDrainFsApi(files: Map<string, string>) {
+    return {
+      existsSync: jest.fn((path: string) => files.has(path)),
+      rmSync: jest.fn((path: string) => { files.delete(path) }),
+      readFileSync: jest.fn((path: string) => {
+        const content = files.get(path)
+        if (content === undefined) throw new Error('ENOENT')
+        return content
+      }),
+      readdirSync: jest.fn(() => {
+        const names: string[] = []
+        for (const key of files.keys()) {
+          if (key.startsWith(`${TYPING_DIR}/`)) names.push(key.slice(TYPING_DIR.length + 1))
+        }
+        return names
+      }),
+      _files: files,
+    }
+  }
+
+  it('U-TY-DR-01: delivers an orphan JSON forward with HTML format and removes the file', async () => {
+    const files = new Map([[`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: '<b>plan</b> ready', format: 'html' })]])
+    const fsApi = makeDrainFsApi(files)
+    const bot = makeBotApi()
+
+    drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)
+    await Promise.resolve()
+
+    expect(bot.sendMessage).toHaveBeenCalledTimes(1)
+    expect(bot.sendMessage).toHaveBeenCalledWith(CHAT_ID, '<b>plan</b> ready', { parse_mode: 'HTML' })
+    expect(files.has(`${TYPING_DIR}/${CHAT_ID}.forward`)).toBe(false)
+  })
+
+  it('U-TY-DR-02: skips chats with a live typing state (stop() owns their delivery)', () => {
+    const files = new Map([[`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'hi', format: 'text' })]])
+    const fsApi = makeDrainFsApi(files)
+    const bot = makeBotApi()
+
+    drainOrphanForwards(TYPING_DIR, new Set([CHAT_ID]), bot, fsApi)
+
+    expect(bot.sendMessage).not.toHaveBeenCalled()
+    expect(files.has(`${TYPING_DIR}/${CHAT_ID}.forward`)).toBe(true)
+  })
+
+  it('U-TY-DR-03: lingering .replied means the reply tool already sent — removes both, no send', () => {
+    const files = new Map([
+      [`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'dup', format: 'text' })],
+      [`${TYPING_DIR}/${CHAT_ID}.replied`, '1'],
+    ])
+    const fsApi = makeDrainFsApi(files)
+    const bot = makeBotApi()
+
+    drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)
+
+    expect(bot.sendMessage).not.toHaveBeenCalled()
+    expect(files.has(`${TYPING_DIR}/${CHAT_ID}.forward`)).toBe(false)
+    expect(files.has(`${TYPING_DIR}/${CHAT_ID}.replied`)).toBe(false)
+  })
+
+  it('U-TY-DR-04: legacy plain-text forward (non-JSON) is delivered without parse_mode', async () => {
+    const files = new Map([[`${TYPING_DIR}/${CHAT_ID}.forward`, 'plain old text']])
+    const fsApi = makeDrainFsApi(files)
+    const bot = makeBotApi()
+
+    drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)
+    await Promise.resolve()
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(CHAT_ID, 'plain old text', {})
+  })
+
+  it('U-TY-DR-05: file is removed BEFORE sending so a slow send cannot double-deliver', async () => {
+    const files = new Map([[`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'once', format: 'text' })]])
+    const fsApi = makeDrainFsApi(files)
+    const bot = makeBotApi()
+
+    drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)
+
+    const rmOrder = fsApi.rmSync.mock.invocationCallOrder[0]
+    const sendOrder = bot.sendMessage.mock.invocationCallOrder[0]
+    expect(rmOrder).toBeLessThan(sendOrder)
+
+    // A second pass sees no file — nothing is re-sent.
+    drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)
+    await Promise.resolve()
+    expect(bot.sendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('U-TY-DR-06: unreadable typing dir is a no-op', () => {
+    const bot = makeBotApi()
+    const fsApi = makeDrainFsApi(new Map())
+    fsApi.readdirSync.mockImplementation(() => { throw new Error('ENOENT') })
+
+    expect(() => drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)).not.toThrow()
+    expect(bot.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('U-TY-DR-07: ignores non-forward files in the typing dir', () => {
+    const files = new Map([
+      [`${TYPING_DIR}/${CHAT_ID}`, '1'],
+      [`${TYPING_DIR}/${CHAT_ID}.heartbeat`, '1'],
+      [`${TYPING_DIR}/${CHAT_ID}.menu`, '{}'],
+    ])
+    const fsApi = makeDrainFsApi(files)
+    const bot = makeBotApi()
+
+    drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)
+
+    expect(bot.sendMessage).not.toHaveBeenCalled()
+    expect(files.size).toBe(3)
   })
 })

--- a/tests/unit/telegram-plugin/typing.test.ts
+++ b/tests/unit/telegram-plugin/typing.test.ts
@@ -1062,6 +1062,31 @@ describe('createWorkingStateManager', () => {
     it('U-TY-20: htmlToPlain strips tags and unescapes entities', () => {
       expect(htmlToPlain('<b>bold</b> <code>x &lt; y &amp;&amp; z &gt; w</code>')).toBe('bold x < y && z > w')
     })
+
+    it('U-TY-21: tag + space + unbroken over-limit token terminates (no infinite loop)', () => {
+      // Regression: the cut used to land on the space right after the opening
+      // tag, the balancer reopened the tag at the head of the remainder, and
+      // `rest` never shrank — hanging the whole receiver event loop.
+      const input = '<b> ' + 'x'.repeat(9000)
+      const chunks = chunkText(input, 4096, true)
+      expect(chunks.length).toBeGreaterThan(1)
+      const combined = chunks.map(c => c.replace(/<[^>]+>/g, '')).join('')
+      expect((combined.match(/x/g) ?? []).length).toBe(9000)
+      for (const c of chunks) expect(c.length).toBeLessThanOrEqual(4096)
+    })
+
+    it('U-TY-21b: degenerate single huge tag falls back to one oversized chunk instead of hanging', () => {
+      // A giant <a href> spanning past the limit can never be cut cleanly —
+      // emitting the remainder oversized (plain retry rescues it) beats looping.
+      const input = `<a href="https://example.com/${'q'.repeat(9000)}">link</a>`
+      const chunks = chunkText(input, 4096, true)
+      expect(chunks.length).toBeGreaterThanOrEqual(1)
+      expect(chunks.join('')).toContain('link')
+    })
+
+    it('U-TY-22: openTagStack tolerates ">" inside a quoted href', () => {
+      expect(openTagStack('<a href="https://x.y/a>b">link')).toEqual(['<a href="https://x.y/a>b">'])
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
Fixes three wrap-shell (PTY mode) delivery bugs that caused Telegram users to lose agent output: HTML chunking broke long-message delivery entirely, bridged AskUserQuestion menus arrived without the question text, and turns started autonomously after a background Task completion were never forwarded (plan-approval menus blocked the session silently).

## Related Issue
Closes #193

## Changes Made
- `mcp/tools/telegram/typing.ts`: tag-balancing chunker (close open tags at each cut, reopen at next chunk start, with headroom); `deliverForwardText()` retries each rejected HTML chunk as plain text — the generic delivery warning is a last resort only when plain delivery also fails; `drainOrphanForwards()` extracted for orphan `.forward` delivery
- `mcp/tools/telegram/receiver-server.ts`: standalone 1s poller draining orphan `.forward` files (skips chats with a live typing state, removes before send, honors `.replied` dedup) — mirrors the Discord receiver
- `src/shell/screen.ts`: `extractMenuContext()` captures the question lines above a bridged option run (bounded at the question box top border, capped at 12 lines / 1200 chars keeping the tail); `formatMenuPrompt()` prepends it
- `src/shell/claude-pty-shell.ts`: adopts an assistant record arriving with no `ActiveTurn` on a working screen as a synthetic turn, so result forwarding and menu bridging apply to autonomous wakes
- `src/shell/orphan-wake.ts` (new): `shouldAdoptOrphanWake()` pure gate with straggler-record safety (idle prompt on screen → no adoption)
- `src/agent/runner.ts`: forwards result prose preceding a bridged menu, stripping only the duplicated menu-text suffix (previously the whole result was dropped)
- `tests/unit/`: ~30 new unit cases across `typing.test.ts`, `pty-shell.test.ts`, and `agent-runner.test.ts` covering tag balancing, plain-text retry, context extraction, the orphan-wake gate, menu-suffix stripping, and the forward drainer

## Testing
- `npm run typecheck`: pass
- `npm test`: 111 suites / 2,172 tests pass
