### PR TITLE
[Fix] Resolve claude binary across native-installer and legacy layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 
 - Node.js 22+
 - [Claude Code CLI](https://claude.ai/code) v2.1.0+ installed and authenticated — `channels mode` is required (`claude --version`)
+  - The gateway must be able to find the `claude` executable: either have `claude` on the `PATH` of the process that launches the gateway, or set `CLAUDE_BIN` to its full path. When `CLAUDE_BIN` is unset, the gateway also probes the native-installer locations (`~/.local/bin/claude`, then `~/.local/share/claude/versions/`) and the legacy npm/nvm layout, so a Claude Code installer migration does not break new sessions. If none resolve, set `CLAUDE_BIN` explicitly (e.g. `CLAUDE_BIN=~/.local/bin/claude`).
 - [Bun](https://bun.sh) — runs the MCP server subprocess (`mcp/server.ts`)
 - A bot token per agent — Telegram (from [@BotFather](https://t.me/BotFather)) or Discord (from [Discord Developer Portal](https://discord.com/developers/applications))
 - **PTY backend only** (`claude.headless: false`): native build tools required for `node-pty` — `gcc`, `python3`, and `node-gyp` must be available at `npm install` time (pre-built binaries are included for common platforms; build tools are only needed if a pre-built binary is unavailable for your platform)

--- a/src/session/claude-bin.ts
+++ b/src/session/claude-bin.ts
@@ -1,0 +1,151 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Resolution of the `claude` executable shared by every host-side spawn site
+ * (session subprocess in `process.ts`, `claude --print` in `compactor.ts`).
+ *
+ * The Claude Code native-installer migration (2026-07) moved the binary out of
+ * the legacy npm/nvm layout into `~/.local`, so a gateway launched with a minimal
+ * PATH can no longer find `claude` on PATH alone. Centralizing the probe here
+ * keeps every spawn site consistent and avoids re-introducing the bug one call
+ * site at a time.
+ *
+ * NOTE: this resolves against the HOST filesystem. App-agents run claude inside a
+ * docker container, so they must NOT use this — a host path is meaningless in the
+ * container. Those call sites keep bare `claude` (resolved by the container PATH).
+ */
+
+/** Directory holding the native-installer stable `claude` symlink (`~/.local/bin`). */
+export function nativeClaudeBinDir(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.local', 'bin');
+}
+
+/** True if `p` is an existing, executable regular file (symlinks are followed). */
+export function isExecutableFile(p: string): boolean {
+  try {
+    if (!fs.statSync(p).isFile()) return false;
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve `cmd` against a PATH string, returning the first executable hit. */
+function findOnPath(cmd: string, pathEnv: string | undefined): string | null {
+  if (!pathEnv) return null;
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, cmd);
+    if (isExecutableFile(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Return the newest executable `claude` under a native-installer versions dir.
+ * Each version may be the binary itself (`versions/<ver>`) or a directory
+ * containing it (`versions/<ver>/claude`). Newest is decided by numeric-aware
+ * descending name sort so `2.1.206` beats `2.1.99`.
+ */
+function newestNativeVersion(versionsDir: string): string | null {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(versionsDir);
+  } catch {
+    return null;
+  }
+  const sorted = entries.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+  for (const name of sorted) {
+    const base = path.join(versionsDir, name);
+    if (isExecutableFile(base)) return base;
+    const nested = path.join(base, 'claude');
+    if (isExecutableFile(nested)) return nested;
+  }
+  return null;
+}
+
+export type ClaudeBinSource = 'PATH' | 'native-bin' | 'native-versions' | 'legacy-npm' | 'fallback';
+
+export interface ClaudeBinResolution {
+  /** Binary to spawn — a resolved absolute path, or bare `claude` as a last resort. */
+  bin: string;
+  /** Which probe resolved it (`fallback` = nothing found, spawning bare `claude`). */
+  source: ClaudeBinSource;
+  /** Ordered list of locations probed, for actionable error logging. */
+  searched: string[];
+}
+
+/**
+ * Resolve the `claude` executable when `CLAUDE_BIN` is not set. Probe order:
+ *   1. bare `claude` on PATH — respects the operator's environment when present
+ *   2. native stable symlink `~/.local/bin/claude`
+ *   3. newest native version under `~/.local/share/claude/versions/`
+ *   4. legacy npm-under-nvm `~/.nvm/versions/node/<v>/bin/claude`
+ * If every probe misses, fall back to bare `claude` so spawn still runs (and the
+ * failure surfaces through the caller's error log with the searched paths).
+ *
+ * LIMITATION: the PATH probe accepts the first *executable* `claude` it finds,
+ * so a broken drop-in shim that is executable but exits non-zero (the exact
+ * failure that motivated this) still wins here. Detecting that would require
+ * running the binary, which is out of scope (see issue #192 — the deployed host
+ * shim is an ops fix). The child PATH is hardened with the native bin dir (see
+ * pathWithNativeBin) so a genuine native install is preferred when both exist.
+ */
+export function resolveClaudeBin(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir(),
+): ClaudeBinResolution {
+  const searched: string[] = [];
+
+  searched.push('claude (PATH)');
+  if (findOnPath('claude', env.PATH)) {
+    return { bin: 'claude', source: 'PATH', searched };
+  }
+
+  const nativeBin = path.join(nativeClaudeBinDir(homeDir), 'claude');
+  searched.push(nativeBin);
+  if (isExecutableFile(nativeBin)) {
+    return { bin: nativeBin, source: 'native-bin', searched };
+  }
+
+  const versionsDir = path.join(homeDir, '.local', 'share', 'claude', 'versions');
+  searched.push(path.join(versionsDir, '*'));
+  const nativeVersion = newestNativeVersion(versionsDir);
+  if (nativeVersion) {
+    return { bin: nativeVersion, source: 'native-versions', searched };
+  }
+
+  const nvmDir = path.join(homeDir, '.nvm', 'versions', 'node');
+  searched.push(path.join(nvmDir, '*', 'bin', 'claude'));
+  try {
+    for (const node of fs.readdirSync(nvmDir).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))) {
+      const candidate = path.join(nvmDir, node, 'bin', 'claude');
+      if (isExecutableFile(candidate)) {
+        return { bin: candidate, source: 'legacy-npm', searched };
+      }
+    }
+  } catch {
+    /* no nvm layout */
+  }
+
+  return { bin: 'claude', source: 'fallback', searched };
+}
+
+/**
+ * PATH with the native-installer bin dir prepended when it holds an executable
+ * `claude`, so a spawned child resolves the native install ahead of a stale
+ * legacy shim even if the gateway itself launched with a pre-migration PATH.
+ * Returns the original PATH unchanged when there is no native install.
+ */
+export function pathWithNativeBin(
+  homeDir: string = os.homedir(),
+  pathEnv: string | undefined = process.env.PATH,
+): string | undefined {
+  const nativeBinDir = nativeClaudeBinDir(homeDir);
+  return isExecutableFile(path.join(nativeBinDir, 'claude'))
+    ? `${nativeBinDir}${path.delimiter}${pathEnv ?? ''}`
+    : pathEnv;
+}

--- a/src/session/compactor.ts
+++ b/src/session/compactor.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import { Message } from '../types';
 import { SessionStore } from './store';
+import { resolveClaudeBin, pathWithNativeBin } from './claude-bin';
 
 export interface CompactionResult {
   beforeMessages: number;
@@ -144,11 +145,19 @@ export class SessionCompactor {
     // Wrap content in XML tags so claude treats it as data to analyze, not an active conversation
     const prompt = `${COMPACTOR_SYSTEM_PROMPT}\n\n${instruction}\n\n<transcript>\n${text}\n</transcript>\n\nWrite a concise summary of the above transcript now:`;
 
-    const result = spawnSync('claude', ['--print'], {
+    // Resolve claude the same way the session subprocess does: honor CLAUDE_BIN
+    // (which may carry args), else probe PATH and the native/legacy install
+    // locations. This runs in the gateway's own (possibly minimal) PATH, so
+    // without resolution `claude --print` would fail identically to a session
+    // spawn after the native-installer migration.
+    const claudeBinRaw = process.env.CLAUDE_BIN ?? resolveClaudeBin().bin;
+    const [claudeBin, ...claudeBinArgs] = claudeBinRaw.split(' ');
+
+    const result = spawnSync(claudeBin, [...claudeBinArgs, '--print'], {
       input: prompt,
       encoding: 'utf-8',
       timeout: 300_000,
-      env: process.env,
+      env: { ...process.env, PATH: pathWithNativeBin() },
     });
 
     if (result.error) {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -64,9 +64,14 @@ export class SessionProcess extends EventEmitter {
   private thinkingRecoveryCount = 0;
   // Binary path last spawned and the last non-empty stderr line, retained so a
   // fatal `Session max restarts reached` names what actually failed (e.g. an
-  // unresolvable `claude` binary) instead of ending in silence.
+  // unresolvable `claude` binary) instead of ending in silence. `stderrBuffer`
+  // holds an unterminated trailing fragment so a line split across two `data`
+  // chunks is not captured as two partial lines.
   private lastClaudeBin = 'claude';
   private lastStderrLine: string | null = null;
+  private stderrBuffer = '';
+  // Log the resolved-binary source once per instance, not on every restart spawn.
+  private resolvedBinLogged = false;
   private _queryResolve?: (text: string) => void;
   private _queryBuffer = '';
   private _queryTimer?: ReturnType<typeof setTimeout>;
@@ -434,7 +439,10 @@ export class SessionProcess extends EventEmitter {
           searched: resolution.searched,
           hint: 'set CLAUDE_BIN to the claude executable path (native install: ~/.local/bin/claude)',
         });
-      } else if (resolution.source !== 'PATH') {
+      } else if (resolution.source !== 'PATH' && !this.resolvedBinLogged) {
+        // Log the non-PATH resolution once per instance; auto-restarts re-resolve
+        // the same location and would otherwise repeat this line on every spawn.
+        this.resolvedBinLogged = true;
         this.logger.info('Resolved claude binary from an install location', {
           sessionId: this.sessionId,
           bin: resolution.bin,
@@ -735,12 +743,22 @@ export class SessionProcess extends EventEmitter {
 
     proc.stderr?.on('data', (data: Buffer) => {
       const text = data.toString();
-      const lastLine = text.split('\n').map(l => l.trim()).filter(Boolean).pop();
+      // Buffer across chunks: split into complete lines and retain any unterminated
+      // trailing fragment so a line split on a chunk boundary is not seen as two.
+      this.stderrBuffer += text;
+      const lines = this.stderrBuffer.split('\n');
+      this.stderrBuffer = lines.pop() ?? '';
+      const lastLine = lines.map(l => l.trim()).filter(Boolean).pop();
       if (lastLine) this.lastStderrLine = lastLine;
       this.logger.warn('session stderr', { stderr: text });
     });
 
     proc.on('exit', (code, signal) => {
+      // Flush any unterminated trailing stderr fragment (a process that dies
+      // mid-line writes no final newline) so it can still surface as lastStderr.
+      const trailing = this.stderrBuffer.trim();
+      if (trailing) this.lastStderrLine = trailing;
+      this.stderrBuffer = '';
       this.logger.info('session subprocess exited', {
         code,
         signal,
@@ -760,6 +778,11 @@ export class SessionProcess extends EventEmitter {
     });
 
     proc.on('error', (err) => {
+      // A missing/unresolvable binary surfaces here as an ENOENT `error` event
+      // (e.g. `spawn /path/claude ENOENT`), NOT on stderr — capture it so the
+      // fatal max-restarts log can name the real cause and fire the CLAUDE_BIN
+      // hint. This is the exact failure the binary-resolution work targets.
+      this.lastStderrLine = err.message;
       this.logger.error('session subprocess error', { error: err.message });
     });
   }
@@ -772,7 +795,9 @@ export class SessionProcess extends EventEmitter {
       this.restartCount = 0;
     }
     if (this.restartCount >= MAX_RESTARTS) {
-      const binNotFound = this.lastStderrLine?.includes('binary not found');
+      // Match both the CLI's own "binary not found" text and Node's spawn ENOENT
+      // (the shape a genuinely unresolvable claude binary produces).
+      const binNotFound = /binary not found|ENOENT/i.test(this.lastStderrLine ?? '');
       this.logger.error('Session max restarts reached', {
         sessionId: this.sessionId,
         claudeBin: this.lastClaudeBin,

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -9,6 +9,7 @@ import { SessionStore } from './store';
 import { createLogger } from '../logger';
 import { ptyStreamRegistry } from '../shell/pty-stream-registry';
 import { neutralizeTuiTriggers } from '../shell/screen';
+import { resolveClaudeBin, pathWithNativeBin } from './claude-bin';
 import {
   CODING_TOOLS,
   TOOL_LABELS,
@@ -24,120 +25,6 @@ const MAX_RESTARTS = 3;
 const MAX_THINKING_RECOVERIES = 2;
 const CHANNELS_ACTIVATION_PROMPT =
   'Channels mode is active. Wait for incoming messages from your channels and respond to them.';
-
-/** Directory holding the native-installer stable `claude` symlink (`~/.local/bin`). */
-function nativeClaudeBinDir(homeDir: string): string {
-  return path.join(homeDir, '.local', 'bin');
-}
-
-/** True if `p` is an existing, executable regular file. */
-function isExecutableFile(p: string): boolean {
-  try {
-    if (!fs.statSync(p).isFile()) return false;
-    fs.accessSync(p, fs.constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/** Resolve `cmd` against a PATH string, returning the first executable hit. */
-function findOnPath(cmd: string, pathEnv: string | undefined): string | null {
-  if (!pathEnv) return null;
-  for (const dir of pathEnv.split(path.delimiter)) {
-    if (!dir) continue;
-    const candidate = path.join(dir, cmd);
-    if (isExecutableFile(candidate)) return candidate;
-  }
-  return null;
-}
-
-/**
- * Return the newest executable `claude` under a native-installer versions dir.
- * Each version may be the binary itself (`versions/<ver>`) or a directory
- * containing it (`versions/<ver>/claude`). Newest is decided by numeric-aware
- * descending name sort so `2.1.206` beats `2.1.99`.
- */
-function newestNativeVersion(versionsDir: string): string | null {
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(versionsDir);
-  } catch {
-    return null;
-  }
-  const sorted = entries.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
-  for (const name of sorted) {
-    const base = path.join(versionsDir, name);
-    if (isExecutableFile(base)) return base;
-    const nested = path.join(base, 'claude');
-    if (isExecutableFile(nested)) return nested;
-  }
-  return null;
-}
-
-export type ClaudeBinSource = 'PATH' | 'native-bin' | 'native-versions' | 'legacy-npm' | 'fallback';
-
-export interface ClaudeBinResolution {
-  /** Binary to spawn — a resolved absolute path, or bare `claude` as a last resort. */
-  bin: string;
-  /** Which probe resolved it (`fallback` = nothing found, spawning bare `claude`). */
-  source: ClaudeBinSource;
-  /** Ordered list of locations probed, for actionable error logging. */
-  searched: string[];
-}
-
-/**
- * Resolve the `claude` executable when `CLAUDE_BIN` is not set.
- *
- * The Claude Code native-installer migration (2026-07) moved the binary out of
- * the legacy npm/nvm layout into `~/.local/...`, so a gateway started with a
- * minimal PATH can no longer find `claude` on PATH alone. Probe order:
- *   1. bare `claude` on PATH — respects the operator's environment when present
- *   2. native stable symlink `~/.local/bin/claude`
- *   3. newest native version under `~/.local/share/claude/versions/`
- *   4. legacy npm-under-nvm `~/.nvm/versions/node/<v>/bin/claude`
- * If every probe misses, fall back to bare `claude` so spawn still runs (and the
- * failure surfaces through the retry logger with the searched paths).
- */
-export function resolveClaudeBin(
-  env: NodeJS.ProcessEnv = process.env,
-  homeDir: string = os.homedir(),
-): ClaudeBinResolution {
-  const searched: string[] = [];
-
-  searched.push('claude (PATH)');
-  if (findOnPath('claude', env.PATH)) {
-    return { bin: 'claude', source: 'PATH', searched };
-  }
-
-  const nativeBin = path.join(nativeClaudeBinDir(homeDir), 'claude');
-  searched.push(nativeBin);
-  if (isExecutableFile(nativeBin)) {
-    return { bin: nativeBin, source: 'native-bin', searched };
-  }
-
-  const versionsDir = path.join(homeDir, '.local', 'share', 'claude', 'versions');
-  searched.push(path.join(versionsDir, '*'));
-  const nativeVersion = newestNativeVersion(versionsDir);
-  if (nativeVersion) {
-    return { bin: nativeVersion, source: 'native-versions', searched };
-  }
-
-  const nvmDir = path.join(homeDir, '.nvm', 'versions', 'node');
-  searched.push(path.join(nvmDir, '*', 'bin', 'claude'));
-  try {
-    for (const node of fs.readdirSync(nvmDir).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))) {
-      const candidate = path.join(nvmDir, node, 'bin', 'claude');
-      if (isExecutableFile(candidate)) {
-        return { bin: candidate, source: 'legacy-npm', searched };
-      }
-    }
-  } catch {
-    /* no nvm layout */
-  }
-
-  return { bin: 'claude', source: 'fallback', searched };
-}
 
 export class SessionProcess extends EventEmitter {
   readonly sessionId: string;
@@ -532,6 +419,12 @@ export class SessionProcess extends EventEmitter {
     let claudeBinRaw: string;
     if (process.env.CLAUDE_BIN) {
       claudeBinRaw = process.env.CLAUDE_BIN;
+    } else if (isAppAgent) {
+      // App-agents run claude INSIDE the container; host-side resolution would
+      // point at a host path that need not exist in the container. Keep bare
+      // `claude` so the container's own PATH resolves it (agentConfig.claudeBin
+      // overrides below when the image installs claude elsewhere).
+      claudeBinRaw = 'claude';
     } else {
       const resolution = resolveClaudeBin();
       claudeBinRaw = resolution.bin;
@@ -629,10 +522,7 @@ export class SessionProcess extends EventEmitter {
     // Ensure the native-installer bin dir is on the child's PATH when it exists,
     // so a bare `claude` resolves even if the gateway itself was launched with a
     // minimal PATH that predates the native-installer migration.
-    const nativeBinDir = nativeClaudeBinDir(os.homedir());
-    const hardenedPath = isExecutableFile(path.join(nativeBinDir, 'claude'))
-      ? `${nativeBinDir}${path.delimiter}${process.env.PATH ?? ''}`
-      : process.env.PATH;
+    const hardenedPath = pathWithNativeBin();
 
     const proc = spawn(spawnBin, spawnArgs, {
       env: {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -25,6 +25,120 @@ const MAX_THINKING_RECOVERIES = 2;
 const CHANNELS_ACTIVATION_PROMPT =
   'Channels mode is active. Wait for incoming messages from your channels and respond to them.';
 
+/** Directory holding the native-installer stable `claude` symlink (`~/.local/bin`). */
+function nativeClaudeBinDir(homeDir: string): string {
+  return path.join(homeDir, '.local', 'bin');
+}
+
+/** True if `p` is an existing, executable regular file. */
+function isExecutableFile(p: string): boolean {
+  try {
+    if (!fs.statSync(p).isFile()) return false;
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve `cmd` against a PATH string, returning the first executable hit. */
+function findOnPath(cmd: string, pathEnv: string | undefined): string | null {
+  if (!pathEnv) return null;
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, cmd);
+    if (isExecutableFile(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Return the newest executable `claude` under a native-installer versions dir.
+ * Each version may be the binary itself (`versions/<ver>`) or a directory
+ * containing it (`versions/<ver>/claude`). Newest is decided by numeric-aware
+ * descending name sort so `2.1.206` beats `2.1.99`.
+ */
+function newestNativeVersion(versionsDir: string): string | null {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(versionsDir);
+  } catch {
+    return null;
+  }
+  const sorted = entries.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+  for (const name of sorted) {
+    const base = path.join(versionsDir, name);
+    if (isExecutableFile(base)) return base;
+    const nested = path.join(base, 'claude');
+    if (isExecutableFile(nested)) return nested;
+  }
+  return null;
+}
+
+export type ClaudeBinSource = 'PATH' | 'native-bin' | 'native-versions' | 'legacy-npm' | 'fallback';
+
+export interface ClaudeBinResolution {
+  /** Binary to spawn — a resolved absolute path, or bare `claude` as a last resort. */
+  bin: string;
+  /** Which probe resolved it (`fallback` = nothing found, spawning bare `claude`). */
+  source: ClaudeBinSource;
+  /** Ordered list of locations probed, for actionable error logging. */
+  searched: string[];
+}
+
+/**
+ * Resolve the `claude` executable when `CLAUDE_BIN` is not set.
+ *
+ * The Claude Code native-installer migration (2026-07) moved the binary out of
+ * the legacy npm/nvm layout into `~/.local/...`, so a gateway started with a
+ * minimal PATH can no longer find `claude` on PATH alone. Probe order:
+ *   1. bare `claude` on PATH — respects the operator's environment when present
+ *   2. native stable symlink `~/.local/bin/claude`
+ *   3. newest native version under `~/.local/share/claude/versions/`
+ *   4. legacy npm-under-nvm `~/.nvm/versions/node/<v>/bin/claude`
+ * If every probe misses, fall back to bare `claude` so spawn still runs (and the
+ * failure surfaces through the retry logger with the searched paths).
+ */
+export function resolveClaudeBin(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir(),
+): ClaudeBinResolution {
+  const searched: string[] = [];
+
+  searched.push('claude (PATH)');
+  if (findOnPath('claude', env.PATH)) {
+    return { bin: 'claude', source: 'PATH', searched };
+  }
+
+  const nativeBin = path.join(nativeClaudeBinDir(homeDir), 'claude');
+  searched.push(nativeBin);
+  if (isExecutableFile(nativeBin)) {
+    return { bin: nativeBin, source: 'native-bin', searched };
+  }
+
+  const versionsDir = path.join(homeDir, '.local', 'share', 'claude', 'versions');
+  searched.push(path.join(versionsDir, '*'));
+  const nativeVersion = newestNativeVersion(versionsDir);
+  if (nativeVersion) {
+    return { bin: nativeVersion, source: 'native-versions', searched };
+  }
+
+  const nvmDir = path.join(homeDir, '.nvm', 'versions', 'node');
+  searched.push(path.join(nvmDir, '*', 'bin', 'claude'));
+  try {
+    for (const node of fs.readdirSync(nvmDir).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))) {
+      const candidate = path.join(nvmDir, node, 'bin', 'claude');
+      if (isExecutableFile(candidate)) {
+        return { bin: candidate, source: 'legacy-npm', searched };
+      }
+    }
+  } catch {
+    /* no nvm layout */
+  }
+
+  return { bin: 'claude', source: 'fallback', searched };
+}
+
 export class SessionProcess extends EventEmitter {
   readonly sessionId: string;
   readonly chatId: string;
@@ -61,6 +175,11 @@ export class SessionProcess extends EventEmitter {
   // reset to 0 until the first tokenUsage event fires.
   private lastTotalTokens = 0;
   private thinkingRecoveryCount = 0;
+  // Binary path last spawned and the last non-empty stderr line, retained so a
+  // fatal `Session max restarts reached` names what actually failed (e.g. an
+  // unresolvable `claude` binary) instead of ending in silence.
+  private lastClaudeBin = 'claude';
+  private lastStderrLine: string | null = null;
   private _queryResolve?: (text: string) => void;
   private _queryBuffer = '';
   private _queryTimer?: ReturnType<typeof setTimeout>;
@@ -407,7 +526,29 @@ export class SessionProcess extends EventEmitter {
     const freshModel = this.readFreshModel();
     const args = this.buildArgs(effectiveMcpPath, freshModel);
 
-    const claudeBinRaw = process.env.CLAUDE_BIN ?? 'claude';
+    // Resolve the claude binary. An explicit CLAUDE_BIN (which may carry args) is
+    // trusted verbatim; otherwise probe PATH and the native-installer / legacy
+    // install locations so a gateway launched with a minimal PATH still finds it.
+    let claudeBinRaw: string;
+    if (process.env.CLAUDE_BIN) {
+      claudeBinRaw = process.env.CLAUDE_BIN;
+    } else {
+      const resolution = resolveClaudeBin();
+      claudeBinRaw = resolution.bin;
+      if (resolution.source === 'fallback') {
+        this.logger.warn('Could not resolve the claude binary — spawning bare "claude" as a last resort', {
+          sessionId: this.sessionId,
+          searched: resolution.searched,
+          hint: 'set CLAUDE_BIN to the claude executable path (native install: ~/.local/bin/claude)',
+        });
+      } else if (resolution.source !== 'PATH') {
+        this.logger.info('Resolved claude binary from an install location', {
+          sessionId: this.sessionId,
+          bin: resolution.bin,
+          source: resolution.source,
+        });
+      }
+    }
     const claudeBinParts = claudeBinRaw.split(' ');
     let claudeBin = claudeBinParts[0];
     let allArgs = [...claudeBinParts.slice(1), ...args];
@@ -450,6 +591,9 @@ export class SessionProcess extends EventEmitter {
     });
 
     const spawnBin = isAppAgent ? 'docker' : claudeBin;
+    // Record the claude binary targeted this spawn so a fatal restart failure
+    // can name it (app-agents run claude inside the container).
+    this.lastClaudeBin = isAppAgent ? (this.agentConfig.claudeBin ?? claudeBinRaw) : claudeBinRaw;
 
     // env vars that must be forwarded into the container via `docker exec -e`
     let containerUid = 1000;
@@ -482,9 +626,18 @@ export class SessionProcess extends EventEmitter {
       ptyStreamRegistry.listen(this.sessionId, ptyStreamSocketPath);
     }
 
+    // Ensure the native-installer bin dir is on the child's PATH when it exists,
+    // so a bare `claude` resolves even if the gateway itself was launched with a
+    // minimal PATH that predates the native-installer migration.
+    const nativeBinDir = nativeClaudeBinDir(os.homedir());
+    const hardenedPath = isExecutableFile(path.join(nativeBinDir, 'claude'))
+      ? `${nativeBinDir}${path.delimiter}${process.env.PATH ?? ''}`
+      : process.env.PATH;
+
     const proc = spawn(spawnBin, spawnArgs, {
       env: {
         ...process.env,
+        ...(hardenedPath ? { PATH: hardenedPath } : {}),
         CLAUDE_WORKSPACE: isAppAgent ? '/workspace' : this.agentConfig.workspace,
         TELEGRAM_BOT_TOKEN: this.agentConfig.telegram?.botToken ?? '',
         GATEWAY_RESTART_SIGNAL_PATH: this.restartSignalPath,
@@ -691,7 +844,10 @@ export class SessionProcess extends EventEmitter {
     });
 
     proc.stderr?.on('data', (data: Buffer) => {
-      this.logger.warn('session stderr', { stderr: data.toString() });
+      const text = data.toString();
+      const lastLine = text.split('\n').map(l => l.trim()).filter(Boolean).pop();
+      if (lastLine) this.lastStderrLine = lastLine;
+      this.logger.warn('session stderr', { stderr: text });
     });
 
     proc.on('exit', (code, signal) => {
@@ -726,7 +882,15 @@ export class SessionProcess extends EventEmitter {
       this.restartCount = 0;
     }
     if (this.restartCount >= MAX_RESTARTS) {
-      this.logger.error('Session max restarts reached', { sessionId: this.sessionId });
+      const binNotFound = this.lastStderrLine?.includes('binary not found');
+      this.logger.error('Session max restarts reached', {
+        sessionId: this.sessionId,
+        claudeBin: this.lastClaudeBin,
+        lastStderr: this.lastStderrLine ?? null,
+        ...(binNotFound
+          ? { hint: 'claude executable is not resolvable — set CLAUDE_BIN to the claude path (native install: ~/.local/bin/claude)' }
+          : {}),
+      });
       this.emit('failed');
       return;
     }

--- a/tests/unit/claude-bin.test.ts
+++ b/tests/unit/claude-bin.test.ts
@@ -1,0 +1,153 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveClaudeBin, pathWithNativeBin, isExecutableFile } from '../../src/session/claude-bin';
+
+// Exercised against real temp dirs so the executable-file checks run for real.
+describe('resolveClaudeBin', () => {
+  let dir: string;
+
+  const mkExec = (p: string): void => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '#!/bin/sh\n');
+    fs.chmodSync(p, 0o755);
+  };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rcb-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('resolves bare `claude` from PATH when present', () => {
+    const binDir = path.join(dir, 'pathbin');
+    mkExec(path.join(binDir, 'claude'));
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(home);
+
+    const r = resolveClaudeBin({ PATH: binDir }, home);
+    expect(r.bin).toBe('claude');
+    expect(r.source).toBe('PATH');
+  });
+
+  it('falls back to the native ~/.local/bin/claude symlink when not on PATH', () => {
+    const home = path.join(dir, 'home');
+    const nativeBin = path.join(home, '.local', 'bin', 'claude');
+    mkExec(nativeBin);
+
+    const r = resolveClaudeBin({ PATH: path.join(dir, 'empty') }, home);
+    expect(r.bin).toBe(nativeBin);
+    expect(r.source).toBe('native-bin');
+  });
+
+  it('falls back to the newest native version dir (numeric-aware)', () => {
+    const home = path.join(dir, 'home');
+    const versions = path.join(home, '.local', 'share', 'claude', 'versions');
+    mkExec(path.join(versions, '2.1.99', 'claude'));
+    mkExec(path.join(versions, '2.1.206', 'claude'));
+
+    const r = resolveClaudeBin({ PATH: '' }, home);
+    expect(r.source).toBe('native-versions');
+    expect(r.bin).toBe(path.join(versions, '2.1.206', 'claude'));
+  });
+
+  it('resolves a native version stored as a bare file (versions/<ver>)', () => {
+    const home = path.join(dir, 'home');
+    const versions = path.join(home, '.local', 'share', 'claude', 'versions');
+    mkExec(path.join(versions, '2.1.206'));
+
+    const r = resolveClaudeBin({ PATH: '' }, home);
+    expect(r.source).toBe('native-versions');
+    expect(r.bin).toBe(path.join(versions, '2.1.206'));
+  });
+
+  it('falls back to the legacy npm-under-nvm path', () => {
+    const home = path.join(dir, 'home');
+    const legacy = path.join(home, '.nvm', 'versions', 'node', 'v22.22.3', 'bin', 'claude');
+    mkExec(legacy);
+
+    const r = resolveClaudeBin({ PATH: '' }, home);
+    expect(r.source).toBe('legacy-npm');
+    expect(r.bin).toBe(legacy);
+  });
+
+  it('returns fallback `claude` with the searched paths when nothing resolves', () => {
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(home);
+
+    const r = resolveClaudeBin({ PATH: path.join(dir, 'nope') }, home);
+    expect(r.bin).toBe('claude');
+    expect(r.source).toBe('fallback');
+    expect(r.searched).toContain('claude (PATH)');
+    expect(r.searched.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('ignores a non-executable `claude` on PATH', () => {
+    const binDir = path.join(dir, 'pathbin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'claude'), 'plain'); // no +x bit
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(home);
+
+    const r = resolveClaudeBin({ PATH: binDir }, home);
+    expect(r.source).toBe('fallback');
+  });
+});
+
+describe('pathWithNativeBin', () => {
+  let dir: string;
+
+  const mkExec = (p: string): void => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '#!/bin/sh\n');
+    fs.chmodSync(p, 0o755);
+  };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pwnb-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('prepends ~/.local/bin when it holds an executable claude', () => {
+    const home = path.join(dir, 'home');
+    mkExec(path.join(home, '.local', 'bin', 'claude'));
+
+    const result = pathWithNativeBin(home, '/usr/bin');
+    expect(result).toBe(`${path.join(home, '.local', 'bin')}${path.delimiter}/usr/bin`);
+  });
+
+  it('returns the original PATH unchanged when there is no native install', () => {
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(home);
+
+    expect(pathWithNativeBin(home, '/usr/bin')).toBe('/usr/bin');
+  });
+});
+
+describe('isExecutableFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exe-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('is false for a directory, a missing path, and a non-executable file', () => {
+    const subdir = path.join(dir, 'sub');
+    fs.mkdirSync(subdir);
+    const plain = path.join(dir, 'plain');
+    fs.writeFileSync(plain, 'x');
+
+    expect(isExecutableFile(subdir)).toBe(false);
+    expect(isExecutableFile(path.join(dir, 'missing'))).toBe(false);
+    expect(isExecutableFile(plain)).toBe(false);
+  });
+});

--- a/tests/unit/session-compactor.test.ts
+++ b/tests/unit/session-compactor.test.ts
@@ -119,6 +119,61 @@ describe('SessionCompactor', () => {
   });
 
   // -------------------------------------------------------------------------
+  // U-CB1: the summary call honors CLAUDE_BIN (which may carry args) and always
+  // appends --print. Prevents the `claude --print` site from regressing to a
+  // hardcoded bare `claude` that a native-installer migration would break.
+  // -------------------------------------------------------------------------
+  it('U-CB1: honors CLAUDE_BIN (with args) and passes --print', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+    for (let i = 0; i < 6; i++) {
+      const role = i % 2 === 0 ? 'user' : 'assistant';
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `m${i}`));
+    }
+    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('summary'));
+
+    const prev = process.env.CLAUDE_BIN;
+    process.env.CLAUDE_BIN = 'node /opt/claude/cli.js';
+    try {
+      await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_BIN;
+      else process.env.CLAUDE_BIN = prev;
+    }
+
+    const [bin, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
+    expect(bin).toBe('node');
+    expect(args).toEqual(['/opt/claude/cli.js', '--print']);
+  });
+
+  // -------------------------------------------------------------------------
+  // U-CB2: with CLAUDE_BIN unset the binary is resolved (non-empty) and --print
+  // is still the final arg.
+  // -------------------------------------------------------------------------
+  it('U-CB2: resolves a binary and passes --print when CLAUDE_BIN is unset', async () => {
+    const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+    const sessionId = index.activeSessionId;
+    for (let i = 0; i < 6; i++) {
+      const role = i % 2 === 0 ? 'user' : 'assistant';
+      await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `m${i}`));
+    }
+    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('summary'));
+
+    const prev = process.env.CLAUDE_BIN;
+    delete process.env.CLAUDE_BIN;
+    try {
+      await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+    } finally {
+      if (prev !== undefined) process.env.CLAUDE_BIN = prev;
+    }
+
+    const [bin, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
+    expect(typeof bin).toBe('string');
+    expect(bin.length).toBeGreaterThan(0);
+    expect(args[args.length - 1]).toBe('--print');
+  });
+
+  // -------------------------------------------------------------------------
   // U20: compacted history has summary system message + last 40 verbatim
   // -------------------------------------------------------------------------
   it('U20: compacted history has summary system message as first entry plus last 40 verbatim messages', async () => {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -13,6 +13,18 @@ jest.mock('os', () => {
   };
 });
 
+// ── claude-bin mock (override the resolved binary per-test) ───────────────────
+// Default 'claude' mirrors PATH resolution, so existing specs are unaffected;
+// the app-agent guard specs raise it to a host-only path to prove the guard.
+let mockResolvedBin = 'claude';
+jest.mock('../../src/session/claude-bin', () => {
+  const real = jest.requireActual('../../src/session/claude-bin');
+  return {
+    ...real,
+    resolveClaudeBin: () => ({ bin: mockResolvedBin, source: 'native-bin', searched: [] }),
+  };
+});
+
 // ── Minimal mock types ────────────────────────────────────────────────────────
 
 interface MockStdin {
@@ -72,7 +84,7 @@ jest.mock('child_process', () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { SessionProcess, resolveClaudeBin } from '../../src/session/process';
+import { SessionProcess } from '../../src/session/process';
 import { SessionStore } from '../../src/session/store';
 import { AgentConfig, GatewayConfig } from '../../src/types';
 
@@ -119,6 +131,8 @@ describe('SessionProcess', () => {
     sessionStore = new SessionStore(path.join(tmpDir, 'sessions'));
     lastProcess = null;
     mockHomeDir = null;
+    mockResolvedBin = 'claude';
+    delete process.env.CLAUDE_BIN; // keep binary-resolution specs deterministic
     spawnMock = require('child_process').spawn as jest.Mock;
     spawnMock.mockClear();
   });
@@ -1959,99 +1973,41 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
 
     await sp.stop();
   });
-});
 
-// ── resolveClaudeBin ──────────────────────────────────────────────────────────
-// Pure binary-resolution probe used when CLAUDE_BIN is unset. Exercised against
-// real temp dirs so the executable-file checks run for real (fs is not mocked).
-describe('resolveClaudeBin', () => {
-  let dir: string;
+  // --------------------------------------------------------------------------
+  // U-SP-BIN3: a non-app-agent session spawns the host-resolved binary directly.
+  // --------------------------------------------------------------------------
+  it('U-SP-BIN3: host session spawns the resolved binary path', async () => {
+    mockResolvedBin = '/home/u/.local/bin/claude';
+    const sp = new SessionProcess('chat:bin3', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
 
-  const mkExec = (p: string): void => {
-    fs.mkdirSync(path.dirname(p), { recursive: true });
-    fs.writeFileSync(p, '#!/bin/sh\n');
-    fs.chmodSync(p, 0o755);
-  };
+    expect(spawnMock.mock.calls[0][0]).toBe('/home/u/.local/bin/claude');
 
-  beforeEach(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rcb-'));
+    await sp.stop();
   });
 
-  afterEach(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
+  // --------------------------------------------------------------------------
+  // U-SP-BIN4: app-agents run claude INSIDE the container, so host-side
+  // resolution must NOT leak a host path into the container — the in-container
+  // binary stays bare `claude` (resolved by the container PATH). Regression guard.
+  // --------------------------------------------------------------------------
+  it('U-SP-BIN4: app-agent does not leak the host-resolved path into the container', async () => {
+    mockResolvedBin = '/home/u/.local/bin/claude'; // a host-only path
+    const appAgent = makeAgentConfig({
+      workspace: agentConfig.workspace,
+      type: 'app-agent',
+      container: 'my-app-container',
+    });
+    const sp = new SessionProcess('chat:bin4', 'telegram', appAgent, gatewayConfig, sessionStore);
+    await sp.start();
 
-  it('resolves bare `claude` from PATH when present', () => {
-    const binDir = path.join(dir, 'pathbin');
-    mkExec(path.join(binDir, 'claude'));
-    const home = path.join(dir, 'home');
-    fs.mkdirSync(home);
+    const [spawnBin, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(spawnBin).toBe('docker');
+    // The in-container binary is bare `claude`, never the host-resolved path.
+    expect(spawnArgs).toContain('claude');
+    expect(spawnArgs).not.toContain('/home/u/.local/bin/claude');
 
-    const r = resolveClaudeBin({ PATH: binDir }, home);
-    expect(r.bin).toBe('claude');
-    expect(r.source).toBe('PATH');
-  });
-
-  it('falls back to the native ~/.local/bin/claude symlink when not on PATH', () => {
-    const home = path.join(dir, 'home');
-    const nativeBin = path.join(home, '.local', 'bin', 'claude');
-    mkExec(nativeBin);
-
-    const r = resolveClaudeBin({ PATH: path.join(dir, 'empty') }, home);
-    expect(r.bin).toBe(nativeBin);
-    expect(r.source).toBe('native-bin');
-  });
-
-  it('falls back to the newest native version dir (numeric-aware)', () => {
-    const home = path.join(dir, 'home');
-    const versions = path.join(home, '.local', 'share', 'claude', 'versions');
-    mkExec(path.join(versions, '2.1.99', 'claude'));
-    mkExec(path.join(versions, '2.1.206', 'claude'));
-
-    const r = resolveClaudeBin({ PATH: '' }, home);
-    expect(r.source).toBe('native-versions');
-    expect(r.bin).toBe(path.join(versions, '2.1.206', 'claude'));
-  });
-
-  it('resolves a native version stored as a bare file (versions/<ver>)', () => {
-    const home = path.join(dir, 'home');
-    const versions = path.join(home, '.local', 'share', 'claude', 'versions');
-    mkExec(path.join(versions, '2.1.206'));
-
-    const r = resolveClaudeBin({ PATH: '' }, home);
-    expect(r.source).toBe('native-versions');
-    expect(r.bin).toBe(path.join(versions, '2.1.206'));
-  });
-
-  it('falls back to the legacy npm-under-nvm path', () => {
-    const home = path.join(dir, 'home');
-    const legacy = path.join(home, '.nvm', 'versions', 'node', 'v22.22.3', 'bin', 'claude');
-    mkExec(legacy);
-
-    const r = resolveClaudeBin({ PATH: '' }, home);
-    expect(r.source).toBe('legacy-npm');
-    expect(r.bin).toBe(legacy);
-  });
-
-  it('returns fallback `claude` with the searched paths when nothing resolves', () => {
-    const home = path.join(dir, 'home');
-    fs.mkdirSync(home);
-
-    const r = resolveClaudeBin({ PATH: path.join(dir, 'nope') }, home);
-    expect(r.bin).toBe('claude');
-    expect(r.source).toBe('fallback');
-    expect(r.searched).toContain('claude (PATH)');
-    expect(r.searched.length).toBeGreaterThanOrEqual(4);
-  });
-
-  it('ignores a non-executable `claude` on PATH', () => {
-    const binDir = path.join(dir, 'pathbin');
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.writeFileSync(path.join(binDir, 'claude'), 'plain'); // no +x bit
-    const home = path.join(dir, 'home');
-    fs.mkdirSync(home);
-
-    const r = resolveClaudeBin({ PATH: binDir }, home);
-    expect(r.source).toBe('fallback');
+    await sp.stop();
   });
 });

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -72,7 +72,7 @@ jest.mock('child_process', () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { SessionProcess } from '../../src/session/process';
+import { SessionProcess, resolveClaudeBin } from '../../src/session/process';
 import { SessionStore } from '../../src/session/store';
 import { AgentConfig, GatewayConfig } from '../../src/types';
 
@@ -1919,5 +1919,139 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
     expect((sp as unknown as { restartRequested: boolean }).restartRequested).toBe(false);
 
     await sp.stop();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-BIN1: the last non-empty stderr line is retained so a fatal restart
+  // failure can name what actually died (e.g. an unresolvable claude binary).
+  // --------------------------------------------------------------------------
+  it('U-SP-BIN1: retains the last stderr line and the spawned binary', async () => {
+    const sp = new SessionProcess('chat:bin1', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    lastProcess!.stderr!.emit('data', Buffer.from('some warning\nclaude: binary not found\n'));
+
+    const priv = sp as unknown as { lastStderrLine: string | null; lastClaudeBin: string };
+    expect(priv.lastStderrLine).toBe('claude: binary not found');
+    expect(typeof priv.lastClaudeBin).toBe('string');
+    expect(priv.lastClaudeBin.length).toBeGreaterThan(0);
+
+    await sp.stop();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-BIN2: once MAX_RESTARTS is hit the session emits 'failed' rather than
+  // looping silently — the fatal branch that logs the actionable error.
+  // --------------------------------------------------------------------------
+  it("U-SP-BIN2: emits 'failed' after MAX_RESTARTS is reached", async () => {
+    const sp = new SessionProcess('chat:bin2', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    lastProcess!.stderr!.emit('data', Buffer.from('claude: binary not found\n'));
+
+    let failed = false;
+    sp.on('failed', () => { failed = true; });
+
+    const priv = sp as unknown as { restartCount: number; scheduleRestart: () => void };
+    priv.restartCount = 3; // at the MAX_RESTARTS cap
+    priv.scheduleRestart();
+
+    expect(failed).toBe(true);
+
+    await sp.stop();
+  });
+});
+
+// ── resolveClaudeBin ──────────────────────────────────────────────────────────
+// Pure binary-resolution probe used when CLAUDE_BIN is unset. Exercised against
+// real temp dirs so the executable-file checks run for real (fs is not mocked).
+describe('resolveClaudeBin', () => {
+  let dir: string;
+
+  const mkExec = (p: string): void => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '#!/bin/sh\n');
+    fs.chmodSync(p, 0o755);
+  };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rcb-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('resolves bare `claude` from PATH when present', () => {
+    const binDir = path.join(dir, 'pathbin');
+    mkExec(path.join(binDir, 'claude'));
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(home);
+
+    const r = resolveClaudeBin({ PATH: binDir }, home);
+    expect(r.bin).toBe('claude');
+    expect(r.source).toBe('PATH');
+  });
+
+  it('falls back to the native ~/.local/bin/claude symlink when not on PATH', () => {
+    const home = path.join(dir, 'home');
+    const nativeBin = path.join(home, '.local', 'bin', 'claude');
+    mkExec(nativeBin);
+
+    const r = resolveClaudeBin({ PATH: path.join(dir, 'empty') }, home);
+    expect(r.bin).toBe(nativeBin);
+    expect(r.source).toBe('native-bin');
+  });
+
+  it('falls back to the newest native version dir (numeric-aware)', () => {
+    const home = path.join(dir, 'home');
+    const versions = path.join(home, '.local', 'share', 'claude', 'versions');
+    mkExec(path.join(versions, '2.1.99', 'claude'));
+    mkExec(path.join(versions, '2.1.206', 'claude'));
+
+    const r = resolveClaudeBin({ PATH: '' }, home);
+    expect(r.source).toBe('native-versions');
+    expect(r.bin).toBe(path.join(versions, '2.1.206', 'claude'));
+  });
+
+  it('resolves a native version stored as a bare file (versions/<ver>)', () => {
+    const home = path.join(dir, 'home');
+    const versions = path.join(home, '.local', 'share', 'claude', 'versions');
+    mkExec(path.join(versions, '2.1.206'));
+
+    const r = resolveClaudeBin({ PATH: '' }, home);
+    expect(r.source).toBe('native-versions');
+    expect(r.bin).toBe(path.join(versions, '2.1.206'));
+  });
+
+  it('falls back to the legacy npm-under-nvm path', () => {
+    const home = path.join(dir, 'home');
+    const legacy = path.join(home, '.nvm', 'versions', 'node', 'v22.22.3', 'bin', 'claude');
+    mkExec(legacy);
+
+    const r = resolveClaudeBin({ PATH: '' }, home);
+    expect(r.source).toBe('legacy-npm');
+    expect(r.bin).toBe(legacy);
+  });
+
+  it('returns fallback `claude` with the searched paths when nothing resolves', () => {
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(home);
+
+    const r = resolveClaudeBin({ PATH: path.join(dir, 'nope') }, home);
+    expect(r.bin).toBe('claude');
+    expect(r.source).toBe('fallback');
+    expect(r.searched).toContain('claude (PATH)');
+    expect(r.searched.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('ignores a non-executable `claude` on PATH', () => {
+    const binDir = path.join(dir, 'pathbin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'claude'), 'plain'); // no +x bit
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(home);
+
+    const r = resolveClaudeBin({ PATH: binDir }, home);
+    expect(r.source).toBe('fallback');
   });
 });

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -2010,4 +2010,60 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
 
     await sp.stop();
   });
+
+  // --------------------------------------------------------------------------
+  // U-SP-BIN5: a genuinely unresolvable binary surfaces as an ENOENT `error`
+  // event (NOT on stderr). It must still be captured into lastStderrLine so the
+  // fatal max-restarts log can name the cause and fire the CLAUDE_BIN hint.
+  // --------------------------------------------------------------------------
+  it('U-SP-BIN5: captures a spawn ENOENT error into lastStderrLine', async () => {
+    const sp = new SessionProcess('chat:bin5', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    lastProcess!.emit('error', new Error('spawn /home/u/.local/bin/claude ENOENT'));
+
+    const priv = sp as unknown as { lastStderrLine: string | null };
+    expect(priv.lastStderrLine).toBe('spawn /home/u/.local/bin/claude ENOENT');
+    // The fatal-log hint keys off this via /binary not found|ENOENT/i.
+    expect(/binary not found|ENOENT/i.test(priv.lastStderrLine ?? '')).toBe(true);
+
+    await sp.stop();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-BIN6: a stderr line split across two `data` chunks is reassembled into
+  // one line, not captured as two partials.
+  // --------------------------------------------------------------------------
+  it('U-SP-BIN6: reassembles a stderr line split across chunks', async () => {
+    const sp = new SessionProcess('chat:bin6', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    lastProcess!.stderr!.emit('data', Buffer.from('claude: binary not '));
+    const priv = sp as unknown as { lastStderrLine: string | null };
+    // Nothing complete yet — the fragment stays buffered.
+    expect(priv.lastStderrLine).toBeNull();
+
+    lastProcess!.stderr!.emit('data', Buffer.from('found\n'));
+    expect(priv.lastStderrLine).toBe('claude: binary not found');
+
+    await sp.stop();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-BIN7: an unterminated final stderr line (process dies mid-line, no
+  // trailing newline) is flushed into lastStderrLine on exit.
+  // --------------------------------------------------------------------------
+  it('U-SP-BIN7: flushes an unterminated trailing stderr line on exit', async () => {
+    const sp = new SessionProcess('chat:bin7', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    lastProcess!.stderr!.emit('data', Buffer.from('fatal: claude crashed mid-line'));
+    const priv = sp as unknown as { lastStderrLine: string | null };
+    expect(priv.lastStderrLine).toBeNull(); // still buffered, no newline yet
+
+    lastProcess!.emit('exit', 1, null);
+    expect(priv.lastStderrLine).toBe('fatal: claude crashed mid-line');
+
+    await sp.stop();
+  });
 });


### PR DESCRIPTION
## Summary
Session subprocesses died with `claude: binary not found` after the Claude Code native-installer migration relocated the binary out of the legacy npm/nvm layout. A gateway launched with a minimal PATH could no longer resolve a bare `claude`, so every new Telegram/Discord session hit max restarts and died silently. This adds robust binary resolution so new sessions spawn regardless of install layout, and surfaces the failure actionably when it genuinely cannot be resolved.

## Related Issue
Closes #192

## Changes Made
- `src/session/process.ts`: add `resolveClaudeBin()` — when `CLAUDE_BIN` is unset, probe PATH, the native stable symlink (`~/.local/bin/claude`), the newest `~/.local/share/claude/versions/` entry, and the legacy npm-under-nvm path, falling back to bare `claude`. Prepend the native bin dir to the child PATH when present. Include the last stderr line and attempted binary in the fatal `Session max restarts reached` log with a hint to set `CLAUDE_BIN`.
- `README.md`: document the `CLAUDE_BIN` / PATH requirement and native-install locations.
- `tests/unit/session-process.test.ts`: 9 new tests (7 for `resolveClaudeBin`, stderr retention, and failed-emit on max restarts).

## Testing
- `npm run typecheck`: pass
- `npm run test:unit`: 93 suites / 1936 tests pass