### PR TITLE
Add interactive input + keyboard scroll to Terminal Viewer with localhost-only default (#201)

### DIFF
--- a/API.md
+++ b/API.md
@@ -225,6 +225,8 @@ ws://localhost:10850/api/v1/agents/<agentId>/pty-stream?session=<sessionId>
 
 Closes with code `4404` if the session is not running in PTY mode.
 
+**Direction:** the stream is server → client (live PTY output) by default, and the socket is bidirectional: inbound **text** frames carry raw keystroke bytes that are written into the live PTY (interactive terminal mode), bounded per frame and dropped for headless sessions. A dashboard viewer only sends these frames while its mode toggle is in input mode (a client-side choice); binary and oversized/empty frames are always dropped. Access is protected by the socket's auth (ticket/API key) and the localhost-default [`gateway.bind`](README.md#gatewaybind) — see the [Terminal Viewer](README.md#terminal-viewer--interactive-terminal-mode) docs.
+
 **Auth levels:** `Key` = any valid API key, `Write` = key with write access to the agent, `Admin` = key with `agents: "*"`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -314,6 +314,29 @@ Recovery actions are clamped to a per-stage whitelist and a per-turn budget, and
 }
 ```
 
+### `gateway.bind`
+
+Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (localhost-only), so the dashboard and API are **not** exposed to the local network out of the box. Set to `0.0.0.0` to listen on all interfaces (for example when a containerized reverse proxy needs to reach the gateway). The `GATEWAY_BIND` environment variable, when set, takes precedence over this field.
+
+```json
+{
+  "gateway": {
+    "bind": "127.0.0.1"
+  }
+}
+```
+
+### Terminal Viewer — interactive terminal mode
+
+The dashboard's **Terminal Viewer** opens read-only (a live mirror of the PTY). A toggle in the top-right of the viewer switches it into an **interactive terminal**: keystrokes typed into the panel — printable characters, Enter, arrows, Ctrl-combos, Esc — are streamed into the live PTY, and the panel title changes to reflect the active mode. This is a per-browser client-side choice (Issue #201); there is no server config flag to enable it.
+
+Because interactive mode turns a read-only view into a remote-write surface, access is protected upstream rather than by a feature flag:
+
+- **Authentication** — the WebSocket requires a valid dashboard ticket or API key.
+- **`gateway.bind`** — the gateway binds to `127.0.0.1` (localhost) by default, so the dashboard is not reachable from the network out of the box. Expose a non-loopback bind (`0.0.0.0`) **only** behind a trusted authenticating reverse proxy.
+
+Inbound frames are always bounded (text-only, size-capped) and are dropped for headless sessions (no PTY).
+
 ### `gateway.api.keys`
 
 Each key has a `key` string (supports `${ENV_VAR}` interpolation), an optional `description`, and an `agents` field — either an array of agent IDs or `"*"` for full access. Keys support both `Authorization: Bearer` and `X-Api-Key` headers.
@@ -506,7 +529,7 @@ The gateway proxies `/app/:name/:portName/*` to the app containers. Two env vars
 
 | Env var | Default | Description |
 |---------|---------|-------------|
-| `GATEWAY_BIND` | `0.0.0.0` | Gateway HTTP listen address. Must be `0.0.0.0` (default) when a **containerized** reverse proxy (Caddy, nginx in Docker) needs to reach the gateway. Set to `127.0.0.1` only if using a **host-network** proxy (Traefik on host) — loopback is not reachable across container boundaries. |
+| `GATEWAY_BIND` | `127.0.0.1` | Gateway HTTP listen address. Overrides the `gateway.bind` config field when set. Defaults to localhost-only; set to `0.0.0.0` when a **containerized** reverse proxy (Caddy, nginx in Docker) needs to reach the gateway across container boundaries. A **host-network** proxy (Traefik on host) can keep the localhost default. |
 | `DOCKER_HOST` | _(system default)_ | Docker socket/TCP address. When set to `tcp://host:port` (e.g. DinD), the gateway automatically uses the host extracted from `DOCKER_HOST` to proxy to app containers instead of `127.0.0.1`. |
 
 Example Caddyfile for apps behind Caddy in Docker:

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (l
 }
 ```
 
+> **⚠️ Upgrade note (configVersion 1.0.13):** the default bind changed from `0.0.0.0` to `127.0.0.1`. If you reach the dashboard/API from another host — most commonly through a **containerized** reverse proxy that connects across the container boundary — the gateway will no longer be reachable after upgrading unless you opt back in explicitly by setting `gateway.bind` to `0.0.0.0` (or the `GATEWAY_BIND` env var). Deployments that only use a host-network proxy or access the dashboard on `localhost` need no change.
+
 ### Terminal Viewer — interactive terminal mode
 
 The dashboard's **Terminal Viewer** opens read-only (a live mirror of the PTY). A toggle in the top-right of the viewer switches it into an **interactive terminal**: keystrokes typed into the panel — printable characters, Enter, arrows, Ctrl-combos, Esc — are streamed into the live PTY, and the panel title changes to reflect the active mode. This is a per-browser client-side choice (Issue #201); there is no server config flag to enable it.

--- a/config.template.json
+++ b/config.template.json
@@ -10,10 +10,11 @@
       "claude.dangerouslySkipPermissions"
     ]
   },
-  "configVersion": "1.0.12",
+  "configVersion": "1.0.13",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
+    "bind": "127.0.0.1",
     "models": [
       { "id": "claude-fable-5[1m]",        "label": "Fable 5 (1M)",     "alias": "fable[1m]",   "contextWindow": 1000000 },
       { "id": "claude-opus-4-8[1m]",       "label": "Opus 4.8 (1M)",    "alias": "opus[1m]",    "contextWindow": 1000000 },

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -484,6 +484,24 @@ export class AgentRunner extends EventEmitter {
   }
 
   /**
+   * Route raw interactive-terminal input to the session with this actual
+   * sessionId (Issue #201). The dashboard's Terminal Viewer input mode
+   * streams keystrokes here via the pty-stream WebSocket. Sessions are keyed by
+   * chatId internally, so we match on the process's own sessionId. Returns true
+   * only when a live pty-shell session accepted the bytes (headless / missing /
+   * not-writable → false), so the caller can surface an accurate result.
+   */
+  sendInputToSession(sessionId: string, data: string): boolean {
+    if (!sessionId || typeof data !== 'string' || data.length === 0) return false;
+    for (const proc of this.sessions.values()) {
+      if (proc.sessionId === sessionId) {
+        return proc.sendInput(data);
+      }
+    }
+    return false;
+  }
+
+  /**
    * Build the recovery effects bound to one chat's session (Phase 3b). Each
    * effect resolves the session fresh so it survives a restart mid-recovery.
    * Keystroke effects go through the wrapper control channel; restart/backend

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -6,10 +6,11 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { Server } from 'http';
-import { WebSocketServer, WebSocket } from 'ws';
+import { WebSocketServer, WebSocket, type RawData } from 'ws';
 import { AgentRunner } from '../agent/runner';
 import { AgentConfig, AgentStats, ApiKey, GatewayConfig, HeartbeatResult } from '../types';
 import { ptyStreamRegistry } from '../shell/pty-stream-registry';
+import { shouldRoutePtyInput } from '../shell/control-channel';
 import { getWatcherHealth } from '../watch/factory';
 import { CronScheduler } from '../cron/scheduler';
 import { CronManager } from '../cron/manager';
@@ -39,6 +40,22 @@ function getGatewayVersion(): string {
 }
 
 const GATEWAY_VERSION = getGatewayVersion();
+
+/**
+ * Resolve the network interface the server binds to (Issue #201). Precedence:
+ * GATEWAY_BIND env → gateway.bind config → localhost-only default. Empty/blank
+ * values fall through, so an unset or whitespace override never accidentally
+ * binds all interfaces. The localhost default keeps the dashboard/API off the
+ * local network out of the box.
+ */
+export function resolveBindHost(
+  envBind: string | undefined,
+  configuredBind: string | undefined,
+): string {
+  const env = envBind?.trim();
+  const configured = configuredBind?.trim();
+  return env || configured || '127.0.0.1';
+}
 
 // ─── Proxy types ──────────────────────────────────────────────────────────────
 
