### PR TITLE
test: guard gateway.bind upgrade with a real v1.3.25 artifact

### DIFF
--- a/tests/fixtures/configs/baseline-v1.3.25.json
+++ b/tests/fixtures/configs/baseline-v1.3.25.json
@@ -1,0 +1,70 @@
+{
+  "configVersion": "1.0.11",
+  "gateway": {
+    "logDir": "~/.claude-gateway/logs",
+    "timezone": "Asia/Bangkok",
+    "models": [
+      {
+        "id": "claude-fable-5[1m]",
+        "label": "Fable 5 (1M)",
+        "alias": "fable[1m]",
+        "contextWindow": 1000000
+      },
+      {
+        "id": "claude-opus-4-8[1m]",
+        "label": "Opus 4.8 (1M)",
+        "alias": "opus[1m]",
+        "contextWindow": 1000000
+      },
+      {
+        "id": "claude-sonnet-5[1m]",
+        "label": "Sonnet 5 (1M)",
+        "alias": "sonnet[1m]",
+        "contextWindow": 1000000
+      },
+      {
+        "id": "claude-fable-5",
+        "label": "Fable 5",
+        "alias": "fable",
+        "contextWindow": 200000
+      },
+      {
+        "id": "claude-opus-4-8",
+        "label": "Opus 4.8",
+        "alias": "opus",
+        "contextWindow": 200000
+      },
+      {
+        "id": "claude-opus-4-6",
+        "label": "Opus 4.6",
+        "alias": "opus46",
+        "contextWindow": 200000
+      },
+      {
+        "id": "claude-sonnet-5",
+        "label": "Sonnet 5",
+        "alias": "sonnet",
+        "contextWindow": 200000
+      },
+      {
+        "id": "claude-sonnet-4-6",
+        "label": "Sonnet 4.6",
+        "alias": "sonnet46",
+        "contextWindow": 200000
+      },
+      {
+        "id": "claude-haiku-4-5-20251001",
+        "label": "Haiku 4.5",
+        "alias": "haiku",
+        "contextWindow": 200000
+      }
+    ],
+    "history": {
+      "retentionDays": 60,
+      "cleanupHour": 0,
+      "cleanupTimezone": "UTC"
+    },
+    "headless": true
+  },
+  "agents": []
+}

--- a/tests/unit/config-migration-real-upgrade.test.ts
+++ b/tests/unit/config-migration-real-upgrade.test.ts
@@ -1,0 +1,177 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import {
+  detectMigration,
+  applyMigration,
+  loadCleanTemplate,
+  stripIgnoredPaths,
+  BIND_PRESERVED_WARNING,
+} from '../../src/config/migrator';
+
+/**
+ * Real-artifact upgrade tests for gateway.bind (Issue #204).
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The unit tests in config-migrator.test.ts build a *hand-written mirror* of
+ * config.template.json. That mirror can silently drift from the real template
+ * (e.g. someone bumps configVersion or changes the shipped bind default), so a
+ * green suite did NOT prove the real upgrade works — v1.3.29 shipped a broken
+ * migration that every unit test passed. These tests close that gap by driving
+ * the migration exactly like src/index.ts main() does:
+ *
+ *   - the ACTUAL repo config.template.json (not a stub), and
+ *   - a REAL config.json captured from the published v1.3.25 package
+ *     (tests/fixtures/configs/baseline-v1.3.25.json).
+ *
+ * If the real template or the migrator regresses the bind-preservation ordering,
+ * scenario A goes red — before release, not in production.
+ */
+
+// The real files that ship to users.
+const REAL_TEMPLATE = path.join(__dirname, '..', '..', 'config.template.json');
+const V1325_BASELINE = path.join(
+  __dirname,
+  '..',
+  'fixtures',
+  'configs',
+  'baseline-v1.3.25.json',
+);
+
+const templateVersion = (): string =>
+  JSON.parse(fs.readFileSync(REAL_TEMPLATE, 'utf-8')).configVersion as string;
+
+/** Drive the migration the same way src/index.ts main() does on startup. */
+function runRealUpgrade(configPath: string): {
+  needed: boolean;
+  addedFields: string[];
+  warnings: string[];
+} {
+  const tv = templateVersion();
+  const detection = detectMigration(configPath, REAL_TEMPLATE, tv);
+  if (!detection.needed) {
+    return { needed: false, addedFields: [], warnings: [] };
+  }
+  const { ignorePaths, removePaths } = loadCleanTemplate(REAL_TEMPLATE);
+  const result = applyMigration(
+    configPath,
+    detection.config,
+    detection.template,
+    tv,
+    ignorePaths,
+    removePaths,
+  );
+  return { needed: true, addedFields: result.addedFields, warnings: result.warnings };
+}
+
+describe('config migration — real v1.3.25 -> current upgrade (Issue #204)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'real-upgrade-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(data: unknown): string {
+    const p = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(p, JSON.stringify(data, null, 2), 'utf-8');
+    return p;
+  }
+
+  /** Reproduce a fresh install: create-agent copies the template minus ignorePaths. */
+  function freshInstallConfig(): string {
+    const { template, ignorePaths } = loadCleanTemplate(REAL_TEMPLATE);
+    stripIgnoredPaths(template, ignorePaths);
+    (template as Record<string, unknown>).agents = [];
+    const p = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(p, JSON.stringify(template, null, 2), 'utf-8');
+    return p;
+  }
+
+  // Sanity: the fixture is a genuine pre-1.0.13 config with no bind key. If this
+  // ever fails, the fixture was mangled and the upgrade tests below are meaningless.
+  it('the v1.3.25 baseline fixture is pre-localhost-default and never set bind', () => {
+    const baseline = JSON.parse(fs.readFileSync(V1325_BASELINE, 'utf-8'));
+    expect(baseline.configVersion).toBe('1.0.11');
+    expect('bind' in baseline.gateway).toBe(false);
+  });
+
+  // A) The regression that bit prod three times: an upgrading user from v1.3.25
+  //    must keep external access. Bound to the REAL template, so a migrator
+  //    ordering regression (deepMerge before preserve) makes this go red.
+  it('A) real v1.3.25 config upgrades to gateway.bind = "0.0.0.0" with a warning', () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.copyFileSync(V1325_BASELINE, configPath);
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.needed).toBe(true);
+    expect(result.addedFields).toContain('gateway.bind');
+    expect(result.warnings).toContain(BIND_PRESERVED_WARNING);
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(migrated.gateway.bind).toBe('0.0.0.0');
+    expect(migrated.configVersion).toBe(templateVersion());
+  });
+
+  // B) A brand-new install must NOT be forced open — it keeps the secure
+  //    localhost default shipped in the real template.
+  it('B) a fresh install keeps gateway.bind = "127.0.0.1" and needs no migration', () => {
+    const configPath = freshInstallConfig();
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.needed).toBe(false);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(config.gateway.bind).toBe('127.0.0.1');
+  });
+
+  // C) An ancient config with no configVersion at all is also pre-default.
+  it('C) a config with no configVersion and no bind upgrades to "0.0.0.0"', () => {
+    const configPath = writeConfig({ gateway: { logDir: '/logs' }, agents: [] });
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.warnings).toContain(BIND_PRESERVED_WARNING);
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(migrated.gateway.bind).toBe('0.0.0.0');
+  });
+
+  // D) Documents the known limitation the user hit: a config already "poisoned"
+  //    by a broken intermediate build (bind persisted + configVersion already at
+  //    the template version) is NOT auto-repaired — no migration runs, and the
+  //    migrator must never override a bind the user might have set on purpose.
+  //    Such configs need a one-line manual fix (set bind to "0.0.0.0").
+  it('D) an already-migrated config with a persisted bind is left untouched', () => {
+    const configPath = writeConfig({
+      configVersion: templateVersion(),
+      gateway: { bind: '127.0.0.1', logDir: '/logs' },
+      agents: [],
+    });
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.needed).toBe(false);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(config.gateway.bind).toBe('127.0.0.1');
+  });
+
+  // E) An explicit localhost choice on an old config is honoured, not clobbered.
+  it('E) an explicit bind on a pre-1.0.13 config is preserved, not overwritten', () => {
+    const configPath = writeConfig({
+      configVersion: '1.0.11',
+      gateway: { bind: '127.0.0.1', logDir: '/logs' },
+      agents: [],
+    });
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.warnings).not.toContain(BIND_PRESERVED_WARNING);
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(migrated.gateway.bind).toBe('127.0.0.1');
+  });
+});


