### PR TITLE
feat(history): ascending (seek-forward) message pagination for jump-to-date

### DIFF
--- a/API.md
+++ b/API.md
@@ -2367,7 +2367,7 @@ curl -H "X-Api-Key: my-secret-key-123" \
 
 ### GET /api/v1/agents/:agentId/chats/:chatId/messages
 
-Paginated message history (cursor-based). Returns messages in reverse chronological order.
+Paginated message history (cursor-based). Returns messages in reverse chronological order by default; pass `order=asc` to read forward.
 
 **Query parameters:**
 
@@ -2377,6 +2377,7 @@ Paginated message history (cursor-based). Returns messages in reverse chronologi
 | `before` | Return messages before this timestamp (ms) |
 | `after` | Return messages after this timestamp (ms) |
 | `session_id` | Filter to a specific session |
+| `order` | `asc` reads forward (oldest→newest) from `after`; default `desc` (newest→oldest) |
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
@@ -2392,6 +2393,15 @@ curl -H "X-Api-Key: my-secret-key-123" \
   "hasMore": false
 }
 ```
+
+**Seek-forward example** (jump to a date and read that day's first messages in one round-trip):
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:10850/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages?order=asc&after=<startOfDay-1>&limit=20" | jq
+```
+
+`nextCursor` continues forward via `after` when `order=asc` (vs. `before` for the default `desc`).
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2377,7 +2377,7 @@ Paginated message history (cursor-based). Returns messages in reverse chronologi
 | `before` | Return messages before this timestamp (ms) |
 | `after` | Return messages after this timestamp (ms) |
 | `session_id` | Filter to a specific session |
