### PR TITLE
Fix claude-code version detection for native installer

### DIFF
--- a/API.md
+++ b/API.md
@@ -2780,6 +2780,8 @@ Endpoints for checking and installing newer versions of `@0xmaxma/claude-gateway
 
 Returns the current and latest version for both packages. Result is cached for 5 minutes to avoid hammering the npm registry.
 
+`latest` is read from the npm registry for both packages. `current` is resolved per package: `claude-gateway` (an npm global) via `npm list -g`, and `claude-code` (native installer) from the installed binary (`claude --version`). If Claude Code is not installed, its `current` is `null` and the UI renders `—`.
+
 ```bash
 curl -H "X-Api-Key: admin-secret" \
   http://localhost:10850/api/v1/packages | jq
@@ -2819,7 +2821,7 @@ curl -H "X-Api-Key: admin-secret" \
 Installs the latest version of the specified package. `:name` accepts `claude-gateway` or `claude-code`.
 
 - **claude-gateway**: runs `npm install -g @0xmaxma/claude-gateway@latest` then calls `process.exit(0)` so the process manager (systemd/pm2) restarts the service.
-- **claude-code**: runs `npm install -g @anthropic-ai/claude-code@latest`. No restart needed.
+- **claude-code**: runs the native updater (`claude update`) so the actual binary on PATH is updated. No restart needed. (npm install is not used — Claude Code ships via the native installer, so an npm-global copy would not be the running binary.)
 
 If the package is already on the latest version the call is a no-op (`updated: false`).
 

--- a/API.md
+++ b/API.md
@@ -2780,7 +2780,7 @@ Endpoints for checking and installing newer versions of `@0xmaxma/claude-gateway
 
 Returns the current and latest version for both packages. Result is cached for 5 minutes to avoid hammering the npm registry.
 
-`latest` is read from the npm registry for both packages. `current` is resolved per package: `claude-gateway` (an npm global) via `npm list -g`, and `claude-code` (native installer) from the installed binary (`claude --version`). If Claude Code is not installed, its `current` is `null` and the UI renders `—`.
+`latest` is read from the npm registry for both packages. `current` is resolved per package: `claude-gateway` (an npm global) via `npm list -g`, and `claude-code` (native installer) from the installed binary (`claude --version`). If Claude Code is not installed, its `current` is `null` and the UI renders `—`. `hasUpdate` is `true` only when `latest` is strictly newer than `current` by semver ordering, so a binary that is *ahead* of the registry `latest` does not report a spurious update.
 
 ```bash
 curl -H "X-Api-Key: admin-secret" \

--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -4,6 +4,7 @@ import { readdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { ApiKey } from '../types';
 import { createApiAuthMiddleware, isAdmin } from './auth';
+import { compareSemver } from '../config/migrator';
 
 type AuthedRequest = Request & { apiKey: ApiKey };
 
@@ -93,7 +94,10 @@ function getBinaryVersion(bin: string): string | null {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 10_000,
     });
-    const match = output.match(/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/);
+    // `claude --version` prints the version first (e.g. "2.1.207 (Claude Code)").
+    // Anchor to the start of the trimmed output so a version-like token later in
+    // the line can never be mistaken for the installed version.
+    const match = output.trim().match(/^(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/);
     return match ? match[1] : null;
   } catch {
     return null;
@@ -106,6 +110,14 @@ function resolveCurrent(config: PackageConfig): string | null {
     return getBinaryVersion(config.bin);
   }
   return getNpmListVersion(config.npm);
+}
+
+// An update is available only when `latest` is strictly newer than `current`.
+// Using semver ordering (not `current !== latest`) avoids a false "update
+// available" when the installed version is *ahead* of the npm-registry latest
+// — e.g. a native-installer channel that leads the npm dist-tag.
+function updateAvailable(current: string | null, latest: string | null): boolean {
+  return !!(current && latest && compareSemver(latest, current) > 0);
 }
 
 async function getLatestVersion(packageName: string): Promise<string | null> {
@@ -128,7 +140,7 @@ async function fetchAllPackageVersions(): Promise<PackageInfo[]> {
         package: config.npm,
         current,
         latest,
-        hasUpdate: !!(current && latest && current !== latest),
+        hasUpdate: updateAvailable(current, latest),
       };
     }),
   );