@@ -548,7 +565,11 @@ export class GatewayRouter {
   }
 
   async start(port: number): Promise<void> {
-    const host = process.env.GATEWAY_BIND ?? '0.0.0.0';
+    // Bind resolution precedence: GATEWAY_BIND env → gateway.bind config →
+    // localhost-only default. The default is "127.0.0.1" so the dashboard/API
+    // are not exposed to the local network out of the box; operators opt into
+    // wider exposure via config or the env var (e.g. "0.0.0.0" behind a proxy).
+    const host = resolveBindHost(process.env.GATEWAY_BIND, this.gatewayConfig?.gateway?.bind);
     return new Promise((resolve, reject) => {
       this.server = this.app.listen(port, host, () => {
         resolve();
@@ -606,14 +627,7 @@ export class GatewayRouter {
             return;
           }
           this.wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-            // Subscribe by sessionId — each session is its own isolated stream.
-            if (!ptyStreamRegistry.hasSockets(sessionId)) {
-              ws.close(4404, 'session not running in PTY mode');
-              return;
-            }
-            ptyStreamRegistry.subscribe(sessionId, ws);
-            ws.on('close', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
-            ws.on('error', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
+            this.attachPtyStreamSocket(ws, agentId, sessionId);
           });
           return;
         }
@@ -645,15 +659,40 @@ export class GatewayRouter {
         }
 
         this.wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-          if (!ptyStreamRegistry.hasSockets(sessionId)) {
-            ws.close(4404, 'session not running in PTY mode');
-            return;
-          }
-          ptyStreamRegistry.subscribe(sessionId, ws);
-          ws.on('close', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
-          ws.on('error', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
+          this.attachPtyStreamSocket(ws, agentId, sessionId);
         });
       });
+    });
+  }
+
+  /**
+   * Subscribe an authenticated WebSocket to a session's PTY output stream and
+   * route inbound frames back into the live PTY (Issue #201). Output is one-way
+   * (server → browser); inbound keystrokes are opt-in per browser via the Shell
+   * Process Viewer's mode toggle (client-side UX), so a viewer only sends bytes
+   * while in input mode. Access to this socket is protected upstream: the caller
+   * has already authenticated (ticket or API key) and the gateway binds to
+   * localhost by default (`gateway.bind`) — set a non-loopback bind only behind
+   * a trusted proxy. Bytes are bounded (text-only, size-capped) and routed to
+   * the owning session; a headless session (no PTY) silently drops them
+   * (sendInputToSession → false).
+   */
+  private attachPtyStreamSocket(ws: WebSocket, agentId: string, sessionId: string): void {
+    if (!ptyStreamRegistry.hasSockets(sessionId)) {
+      ws.close(4404, 'session not running in PTY mode');
+      return;
+    }
+    ptyStreamRegistry.subscribe(sessionId, ws);
+    ws.on('close', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
+    ws.on('error', () => ptyStreamRegistry.unsubscribe(sessionId, ws));
+
+    ws.on('message', (data: RawData, isBinary: boolean) => {
+      // Text frames carry raw keystroke bytes from xterm's onData; binary frames
+      // and oversized/empty payloads are dropped rather than routed into the PTY
+      // (shared gate with the wrapper).
+      const text = isBinary ? '' : data.toString('utf8');
+      if (!shouldRoutePtyInput(isBinary, text)) return;
+      this.agents.get(agentId)?.sendInputToSession(sessionId, text);
     });
   }
 

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -10,7 +10,7 @@ import { WebSocketServer, WebSocket, type RawData } from 'ws';
 import { AgentRunner } from '../agent/runner';
 import { AgentConfig, AgentStats, ApiKey, GatewayConfig, HeartbeatResult } from '../types';
 import { ptyStreamRegistry } from '../shell/pty-stream-registry';
-import { shouldRoutePtyInput } from '../shell/control-channel';
+import { shouldRoutePtyInput, MAX_PTY_INPUT_BYTES } from '../shell/control-channel';
 import { getWatcherHealth } from '../watch/factory';
 import { CronScheduler } from '../cron/scheduler';
 import { CronManager } from '../cron/manager';
@@ -582,7 +582,13 @@ export class GatewayRouter {
         }
       });
 
