### PR TITLE
fix(config): always preserve external bind for pre-1.0.13 upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (l
 }
 ```
 
-> **⚠️ Upgrade note (configVersion 1.0.13):** the default bind changed from `0.0.0.0` to `127.0.0.1`. To avoid silently cutting off external access, the config migrator is **behavior-preserving**: when it upgrades a config created before this change and that config never set `gateway.bind`, it pins `bind` to `0.0.0.0` and logs a one-time warning, so a deployment that was reachable from another host stays reachable. New installs (no prior config, so no migration runs) keep the secure `127.0.0.1` default. If you *want* localhost-only after upgrading, set `gateway.bind` to `127.0.0.1` explicitly (or the `GATEWAY_BIND` env var).
+> **⚠️ Upgrade note:** the default bind changed from `0.0.0.0` to `127.0.0.1` (configVersion 1.0.13). To avoid silently cutting off external access, the config migrator is **behavior-preserving**: whenever it upgrades a config that never set `gateway.bind`, it pins `bind` to `0.0.0.0` and logs a one-time warning, so a deployment that was reachable from another host stays reachable. This applies to *any* upgraded config with no `bind` key — including one already stamped `1.0.13` that never received a bind (an earlier version gated this on `< 1.0.13` and left such configs stuck on the `127.0.0.1` default). New installs (no prior config, so no migration runs) keep the secure `127.0.0.1` default. If you *want* localhost-only after upgrading, set `gateway.bind` to `127.0.0.1` explicitly (or the `GATEWAY_BIND` env var).
 
 ### Terminal Viewer — interactive terminal mode
 

--- a/config.template.json
+++ b/config.template.json
@@ -10,7 +10,7 @@
       "claude.dangerouslySkipPermissions"
     ]
   },
-  "configVersion": "1.0.13",
+  "configVersion": "1.0.14",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -226,15 +226,6 @@ function compareSemver(a: string, b: string): number {
   return 0;
 }
 
-/**
- * `configVersion` at which the localhost-only `gateway.bind` default landed
- * (Issue #201 / PR #202, shipped in package v1.3.26). Note: `configVersion`
- * (config.json schema version, currently 1.0.x) is a SEPARATE series from the
- * package/release version (1.3.x) — the gate below compares against the
- * config schema version, not the release version.
- */
-const BIND_LOCALHOST_DEFAULT_CONFIG_VERSION = '1.0.13';
-
 /** Warning surfaced when a migration pins `gateway.bind` to preserve external access (Issue #204). */
 export const BIND_PRESERVED_WARNING =
   'gateway.bind was pinned to "0.0.0.0" to preserve external API/dashboard access across this upgrade. ' +
@@ -243,24 +234,25 @@ export const BIND_PRESERVED_WARNING =
 /**
  * Behavior-preserving migration for `gateway.bind` (Issue #204).
  *
- * configVersion 1.0.13 (package v1.3.26, #201/#202) made the server default to
- * binding 127.0.0.1 when `gateway.bind` is unset. Configs written before that
- * schema version were implicitly bound to 0.0.0.0, so silently applying the new
- * localhost default cuts off external API/dashboard access with no warning. To
- * preserve prior behavior, pin `bind` to "0.0.0.0" for configs older than
- * 1.0.13 that never set it. Fresh installs (no prior config, so no migration
- * runs) keep the secure localhost default.
+ * The localhost-only `gateway.bind` default (Issue #201 / PR #202) makes the
+ * server bind 127.0.0.1 when `gateway.bind` is unset, which silently cuts off
+ * external API/dashboard access for any pre-existing deployment that used to be
+ * reachable on all interfaces.
+ *
+ * This runs ONLY inside a migration, which fires only when the config's
+ * `configVersion` is OLDER than the template's — i.e. only for configs that are
+ * being upgraded, never for fresh installs (a fresh install copies the template
+ * verbatim, so it already carries `bind: "127.0.0.1"` and no migration runs).
+ * Therefore any config that reaches this point WITHOUT a `bind` key predates the
+ * localhost default and was externally reachable, so we pin "0.0.0.0" to
+ * preserve that. We do NOT gate on a specific configVersion: an earlier gate of
+ * `< 1.0.13` wrongly skipped configs already stamped 1.0.13 that never got a
+ * bind, leaving them on the 127.0.0.1 runtime default with no way to recover.
  *
  * Mutates `config` in place when it pins the value. Returns the added field
  * path (`gateway.bind`) if pinned, otherwise null.
  */
-function preserveBindDefault(
-  config: Record<string, unknown>,
-  fromVersion: string,
-): string | null {
-  // Only configs older than the localhost-default schema version were bound to all interfaces.
-  if (compareSemver(fromVersion, BIND_LOCALHOST_DEFAULT_CONFIG_VERSION) >= 0) return null;
-
+function preserveBindDefault(config: Record<string, unknown>): string | null {
   const gateway = config.gateway;
   if (!gateway || typeof gateway !== 'object' || Array.isArray(gateway)) return null;
 
@@ -395,10 +387,10 @@ export function detectMigration(
   const added: string[] = [];
   const warnings: string[] = [];
 
-  // Preserve external bind behavior for pre-1.0.13 configs (Issue #204) BEFORE
-  // the template merge — mirrors applyMigration so the dry-run reports the same
+  // Preserve external bind for an upgrading config (Issue #204) BEFORE the
+  // template merge — mirrors applyMigration so the dry-run reports the same
   // gateway.bind = "0.0.0.0" instead of the template's localhost default.
-  const bindField = preserveBindDefault(configClone, configVersion);
+  const bindField = preserveBindDefault(configClone);
   if (bindField) {
     added.push(bindField);
     warnings.push(BIND_PRESERVED_WARNING);
@@ -475,15 +467,12 @@ export function applyMigration(
   const added: string[] = [];
   const warnings: string[] = [];
 
-  // Capture the pre-migration version before configVersion is overwritten below.
-  const fromVersion = (config.configVersion as string) ?? '0.0.0';
-
-  // Preserve external bind behavior for pre-1.0.13 configs (Issue #204) BEFORE
-  // the template merge: config.template.json ships gateway.bind = "127.0.0.1",
-  // and deepMerge would inject that localhost default into a config that never
-  // set bind. Pinning here first means deepMerge (which only adds missing keys)
+  // Preserve external bind for an upgrading config (Issue #204) BEFORE the
+  // template merge: config.template.json ships gateway.bind = "127.0.0.1", and
+  // deepMerge would inject that localhost default into a config that never set
+  // bind. Pinning here first means deepMerge (which only adds missing keys)
   // leaves our 0.0.0.0 untouched, so old deployments keep external access.
-  const bindField = preserveBindDefault(config, fromVersion);
+  const bindField = preserveBindDefault(config);
   if (bindField) {
     added.push(bindField);
     warnings.push(BIND_PRESERVED_WARNING);

--- a/tests/unit/config-migration-real-upgrade.test.ts
+++ b/tests/unit/config-migration-real-upgrade.test.ts
@@ -174,4 +174,29 @@ describe('config migration — real v1.3.25 -> current upgrade (Issue #204)', ()
     const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(migrated.gateway.bind).toBe('127.0.0.1');
   });
+
+  // F) The exact field report: a config stamped at the PREVIOUS template
+  //    version (1.0.13) with no bind key was stuck on the 127.0.0.1 runtime
+  //    default because migration either did not run or was version-gated out.
+  //    With the current template ahead of it, the upgrade must now reach it and
+  //    pin 0.0.0.0. Uses the literal 1.0.13 (the version that shipped the
+  //    localhost default) rather than templateVersion() so the regression stays
+  //    pinned to the real broken value even after future version bumps.
+  it('F) a 1.0.13 config with no bind key upgrades to "0.0.0.0"', () => {
+    // Guard: this scenario is only meaningful while the template is ahead of
+    // 1.0.13, otherwise no migration runs and there is nothing to assert.
+    expect(templateVersion()).not.toBe('1.0.13');
+    const configPath = writeConfig({
+      configVersion: '1.0.13',
+      gateway: { logDir: '/logs' },
+      agents: [],
+    });
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.needed).toBe(true);
+    expect(result.warnings).toContain(BIND_PRESERVED_WARNING);
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(migrated.gateway.bind).toBe('0.0.0.0');
+  });
 });

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -909,9 +909,11 @@ describe('config-migrator', () => {
   // ---------------------------------------------------------------------------
   // gateway.bind behavior-preserving migration (Issue #204)
   // ---------------------------------------------------------------------------
-  // The localhost-only bind default landed at configVersion 1.0.13 (package
-  // v1.3.26). configVersion is a 1.0.x series, SEPARATE from the release
-  // version — these tests use the real configVersion scale, not 1.3.x.
+  // Any config that reaches a migration without a `bind` key predates the
+  // localhost-only default and was externally reachable, so migration pins
+  // "0.0.0.0" regardless of its configVersion (there is no version gate — an
+  // earlier `< 1.0.13` gate wrongly skipped configs already stamped 1.0.13).
+  // A fresh install carries bind from the template and never migrates.
   describe('gateway.bind behavior-preserving migration', () => {
     // Mirror the real config.template.json, which ships gateway.bind = "127.0.0.1".
     // The template MUST carry bind here, otherwise the test misses the deepMerge
@@ -922,7 +924,7 @@ describe('config-migrator', () => {
         gateway: { timezone: 'UTC', bind: '127.0.0.1' },
       });
 
-    it('pins gateway.bind to 0.0.0.0 when migrating a pre-1.0.13 config that never set it', () => {
+    it('pins gateway.bind to 0.0.0.0 when migrating a config that never set it', () => {
       const configPath = writeJson('config.json', {
         configVersion: '1.0.12',
         gateway: { logDir: '/logs' },
@@ -937,19 +939,21 @@ describe('config-migrator', () => {
       expect(updated.gateway.bind).toBe('0.0.0.0');
     });
 
-    it('does not pin at the 1.0.13 boundary — takes the template localhost default instead', () => {
+    // Regression for the field report: a config already stamped 1.0.13 with no
+    // bind key was left on the 127.0.0.1 runtime default because the old
+    // `< 1.0.13` gate skipped it. It must now pin 0.0.0.0 like any other
+    // no-bind upgrade.
+    it('pins gateway.bind to 0.0.0.0 for a 1.0.13 config that never set bind', () => {
       const configPath = writeJson('config.json', {
         configVersion: '1.0.13',
         gateway: { logDir: '/logs' },
       });
       const result = migrateConfig(configPath, template(), '1.0.14');
 
-      expect(result.migrated).toBe(true); // migration still runs (1.0.13 < 1.0.14)
-      // Our preserve logic must NOT fire (no 0.0.0.0, no warning); the config
-      // simply inherits the template's secure localhost default via deepMerge.
-      expect(result.warnings).not.toContain(BIND_PRESERVED_WARNING);
+      expect(result.migrated).toBe(true); // migration runs (1.0.13 < 1.0.14)
+      expect(result.warnings).toContain(BIND_PRESERVED_WARNING);
       const updated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      expect(updated.gateway.bind).toBe('127.0.0.1');
+      expect(updated.gateway.bind).toBe('0.0.0.0');
     });
 
     it('never overwrites an explicit bind on a pre-1.0.13 config', () => {


### PR DESCRIPTION
## Summary

Fixes the last hole in the `gateway.bind` upgrade-preservation logic. A config already at `configVersion 1.0.13` with **no `bind` key** (the real upgrade case reproduced on a live v1.3.25 box) skipped the migration and fell through to the template default `127.0.0.1`, silently cutting external API access on upgrade — the exact regression the fix was meant to prevent.

## Root cause

The preservation helper was gated on `compareSemver(fromVersion, '1.0.13') < 0`. Configs sitting *at* 1.0.13 never triggered it.

## Fix

- Drop the version gate: **any** migrating config with no `bind` key now gets `bind="0.0.0.0"`.
- Bump `config.template.json` to `configVersion 1.0.14` so existing 1.0.13 configs actually run the migration.
- Fresh installs still get `127.0.0.1` (they copy the full template, which carries the key → migrator never touches it).
- Explicit user-set `bind` values are still respected.

## Behavior matrix (proven end-to-end with real v1.3.25 artifact + real template)

| Case | Result |
|------|--------|
| v1.3.25 upgrade (no bind, cfgVer 1.0.11/1.0.12/1.0.13) | `0.0.0.0` + warning ✅ |
| Fresh install (config = full template) | `127.0.0.1` ✅ |
| User already set `bind` explicitly | untouched ✅ |

## Tests

- Rewrote the stale 1.0.13 boundary test to assert the new behavior.
- Added the exact reproduced bug case (no-bind + 1.0.13 → `0.0.0.0`) to the real-artifact upgrade test, bound to the **real** `config.template.json`.
- Full unit suite green: 106 suites / 2162 tests.

Refs #204