@@ -245,8 +257,8 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
       return;
     }
 
-    // Already on latest — no install needed
-    if (from === latest) {
+    // Already on latest (or ahead of it) — no install needed
+    if (from && !updateAvailable(from, latest)) {
       res.json({ package: packageName, from, to: from, updated: false, warning: null });
       return;
     }
@@ -282,10 +294,12 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
           return;
         }
 
-        // Invalidate version cache and re-read the actual binary version
+        // Invalidate version cache and re-read the actual binary version.
+        // The native updater may legitimately be a no-op (already newest on its
+        // own channel), so report `updated` from whether the version changed.
         versionCache = null;
         const to = resolveCurrent(config);
-        res.json({ package: packageName, from, to, updated: true, warning: null });
+        res.json({ package: packageName, from, to, updated: to !== from, warning: null });
         return;
       }
 

--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -7,10 +7,35 @@ import { createApiAuthMiddleware, isAdmin } from './auth';
 
 type AuthedRequest = Request & { apiKey: ApiKey };
 
-// URL param "name" → npm package name
-const PACKAGE_MAP: Record<string, string> = {
-  'claude-gateway': '@0xmaxma/claude-gateway',
-  'claude-code': '@anthropic-ai/claude-code',
+// Per-package resolver strategy.
+//   npm    — npm registry name (used to look up `latest` for every package,
+//            and to detect/update packages installed as an npm global)
+//   detect — how the currently-installed version is resolved:
+//              'npm'    → `npm list -g` (npm global package)
+//              'binary' → shell out to the binary on PATH (native installer)
+//   bin    — binary name for detect: 'binary' / update: 'native'
+//   update — how the Update action installs the latest version:
+//              'npm'    → `npm install -g <pkg>@latest`
+//              'native' → the package's own native updater (`<bin> update`)
+interface PackageConfig {
+  npm: string;
+  detect: 'npm' | 'binary';
+  bin?: string;
+  update: 'npm' | 'native';
+}
+
+// URL param "name" → package config.
+// claude-gateway is a genuine npm global — keep npm detect/update.
+// claude-code ships via the native installer (no longer an npm global), so
+// detect from the `claude` binary and update via its native updater.
+const PACKAGES: Record<string, PackageConfig> = {
+  'claude-gateway': { npm: '@0xmaxma/claude-gateway', detect: 'npm', update: 'npm' },
+  'claude-code': {
+    npm: '@anthropic-ai/claude-code',
+    detect: 'binary',
+    bin: 'claude',
+    update: 'native',
+  },
 };
 
 interface PackageInfo {
@@ -56,6 +81,33 @@ function getNpmListVersion(packageName: string): string | null {
   }
 }
 
+// Resolve the installed version by shelling out to the binary on PATH
+// (e.g. `claude --version` → "2.1.207 (Claude Code)"). Parses the leading
+// semver (with optional prerelease) and returns null on any failure —
+// binary missing, non-zero exit, or unparseable output. `bin` is always a
+// trusted constant from PACKAGES, never request-derived.
+function getBinaryVersion(bin: string): string | null {
+  try {
+    const output = execSync(`${bin} --version`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10_000,
+    });
+    const match = output.match(/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+// Resolve the currently-installed version per the package's detect strategy.
+function resolveCurrent(config: PackageConfig): string | null {
+  if (config.detect === 'binary' && config.bin) {
+    return getBinaryVersion(config.bin);
+  }
+  return getNpmListVersion(config.npm);
+}
+
 async function getLatestVersion(packageName: string): Promise<string | null> {
   const encodedName = packageName.replace('/', '%2F');
   const res = await fetch(`https://registry.npmjs.org/${encodedName}/latest`);
@@ -65,15 +117,15 @@ async function getLatestVersion(packageName: string): Promise<string | null> {
 }
 
 async function fetchAllPackageVersions(): Promise<PackageInfo[]> {
-  const pkgs = Object.values(PACKAGE_MAP);
-  // Run all synchronous npm list calls before entering async Promise.all
-  const currents = pkgs.map(getNpmListVersion);
+  const configs = Object.values(PACKAGES);
+  // Run all synchronous current-version lookups before entering async Promise.all
+  const currents = configs.map(resolveCurrent);
   return Promise.all(
-    pkgs.map(async (pkg, i) => {
+    configs.map(async (config, i) => {
       const current = currents[i];
-      const latest = await getLatestVersion(pkg);
+      const latest = await getLatestVersion(config.npm);
       return {
-        package: pkg,
+        package: config.npm,
         current,
         latest,
         hasUpdate: !!(current && latest && current !== latest),
@@ -171,13 +223,14 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
     }
 
     const { name } = req.params as { name: string };
-    const packageName = PACKAGE_MAP[name];
-    if (!packageName) {
+    const config = PACKAGES[name];
+    if (!config) {
       res.status(404).json({ error: `unknown package: ${name}` });
       return;
     }
+    const packageName = config.npm;
 
-    const from = getNpmListVersion(packageName);
+    const from = resolveCurrent(config);
 
     let latest: string | null;
     try {
@@ -206,6 +259,37 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
 
     isUpdating = true;
     try {
+      // Native-installer packages (e.g. claude-code) update the binary on PATH
+      // via their own updater. npm install -g would write a separate npm copy
+      // that isn't the running binary, so it must not be used here.
+      if (config.update === 'native' && config.bin) {
+        let updateErr: unknown = null;
+        try {
+          execSync(`${config.bin} update`, {
+            stdio: ['pipe', 'pipe', 'pipe'],
+            timeout: 300_000,
+          });
+        } catch (err) {
+          updateErr = err;
+        }
+
+        if (updateErr !== null) {
+          const stderr =
+            (updateErr as { stderr?: Buffer }).stderr?.toString() ??
+            (updateErr as { message?: string }).message ??
+            'update failed';
+          res.status(500).json({ error: stderr });
+          return;
+        }
+
+        // Invalidate version cache and re-read the actual binary version
+        versionCache = null;
+        const to = resolveCurrent(config);
+        res.json({ package: packageName, from, to, updated: true, warning: null });
+        return;
+      }
+
+      // npm-global packages (e.g. claude-gateway) update via npm install -g.
       // Resolve npm global root for temp dir cleanup
       let npmRoot = '';
       try {

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -27,6 +27,9 @@
  * T22: claude-code update runs the native updater (`claude update`), not npm install
  * T23: claude-code native update failure → 500 with stderr
  * T24: claude-code already on latest → updated:false, native updater not invoked
+ * T25: GET — current newer than registry latest → hasUpdate:false (no false positive)
+ * T26: update when current is ahead of latest → updated:false, native updater not invoked
+ * T27: native updater runs but version unchanged (no-op) → updated:false (honest)
  */
 
 import express from 'express';
@@ -714,5 +717,91 @@ describe('T20-T24: claude-code native detection & update', () => {
       warning: null,
     });
     expect(ranNativeUpdate).toBe(false);
+  });
+
+  it('T25: current newer than registry latest → hasUpdate:false (no false positive)', async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm list') && cmdStr.includes('@0xmaxma/claude-gateway')) {
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.2.0' } } });
+      }
+      // Native binary is ahead of the npm-registry latest below
+      if (cmdStr.includes('claude --version')) {
+        return '2.1.210 (Claude Code)';
+      }
+      return '{}';
+    });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.2.0', '@anthropic-ai/claude-code': '2.1.207' });
+
+    const res = await request(makeApp())
+      .get('/api/v1/packages')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    const cc = res.body.packages.find((p: { package: string }) => p.package === '@anthropic-ai/claude-code');
+    expect(cc).toMatchObject({ current: '2.1.210', latest: '2.1.207', hasUpdate: false });
+  });
+
+  it('T26: update when current is ahead of latest → updated:false, native updater not invoked', async () => {
+    let ranNativeUpdate = false;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('claude --version')) {
+        return '2.1.210 (Claude Code)';
+      }
+      if (cmdStr.includes('claude update')) {
+        ranNativeUpdate = true;
+        return '';
+      }
+      return '';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '2.1.207' });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      package: '@anthropic-ai/claude-code',
+      from: '2.1.210',
+      to: '2.1.210',
+      updated: false,
+      warning: null,
+    });
+    expect(ranNativeUpdate).toBe(false);
+  });
+
+  it('T27: native updater runs but version unchanged → updated:false (honest)', async () => {
+    let ranNativeUpdate = false;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      // Binary reports the same version before and after `claude update`
+      if (cmdStr.includes('claude --version')) {
+        return '2.1.200 (Claude Code)';
+      }
+      if (cmdStr.includes('claude update')) {
+        ranNativeUpdate = true;
+        return '';
+      }
+      return '';
+    });
+    // Registry advertises a newer version, so the update path is entered...
+    mockFetch({ '@anthropic-ai/claude-code': '2.1.207' });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    // ...but the binary did not move, so report updated:false honestly
+    expect(res.body).toMatchObject({
+      package: '@anthropic-ai/claude-code',
+      from: '2.1.200',
+      to: '2.1.200',
+      updated: false,
+      warning: null,
+    });
+    expect(ranNativeUpdate).toBe(true);
   });
 });

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -14,12 +14,19 @@
  * T11: POST /api/v1/packages/claude-gateway/update — success, systemd warning
  * T12: POST /api/v1/packages/claude-gateway/update — npm install fails → 500
  * T13: POST /api/v1/packages/claude-gateway/update — registry unavailable → 503