-      this.wss = new WebSocketServer({ noServer: true });
+      // Cap inbound frame size at the WS layer so oversized frames are rejected
+      // before we ever allocate a string from them (Issue #201). The only inbound
+      // frames on this socket are interactive keystrokes, already bounded to
+      // MAX_PTY_INPUT_BYTES; the headroom (8×) tolerates paste bursts while still
+      // refusing abusive payloads. maxPayload only limits frames the server
+      // *receives* — server → client PTY output is unaffected.
+      this.wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PTY_INPUT_BYTES * 8 });
       const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
 
       // Prune expired tickets and dashboard tokens every 60s.

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -920,6 +920,32 @@ export class SessionProcess extends EventEmitter {
     this.process.stdin.write(JSON.stringify(msg) + '\n');
   }
 
+  /**
+   * Send raw interactive-terminal input to the PTY wrapper (Issue #201). Used by
+   * the dashboard's Terminal Viewer input mode to type any key into the
+   * live TUI. Only meaningful on the interactive (pty-shell) backend — the
+   * headless backend has no TUI, so this is a no-op there. The wrapper bounds
+   * the size again before writing to the PTY. Returns true when the bytes were
+   * handed to the subprocess stdin.
+   */
+  sendInput(data: string): boolean {
+    if (this.backend !== 'pty-shell') {
+      this.logger.debug('Ignoring interactive input on headless backend', {
+        sessionId: this.sessionId,
+      });
+      return false;
+    }
+    if (typeof data !== 'string' || data.length === 0) return false;
+    if (!this.process?.stdin?.writable) {
+      this.logger.warn('Cannot send input: subprocess not running', {
+        sessionId: this.sessionId,
+      });
+      return false;
+    }
+    this.process.stdin.write(JSON.stringify({ type: 'input', data }) + '\n');
+    return true;
+  }
+
   query(prompt: string, timeoutMs = 60_000): Promise<string> {
     return new Promise((resolve, reject) => {
       if (!this.process?.stdin?.writable) {

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -21,7 +21,7 @@ import { ProtocolEmitter } from './emitter';
 import { preTrustWorkspace, checkAuthStatus } from './trust';
 import { decideMenuCancel } from './menu-cancel';
 import { shouldAdoptOrphanWake } from './orphan-wake';
-import { parseControlCommand, keystrokesFor, KEY_ENTER } from './control-channel';
+import { parseControlCommand, keystrokesFor, KEY_ENTER, isAcceptablePtyInput, MAX_PTY_INPUT_BYTES } from './control-channel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
 
 const POLL_MS = 200;
@@ -261,6 +261,16 @@ class Driver {
         this.handleControl(obj);
         return;
       }
+      // Interactive input (Issue #201): the dashboard's Terminal Viewer in
+      // input mode streams raw keystroke bytes to type into the live TUI, like a
+      // real terminal. Unlike the closed `control` vocabulary this is arbitrary
+      // bytes, so access is deliberately gated at the gateway (auth + the
+      // localhost-default `gateway.bind`) before ever reaching this wrapper; here
+      // we only bound its size and write it straight to the PTY.
+      if (obj.type === 'input') {
+        this.handleInput(obj);
+        return;
+      }
       if (obj.type !== 'user') {
         logDebug(`ignoring stdin message type=${String(obj.type)}`);
         return;
@@ -323,6 +333,21 @@ class Driver {
         if (this.screen.interactivePromptBlocking()) this.host.writeRaw(KEY_ENTER);
       }, MENU_SELECT_ENTER_DELAY_MS);
     }
+  }
+
+  /**
+   * Handle interactive-terminal input (Issue #201). `data` is raw keystroke
+   * bytes from an authenticated dashboard viewer in input mode. It is written
+   * straight to the PTY so every key behaves like a real terminal. The size is
+   * bounded (defense in depth — the gateway already bounds it) and a non-string
+   * / oversized / empty payload is dropped rather than written.
+   */
+  private handleInput(obj: Record<string, unknown>): void {
+    if (!isAcceptablePtyInput(obj.data)) {
+      logWarn(`ignoring invalid/oversized input message (max ${MAX_PTY_INPUT_BYTES} bytes)`);
+      return;
+    }
+    this.host.writeRaw(obj.data);
   }
 
   private attachSignals(): void {

--- a/src/shell/control-channel.ts
+++ b/src/shell/control-channel.ts
@@ -89,3 +89,36 @@ export function keystrokesFor(cmd: ControlCommand): string[] {
       return [String(cmd.option)]
   }
 }
+
+/**
+ * Interactive terminal input (Issue #201). Unlike the closed control vocabulary,
+ * input-mode carries arbitrary raw keystroke bytes so a viewer can type any key.
+ * Access is gated at the gateway (auth + the localhost-default `gateway.bind`);
+ * these pure helpers bound and validate a single frame, and are reused on both
+ * sides of the pipe (the gateway WS handler and the PTY wrapper) so the two never
+ * drift on what counts as an acceptable frame.
+ */
+export const MAX_PTY_INPUT_BYTES = 8192
+
+/** True when `data` is a non-empty string within the per-frame byte bound. */
+export function isAcceptablePtyInput(
+  data: unknown,
+  maxBytes: number = MAX_PTY_INPUT_BYTES,
+): data is string {
+  return typeof data === 'string' && data.length > 0 && data.length <= maxBytes
+}
+
+/**
+ * Whether one inbound WebSocket frame should be routed into the live PTY.
+ * Requires a text (non-binary) frame and an acceptable payload; binary frames
+ * and oversized/empty payloads are dropped. Pure — no IO. (Whether a browser
+ * sends input at all is a client-side choice via the viewer's mode toggle;
+ * access to the socket is gated upstream by auth + `gateway.bind`.)
+ */
+export function shouldRoutePtyInput(
+  isBinary: boolean,
+  data: unknown,
+  maxBytes: number = MAX_PTY_INPUT_BYTES,
+): data is string {
+  return !isBinary && isAcceptablePtyInput(data, maxBytes)
+}

--- a/src/shell/control-channel.ts
+++ b/src/shell/control-channel.ts
@@ -100,12 +100,21 @@ export function keystrokesFor(cmd: ControlCommand): string[] {
  */
 export const MAX_PTY_INPUT_BYTES = 8192
 
-/** True when `data` is a non-empty string within the per-frame byte bound. */
+/**
+ * True when `data` is a non-empty string within the per-frame byte bound. The
+ * bound is measured in real UTF-8 bytes (not UTF-16 code units), so multi-byte
+ * input (emoji, non-Latin scripts) is capped at the same byte budget that will
+ * actually be written to the PTY.
+ */
 export function isAcceptablePtyInput(
   data: unknown,
   maxBytes: number = MAX_PTY_INPUT_BYTES,
 ): data is string {
-  return typeof data === 'string' && data.length > 0 && data.length <= maxBytes
+  return (
+    typeof data === 'string' &&
+    data.length > 0 &&
+    Buffer.byteLength(data, 'utf8') <= maxBytes
+  )
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,14 @@ export interface GatewayConfig {
   gateway: {
     logDir: string;
     timezone: string;
+    /**
+     * Network interface the HTTP/WebSocket server binds to. Defaults to
+     * "127.0.0.1" (localhost-only) so the dashboard and API are not exposed to
+     * the local network out of the box. Set to "0.0.0.0" to expose all
+     * interfaces (e.g. behind a trusted reverse proxy). The `GATEWAY_BIND` env
+     * var, when set, takes precedence over this field.
+     */
+    bind?: string;
     models?: ModelConfig[];
     api?: {
       keys: ApiKey[];

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -116,6 +116,22 @@ export function generateDashboardHtml(dashToken = ''): string {
     }
     .pty-close:hover { color: #fc8181; }
     .pty-refresh:hover { color: #63b3ed; }
+    /* Keyboard-focus outline on the viewer (it is tabindex focusable so PageUp/
+       PageDown reach the terminal); keep it subtle rather than the default ring. */
+    #pty-terminal:focus, #pty-terminal:focus-visible { outline: 1px solid #2d3748; }
+    .pty-mode-toggle {
+      background: none;
+      border: 1px solid #2d3748;
+      border-radius: 4px;
+      color: #718096;
+      cursor: pointer;
+      font-size: 0.72rem;
+      padding: 1px 7px;
+      margin-right: 6px;
+    }
+    .pty-mode-toggle:hover { color: #63b3ed; border-color: #3d4a5f; }
+    /* Active (input) mode — clearly signals the viewer now types into the PTY. */
+    .pty-mode-toggle.input-active { color: #0d1117; background: #63b3ed; border-color: #63b3ed; font-weight: 600; }
     /* Fixed-size terminal viewport — the server PTY runs at 200x50, so the
        viewer must NOT resize to the panel (that mismatch is what garbles the
        output). We render at the native size and pan horizontally if the 200-col
@@ -230,13 +246,16 @@ export function generateDashboardHtml(dashToken = ''): string {
        in view when streaming. -->
   <div class="pty-viewer" id="pty-viewer">
     <div class="pty-viewer-header">
-      <span>Shell Process Viewer &mdash; <span class="agent-label" id="pty-agent-label"></span><span class="session-label" id="pty-session-label"></span></span>
+      <span><span id="pty-title-text">Terminal Viewer</span> &mdash; <span class="agent-label" id="pty-agent-label"></span><span class="session-label" id="pty-session-label"></span></span>
       <span>
+        <button class="pty-mode-toggle" id="pty-mode-toggle-btn" title="Toggle input mode (type into the live terminal)">&#x2328; View</button>
         <button class="pty-refresh" id="pty-refresh-btn" title="Refresh (reconnect &amp; redraw)">&#x21ba;</button>
         <button class="pty-close" id="pty-close-btn" title="Close">&#x2715;</button>
       </span>
     </div>
-    <div id="pty-terminal"></div>
+    <!-- tabindex makes the viewer keyboard-focusable so PageUp/PageDown reach it
+         even in read-only view mode (xterm stdin is disabled there). -->
+    <div id="pty-terminal" tabindex="0"></div>
   </div>
 
   <!-- Sessions — full width (session-centric, flat list) -->
@@ -347,6 +366,11 @@ export function generateDashboardHtml(dashToken = ''): string {
     // multi-byte char into noise — decode as UTF-8 with {stream:true} so sequences
     // split across WebSocket frames are reassembled instead of corrupted.
     let utf8Decoder = null;
+    // Interactive input mode (Issue #201). When on, keystrokes typed into the
+    // terminal are streamed to the live PTY over the same WebSocket. Off by
+    // default (read-only mirror); the viewer flips it on via the mode toggle.
+    let ptyInputMode = false;
+    let ptyOnDataDisposable = null;
 
     // The agent's TUI enables mouse tracking (DECSET 1000/1002/1003/1006...).
     // While those modes are active, xterm.js forwards wheel/click events to the
@@ -370,6 +394,9 @@ export function generateDashboardHtml(dashToken = ''): string {
       // Append the session id after the agent name, e.g. "claude-founder · 3c01897c…".
       document.getElementById('pty-session-label').textContent = sessionId ? ' \\u00b7 ' + sessionId : '';
       document.getElementById('pty-viewer').style.display = 'block';
+      // Always (re)open a fresh session in read-only view mode; the mode toggle
+      // lets the viewer switch into interactive input on demand.
+      setPtyInputMode(false);
 
       if (!term) {
         term = new Terminal({
@@ -485,10 +512,51 @@ export function generateDashboardHtml(dashToken = ''): string {
       // are about to close intentionally, so it does not schedule a new one.
       if (ptyReconnectTimer) { clearTimeout(ptyReconnectTimer); ptyReconnectTimer = null; }
       ptyReconnectAttempts = 0;
+      setPtyInputMode(false); // always leave input mode when closing/switching
       if (ptyWs) { ptyWs.onclose = null; ptyWs.onerror = null; ptyWs.close(); ptyWs = null; }
       currentPtyAgent = null;
       currentPtySession = null;
       document.getElementById('pty-viewer').style.display = 'none';
+    }
+
+    // Switch the viewer between read-only mirror and interactive input. In input
+    // mode the terminal accepts stdin and every keystroke (printable chars,
+    // Enter, arrows, Ctrl-combos, Esc) is streamed to the live PTY over the WS,
+    // like a real terminal; the title and toggle reflect the active mode.
+    function setPtyInputMode(on) {
+      if (!term) on = false;
+      ptyInputMode = !!on;
+      const toggleBtn = document.getElementById('pty-mode-toggle-btn');
+      const titleEl = document.getElementById('pty-title-text');
+      if (term) term.options.disableStdin = !ptyInputMode;
+      // Detach any previous onData listener before (re)attaching, so toggling
+      // off — or toggling on twice — never leaves a duplicate keystroke stream.
+      if (ptyOnDataDisposable) { ptyOnDataDisposable.dispose(); ptyOnDataDisposable = null; }
+      if (ptyInputMode && term) {
+        ptyOnDataDisposable = term.onData(function(data) {
+          if (ptyWs && ptyWs.readyState === WebSocket.OPEN) ptyWs.send(data);
+        });
+      }
+      if (titleEl) titleEl.textContent = ptyInputMode ? 'Interactive Terminal' : 'Terminal Viewer';
+      if (toggleBtn) {
+        toggleBtn.innerHTML = ptyInputMode ? '\\u2328 Input' : '\\u2328 View';
+        toggleBtn.classList.toggle('input-active', ptyInputMode);
+        toggleBtn.title = ptyInputMode
+          ? 'Input mode — keystrokes go to the live terminal (click for read-only)'
+          : 'Toggle input mode (type into the live terminal)';
+      }
+      if (ptyInputMode && term) {
+        term.focus(); // typing goes to xterm's textarea
+      } else {
+        // View mode: focus the container (tabindex) so PageUp/PageDown reach our
+        // key handler instead of scrolling the browser page.
+        const host = document.getElementById('pty-terminal');
+        if (host) host.focus();
+      }
+    }
+
+    function togglePtyInputMode() {
+      setPtyInputMode(!ptyInputMode);
     }
 
     // Refresh: force a clean reconnect of the CURRENT session. The server replays
@@ -502,8 +570,41 @@ export function generateDashboardHtml(dashToken = ''): string {
       await openPtyViewer(agentId, sessionId);
     }
 
+    // Page Up / Page Down keys (Issue #201): the alt-screen mirror keeps no
+    // scrollback of its own, so a physical PageUp/PageDown key is forwarded to the
+    // live TUI — which holds the history and scrolls itself. In read-only view mode
+    // xterm's stdin is disabled, so without this those keys would just scroll the
+    // browser page; here we intercept ONLY these two keys (never printable input)
+    // and send them to the PTY, so the user can page through earlier output without
+    // enabling the interactive keyboard. In input mode xterm already forwards them
+    // via onData, so we skip to avoid double-send.
+    //
+    // The listener is attached to the document, NOT the viewer container: xterm renders
+    // its own focusable helpers inside #pty-terminal, and with disableStdin the
+    // container rarely holds focus reliably (a reconnect or stray click drops it),
+    // so a container-scoped keydown silently missed the keys. Gating on the viewer
+    // being open + view mode keeps it from hijacking PageUp elsewhere on the page,
+    // and we bail when focus is in a real text field so form paging still works.
+    // \\x1b[5~ = PageUp, \\x1b[6~ = PageDown.
+    function forwardPageKey(e) {
+      if (e.key !== 'PageUp' && e.key !== 'PageDown') return;
+      if (ptyInputMode) return; // input mode: xterm.onData already sends it
+      // Only while THIS viewer is actually open with a live socket.
+      const viewer = document.getElementById('pty-viewer');
+      if (!viewer || viewer.style.display === 'none') return;
+      if (!ptyWs || ptyWs.readyState !== WebSocket.OPEN) return;
+      // Don't steal paging from a genuine editable field (none in view mode today,
+      // but keep the guard so the document-level listener stays well-behaved).
+      const t = e.target;
+      if (t && (t.tagName === 'INPUT' || (t.tagName === 'TEXTAREA' && !t.disabled) || t.isContentEditable)) return;
+      e.preventDefault();
+      ptyWs.send(e.key === 'PageUp' ? '\\x1b[5~' : '\\x1b[6~');
+    }
+    document.addEventListener('keydown', forwardPageKey);
+
     document.getElementById('pty-close-btn').addEventListener('click', closePtyViewer);
     document.getElementById('pty-refresh-btn').addEventListener('click', function() { void refreshPtyViewer(); });
+    document.getElementById('pty-mode-toggle-btn').addEventListener('click', togglePtyInputMode);
 
     // Event delegation for Live buttons (avoids inline onclick + HTML injection)
     document.getElementById('sessions-tbody').addEventListener('click', function(e) {

--- a/tests/unit/control-channel.test.ts
+++ b/tests/unit/control-channel.test.ts
@@ -13,6 +13,9 @@ import {
   KEY_ENTER,
   KEY_UP,
   KEY_DOWN,
+  isAcceptablePtyInput,
+  shouldRoutePtyInput,
+  MAX_PTY_INPUT_BYTES,
 } from '../../src/shell/control-channel'
 
 describe('parseControlCommand — closed vocabulary', () => {
@@ -70,5 +73,31 @@ describe('keystrokesFor — VT100 mapping', () => {
 
   test('U-CC-08: select-option maps to the digit only (Enter is screen-gated by the caller)', () => {
     expect(keystrokesFor({ key: 'select-option', option: 3 })).toEqual(['3'])
+  })
+})
+
+describe('interactive input gate (Issue #201)', () => {
+  test('U-CC-09: isAcceptablePtyInput accepts a non-empty bounded string', () => {
+    expect(isAcceptablePtyInput('a')).toBe(true)
+    expect(isAcceptablePtyInput('\x03')).toBe(true) // Ctrl-C is valid input
+    expect(isAcceptablePtyInput('x'.repeat(MAX_PTY_INPUT_BYTES))).toBe(true)
+  })
+
+  test('U-CC-10: isAcceptablePtyInput rejects empty, oversized, and non-string', () => {
+    expect(isAcceptablePtyInput('')).toBe(false)
+    expect(isAcceptablePtyInput('x'.repeat(MAX_PTY_INPUT_BYTES + 1))).toBe(false)
+    expect(isAcceptablePtyInput(123 as unknown)).toBe(false)
+    expect(isAcceptablePtyInput(null)).toBe(false)
+    expect(isAcceptablePtyInput(undefined)).toBe(false)
+    expect(isAcceptablePtyInput({ toString: () => 'x' } as unknown)).toBe(false)
+  })
+
+  test('U-CC-11: shouldRoutePtyInput requires a text frame + acceptable payload', () => {
+    expect(shouldRoutePtyInput(false, 'ls\r')).toBe(true)
+    // binary frame → dropped
+    expect(shouldRoutePtyInput(true, 'ls\r')).toBe(false)
+    // empty / oversized → dropped
+    expect(shouldRoutePtyInput(false, '')).toBe(false)
+    expect(shouldRoutePtyInput(false, 'x'.repeat(MAX_PTY_INPUT_BYTES + 1))).toBe(false)
   })
 })

--- a/tests/unit/control-channel.test.ts
+++ b/tests/unit/control-channel.test.ts
@@ -92,6 +92,18 @@ describe('interactive input gate (Issue #201)', () => {
     expect(isAcceptablePtyInput({ toString: () => 'x' } as unknown)).toBe(false)
   })
 
+  test('U-CC-10b: isAcceptablePtyInput bounds real UTF-8 bytes, not UTF-16 code units', () => {
+    // '😀' is 2 UTF-16 code units but 4 UTF-8 bytes. A run whose code-unit
+    // length is under the bound while its byte length exceeds it must be
+    // rejected — otherwise multi-byte input could smuggle past the cap.
+    const overByBytes = '😀'.repeat(MAX_PTY_INPUT_BYTES / 4 + 1) // ~1 byte over
+    expect(overByBytes.length).toBeLessThan(MAX_PTY_INPUT_BYTES) // under by code units
+    expect(Buffer.byteLength(overByBytes, 'utf8')).toBeGreaterThan(MAX_PTY_INPUT_BYTES)
+    expect(isAcceptablePtyInput(overByBytes)).toBe(false)
+    // Multi-byte input that fits the byte budget is still accepted.
+    expect(isAcceptablePtyInput('café ✓')).toBe(true)
+  })
+
   test('U-CC-11: shouldRoutePtyInput requires a text frame + acceptable payload', () => {
     expect(shouldRoutePtyInput(false, 'ls\r')).toBe(true)
     // binary frame → dropped

--- a/tests/unit/interactive-shell-viewer.test.ts
+++ b/tests/unit/interactive-shell-viewer.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for the interactive Terminal Viewer + localhost-only bind
+ * (Issue #201). Covers the pure, testable seams of the feature:
+ *   - resolveBindHost precedence (env → config → localhost default)
+ *   - the shipped config.template.json (new fields + configVersion bump)
+ *   - the config migrator picking up the new gateway fields on an old config
+ *   - the generated dashboard HTML (mode toggle markers + valid embedded JS).
+ *     Interactive input is opt-in per browser via the viewer's mode toggle;
+ *     access to the socket is gated upstream by auth + the localhost bind.
+ *
+ * The WS-frame gate and the wrapper input validation are covered in
+ * control-channel.test.ts (shared pure helpers); here we verify the wiring
+ * points that turn those helpers into the shipped feature.
+ */
+
+import * as path from 'path'
+import * as fs from 'fs'
+import { resolveBindHost } from '../../src/api/gateway-router'
+import { generateDashboardHtml } from '../../src/ui/web-ui'
+import { deepMerge } from '../../src/config/migrator'
+
+const TEMPLATE_PATH = path.join(__dirname, '../../config.template.json')
+
+describe('resolveBindHost — bind precedence (Issue #201)', () => {
+  test('U-BIND-01: defaults to localhost when nothing is set', () => {
+    expect(resolveBindHost(undefined, undefined)).toBe('127.0.0.1')
+    expect(resolveBindHost('', '')).toBe('127.0.0.1')
+    expect(resolveBindHost('   ', '   ')).toBe('127.0.0.1') // blank falls through
+  })
+
+  test('U-BIND-02: config bind is used when set and no env override', () => {
+    expect(resolveBindHost(undefined, '0.0.0.0')).toBe('0.0.0.0')
+    expect(resolveBindHost('', '192.168.1.5')).toBe('192.168.1.5')
+  })
+
+  test('U-BIND-03: env var takes precedence over config', () => {
+    expect(resolveBindHost('0.0.0.0', '127.0.0.1')).toBe('0.0.0.0')
+    expect(resolveBindHost('10.0.0.1', '0.0.0.0')).toBe('10.0.0.1')
+  })
+
+  test('U-BIND-04: values are trimmed', () => {
+    expect(resolveBindHost(' 0.0.0.0 ', undefined)).toBe('0.0.0.0')
+    expect(resolveBindHost(undefined, ' 127.0.0.1 ')).toBe('127.0.0.1')
+  })
+})
+
+describe('config.template.json — shipped defaults (Issue #201)', () => {
+  const template = JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8')) as {
+    configVersion: string
+    gateway: { bind?: string; dashboard?: unknown }
+  }
+
+  test('U-TMPL-01: bind defaults to localhost-only', () => {
+    expect(template.gateway.bind).toBe('127.0.0.1')
+  })
+
+  test('U-TMPL-02: no dashboard.interactiveInput flag ships (toggle-only feature)', () => {
+    // Interactive input is controlled entirely by the client-side viewer toggle;
+    // there is no server config flag, so the template must not carry one.
+    expect(template.gateway.dashboard).toBeUndefined()
+  })
+
+  test('U-TMPL-03: configVersion was bumped to at least 1.0.13', () => {
+    // The new fields only reach existing users if the template version leads;
+    // this locks in the bump so a future edit cannot silently drop it.
+    const [maj, min, pat] = template.configVersion.split('.').map((n) => parseInt(n, 10))
+    expect(maj).toBe(1)
+    expect(min * 1000 + pat).toBeGreaterThanOrEqual(13) // >= 1.0.13
+  })
+})
+
+describe('config migrator — merges new gateway fields into an old config', () => {
+  test('U-MIG-01: deepMerge adds gateway.bind, keeps existing values', () => {
+    // An existing user config predating Issue #201 (no bind).
+    const userConfig: Record<string, unknown> = {
+      configVersion: '1.0.12',
+      gateway: { logDir: '/my/logs', headless: false },
+    }
+    // The relevant slice of the new template.
+    const template: Record<string, unknown> = {
+      configVersion: '1.0.13',
+      gateway: {
+        logDir: '/default/logs',
+        bind: '127.0.0.1',
+        headless: true,
+      },
+    }
+    const added: string[] = []
+    deepMerge(userConfig, template, '', added)
+
+    const gw = userConfig.gateway as Record<string, unknown>
+    // New field merged in…
+    expect(gw.bind).toBe('127.0.0.1')
+    // deepMerge records the newly-added leaf under an existing parent.
+    expect(added).toContain('gateway.bind')
+    // …without clobbering the user's existing overrides.
+    expect(gw.logDir).toBe('/my/logs')
+    expect(gw.headless).toBe(false)
+  })
+})
+
+describe('dashboard HTML — mode toggle + embedded JS (Issue #201)', () => {
+  /** Pull the last <script>…</script> block (the dashboard logic) out of the page. */
+  function scriptBody(html: string): string {
+    const blocks = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)]
+    expect(blocks.length).toBeGreaterThan(0)
+    return blocks[blocks.length - 1]![1]!
+  }
+
+  test('U-UI-01: the mode toggle button and swappable title are always in the markup', () => {
+    const html = generateDashboardHtml('tok')
+    expect(html).toContain('id="pty-mode-toggle-btn"')
+    expect(html).toContain('id="pty-title-text"')
+    expect(html).toContain('Terminal Viewer')
+  })
+
+  test('U-UI-02: the mode toggle ships visible (no inline display:none gate)', () => {
+    // With no server flag, the toggle is always rendered — its button markup
+    // must not be hidden with an inline style the way the gated version was.
+    const html = generateDashboardHtml('tok')
+    const btn = html.match(/<button class="pty-mode-toggle"[^>]*>/)![0]
+    expect(btn).not.toContain('display:none')
+  })
+
+  test('U-UI-03: the embedded dashboard script is syntactically valid', () => {
+    const body = scriptBody(generateDashboardHtml('tok'))
+    // Parse-only: throws on a syntax error, does not execute (no DOM needed).
+    expect(() => new Function(body)).not.toThrow()
+  })
+
+  test('U-UI-04: input-mode wiring references the shared send path', () => {
+    const body = scriptBody(generateDashboardHtml('tok'))
+    expect(body).toContain('setPtyInputMode')
+    expect(body).toContain('term.onData')
+    expect(body).toContain('Interactive Terminal') // title in input mode
+  })
+
+  test('U-UI-05: physical PageUp/PageDown keys are forwarded to the PTY in view mode', () => {
+    const html = generateDashboardHtml('tok')
+    // No on-screen page buttons — paging is driven by the real keyboard keys.
+    expect(html).not.toContain('id="pty-pageup-btn"')
+    expect(html).not.toContain('id="pty-pagedown-btn"')
+    const body = scriptBody(html)
+    // A keydown handler forwards ONLY PageUp/PageDown (5~ / 6~), never printable
+    // input, and skips input mode (xterm.onData already sends them there).
+    expect(body).toContain('function forwardPageKey')
+    expect(body).toContain("e.key !== 'PageUp'")
+    expect(body).toContain("e.key !== 'PageDown'")
+    expect(body).toContain('if (ptyInputMode) return') // no double-send in input mode
+    expect(body).toContain('[5~') // PageUp
+    expect(body).toContain('[6~') // PageDown
+  })
+
+  test('U-UI-05b: the page-key listener is on document, not the viewer container (regression)', () => {
+    // Regression guard for Issue #201: the handler was originally attached to the
+    // #pty-terminal container, which only fires while that element holds focus —
+    // and with disableStdin xterm rarely does, so a reconnect or stray click left
+    // PageUp/PageDown dead. Verified end-to-end (headless Chromium) that a
+    // document-level listener delivers the keys with focus OUTSIDE the terminal.
+    const body = scriptBody(generateDashboardHtml('tok'))
+    expect(body).toContain("document.addEventListener('keydown', forwardPageKey)")
+    // Must NOT be re-scoped back to the focus-dependent container.
+    expect(body).not.toContain(
+      "document.getElementById('pty-terminal').addEventListener('keydown', forwardPageKey)",
+    )
+    // The handler self-gates on the viewer being open (so it is harmless page-wide).
+    expect(body).toContain("getElementById('pty-viewer')")
+  })
+})


### PR DESCRIPTION
Closes #201

## Summary
Turns the read-only **Shell Process Viewer** into an interactive **Terminal Viewer** with a top-right view/input toggle, and hardens the dashboard bind to localhost by default.

## ⚠️ Breaking / upgrade note (configVersion 1.0.13)
The default dashboard/API **bind changes from `0.0.0.0` to `127.0.0.1` (localhost-only)**. Deployments that reach the dashboard or API from another host — most commonly a **containerized reverse proxy** that connects across the container boundary — will lose reachability after upgrading unless they opt back in explicitly:

- set `gateway.bind` to `"0.0.0.0"` in the config, **or**
- set the `GATEWAY_BIND=0.0.0.0` environment variable.

Deployments that use a host-network proxy or access the dashboard on `localhost` need no change. The migrator does **not** rewrite an existing `bind` value; only fresh configs pick up the new localhost default.

## Changes

### Frontend (`src/ui/web-ui.ts`)
- Rename **"Shell Process Viewer" → "Terminal Viewer"**; the title changes per active mode.
- **Top-right toggle** switches **view ↔ input** mode (next to ↻ / ✕).
- **Input mode**: wires xterm `onData` → bidirectional WebSocket → PTY, so every keystroke behaves like a real terminal.
- **View mode**: stays read-only but forwards **PageUp / PageDown** keys so users can scroll the TUI's own transcript. The listener is bound at `document` level and gated on *viewer-open + view-mode + non-editable target*, so it works regardless of which element holds focus.

### Backend (`gateway-router.ts`, `process.ts`, `runner.ts`, `control-channel.ts`)
- Bidirectional PTY-stream WebSocket: `ws.on('message')` now routes gated input down to the PTY (previously discarded).
- `isAcceptablePtyInput` / `shouldRoutePtyInput` centralize what may cross into the shell (binary-frame drop + a per-frame size bound measured in real UTF-8 bytes via `Buffer.byteLength`).
- The PTY-stream `WebSocketServer` sets `maxPayload` (8× the input bound) so oversized inbound frames are rejected at the WS layer before any string is allocated. Server → client PTY output is unaffected.
- `SessionProcess.sendInput` + runner-side routing of input by `sessionId`.
- `resolveBindHost` helper; default bind is now **127.0.0.1**.

### Config (`config.template.json`, `types.ts`)
- Default dashboard bind to **localhost-only**; bump `configVersion` **1.0.12 → 1.0.13**.

## Security model (defense in depth)
| Layer | Role | Default |
|---|---|---|
| `bind` localhost | who can reach the dashboard | `127.0.0.1` |
| WS ticket/API-key auth | who can open the stream | required |
| byte-bound + binary-drop input validation + WS `maxPayload` | what may enter the PTY | enforced |
| view/input toggle | UX convenience (client state) | view |

Note: per the issue discussion, the standalone `dashboard.interactiveInput` server flag was dropped — the view/input toggle governs input from the UI, while localhost bind + WS auth + input validation remain the real security boundary.

## Testing
- `tests/unit/interactive-shell-viewer.test.ts` — input gating, bind resolution, migrator merge, PageUp/PageDown keydown-forward regression guard (incl. focus-independent delivery).
- `tests/unit/control-channel.test.ts` — extended `isAcceptablePtyInput` coverage, incl. real-UTF-8-byte bounding (multi-byte input cannot smuggle past the cap).
- PageUp/PageDown path verified end-to-end against a live gateway with headless Chromium (focus on `body` → ESC page sequences reached the PTY; Claude's TUI scrolled).
- typecheck clean; full unit suite green (123 suites / 2,391 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