### PR DESCRIPTION
## Summary

The `gateway.bind` upgrade migration (Issue #204) broke in production across three releases while the unit suite stayed green. Root cause of the blind spot: `config-migrator.test.ts` builds a **hand-written mirror** of `config.template.json` (its own comment says *"Mirror the real config.template.json"*), so the tests never notice drift between the real shipped template and the migrator. v1.3.29 shipped a migration that reintroduced `127.0.0.1` on upgrade, and every unit test passed.

This PR adds a **real-artifact** upgrade test that drives the migration exactly like `src/index.ts main()` does on startup, bound to the actual files that ship to users.

## What's added

- **`tests/fixtures/configs/baseline-v1.3.25.json`** — a real `config.json` produced by the published **v1.3.25** package's own `create-agent` first-run logic (`configVersion: 1.0.11`, no `bind` key). This is what a real pre-localhost-default user's config looks like.
- **`tests/unit/config-migration-real-upgrade.test.ts`** — runs `detectMigration` + `applyMigration` against the **actual repo `config.template.json`** (not a stub) and asserts `gateway.bind` across every scenario:

| Case | Input | Expected |
|------|-------|----------|
| A | real v1.3.25 config → current | `bind: "0.0.0.0"` + warning |
| B | fresh install | `bind: "127.0.0.1"`, no migration |
| C | no `configVersion`, no bind | `bind: "0.0.0.0"` |
| D | already-migrated persisted bind | left untouched (needs manual fix) |
| E | explicit user bind on old config | preserved, never overwritten |

## Why it works where the old tests didn't

Because the test binds to the **real template**, a migrator ordering regression (`deepMerge` before `preserveBindDefault` — the exact v1.3.29 bug) turns scenarios A and C red. Verified by temporarily reverting the ordering: A and C fail with `127.0.0.1`; restoring the fix makes all 6 green.

This suite runs inside `test:unit`, which is the `release.yml` gate **before `npm publish`** — so a broken bind migration can no longer be released.

## Not covered by design

Configs already "poisoned" by a broken intermediate build (bind persisted + `configVersion` already at the template version) are intentionally **not** auto-repaired — the migrator must never override a `bind` the user may have set on purpose. Those need a one-line manual fix (set `bind` to `"0.0.0.0"`). Case D documents this.

## Testing

- `tsc --noEmit` clean
- New + existing migrator suites: `config-migrator` + `config-migration-real-upgrade` = **64 tests green**
- Full `test:unit`: **105 of 106 suites pass**. The one failure is `watch-factory.test.ts` — a pre-existing timing flake unrelated to this change (file-watch debounce timing out under full-suite parallel load; it passes **7/7 in isolation**). This PR touches only test fixtures/specs for config migration.

> Note: `watch-factory.test.ts` flaking under load is a separate CI-reliability risk for `release.yml` and is worth a follow-up (raise the fake-timer/debounce tolerance or run it serially), but it is out of scope here.