- * T14: POST /api/v1/packages/claude-code/update — success, warning: null
+ * T14: POST /api/v1/packages/claude-code/update — native updater, warning: null
  * T15: POST /api/v1/packages/claude-gateway/update — 403 when non-admin key
  * T16: stale npm temp dir exists → pre-clean removes it, update succeeds
  * T17: ENOTEMPTY on first install → temp + package dirs removed, retry succeeds
  * T18: concurrent update request → 409 while first is in flight
  * T19: non-ENOTEMPTY install failure → 500, no retry
+ *
+ * Native-installer (claude-code) coverage:
+ * T20: GET — claude-code current resolved from `claude --version` (native binary)
+ * T21: GET — claude-code binary missing → current null, no crash (UI renders "—")
+ * T22: claude-code update runs the native updater (`claude update`), not npm install
+ * T23: claude-code native update failure → 500 with stderr
+ * T24: claude-code already on latest → updated:false, native updater not invoked
  */
 
 import express from 'express';
@@ -104,11 +111,13 @@ describe('T1-T6: GET /api/v1/packages', () => {
   it('T1: returns version info for both packages', async () => {
     mockExecSync.mockImplementation((cmd: unknown) => {
       const cmdStr = cmd as string;
-      if (cmdStr.includes('@0xmaxma/claude-gateway')) {
+      // claude-gateway is an npm global → detected via `npm list -g`
+      if (cmdStr.includes('npm list') && cmdStr.includes('@0xmaxma/claude-gateway')) {
         return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.2.0' } } });
       }
-      if (cmdStr.includes('@anthropic-ai/claude-code')) {
-        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version: '1.0.5' } } });
+      // claude-code ships native → detected from the `claude` binary
+      if (cmdStr.includes('claude --version')) {
+        return '1.0.5 (Claude Code)';
       }
       return '{}';
     });
@@ -332,14 +341,19 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
     expect(res.body.error).toBe('registry unavailable');
   });
 
