### PR TITLE
[Bug] Preserve external bind on upgrade for pre-1.3.26 configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (l
 }
 ```
 
-> **⚠️ Upgrade note (configVersion 1.0.13):** the default bind changed from `0.0.0.0` to `127.0.0.1`. If you reach the dashboard/API from another host — most commonly through a **containerized** reverse proxy that connects across the container boundary — the gateway will no longer be reachable after upgrading unless you opt back in explicitly by setting `gateway.bind` to `0.0.0.0` (or the `GATEWAY_BIND` env var). Deployments that only use a host-network proxy or access the dashboard on `localhost` need no change.
+> **⚠️ Upgrade note (configVersion 1.0.13):** the default bind changed from `0.0.0.0` to `127.0.0.1`. To avoid silently cutting off external access, the config migrator is **behavior-preserving**: when it upgrades a config created before this change and that config never set `gateway.bind`, it pins `bind` to `0.0.0.0` and logs a one-time warning, so a deployment that was reachable from another host stays reachable. New installs (no prior config, so no migration runs) keep the secure `127.0.0.1` default. If you *want* localhost-only after upgrading, set `gateway.bind` to `127.0.0.1` explicitly (or the `GATEWAY_BIND` env var).
 
 ### Terminal Viewer — interactive terminal mode
 

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -5,6 +5,7 @@ export interface MigrationResult {
   migrated: boolean;
   addedFields: string[];
   removedFields: string[];
+  warnings: string[];
 }
 
 export interface DetectMigrationResult {
@@ -13,6 +14,7 @@ export interface DetectMigrationResult {
   toVersion: string;
   addedFields: string[];
   removedFields: string[];
+  warnings: string[];
   config: Record<string, unknown>;
   template: Record<string, unknown>;
 }
@@ -224,6 +226,46 @@ function compareSemver(a: string, b: string): number {
   return 0;
 }
 
+/** Version that introduced the localhost-only `gateway.bind` default (Issue #201 / PR #202). */
+const BIND_LOCALHOST_DEFAULT_VERSION = '1.3.26';
+
+/** Warning surfaced when a migration pins `gateway.bind` to preserve external access (Issue #204). */
+export const BIND_PRESERVED_WARNING =
+  'gateway.bind was pinned to "0.0.0.0" to preserve external API/dashboard access across this upgrade. ' +
+  'Set gateway.bind to "127.0.0.1" in config.json if you do not need access from outside this host.';
+
+/**
+ * Behavior-preserving migration for `gateway.bind` (Issue #204).
+ *
+ * v1.3.26 (#201/#202) made the server default to binding 127.0.0.1 when
+ * `gateway.bind` is unset. Deployments upgrading from an earlier version were
+ * implicitly bound to 0.0.0.0, so silently applying the new localhost default
+ * cuts off external API/dashboard access with no warning. To preserve prior
+ * behavior, pin `bind` to "0.0.0.0" for pre-1.3.26 configs that never set it.
+ * Fresh installs (no prior config, so no migration runs) keep the secure
+ * localhost default.
+ *
+ * Mutates `config` in place when it pins the value. Returns the added field
+ * path (`gateway.bind`) if pinned, otherwise null.
+ */
+function preserveBindDefault(
+  config: Record<string, unknown>,
+  fromVersion: string,
+): string | null {
+  // Only pre-1.3.26 configs were implicitly bound to all interfaces.
+  if (compareSemver(fromVersion, BIND_LOCALHOST_DEFAULT_VERSION) >= 0) return null;
+
+  const gateway = config.gateway;
+  if (!gateway || typeof gateway !== 'object' || Array.isArray(gateway)) return null;
+
+  const g = gateway as Record<string, unknown>;
+  // Respect any explicit bind the user already set — never overwrite.
+  if ('bind' in g) return null;
+
+  g.bind = '0.0.0.0';
+  return 'gateway.bind';
+}
+
 /**
  * Load a template file, extract the _migration metadata, strip it,
  * and return the clean template along with the ignorePaths set.
@@ -308,6 +350,7 @@ export function detectMigration(
     toVersion: templateVersion,
     addedFields: [],
     removedFields: [],
+    warnings: [],
     config,
     template,
   });
@@ -384,6 +427,14 @@ export function detectMigration(
     );
   }
 
+  // Preserve external bind behavior for pre-1.3.26 configs (Issue #204)
+  const warnings: string[] = [];
+  const bindField = preserveBindDefault(configClone, configVersion);
+  if (bindField) {
+    added.push(bindField);
+    warnings.push(BIND_PRESERVED_WARNING);
+  }
+
   // configVersion will always be updated
   if (!added.includes('configVersion')) {
     added.push('configVersion');
@@ -395,6 +446,7 @@ export function detectMigration(
     toVersion: templateVersion,
     addedFields: added,
     removedFields: removed,
+    warnings,
     config,
     template,
   };
@@ -413,6 +465,10 @@ export function applyMigration(
   removePaths?: string[],
 ): MigrationResult {
   const added: string[] = [];
+  const warnings: string[] = [];
+
+  // Capture the pre-migration version before configVersion is overwritten below.
+  const fromVersion = (config.configVersion as string) ?? '0.0.0';
 
   // Deep-merge top-level keys (except agents)
   const templateWithoutAgents = { ...template };
@@ -453,6 +509,13 @@ export function applyMigration(
     );
   }
 
+  // Preserve external bind behavior for pre-1.3.26 configs (Issue #204)
+  const bindField = preserveBindDefault(config, fromVersion);
+  if (bindField) {
+    added.push(bindField);
+    warnings.push(BIND_PRESERVED_WARNING);
+  }
+
   // Update configVersion
   config.configVersion = templateVersion;
   if (!added.includes('configVersion')) {
@@ -468,7 +531,7 @@ export function applyMigration(
   fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
   fs.renameSync(tmpPath, configPath);
 
-  return { migrated: true, addedFields: added, removedFields: removed };
+  return { migrated: true, addedFields: added, removedFields: removed, warnings };
 }
 
 /**
@@ -485,7 +548,7 @@ export function migrateConfig(
   const detection = detectMigration(configPath, templatePath, templateVersion);
 
   if (!detection.needed) {
-    return { migrated: false, addedFields: [], removedFields: [] };
+    return { migrated: false, addedFields: [], removedFields: [], warnings: [] };
   }
 
   // Load ignorePaths and removePaths again for the actual merge

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -226,8 +226,14 @@ function compareSemver(a: string, b: string): number {
   return 0;
 }
 
-/** Version that introduced the localhost-only `gateway.bind` default (Issue #201 / PR #202). */
-const BIND_LOCALHOST_DEFAULT_VERSION = '1.3.26';
+/**
+ * `configVersion` at which the localhost-only `gateway.bind` default landed
+ * (Issue #201 / PR #202, shipped in package v1.3.26). Note: `configVersion`
+ * (config.json schema version, currently 1.0.x) is a SEPARATE series from the
+ * package/release version (1.3.x) — the gate below compares against the
+ * config schema version, not the release version.
+ */
+const BIND_LOCALHOST_DEFAULT_CONFIG_VERSION = '1.0.13';
 
 /** Warning surfaced when a migration pins `gateway.bind` to preserve external access (Issue #204). */
 export const BIND_PRESERVED_WARNING =
@@ -237,13 +243,13 @@ export const BIND_PRESERVED_WARNING =
 /**
  * Behavior-preserving migration for `gateway.bind` (Issue #204).
  *
- * v1.3.26 (#201/#202) made the server default to binding 127.0.0.1 when
- * `gateway.bind` is unset. Deployments upgrading from an earlier version were
- * implicitly bound to 0.0.0.0, so silently applying the new localhost default
- * cuts off external API/dashboard access with no warning. To preserve prior
- * behavior, pin `bind` to "0.0.0.0" for pre-1.3.26 configs that never set it.
- * Fresh installs (no prior config, so no migration runs) keep the secure
- * localhost default.
+ * configVersion 1.0.13 (package v1.3.26, #201/#202) made the server default to
+ * binding 127.0.0.1 when `gateway.bind` is unset. Configs written before that
+ * schema version were implicitly bound to 0.0.0.0, so silently applying the new
+ * localhost default cuts off external API/dashboard access with no warning. To
+ * preserve prior behavior, pin `bind` to "0.0.0.0" for configs older than
+ * 1.0.13 that never set it. Fresh installs (no prior config, so no migration
+ * runs) keep the secure localhost default.
  *
  * Mutates `config` in place when it pins the value. Returns the added field
  * path (`gateway.bind`) if pinned, otherwise null.
@@ -252,8 +258,8 @@ function preserveBindDefault(
   config: Record<string, unknown>,
   fromVersion: string,
 ): string | null {
-  // Only pre-1.3.26 configs were implicitly bound to all interfaces.
-  if (compareSemver(fromVersion, BIND_LOCALHOST_DEFAULT_VERSION) >= 0) return null;
+  // Only configs older than the localhost-default schema version were bound to all interfaces.
+  if (compareSemver(fromVersion, BIND_LOCALHOST_DEFAULT_CONFIG_VERSION) >= 0) return null;
 
   const gateway = config.gateway;
   if (!gateway || typeof gateway !== 'object' || Array.isArray(gateway)) return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -454,6 +454,9 @@ async function main(): Promise<void> {
       if (migration.addedFields.length) parts.push(`added: ${migration.addedFields.join(', ')}`);
       if (migration.removedFields.length) parts.push(`removed: ${migration.removedFields.join(', ')}`);
       console.log(`[gateway] Config ${parts.join(', ')}.`);
+      for (const warning of migration.warnings) {
+        console.warn(`[gateway] ${warning}`);
+      }
     }
   } catch (err) {
     console.warn(`[gateway] Config migration skipped: ${(err as Error).message}`);

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -909,16 +909,19 @@ describe('config-migrator', () => {
   // ---------------------------------------------------------------------------
   // gateway.bind behavior-preserving migration (Issue #204)
   // ---------------------------------------------------------------------------
+  // The localhost-only bind default landed at configVersion 1.0.13 (package
+  // v1.3.26). configVersion is a 1.0.x series, SEPARATE from the release
+  // version — these tests use the real configVersion scale, not 1.3.x.
   describe('gateway.bind behavior-preserving migration', () => {
     const template = (): string =>
-      writeJson('template.json', { configVersion: '1.3.28', gateway: { timezone: 'UTC' } });
+      writeJson('template.json', { configVersion: '1.0.14', gateway: { timezone: 'UTC' } });
 
-    it('pins gateway.bind to 0.0.0.0 when migrating a pre-1.3.26 config that never set it', () => {
+    it('pins gateway.bind to 0.0.0.0 when migrating a pre-1.0.13 config that never set it', () => {
       const configPath = writeJson('config.json', {
-        configVersion: '1.3.25',
+        configVersion: '1.0.12',
         gateway: { logDir: '/logs' },
       });
-      const result = migrateConfig(configPath, template(), '1.3.28');
+      const result = migrateConfig(configPath, template(), '1.0.14');
 
       expect(result.migrated).toBe(true);
       expect(result.addedFields).toContain('gateway.bind');
@@ -928,25 +931,26 @@ describe('config-migrator', () => {
       expect(updated.gateway.bind).toBe('0.0.0.0');
     });
 
-    it('does not touch bind when migrating a config already on >= 1.3.26', () => {
+    it('does not touch bind at the 1.0.13 boundary (localhost default already applied)', () => {
       const configPath = writeJson('config.json', {
-        configVersion: '1.3.26',
+        configVersion: '1.0.13',
         gateway: { logDir: '/logs' },
       });
-      const result = migrateConfig(configPath, template(), '1.3.28');
+      const result = migrateConfig(configPath, template(), '1.0.14');
 
+      expect(result.migrated).toBe(true); // migration still runs (1.0.13 < 1.0.14)
       expect(result.addedFields).not.toContain('gateway.bind');
       expect(result.warnings).not.toContain(BIND_PRESERVED_WARNING);
       const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
       expect(updated.gateway.bind).toBeUndefined();
     });
 
-    it('never overwrites an explicit bind on a pre-1.3.26 config', () => {
+    it('never overwrites an explicit bind on a pre-1.0.13 config', () => {
       const configPath = writeJson('config.json', {
-        configVersion: '1.3.25',
+        configVersion: '1.0.12',
         gateway: { bind: '127.0.0.1', logDir: '/logs' },
       });
-      const result = migrateConfig(configPath, template(), '1.3.28');
+      const result = migrateConfig(configPath, template(), '1.0.14');
 
       expect(result.addedFields).not.toContain('gateway.bind');
       expect(result.warnings).not.toContain(BIND_PRESERVED_WARNING);
@@ -956,10 +960,10 @@ describe('config-migrator', () => {
 
     it('detectMigration dry-run reports gateway.bind without writing to disk', () => {
       const configPath = writeJson('config.json', {
-        configVersion: '1.3.25',
+        configVersion: '1.0.12',
         gateway: { logDir: '/logs' },
       });
-      const result = detectMigration(configPath, template(), '1.3.28');
+      const result = detectMigration(configPath, template(), '1.0.14');
 
       expect(result.needed).toBe(true);
       expect(result.addedFields).toContain('gateway.bind');
@@ -967,13 +971,13 @@ describe('config-migrator', () => {
 
       // Dry-run must not mutate the file on disk.
       const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      expect(onDisk.configVersion).toBe('1.3.25');
+      expect(onDisk.configVersion).toBe('1.0.12');
       expect(onDisk.gateway.bind).toBeUndefined();
     });
 
     it('does not pin bind for a fresh install (no prior config)', () => {
       const missingConfigPath = path.join(tmpDir, 'does-not-exist.json');
-      const result = detectMigration(missingConfigPath, template(), '1.3.28');
+      const result = detectMigration(missingConfigPath, template(), '1.0.14');
 
       expect(result.needed).toBe(false);
       expect(result.addedFields).not.toContain('gateway.bind');

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -12,6 +12,7 @@ import {
   pruneAgentPaths,
   repairInjectedAgentFields,
   AGENT_CREDENTIAL_FIELDS,
+  BIND_PRESERVED_WARNING,
 } from '../../src/config/migrator';
 
 describe('config-migrator', () => {
@@ -902,6 +903,81 @@ describe('config-migrator', () => {
       for (const field of expected) {
         expect(AGENT_CREDENTIAL_FIELDS.has(field)).toBe(true);
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // gateway.bind behavior-preserving migration (Issue #204)
+  // ---------------------------------------------------------------------------
+  describe('gateway.bind behavior-preserving migration', () => {
+    const template = (): string =>
+      writeJson('template.json', { configVersion: '1.3.28', gateway: { timezone: 'UTC' } });
+
+    it('pins gateway.bind to 0.0.0.0 when migrating a pre-1.3.26 config that never set it', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '1.3.25',
+        gateway: { logDir: '/logs' },
+      });
+      const result = migrateConfig(configPath, template(), '1.3.28');
+
+      expect(result.migrated).toBe(true);
+      expect(result.addedFields).toContain('gateway.bind');
+      expect(result.warnings).toContain(BIND_PRESERVED_WARNING);
+
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.bind).toBe('0.0.0.0');
+    });
+
+    it('does not touch bind when migrating a config already on >= 1.3.26', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '1.3.26',
+        gateway: { logDir: '/logs' },
+      });
+      const result = migrateConfig(configPath, template(), '1.3.28');
+
+      expect(result.addedFields).not.toContain('gateway.bind');
+      expect(result.warnings).not.toContain(BIND_PRESERVED_WARNING);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.bind).toBeUndefined();
+    });
+
+    it('never overwrites an explicit bind on a pre-1.3.26 config', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '1.3.25',
+        gateway: { bind: '127.0.0.1', logDir: '/logs' },
+      });
+      const result = migrateConfig(configPath, template(), '1.3.28');
+
+      expect(result.addedFields).not.toContain('gateway.bind');
+      expect(result.warnings).not.toContain(BIND_PRESERVED_WARNING);
+      const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(updated.gateway.bind).toBe('127.0.0.1'); // preserved as-is
+    });
+
+    it('detectMigration dry-run reports gateway.bind without writing to disk', () => {
+      const configPath = writeJson('config.json', {
+        configVersion: '1.3.25',
+        gateway: { logDir: '/logs' },
+      });
+      const result = detectMigration(configPath, template(), '1.3.28');
+
+      expect(result.needed).toBe(true);
+      expect(result.addedFields).toContain('gateway.bind');
+      expect(result.warnings).toContain(BIND_PRESERVED_WARNING);
+
+      // Dry-run must not mutate the file on disk.
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(onDisk.configVersion).toBe('1.3.25');
+      expect(onDisk.gateway.bind).toBeUndefined();
+    });
+
+    it('does not pin bind for a fresh install (no prior config)', () => {
+      const missingConfigPath = path.join(tmpDir, 'does-not-exist.json');
+      const result = detectMigration(missingConfigPath, template(), '1.3.28');
+
+      expect(result.needed).toBe(false);
+      expect(result.addedFields).not.toContain('gateway.bind');
+      expect(result.warnings).not.toContain(BIND_PRESERVED_WARNING);
     });
   });
 });


### PR DESCRIPTION
## Summary
The localhost-only `gateway.bind` default (Issue #201) silently cut off external API/dashboard access when a deployment upgraded from a version that implicitly bound `0.0.0.0`. The config migrator is now behavior-preserving so external access is not lost on upgrade, while new installs keep the secure localhost default.

## Related Issue
Closes #204

## Changes Made
- `src/config/migrator.ts`: new `preserveBindDefault` helper pins `gateway.bind` to `0.0.0.0` when migrating a config with `configVersion < 1.3.26` that never set it; adds a `warnings[]` field to `MigrationResult`/`DetectMigrationResult`, wired through both `applyMigration` (write path) and `detectMigration` (dry-run). An explicit bind is never overwritten.
- `src/index.ts`: emits the migration warning via `console.warn`.
- `tests/unit/config-migrator.test.ts`: +5 tests (pin pre-1.3.26 / leave >= 1.3.26 untouched / never overwrite explicit bind / dry-run does not write / fresh install not pinned).
- `README.md`: updated the `gateway.bind` upgrade note to reflect the automatic behavior-preserving migration.

## Testing
- `npm run typecheck`: pass
- `npm test`: 105 suites / 2,155 tests pass
