### PR TITLE
[Bug] Pin gateway.bind before template merge so #204 fix applies

### DIFF
--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -393,6 +393,16 @@ export function detectMigration(
   // Dry-run merge on a clone to detect what would be added/removed
   const configClone = structuredClone(config);
   const added: string[] = [];
+  const warnings: string[] = [];
+
+  // Preserve external bind behavior for pre-1.0.13 configs (Issue #204) BEFORE
+  // the template merge — mirrors applyMigration so the dry-run reports the same
+  // gateway.bind = "0.0.0.0" instead of the template's localhost default.
+  const bindField = preserveBindDefault(configClone, configVersion);
+  if (bindField) {
+    added.push(bindField);
+    warnings.push(BIND_PRESERVED_WARNING);
+  }
 
   // Deep-merge top-level keys (except agents which need special handling)
   const templateWithoutAgents = { ...template };
@@ -433,14 +443,6 @@ export function detectMigration(
     );
   }
 
-  // Preserve external bind behavior for pre-1.3.26 configs (Issue #204)
-  const warnings: string[] = [];
-  const bindField = preserveBindDefault(configClone, configVersion);
-  if (bindField) {
-    added.push(bindField);
-    warnings.push(BIND_PRESERVED_WARNING);
-  }
-
   // configVersion will always be updated
   if (!added.includes('configVersion')) {
     added.push('configVersion');
@@ -475,6 +477,17 @@ export function applyMigration(
 
   // Capture the pre-migration version before configVersion is overwritten below.
   const fromVersion = (config.configVersion as string) ?? '0.0.0';
+
+  // Preserve external bind behavior for pre-1.0.13 configs (Issue #204) BEFORE
+  // the template merge: config.template.json ships gateway.bind = "127.0.0.1",
+  // and deepMerge would inject that localhost default into a config that never
+  // set bind. Pinning here first means deepMerge (which only adds missing keys)
+  // leaves our 0.0.0.0 untouched, so old deployments keep external access.
+  const bindField = preserveBindDefault(config, fromVersion);
+  if (bindField) {
+    added.push(bindField);
+    warnings.push(BIND_PRESERVED_WARNING);
+  }
 
   // Deep-merge top-level keys (except agents)
   const templateWithoutAgents = { ...template };
@@ -513,13 +526,6 @@ export function applyMigration(
         templateCreds,
       ),
     );
-  }
-
-  // Preserve external bind behavior for pre-1.3.26 configs (Issue #204)
-  const bindField = preserveBindDefault(config, fromVersion);
-  if (bindField) {
-    added.push(bindField);
-    warnings.push(BIND_PRESERVED_WARNING);
   }
 
   // Update configVersion

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -913,8 +913,14 @@ describe('config-migrator', () => {
   // v1.3.26). configVersion is a 1.0.x series, SEPARATE from the release
   // version — these tests use the real configVersion scale, not 1.3.x.
   describe('gateway.bind behavior-preserving migration', () => {
+    // Mirror the real config.template.json, which ships gateway.bind = "127.0.0.1".
+    // The template MUST carry bind here, otherwise the test misses the deepMerge
+    // interaction that leaks the localhost default into old configs (Issue #204).
     const template = (): string =>
-      writeJson('template.json', { configVersion: '1.0.14', gateway: { timezone: 'UTC' } });
+      writeJson('template.json', {
+        configVersion: '1.0.14',
+        gateway: { timezone: 'UTC', bind: '127.0.0.1' },
+      });
 
     it('pins gateway.bind to 0.0.0.0 when migrating a pre-1.0.13 config that never set it', () => {
       const configPath = writeJson('config.json', {
@@ -931,7 +937,7 @@ describe('config-migrator', () => {
       expect(updated.gateway.bind).toBe('0.0.0.0');
     });
 
-    it('does not touch bind at the 1.0.13 boundary (localhost default already applied)', () => {
+    it('does not pin at the 1.0.13 boundary — takes the template localhost default instead', () => {
       const configPath = writeJson('config.json', {
         configVersion: '1.0.13',
         gateway: { logDir: '/logs' },
@@ -939,10 +945,11 @@ describe('config-migrator', () => {
       const result = migrateConfig(configPath, template(), '1.0.14');
 
       expect(result.migrated).toBe(true); // migration still runs (1.0.13 < 1.0.14)
-      expect(result.addedFields).not.toContain('gateway.bind');
+      // Our preserve logic must NOT fire (no 0.0.0.0, no warning); the config
+      // simply inherits the template's secure localhost default via deepMerge.
       expect(result.warnings).not.toContain(BIND_PRESERVED_WARNING);
       const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      expect(updated.gateway.bind).toBeUndefined();
+      expect(updated.gateway.bind).toBe('127.0.0.1');
     });
 
     it('never overwrites an explicit bind on a pre-1.0.13 config', () => {


### PR DESCRIPTION
## Summary
The behavior-preserving `gateway.bind` migration from #204/#205 never actually took effect: `config.template.json` ships `gateway.bind = "127.0.0.1"`, and `deepMerge` injected that localhost default into pre-1.0.13 configs **before** `preserveBindDefault` ran. The helper then saw `bind` already set and skipped it, so every upgrading config still landed on `127.0.0.1` and lost external API/dashboard access — reproduced with the real template.

## Related Issue
Follow-up to #204 (fix delivered in #205 was incomplete).

## Changes Made
- `src/config/migrator.ts`: move `preserveBindDefault` **ahead of** `deepMerge` in both `applyMigration` and `detectMigration`. Pinning `0.0.0.0` first means `deepMerge` (which only adds missing keys) leaves it untouched, so pre-1.0.13 configs keep external access while new/boundary configs still inherit the template's localhost default.
- `tests/unit/config-migrator.test.ts`: the test template now carries `bind = "127.0.0.1"` like the real `config.template.json`, exercising the deepMerge interaction the previous tests missed; boundary test updated to assert the template default is inherited (not pinned).

## Testing
- `npm run typecheck`: pass
- `npm test`: 105 suites / 2,155 tests pass (`skills-watcher` is load-flaky and passes in isolation)
- Verified end-to-end against the real `config.template.json`: a pre-1.0.13 config with no bind now migrates to `0.0.0.0` with the warning; reverting the reorder makes the regression test fail.