-  it('T14: claude-code updated — warning is null, no process exit', async () => {
-    let callCount = 0;
+  it('T14: claude-code updated via native updater — warning is null, no process exit', async () => {
+    let versionCall = 0;
+    let ranNativeUpdate = false;
     mockExecSync.mockImplementation((cmd: unknown) => {
       const cmdStr = cmd as string;
-      if (cmdStr.includes('npm list')) {
-        callCount++;
-        const version = callCount === 1 ? '1.0.5' : '1.1.0';
-        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version } } });
+      if (cmdStr.includes('claude --version')) {
+        versionCall++;
+        // First read: current (from); after `claude update`: new version (to)
+        return versionCall === 1 ? '1.0.5 (Claude Code)' : '1.1.0 (Claude Code)';
+      }
+      if (cmdStr.includes('claude update')) {
+        ranNativeUpdate = true;
+        return '';
       }
       return '';
     });
@@ -357,6 +371,13 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
       updated: true,
       warning: null,
     });
+
+    // Native updater used, npm install never invoked for claude-code
+    expect(ranNativeUpdate).toBe(true);
+    expect(mockExecSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('npm install -g'),
+      expect.anything(),
+    );
 
     jest.runAllTimers();
     expect(killSpy).not.toHaveBeenCalled();
@@ -389,19 +410,19 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
       if (cmdStr.includes('npm list')) {
         listCount++;
         const version = listCount === 1 ? '1.0.5' : '1.1.0';
-        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version } } });
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version } } });
       }
       // npm install — succeed
       return '';
     });
