### PR TITLE
Fix MCP tools importing unpublished src/ (silent receiver crash on installed packages)

### DIFF
--- a/mcp/tools/skills/handlers.ts
+++ b/mcp/tools/skills/handlers.ts
@@ -161,8 +161,11 @@ export async function installSkill(params: InstallSkillParams): Promise<string> 
     throw new Error(`SKILL.md exceeds ${MAX_SKILL_SIZE / 1024}KB limit (${(content.length / 1024).toFixed(1)}KB)`);
   }
 
-  // Parse frontmatter to extract name
-  const { extractFrontmatter } = await import('../../../src/skills/parser');
+  // Parse frontmatter to extract name. Import the COMPILED dist/ artifact, not
+  // raw src/ — this file is run by bun and packaged as source (files: ["mcp/"]);
+  // src/ is NOT published, so '../../../src/skills/parser' throws "Cannot find
+  // module" from an installed package. Guarded by mcp-no-src-imports.test.ts.
+  const { extractFrontmatter } = await import('../../../dist/skills/parser.js');
   const extracted = extractFrontmatter(content);
   if (!extracted) {
     throw new Error('Invalid SKILL.md: no valid YAML frontmatter found.');

--- a/mcp/tools/skills/handlers.ts
+++ b/mcp/tools/skills/handlers.ts
@@ -161,10 +161,9 @@ export async function installSkill(params: InstallSkillParams): Promise<string> 
     throw new Error(`SKILL.md exceeds ${MAX_SKILL_SIZE / 1024}KB limit (${(content.length / 1024).toFixed(1)}KB)`);
   }
 