-| `order` | `asc` reads forward (oldest→newest) from `after`; default `desc` (newest→oldest) |
+| `order` | `asc` reads forward (oldest→newest) from `after`; `desc` (default) reads newest→oldest. Case-insensitive; any other value returns `400`. |
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2034,7 +2034,7 @@ export function createApiRouter(
   /**
    * GET /api/v1/agents/:agentId/chats/:chatId/messages
    * Paginated message history (cursor-based).
-   * Query: limit, before (ts ms), after (ts ms), session_id
+   * Query: limit, before (ts ms), after (ts ms), session_id, order (asc|desc, default desc)
    */
   router.get('/v1/agents/:agentId/chats/:chatId/messages', auth, (req: Request, res: Response) => {
     const { agentId, chatId } = req.params as { agentId: string; chatId: string };
@@ -2053,8 +2053,9 @@ export function createApiRouter(
     const before = query['before'] ? parseInt(query['before'], 10) : undefined;
     const after = query['after'] ? parseInt(query['after'], 10) : undefined;
     const sessionId = query['session_id'] ?? undefined;
+    const order = query['order'] === 'asc' ? 'asc' : undefined; // ignore anything but 'asc'; undefined ⇒ db default 'desc'
 
-    const page = runner.getHistoryDb().getMessages(chatId, { limit, before, after, sessionId });
+    const page = runner.getHistoryDb().getMessages(chatId, { limit, before, after, sessionId, order });
     res.json(page);
   });
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2057,8 +2057,15 @@ export function createApiRouter(
     // order: case-insensitive; 'asc' seeks forward, 'desc' (or omitted) is the db default.
     // Reject any other explicit value with 400 so client typos surface instead of silently defaulting.
     let order: 'asc' | undefined;
-    if (query['order'] !== undefined) {
-      const normalized = query['order'].toLowerCase();
+    const rawOrder = query['order'] as unknown;
+    if (rawOrder !== undefined) {
+      // Express parses a repeated/structured param (?order=asc&order=asc) as an
+      // array/object, not a string — guard so .toLowerCase() can't throw a 500.
+      if (typeof rawOrder !== 'string') {
+        res.status(400).json({ error: "order must be 'asc' or 'desc'" });
+        return;
+      }
+      const normalized = rawOrder.toLowerCase();
       if (normalized === 'asc') {
         order = 'asc';
       } else if (normalized === 'desc') {

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2053,7 +2053,21 @@ export function createApiRouter(
     const before = query['before'] ? parseInt(query['before'], 10) : undefined;
     const after = query['after'] ? parseInt(query['after'], 10) : undefined;
     const sessionId = query['session_id'] ?? undefined;
-    const order = query['order'] === 'asc' ? 'asc' : undefined; // ignore anything but 'asc'; undefined ⇒ db default 'desc'
+
+    // order: case-insensitive; 'asc' seeks forward, 'desc' (or omitted) is the db default.
+    // Reject any other explicit value with 400 so client typos surface instead of silently defaulting.
+    let order: 'asc' | undefined;
+    if (query['order'] !== undefined) {
+      const normalized = query['order'].toLowerCase();
+      if (normalized === 'asc') {
+        order = 'asc';
+      } else if (normalized === 'desc') {
+        order = undefined; // explicit desc == db default
+      } else {
+        res.status(400).json({ error: "order must be 'asc' or 'desc'" });
+        return;
+      }
+    }
 
     const page = runner.getHistoryDb().getMessages(chatId, { limit, before, after, sessionId, order });
     res.json(page);

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -187,12 +187,17 @@ export class HistoryDB {
     // Fetch limit+1 to determine hasMore
     params.push(limit + 1);
     const order = opts.order === 'asc' ? 'ASC' : 'DESC'; // whitelist; never interpolate raw input
+    // Tiebreak on id (AUTOINCREMENT, monotonic with insertion) so rows sharing a
+    // ts have a deterministic, chronology-consistent order instead of relying on
+    // SQLite's unspecified default. NOTE: nextCursor is ts-only, so a page
+    // boundary landing between equal-ts rows can still skip the tied remainder —
+    // fully closing that needs a composite (ts,id) cursor (tracked separately).
     const sql = `
       SELECT id, chat_id, session_id, source, role, content, sender_name, sender_id,
              platform_message_id, media_files, ts
       FROM messages
       WHERE ${conditions.join(' AND ')}
-      ORDER BY ts ${order}
+      ORDER BY ts ${order}, id ${order}
       LIMIT ?
     `;
 

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -186,12 +186,13 @@ export class HistoryDB {
 
     // Fetch limit+1 to determine hasMore
     params.push(limit + 1);
+    const order = opts.order === 'asc' ? 'ASC' : 'DESC'; // whitelist; never interpolate raw input
     const sql = `
       SELECT id, chat_id, session_id, source, role, content, sender_name, sender_id,
              platform_message_id, media_files, ts
       FROM messages
       WHERE ${conditions.join(' AND ')}
-      ORDER BY ts DESC
+      ORDER BY ts ${order}
       LIMIT ?
     `;
 

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -45,6 +45,7 @@ export interface PaginationOpts {
   before?: number;
   after?: number;
   sessionId?: string;
+  order?: 'asc' | 'desc'; // default 'desc' (reverse-chronological)
 }
 
 export interface SearchOpts {

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -308,6 +308,13 @@ describe('Chat History API integration (planning-50)', () => {
     expect(bad.status).toBe(400);
     expect(bad.body.error).toMatch(/order/i);
 
+    // A repeated param parses as an array, not a string — must 400, never 500
+    const dup = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?order=asc&order=asc`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(dup.status).toBe(400);
+    expect(dup.body.error).toMatch(/order/i);
+
     await router.stop();
     await runner.stop();
   });

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -258,6 +258,60 @@ describe('Chat History API integration (planning-50)', () => {
     await runner.stop();
   });
 
+  // ─── I-HIST-14: GET messages honors the `order` param (asc/desc, case-insensitive, 400 on invalid) ─
+  it('I-HIST-14: order=asc reads forward, is case-insensitive, and rejects invalid values with 400', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-14-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-14-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const sid = 'hist-14-session';
+    for (let i = 0; i < 3; i++) {
+      await sendMessage(router.getApp(), 'alfred', `message-${i}`, sid);
+    }
+    await new Promise((r) => setTimeout(r, 300));
+    const chatId = `api-${sid}`;
+
+    // asc → strictly ascending ts (oldest first)
+    const asc = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?order=asc`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(asc.status).toBe(200);
+    const ascTs = asc.body.messages.map((m: { ts: number }) => m.ts);
+    expect(ascTs).toEqual([...ascTs].sort((a, b) => a - b));
+
+    // Uppercase ASC is accepted (case-insensitive) and matches lowercase asc
+    const ascUpper = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?order=ASC`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(ascUpper.status).toBe(200);
+    expect(ascUpper.body.messages.map((m: { ts: number }) => m.ts)).toEqual(ascTs);
+
+    // desc → strictly descending ts (newest first), same as the default
+    const desc = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?order=desc`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(desc.status).toBe(200);
+    expect(desc.body.messages.map((m: { ts: number }) => m.ts)).toEqual([...ascTs].reverse());
+
+    // An invalid explicit value surfaces as 400 rather than silently defaulting
+    const bad = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?order=sideways`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(bad.status).toBe(400);
+    expect(bad.body.error).toMatch(/order/i);
+
+    await router.stop();
+    await runner.stop();
+  });
+
   // ─── I-HIST-05: FTS search finds matching messages ─────────────────────────
   it('I-HIST-05: GET /chats/:chatId/messages/search finds matching content', async () => {
     const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-05-'));

--- a/tests/unit/history-db.test.ts
+++ b/tests/unit/history-db.test.ts
@@ -107,6 +107,133 @@ describe('HistoryDB.getMessages', () => {
   });
 });
 
+describe('HistoryDB.getMessages — order (asc/desc seek-forward)', () => {
+  const CHAT = 'telegram-12345';
+  const BASE = 1000000;
+
+  function seed(db: HistoryDB, count = 10, overrides: Partial<HistoryMessage> = {}): void {
+    for (let i = 0; i < count; i++) {
+      db.insertMessage(makeMsg({ chatId: CHAT, content: `msg-${i}`, ts: BASE + i, ...overrides }));
+    }
+  }
+
+  it('order="asc" returns oldest-first, strictly ascending', () => {
+    const db = makeDb();
+    seed(db, 10);
+    const page = db.getMessages(CHAT, { order: 'asc' });
+    expect(page.messages).toHaveLength(10);
+    expect(page.messages[0]!.ts).toBe(BASE);
+    for (let i = 1; i < page.messages.length; i++) {
+      expect(page.messages[i]!.ts).toBeGreaterThan(page.messages[i - 1]!.ts);
+    }
+  });
+
+  it('default order (omitted) is desc — newest-first, unchanged from today', () => {
+    const db = makeDb();
+    seed(db, 10);
+    const page = db.getMessages(CHAT);
+    expect(page.messages[0]!.ts).toBe(BASE + 9);
+    for (let i = 1; i < page.messages.length; i++) {
+      expect(page.messages[i]!.ts).toBeLessThan(page.messages[i - 1]!.ts);
+    }
+  });
+
+  it('explicit order="desc" behaves identically to the default', () => {
+    const db = makeDb();
+    seed(db, 10);
+    const implicit = db.getMessages(CHAT);
+    const explicit = db.getMessages(CHAT, { order: 'desc' });
+    expect(explicit.messages.map((m) => m.ts)).toEqual(implicit.messages.map((m) => m.ts));
+  });
+
+  it('asc + after bound excludes everything at or before the bound', () => {
+    const db = makeDb();
+    seed(db, 10); // ts BASE..BASE+9
+    const page = db.getMessages(CHAT, { order: 'asc', after: BASE + 4 });
+    expect(page.messages.map((m) => m.ts)).toEqual([BASE + 5, BASE + 6, BASE + 7, BASE + 8, BASE + 9]);
+    expect(page.messages.every((m) => m.ts > BASE + 4)).toBe(true);
+  });
+
+  it('asc + hasMore is true and exactly `limit` rows are returned when more exist', () => {
+    const db = makeDb();
+    seed(db, 10);
+    const page = db.getMessages(CHAT, { order: 'asc', limit: 3 });
+    expect(page.messages).toHaveLength(3);
+    expect(page.hasMore).toBe(true);
+    expect(page.messages.map((m) => m.ts)).toEqual([BASE, BASE + 1, BASE + 2]);
+  });
+
+  it('asc nextCursor continuation is contiguous — no gap, no overlap across pages', () => {
+    const db = makeDb();
+    seed(db, 10);
+    const page1 = db.getMessages(CHAT, { order: 'asc', limit: 4 });
+    expect(page1.hasMore).toBe(true);
+    expect(page1.nextCursor).toBe(BASE + 3); // newest ts returned in this asc page
+
+    const page2 = db.getMessages(CHAT, { order: 'asc', after: page1.nextCursor!, limit: 4 });
+    const seen = [...page1.messages, ...page2.messages].map((m) => m.ts);
+    expect(seen).toEqual([...new Set(seen)]); // no duplicates
+    expect(page2.messages[0]!.ts).toBe(page1.messages[page1.messages.length - 1]!.ts + 1); // no gap
+  });
+
+  it('asc + before + after returns a bounded ascending window', () => {
+    const db = makeDb();
+    seed(db, 10); // ts BASE..BASE+9
+    const page = db.getMessages(CHAT, { order: 'asc', after: BASE + 2, before: BASE + 7 });
+    expect(page.messages.map((m) => m.ts)).toEqual([BASE + 3, BASE + 4, BASE + 5, BASE + 6]);
+  });
+
+  it('asc + after past the newest ts returns an empty page', () => {
+    const db = makeDb();
+    seed(db, 10);
+    const page = db.getMessages(CHAT, { order: 'asc', after: BASE + 100 });
+    expect(page.messages).toHaveLength(0);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('asc on an unknown chat returns an empty page, not an error', () => {
+    const db = makeDb();
+    seed(db, 3);
+    const page = db.getMessages('telegram-unknown', { order: 'asc' });
+    expect(page.messages).toHaveLength(0);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('asc composes with sessionId filtering', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ chatId: CHAT, sessionId: 'session-a', content: 'a1', ts: BASE }));
+    db.insertMessage(makeMsg({ chatId: CHAT, sessionId: 'session-b', content: 'b1', ts: BASE + 1 }));
+    db.insertMessage(makeMsg({ chatId: CHAT, sessionId: 'session-a', content: 'a2', ts: BASE + 2 }));
+    const page = db.getMessages(CHAT, { order: 'asc', sessionId: 'session-a' });
+    expect(page.messages.map((m) => m.content)).toEqual(['a1', 'a2']);
+  });
+
+  it('an arbitrary/garbage order value falls back to desc — never throws, never reaches SQL raw', () => {
+    const db = makeDb();
+    seed(db, 5);
+    expect(() =>
+      db.getMessages(CHAT, { order: 'sideways; DROP TABLE messages;--' as unknown as 'asc' | 'desc' })
+    ).not.toThrow();
+    const page = db.getMessages(CHAT, { order: 'sideways' as unknown as 'asc' | 'desc' });
+    expect(page.messages[0]!.ts).toBe(BASE + 4); // newest-first, i.e. desc fallback
+    // table must still exist / be intact after the "injection" attempt
+    expect(db.getMessages(CHAT).messages).toHaveLength(5);
+  });
+
+  it('single-row result: asc and desc agree, hasMore false, nextCursor null', () => {
+    const db = makeDb();
+    db.insertMessage(makeMsg({ chatId: CHAT, ts: BASE }));
+    const asc = db.getMessages(CHAT, { order: 'asc' });
+    const desc = db.getMessages(CHAT, { order: 'desc' });
+    expect(asc.messages).toHaveLength(1);
+    expect(desc.messages).toHaveLength(1);
+    expect(asc.hasMore).toBe(false);
+    expect(asc.nextCursor).toBeNull();
+  });
+});
+
 describe('HistoryDB.listChats', () => {
   it('returns empty array when no messages', () => {
     const db = makeDb();

--- a/tests/unit/history-db.test.ts
+++ b/tests/unit/history-db.test.ts
@@ -232,6 +232,18 @@ describe('HistoryDB.getMessages — order (asc/desc seek-forward)', () => {
     expect(asc.hasMore).toBe(false);
     expect(asc.nextCursor).toBeNull();
   });
+
+  it('rows sharing a ts get a deterministic id-tiebroken order (asc = insertion, desc = reverse)', () => {
+    const db = makeDb();
+    // three messages at the SAME ts, inserted in a known order
+    db.insertMessage(makeMsg({ chatId: CHAT, content: 'first', ts: BASE }));
+    db.insertMessage(makeMsg({ chatId: CHAT, content: 'second', ts: BASE }));
+    db.insertMessage(makeMsg({ chatId: CHAT, content: 'third', ts: BASE }));
+    expect(db.getMessages(CHAT, { order: 'asc' }).messages.map((m) => m.content))
+      .toEqual(['first', 'second', 'third']);
+    expect(db.getMessages(CHAT, { order: 'desc' }).messages.map((m) => m.content))
+      .toEqual(['third', 'second', 'first']);
+  });
 });
 
 describe('HistoryDB.listChats', () => {


### PR DESCRIPTION
## Summary

Adds ascending (seek-forward) message pagination to the history API so a **jump-to-date** action can seek forward from a timestamp in `O(1)` per page, instead of walking backward from newest through the whole history.

Fully backward-compatible: the default ordering is unchanged (`desc`); `asc` is opt-in via a new query param.

Closes #211

## Changes (6 files, +243 / −4)

| File | Change |
|------|--------|
| `src/history/types.ts` | Add `order?: 'asc' \| 'desc'` to `PaginationOpts` |
| `src/history/db.ts` | `getMessages` applies a **whitelisted** `ORDER BY ts ${order}` (default `desc`), tiebroken by `id` so rows sharing a `ts` get a deterministic, chronology-consistent order; `nextCursor` / `hasMore` / `limit+1` logic reused unchanged |
| `src/api/router.ts` | Parse `?order=asc` on the messages endpoint; validated against the whitelist before it reaches SQL, and a non-string (repeated/structured) param is rejected with `400` rather than throwing |
| `API.md` | Document the `order` param with a seek-forward example |
| `tests/unit/history-db.test.ts` | 13 new unit tests covering asc/desc ordering, cursor paging in both directions, same-`ts` id tiebreak, and the default |
| `tests/integration/chat-history-api.test.ts` | Integration test I-HIST-14: order asc/desc, case-insensitivity, and `400` on an invalid or repeated `order` |

## Design notes

- **No SQL injection surface** — `order` is validated against `{'asc','desc'}` and never interpolated raw; at the DB layer anything else falls back to `desc`.
- **Invalid input at the HTTP layer returns `400`** — an explicit `order` that isn't `asc`/`desc` (including a repeated/array param that Express parses as a non-string) is rejected so client typos surface instead of silently defaulting.
- **Cursor semantics unchanged** — `nextCursor = slice[last].ts`; continue forward via `after` for `asc`, backward via `before` for `desc`, so no cursor special-casing was needed. Known limitation: because the cursor is `ts`-only, a page boundary landing between equal-`ts` rows can still skip the tied remainder — fully closing that needs a composite `(ts, id)` cursor and is tracked as a separate follow-up.

## Testing

- `tsc` clean
- `history-db` **28/28** (incl. 13 new) · `api-router` **98/98** · `chat-history` integration — all green
- Full suite: pre-existing failures are confined to unrelated subsystems (PTY, telegram-plugin, mcp-pipeline, skills-runtime) — environmental integration tests needing real subprocess/timing; none touch history / messages / pagination.

## Scope

Backend API only. The frontend jump-to-date consumer is a separate issue and out of scope here.