-    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.1.0' });
 
     // Simulate stale temp dir alongside the real package dir
-    mockReaddirSync.mockReturnValue(['claude-code', '.claude-code-O5kzWOwo'] as unknown as ReturnType<typeof readdirSync>);
+    mockReaddirSync.mockReturnValue(['claude-gateway', '.claude-gateway-O5kzWOwo'] as unknown as ReturnType<typeof readdirSync>);
     mockRmSync.mockImplementation(() => undefined);
 
     const res = await request(makeApp())
-      .post('/api/v1/packages/claude-code/update')
+      .post('/api/v1/packages/claude-gateway/update')
       .set('X-Api-Key', ADMIN_KEY);
 
     expect(res.status).toBe(200);
@@ -409,8 +430,8 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
 
     // rmSync called for the stale temp entry only (not the real package dir in pre-clean)
     const rmCalls = mockRmSync.mock.calls.map((c) => c[0] as string);
-    expect(rmCalls.some((p) => p.includes('.claude-code-O5kzWOwo'))).toBe(true);
-    expect(rmCalls.every((p) => !p.endsWith('/claude-code'))).toBe(true);
+    expect(rmCalls.some((p) => p.includes('.claude-gateway-O5kzWOwo'))).toBe(true);
+    expect(rmCalls.every((p) => !p.endsWith('/claude-gateway'))).toBe(true);
   });
 
   it('T17: ENOTEMPTY on first install → temp + package dirs removed, retry succeeds', async () => {
@@ -422,14 +443,14 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
       if (cmdStr.includes('npm list')) {
         listCount++;
         const version = listCount === 1 ? '1.0.5' : '1.1.0';
-        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version } } });
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version } } });
       }
       if (cmdStr.includes('npm install')) {
         installAttempt++;
         if (installAttempt === 1) {
           const err = Object.assign(new Error('ENOTEMPTY'), {
             stderr: Buffer.from(
-              'npm error code ENOTEMPTY\nnpm error syscall rename\nnpm error path /fake/npm/root/@anthropic-ai/claude-code',
+              'npm error code ENOTEMPTY\nnpm error syscall rename\nnpm error path /fake/npm/root/@0xmaxma/claude-gateway',
             ),
           });
           throw err;
@@ -439,13 +460,13 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
       }
       return '{}';
     });
-    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.1.0' });
 
-    mockReaddirSync.mockReturnValue(['.claude-code-O5kzWOwo'] as unknown as ReturnType<typeof readdirSync>);
+    mockReaddirSync.mockReturnValue(['.claude-gateway-O5kzWOwo'] as unknown as ReturnType<typeof readdirSync>);
     mockRmSync.mockImplementation(() => undefined);
 
     const res = await request(makeApp())
-      .post('/api/v1/packages/claude-code/update')
+      .post('/api/v1/packages/claude-gateway/update')
       .set('X-Api-Key', ADMIN_KEY);
 
     expect(res.status).toBe(200);
@@ -454,8 +475,8 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
 
     // Stale temp dir and package dir both removed before retry
     const rmCalls = mockRmSync.mock.calls.map((c) => c[0] as string);
-    expect(rmCalls.some((p) => p.includes('.claude-code-O5kzWOwo'))).toBe(true);
-    expect(rmCalls.some((p) => p.endsWith('/claude-code'))).toBe(true);
+    expect(rmCalls.some((p) => p.includes('.claude-gateway-O5kzWOwo'))).toBe(true);
+    expect(rmCalls.some((p) => p.endsWith('/claude-gateway'))).toBe(true);
   });
 
   it('T18: concurrent update request → 409 while first is in flight', async () => {
@@ -463,18 +484,18 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
     mockExecSync.mockImplementation((cmd: unknown) => {
       const cmdStr = cmd as string;
       if (cmdStr.includes('npm list'))
-        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version: '1.0.5' } } });
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.0.5' } } });
       if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
       return '';
     });