-  // Parse frontmatter to extract name. Import the COMPILED dist/ artifact, not
-  // raw src/ — this file is run by bun and packaged as source (files: ["mcp/"]);
-  // src/ is NOT published, so '../../../src/skills/parser' throws "Cannot find
-  // module" from an installed package. Guarded by mcp-no-src-imports.test.ts.
+  // Parse frontmatter to extract name. Import compiled dist/, not raw src/ —
+  // src/ is not published (files: ["mcp/"]), so a src/ import throws "Cannot find
+  // module" on installed packages. Enforced by mcp-no-src-imports.test.ts.
   const { extractFrontmatter } = await import('../../../dist/skills/parser.js');
   const extracted = extractFrontmatter(content);
   if (!extracted) {

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -30,9 +30,15 @@ import { homedir } from 'os'
 import { join, extname, sep } from 'path'
 import { execFileSync } from 'child_process'
 import { createWorkingStateManager, drainOrphanForwards } from './typing'
-import { formatTurnIncident, type TurnIncident } from '../../../src/agent/turn-trace'
-import { createIncidentStore } from '../../../src/agent/incident-store'
-import type { RecoveryOutcome } from '../../../src/agent/incident'
+// Import the COMPILED artifact from dist/, not raw src/. This file is run by bun
+// and packaged as source (files: ["mcp/"]); src/ is NOT published, so a
+// '../../../src/agent/*' import resolves in the dev repo but throws "Cannot find
+// module" from an installed package (which is exactly what silently broke every
+// Telegram receiver on systemd/global installs). dist/ ships. Guarded by
+// mcp-no-src-imports.test.ts.
+import { formatTurnIncident, type TurnIncident } from '../../../dist/agent/turn-trace.js'
+import { createIncidentStore } from '../../../dist/agent/incident-store.js'
+import type { RecoveryOutcome } from '../../../dist/agent/incident.js'
 import { initDedupDir, isDuplicate as _isDuplicate, pruneDedup as _pruneDedup } from './dedup'
 import { hasMarkdown, toTelegramHtml, migrateAccess } from './pure'
 

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -30,12 +30,10 @@ import { homedir } from 'os'
 import { join, extname, sep } from 'path'
 import { execFileSync } from 'child_process'
 import { createWorkingStateManager, drainOrphanForwards } from './typing'
-// Import the COMPILED artifact from dist/, not raw src/. This file is run by bun
-// and packaged as source (files: ["mcp/"]); src/ is NOT published, so a
-// '../../../src/agent/*' import resolves in the dev repo but throws "Cannot find
-// module" from an installed package (which is exactly what silently broke every
-// Telegram receiver on systemd/global installs). dist/ ships. Guarded by
-// mcp-no-src-imports.test.ts.
+// Import compiled dist/, not raw src/ — src/ is not published (files: ["mcp/"]),
+// so a src/ import crashes this bun-run receiver on installed packages (the bug
+// that silenced every bot on systemd installs). Enforced by
+// tests/unit/mcp-no-src-imports.test.ts.
 import { formatTurnIncident, type TurnIncident } from '../../../dist/agent/turn-trace.js'
 import { createIncidentStore } from '../../../dist/agent/incident-store.js'
 import type { RecoveryOutcome } from '../../../dist/agent/incident.js'

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -13,11 +13,9 @@
  *   STATE_DIR/typing/{chatId}.error     — written by AgentRunner on session failure
  */
 
-// Import the COMPILED artifact from dist/, not raw src/. These MCP scripts are
-// run directly by bun and are packaged as source (files: ["mcp/"]); src/ is NOT
-// published, so importing '../../../src/agent/*' resolves in the dev repo but
-// throws "Cannot find module" from an installed package. dist/ ships and both
-// runtimes (node gateway + bun MCP) consume it. See mcp-no-src-imports.test.ts.
+// Import compiled dist/, not raw src/ — src/ is not published (files: ["mcp/"]),
+// so a src/ import crashes this bun-run tool on installed packages. Enforced by
+// tests/unit/mcp-no-src-imports.test.ts.
 import {
   classifyTurn,
   type TurnObservation,

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -13,13 +13,18 @@
  *   STATE_DIR/typing/{chatId}.error     — written by AgentRunner on session failure
  */
 
+// Import the COMPILED artifact from dist/, not raw src/. These MCP scripts are
+// run directly by bun and are packaged as source (files: ["mcp/"]); src/ is NOT
+// published, so importing '../../../src/agent/*' resolves in the dev repo but
+// throws "Cannot find module" from an installed package. dist/ ships and both
+// runtimes (node gateway + bun MCP) consume it. See mcp-no-src-imports.test.ts.
 import {
   classifyTurn,
   type TurnObservation,
   type TurnStage,
   type TurnIncidentSink,
   type TurnIncidentEvidence,
-} from '../../../src/agent/turn-trace'
+} from '../../../dist/agent/turn-trace.js'
 
 export const TELEGRAM_MAX_CHARS = 4096
 

--- a/tests/unit/mcp-no-src-imports.test.ts
+++ b/tests/unit/mcp-no-src-imports.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression guard for the packaging class of bug that silently broke every
+ * Telegram receiver on systemd/global installs (v1.3.25–v1.3.26).
+ *
+ * Root cause: the MCP tools under `mcp/` are run directly by bun and shipped as
+ * SOURCE (package.json `files` lists "mcp/", not "src/"). When an `mcp/**` file
+ * imported `../../../src/agent/*`, it resolved fine in the dev repo (src exists)
+ * but threw "Cannot find module" from an installed package (src is not
+ * published) — so the receiver crashed on startup and the bot went silent.
+ * Local tests never caught it because the dev tree always has src/.
+ *
+ * The rule this test enforces: a shipped `mcp/**` file may only import from
+ *   (a) within `mcp/` itself (self-contained siblings), or
+ *   (b) a directory that is actually published (the package.json `files` dirs,
+ *       e.g. `dist/` — the compiled artifact both runtimes consume).
+ * It may NEVER reach into `src/` (or any other non-published path), because that
+ * path is absent from the tarball an end user installs.
+ */
+import { readFileSync, readdirSync } from 'fs'
+import { join, resolve, dirname, relative, sep } from 'path'
+
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const MCP_DIR = join(REPO_ROOT, 'mcp')
+
+/** Top-level directories that npm actually publishes (from package.json `files`). */
+function shippedDirs(): string[] {
+  const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'))
+  const files: string[] = pkg.files ?? []
+  return files
+    .filter((f) => f.endsWith('/'))
+    .map((f) => f.replace(/\/+$/, '')) // "dist/" -> "dist"
+}
+
+/** Recursively collect every .ts/.js under mcp/, skipping mcp/node_modules. */
+function collectMcpSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') continue
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) collectMcpSources(full, out)
+    else if (/\.(ts|js)$/.test(entry.name) && !/\.d\.ts$/.test(entry.name)) out.push(full)
+  }
+  return out
+}
+
+/** Pull every relative import/require specifier out of a source file. */
+function relativeSpecifiers(source: string): string[] {
+  const specs: string[] = []
+  const patterns = [
+    /\bfrom\s*['"]([^'"]+)['"]/g, // import ... from '...'
+    /\bimport\s*['"]([^'"]+)['"]/g, // import '...'
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g, // dynamic import('...')
+    /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g, // require('...')
+  ]
+  for (const re of patterns) {
+    let m: RegExpExecArray | null
+    while ((m = re.exec(source)) !== null) {
+      if (m[1].startsWith('.')) specs.push(m[1])
+    }
+  }
+  return specs
+}
+
+describe('mcp/ must not import from unpublished paths (packaging guard)', () => {
+  const SHIPPED = shippedDirs()
+  const mcpFiles = collectMcpSources(MCP_DIR)
+
+  it('publishes dist/ so compiled shared modules are importable at runtime', () => {
+    // The whole strategy (import ../../../dist/agent/*.js from mcp) depends on
+    // dist/ being in the published set. If this ever changes, mcp imports break.
+    expect(SHIPPED).toContain('dist')
+  })
+
+  it('finds mcp source files to scan (guard is not a no-op)', () => {
+    expect(mcpFiles.length).toBeGreaterThan(0)
+  })
+
+  it('no mcp/** file imports a path outside the published file set', () => {
+    const violations: string[] = []
+
+    for (const file of mcpFiles) {
+      const source = readFileSync(file, 'utf8')
+      for (const spec of relativeSpecifiers(source)) {
+        const resolvedRel = relative(REPO_ROOT, resolve(dirname(file), spec))
+        const parts = resolvedRel.split(sep)
+        // Imports that stay inside mcp/ are always fine (self-contained siblings).
+        if (parts[0] === 'mcp') continue
+        // Anything escaping mcp/ must land in a published directory.
+        const topDir = parts[0]
+        if (!SHIPPED.includes(topDir)) {
+          violations.push(
+            `${relative(REPO_ROOT, file)} imports "${spec}" -> "${resolvedRel}" ` +
+              `(top-level "${topDir}" is NOT in package.json files: ${SHIPPED.join(', ')})`,
+          )
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      throw new Error(
+        'mcp/ imports an unpublished path — this crashes the receiver on ' +
+          'installed packages (import the compiled dist/ artifact instead):\n  ' +
+          violations.join('\n  '),
+      )
+    }
+    expect(violations).toEqual([])
+  })
+})

--- a/tests/unit/mcp-no-src-imports.test.ts
+++ b/tests/unit/mcp-no-src-imports.test.ts
@@ -15,6 +15,12 @@
  *       e.g. `dist/` — the compiled artifact both runtimes consume).
  * It may NEVER reach into `src/` (or any other non-published path), because that
  * path is absent from the tarball an end user installs.
+ *
+ * Consequence for local dev: because the bun MCP tools consume the COMPILED
+ * `dist/` artifact, `npm run build` must have run before they can resolve those
+ * imports. This is a non-issue in practice — the gateway itself runs from
+ * `dist/`, and `make start` builds first — but a fresh checkout that launches an
+ * MCP tool without building will hit the same "Cannot find module".
  */
 import { readFileSync, readdirSync } from 'fs'
 import { join, resolve, dirname, relative, sep } from 'path'
@@ -42,8 +48,24 @@ function collectMcpSources(dir: string, out: string[] = []): string[] {
   return out
 }
 
+/**
+ * Strip line and block comments before scanning. Import specifiers only ever
+ * appear in real code, so this avoids false positives from prose that mentions
+ * an import path (e.g. the very comments this repo uses to explain why these
+ * files import from dist/ and not src/). Over-stripping is harmless here: we
+ * only extract *relative* specifiers, which never live inside string URLs, so
+ * mangling a `'https://…'` literal cannot change the result, and a real import
+ * statement is never hidden behind a `//` on its own line.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/\/\/[^\n]*/g, '') // line comments
+}
+
 /** Pull every relative import/require specifier out of a source file. */
 function relativeSpecifiers(source: string): string[] {
+  source = stripComments(source)
   const specs: string[] = []
   const patterns = [
     /\bfrom\s*['"]([^'"]+)['"]/g, // import ... from '...'

--- a/tests/unit/mcp-no-src-imports.test.ts
+++ b/tests/unit/mcp-no-src-imports.test.ts
@@ -10,32 +10,38 @@
  * Local tests never caught it because the dev tree always has src/.
  *
  * The rule this test enforces: a shipped `mcp/**` file may only import from
- *   (a) within `mcp/` itself (self-contained siblings), or
- *   (b) a directory that is actually published (the package.json `files` dirs,
- *       e.g. `dist/` — the compiled artifact both runtimes consume).
+ *   (a) within `mcp/` itself (self-contained siblings),
+ *   (b) a published directory from package.json `files` (e.g. `dist/` — the
+ *       compiled artifact both runtimes consume), or
+ *   (c) an exact published top-level file (e.g. `config.template.json`).
  * It may NEVER reach into `src/` (or any other non-published path), because that
- * path is absent from the tarball an end user installs.
+ * path is absent from the tarball an end user installs. For `dist/` imports it
+ * also checks that a matching `src/` source exists, so a typo'd dist path (whose
+ * directory ships but whose file does not exist) is caught too.
  *
  * Consequence for local dev: because the bun MCP tools consume the COMPILED
  * `dist/` artifact, `npm run build` must have run before they can resolve those
- * imports. This is a non-issue in practice — the gateway itself runs from
+ * imports. This is a non-issue in normal operation — the gateway runs from
  * `dist/`, and `make start` builds first — but a fresh checkout that launches an
  * MCP tool without building will hit the same "Cannot find module".
  */
-import { readFileSync, readdirSync } from 'fs'
+import { readFileSync, readdirSync, existsSync } from 'fs'
 import { join, resolve, dirname, relative, sep } from 'path'
 
 const REPO_ROOT = resolve(__dirname, '..', '..')
 const MCP_DIR = join(REPO_ROOT, 'mcp')
 
-/** Top-level directories that npm actually publishes (from package.json `files`). */
-function shippedDirs(): string[] {
+/** package.json `files`, split into published directory prefixes and exact files. */
+function shippedEntries(): { dirs: string[]; files: string[] } {
   const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'))
   const files: string[] = pkg.files ?? []
-  return files
-    .filter((f) => f.endsWith('/'))
-    .map((f) => f.replace(/\/+$/, '')) // "dist/" -> "dist"
+  return {
+    dirs: files.filter((f) => f.endsWith('/')).map((f) => f.replace(/\/+$/, '')), // "dist/" -> "dist"
+    files: files.filter((f) => !f.endsWith('/')), // "config.template.json"
+  }
 }
+
+const SHIPPED = shippedEntries()
 
 /** Recursively collect every .ts/.js under mcp/, skipping mcp/node_modules. */
 function collectMcpSources(dir: string, out: string[] = []): string[] {
@@ -49,22 +55,50 @@ function collectMcpSources(dir: string, out: string[] = []): string[] {
 }
 
 /**
- * Strip line and block comments before scanning. Import specifiers only ever
- * appear in real code, so this avoids false positives from prose that mentions
- * an import path (e.g. the very comments this repo uses to explain why these
- * files import from dist/ and not src/). Over-stripping is harmless here: we
- * only extract *relative* specifiers, which never live inside string URLs, so
- * mangling a `'https://…'` literal cannot change the result, and a real import
- * statement is never hidden behind a `//` on its own line.
+ * Strip line and block comments WITHOUT touching string-literal contents, so a
+ * URL like 'https://a//b' or a comment-looking path inside a string survives
+ * intact (import specifiers only ever appear in real code, never in a string, so
+ * nothing is lost). A small state machine walks the source tracking whether we
+ * are inside a '…', "…", or `…` literal (respecting backslash escapes); a `//`
+ * or block comment opener is only a comment in code context. Regex literals are
+ * not special-cased — they are rare in these files and at worst leave a comment
+ * unstripped, which can never hide a real import.
  */
 function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
-    .replace(/\/\/[^\n]*/g, '') // line comments
+  let out = ''
+  let quote: string | null = null
+  for (let i = 0; i < source.length; i++) {
+    const c = source[i]
+    const c2 = source[i + 1] ?? ''
+    if (quote) {
+      out += c
+      if (c === '\\' && i + 1 < source.length) {
+        out += source[i + 1] // keep escaped char verbatim
+        i++
+      } else if (c === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (c === '/' && c2 === '/') {
+      while (i < source.length && source[i] !== '\n') i++
+      out += '\n'
+      continue
+    }
+    if (c === '/' && c2 === '*') {
+      i += 2
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) i++
+      i++ // land on '/', the loop's i++ steps past it
+      continue
+    }
+    if (c === '"' || c === "'" || c === '`') quote = c
+    out += c
+  }
+  return out
 }
 
 /** Pull every relative import/require specifier out of a source file. */
-function relativeSpecifiers(source: string): string[] {
+export function relativeSpecifiers(source: string): string[] {
   source = stripComments(source)
   const specs: string[] = []
   const patterns = [
@@ -82,14 +116,51 @@ function relativeSpecifiers(source: string): string[] {
   return specs
 }
 
+/**
+ * Classify one relative import from one mcp file. Returns a violation message,
+ * or null if the import is safe to publish. Exported so the rules can be tested
+ * directly with synthetic inputs, not only against the live tree.
+ */
+export function classifyImport(fileAbs: string, spec: string): string | null {
+  const resolvedRel = relative(REPO_ROOT, resolve(dirname(fileAbs), spec))
+  const where = `${relative(REPO_ROOT, fileAbs)} imports "${spec}" -> "${resolvedRel}"`
+  const parts = resolvedRel.split(sep)
+
+  // (a) sibling within mcp/ — always fine.
+  if (parts[0] === 'mcp') return null
+  // (c) an exact published top-level file (e.g. config.template.json).
+  if (SHIPPED.files.includes(resolvedRel)) return null
+  // (b) must land in a published directory.
+  const topDir = parts[0]
+  if (!SHIPPED.dirs.includes(topDir)) {
+    return `${where} (top-level "${topDir}" is NOT in package.json files: ${[...SHIPPED.dirs, ...SHIPPED.files].join(', ')})`
+  }
+  // dist/ ships, but verify the import points at a real compiled module: dist is
+  // built 1:1 from src, so a matching src/<path>.ts(x) (or dir/index) must exist.
+  // This catches a typo'd dist path without requiring dist to be built first.
+  if (topDir === 'dist') {
+    const rel = parts.slice(1).join(sep).replace(/\.(js|mjs|cjs)$/, '')
+    const candidates = [
+      join(REPO_ROOT, 'src', `${rel}.ts`),
+      join(REPO_ROOT, 'src', `${rel}.tsx`),
+      join(REPO_ROOT, 'src', rel), // extensionless file or directory (index)
+      join(REPO_ROOT, 'src', rel, 'index.ts'),
+    ]
+    if (!candidates.some((p) => existsSync(p))) {
+      return `${where} (no src counterpart src/${rel}.ts — typo?)`
+    }
+  }
+  return null
+}
+
 describe('mcp/ must not import from unpublished paths (packaging guard)', () => {
-  const SHIPPED = shippedDirs()
   const mcpFiles = collectMcpSources(MCP_DIR)
+  const anchor = join(MCP_DIR, 'tools', 'telegram', 'receiver-server.ts')
 
   it('publishes dist/ so compiled shared modules are importable at runtime', () => {
     // The whole strategy (import ../../../dist/agent/*.js from mcp) depends on
     // dist/ being in the published set. If this ever changes, mcp imports break.
-    expect(SHIPPED).toContain('dist')
+    expect(SHIPPED.dirs).toContain('dist')
   })
 
   it('finds mcp source files to scan (guard is not a no-op)', () => {
@@ -98,25 +169,12 @@ describe('mcp/ must not import from unpublished paths (packaging guard)', () => 
 
   it('no mcp/** file imports a path outside the published file set', () => {
     const violations: string[] = []
-
     for (const file of mcpFiles) {
-      const source = readFileSync(file, 'utf8')
-      for (const spec of relativeSpecifiers(source)) {
-        const resolvedRel = relative(REPO_ROOT, resolve(dirname(file), spec))
-        const parts = resolvedRel.split(sep)
-        // Imports that stay inside mcp/ are always fine (self-contained siblings).
-        if (parts[0] === 'mcp') continue
-        // Anything escaping mcp/ must land in a published directory.
-        const topDir = parts[0]
-        if (!SHIPPED.includes(topDir)) {
-          violations.push(
-            `${relative(REPO_ROOT, file)} imports "${spec}" -> "${resolvedRel}" ` +
-              `(top-level "${topDir}" is NOT in package.json files: ${SHIPPED.join(', ')})`,
-          )
-        }
+      for (const spec of relativeSpecifiers(readFileSync(file, 'utf8'))) {
+        const v = classifyImport(file, spec)
+        if (v) violations.push(v)
       }
     }
-
     if (violations.length > 0) {
       throw new Error(
         'mcp/ imports an unpublished path — this crashes the receiver on ' +
@@ -125,5 +183,35 @@ describe('mcp/ must not import from unpublished paths (packaging guard)', () => 
       )
     }
     expect(violations).toEqual([])
+  })
+
+  // ── Rule-level tests (synthetic inputs, independent of the live tree) ────────
+
+  it('rejects a raw src/ import', () => {
+    expect(classifyImport(anchor, '../../../src/agent/turn-trace')).toMatch(/NOT in package.json files/)
+  })
+
+  it('accepts a real dist/ import but rejects a typo with no src counterpart', () => {
+    expect(classifyImport(anchor, '../../../dist/agent/turn-trace.js')).toBeNull()
+    expect(classifyImport(anchor, '../../../dist/agent/does-not-exist.js')).toMatch(/no src counterpart/)
+  })
+
+  it('accepts a self-contained sibling import within mcp/', () => {
+    expect(classifyImport(anchor, './typing')).toBeNull()
+  })
+
+  it('accepts an exact published top-level file (not just a directory)', () => {
+    // config.template.json is a published file entry, not a directory prefix.
+    expect(SHIPPED.files).toContain('config.template.json')
+    expect(classifyImport(anchor, '../../../config.template.json')).toBeNull()
+  })
+
+  it('strips comments and string contents so import-like prose does not trigger', () => {
+    // A path mentioned in a comment must not be treated as an import.
+    expect(relativeSpecifiers("// import x from '../../../src/foo'\n")).toEqual([])
+    // A '//' inside a string literal must not be mistaken for a comment.
+    expect(
+      relativeSpecifiers("const u = 'https://a//b'\nimport x from '../../../dist/y.js'"),
+    ).toEqual(['../../../dist/y.js'])
   })
 })


### PR DESCRIPTION
## Summary

On a systemd/global install (`make system-start`), **every Telegram receiver crashed at startup** and the bot went completely silent — while `make start` (run from the repo) worked fine.

Root cause is a packaging bug: the MCP tool scripts under `mcp/` are run directly by bun and are shipped as **source** (`package.json` `files` lists `"mcp/"`, not `"src/"`). Several of them imported from `../../../src/agent/*` and `../../../src/skills/*`. Those paths resolve in the dev repo but are **absent from the published tarball**, so bun threw:

```
Cannot find module '../../../src/agent/turn-trace'
  from .../mcp/tools/telegram/receiver-server.ts
```

`make start` masked it because the repo always has `src/`. The bug shipped silently in **v1.3.25 and v1.3.26** (introduced with the self-healing work in #200).

## Fix

Import the **compiled `dist/` artifact** (which is published, and is the shared artifact both the node gateway and the bun MCP tools already consume) instead of raw `src/`. These modules are used by **both** trees (node: `runner`/`recovery-executor`; bun: `typing`/`receiver`), so relocating them into `mcp/` is not an option.

| File | Before | After |
|---|---|---|
| `mcp/tools/telegram/typing.ts` | `src/agent/turn-trace` | `dist/agent/turn-trace.js` |
| `mcp/tools/telegram/receiver-server.ts` | `src/agent/{turn-trace,incident-store,incident}` | `dist/agent/*.js` |
| `mcp/tools/skills/handlers.ts` | dynamic `import('src/skills/parser')` | `dist/skills/parser.js` |

The `skills/handlers.ts` case was a **latent second instance** surfaced by the new guard — a lazy import that would only throw when parsing `SKILL.md` frontmatter on an installed package.

`package.json` is unchanged (no raw `src/` is shipped).

## Regression guard

`tests/unit/mcp-no-src-imports.test.ts` scans every `mcp/**` source file and fails if any relative import escapes `mcp/` into a directory that `package.json` `files` does not publish. This is the check that was missing and let the bug ship twice. It is proven to catch the failure (a `src/` import makes it red) and it is what found the `skills/handlers.ts` instance.

## Verification

- `npm pack` → the tarball contains **no `src/`**; extracting it and resolving the new `dist/` imports with bun from the real `mcp/tools/**` locations succeeds (before the fix it threw `Cannot find module`).
- `tsc --noEmit` clean (`mcp/` is outside the root tsconfig; `dist/` ships `.d.ts`).
- Full unit suite green: **105 suites / 2,145 tests**.

## Why not ship `src/` in `files`?

That would work but ships raw internal source and stays fragile: any future `mcp → src` import re-breaks silently unless someone remembers to whitelist it. Importing the already-published `dist/` artifact respects the packaging boundary, and the guard test prevents recurrence regardless.