-    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.1.0' });
     mockReaddirSync.mockReturnValue([] as unknown as ReturnType<typeof readdirSync>);
 
     // Simulate another update already in progress
     _setLock();
 
     const res = await request(makeApp())
-      .post('/api/v1/packages/claude-code/update')
+      .post('/api/v1/packages/claude-gateway/update')
       .set('X-Api-Key', ADMIN_KEY);
 
     expect(res.status).toBe(409);
@@ -493,24 +514,24 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
       if (cmdStr.includes('npm list')) {
         listCount++;
         const version = listCount <= 2 ? '1.0.5' : '1.1.0';
-        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version } } });
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version } } });
       }
       return '';
     });
-    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.1.0' });
     mockReaddirSync.mockReturnValue([] as unknown as ReturnType<typeof readdirSync>);
 
     const app = makeApp();
 
     const res1 = await request(app)
-      .post('/api/v1/packages/claude-code/update')
+      .post('/api/v1/packages/claude-gateway/update')
       .set('X-Api-Key', ADMIN_KEY);
     expect(res1.status).toBe(200);
 
     // Reset fetch version so second request also sees an update available
     listCount = 0;
     const res2 = await request(app)
-      .post('/api/v1/packages/claude-code/update')
+      .post('/api/v1/packages/claude-gateway/update')
       .set('X-Api-Key', ADMIN_KEY);
     expect(res2.status).not.toBe(409);
   });
@@ -521,25 +542,177 @@ describe('T16-T19: ENOTEMPTY recovery & concurrency lock', () => {
       const cmdStr = cmd as string;
       if (cmdStr.includes('npm root -g')) return `${NPM_ROOT}\n`;
       if (cmdStr.includes('npm list')) {
-        return JSON.stringify({ dependencies: { '@anthropic-ai/claude-code': { version: '1.0.5' } } });
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.0.5' } } });
       }
       if (cmdStr.includes('npm install')) {
         installAttempt++;
         throw Object.assign(new Error('npm ERR! 404 Not Found'), {
-          stderr: Buffer.from('npm ERR! 404 Not Found — @anthropic-ai/claude-code@9.9.9'),
+          stderr: Buffer.from('npm ERR! 404 Not Found — @0xmaxma/claude-gateway@9.9.9'),
         });
       }
       return '{}';
     });
-    mockFetch({ '@anthropic-ai/claude-code': '1.1.0' });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.1.0' });
     mockReaddirSync.mockReturnValue([] as unknown as ReturnType<typeof readdirSync>);
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-gateway/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain('npm ERR!');
+    expect(installAttempt).toBe(1);
+  });
+});
+
+// ─── T20-T24: native-installer (claude-code) detection & update ──────────────
+
+describe('T20-T24: claude-code native detection & update', () => {
+  it('T20: claude-code current resolved from `claude --version` (native binary)', async () => {
+    let ranNpmListForClaudeCode = false;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm list') && cmdStr.includes('@anthropic-ai/claude-code')) {
+        ranNpmListForClaudeCode = true;
+      }
+      if (cmdStr.includes('npm list') && cmdStr.includes('@0xmaxma/claude-gateway')) {
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.2.0' } } });
+      }
+      if (cmdStr.includes('claude --version')) {
+        return '2.1.207 (Claude Code)';
+      }
+      return '{}';
+    });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.2.0', '@anthropic-ai/claude-code': '2.1.207' });
+
+    const res = await request(makeApp())
+      .get('/api/v1/packages')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    const cc = res.body.packages.find((p: { package: string }) => p.package === '@anthropic-ai/claude-code');
+    expect(cc).toMatchObject({ current: '2.1.207', latest: '2.1.207', hasUpdate: false });
+    // Detection must not fall back to npm list for the native package
+    expect(ranNpmListForClaudeCode).toBe(false);
+  });
+
+  it('T21: claude-code binary missing → current null, no crash (UI renders "—")', async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('npm list') && cmdStr.includes('@0xmaxma/claude-gateway')) {
+        return JSON.stringify({ dependencies: { '@0xmaxma/claude-gateway': { version: '1.2.0' } } });
+      }
+      if (cmdStr.includes('claude --version')) {
+        // Binary not installed → command fails
+        throw Object.assign(new Error('command not found: claude'), {
+          stderr: Buffer.from('command not found'),
+        });
+      }
+      return '{}';
+    });
+    mockFetch({ '@0xmaxma/claude-gateway': '1.2.0', '@anthropic-ai/claude-code': '2.1.207' });
+
+    const res = await request(makeApp())
+      .get('/api/v1/packages')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    const cc = res.body.packages.find((p: { package: string }) => p.package === '@anthropic-ai/claude-code');
+    expect(cc).toMatchObject({ current: null, latest: '2.1.207', hasUpdate: false });
+  });
+
+  it('T22: claude-code update runs the native updater, not npm install', async () => {
+    let versionCall = 0;
+    let ranNativeUpdate = false;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('claude --version')) {
+        versionCall++;
+        return versionCall === 1 ? '2.1.200 (Claude Code)' : '2.1.207 (Claude Code)';
+      }
+      if (cmdStr.includes('claude update')) {
+        ranNativeUpdate = true;
+        return '';
+      }
+      if (cmdStr.includes('npm install')) {
+        throw new Error('npm install must not be called for native package');
+      }
+      return '';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '2.1.207' });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      package: '@anthropic-ai/claude-code',
+      from: '2.1.200',
+      to: '2.1.207',
+      updated: true,
+      warning: null,
+    });
+    expect(ranNativeUpdate).toBe(true);
+    expect(mockExecSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('npm install -g'),
+      expect.anything(),
+    );
+
+    jest.runAllTimers();
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it('T23: claude-code native update failure → 500 with stderr', async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('claude --version')) {
+        return '2.1.200 (Claude Code)';
+      }
+      if (cmdStr.includes('claude update')) {
+        throw Object.assign(new Error('update failed'), {
+          stderr: Buffer.from('native update error: disk full'),
+        });
+      }
+      return '';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '2.1.207' });
 
     const res = await request(makeApp())
       .post('/api/v1/packages/claude-code/update')
       .set('X-Api-Key', ADMIN_KEY);
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toContain('npm ERR!');
-    expect(installAttempt).toBe(1);
+    expect(res.body.error).toContain('native update error');
+  });
+
+  it('T24: claude-code already on latest → updated:false, native updater not invoked', async () => {
+    let ranNativeUpdate = false;
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = cmd as string;
+      if (cmdStr.includes('claude --version')) {
+        return '2.1.207 (Claude Code)';
+      }
+      if (cmdStr.includes('claude update')) {
+        ranNativeUpdate = true;
+        return '';
+      }
+      return '';
+    });
+    mockFetch({ '@anthropic-ai/claude-code': '2.1.207' });
+
+    const res = await request(makeApp())
+      .post('/api/v1/packages/claude-code/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      package: '@anthropic-ai/claude-code',
+      from: '2.1.207',
+      to: '2.1.207',
+      updated: false,
+      warning: null,
+    });
+    expect(ranNativeUpdate).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Gateway Settings showed the installed Claude Code version as `—` because version detection was npm-only (`npm list -g`), but Claude Code now ships via the native installer (no longer an npm global). The same root cause made the Update button write a separate npm-global copy that is not the binary on PATH.

This introduces a per-package resolver strategy: `claude-code` detects its current version from the binary (`claude --version`) and updates via the native updater (`claude update`), while `@0xmaxma/claude-gateway` keeps its existing npm-global detect/update path.

## Related Issue
Closes #197

## Changes Made
- `src/api/packages.ts`: replaced `PACKAGE_MAP` with a `PACKAGES` config (per-package `detect` and `update` strategy); added `getBinaryVersion()` and `resolveCurrent()`; the update endpoint now branches to the native updater for native packages and the npm path (with ENOTEMPTY recovery + restart) for npm globals. A missing binary resolves to `current: null` gracefully.
- `tests/unit/packages-router.test.ts`: updated detection/update expectations, moved npm ENOTEMPTY-recovery tests to `claude-gateway`, added T20–T24 covering native detection, missing binary, native update, native-update failure, and already-latest.
- `API.md`: updated the detection and update notes for `claude-code`.

## Testing
- `npm run typecheck`: pass
- `npm test` (unit): 94 suites / 1951 tests pass