### PR TITLE
[Feature] Active-days endpoint for jump-to-date calendar

### DIFF
--- a/API.md
+++ b/API.md
@@ -140,6 +140,7 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 | `GET` | `/api/v1/agents/:agentId/chats/:chatId/sessions` | Key | List sessions for a specific chat |
 | `GET` | `/api/v1/agents/:agentId/chats/:chatId/messages` | Key | Paginated message history (cursor-based) |
 | `GET` | `/api/v1/agents/:agentId/chats/:chatId/messages/search` | Key | Full-text search across messages (SQLite FTS5) |
+| `GET` | `/api/v1/agents/:agentId/chats/:chatId/messages/active-days` | Key | Distinct local calendar days with >= 1 message in a window (jump-to-date dots) |
 | `POST` | `/api/v1/agents/:agentId/chats/:chatId/sessions/:sessionId/messages` | Key | Inject a message into an existing channel session (SSE stream) |
 
 ### Media API
@@ -2436,6 +2437,49 @@ curl -H "X-Api-Key: my-secret-key-123" \
 | Status | When |
 |--------|------|
 | 400 | `q` is missing or empty |
+
+---
+
+### GET /api/v1/agents/:agentId/chats/:chatId/messages/active-days
+
+Returns the distinct **local calendar days** that have at least one message inside a `[from, to)`
+window. Intended for a jump-to-date calendar: the client requests the visible month once and
+draws a "has history" dot under each returned day, without paging the whole thread into memory.
+The query rides the `(chat_id, ts)` index as a bounded range scan, so a one-month window returns
+at most ~31 days.
+
+**Query parameters:**
+
+| Param | Required | Description |
+|-------|----------|-------------|
+| `from` | Yes | Window start, UTC epoch ms, **inclusive** (`ts >= from`) |
+| `to` | Yes | Window end, UTC epoch ms, **exclusive** (`ts < to`) |
+| `tz_offset` | No | Viewer's timezone offset in **minutes east of UTC** (`local = UTC + offset`). Bangkok (UTC+7) is `+420`, India (UTC+5:30) is `+330`, New York (UTC-4 DST) is `-240`. Default `0` (UTC bucketing). Clients computing this from JavaScript should send `-new Date().getTimezoneOffset()` (that API returns the opposite sign). |
+| `session_id` | No | Restrict to a single session (parity with the messages endpoint) |
+
+Days are returned as `YYYY-MM-DD` strings, **distinct and sorted ascending**. An empty or
+inverted window (`to <= from`) and a window with no messages both return `{ "days": [] }` with
+status `200`. The window may span at most **366 days** (`to - from`); a larger range returns 400,
+since the calendar only ever requests one visible month at a time.
+
+```bash
+curl -H "X-Api-Key: my-secret-key-123" \
+  "http://localhost:10850/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages/active-days?from=1751328000000&to=1754006400000&tz_offset=420" | jq
+```
+
+```json
+{
+  "days": ["2026-07-02", "2026-07-03", "2026-07-05", "2026-07-09"]
+}
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | `from` or `to` is missing or non-numeric |
+| 400 | `tz_offset` is present but non-numeric |
+| 400 | window is larger than 366 days (`to - from`) |
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2462,6 +2462,12 @@ inverted window (`to <= from`) and a window with no messages both return `{ "day
 status `200`. The window may span at most **366 days** (`to - from`); a larger range returns 400,
 since the calendar only ever requests one visible month at a time.
 
+> **Window is filtered in UTC, days are bucketed in local time.** `from`/`to` are matched against
+> the raw stored `ts` (UTC ms), while the returned day labels use `tz_offset`. For a viewer east of
+> UTC, the first local day of a month begins *before* its UTC midnight (e.g. Bangkok's `2026-07-01`
+> starts at `2026-06-30T17:00Z`). Send `from`/`to` covering the visible month **in the viewer's
+> local time** — i.e. widen the UTC window by `tz_offset` — so edge days aren't under-counted.
+
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
   "http://localhost:10850/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages/active-days?from=1751328000000&to=1754006400000&tz_offset=420" | jq

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2111,6 +2111,56 @@ export function createApiRouter(
   });
 
   /**
+   * GET /api/v1/agents/:agentId/chats/:chatId/messages/active-days
+   * Distinct local calendar days (YYYY-MM-DD) with >= 1 message in a [from, to) window.
+   * Powers the jump-to-date calendar's per-day "has history" dot in one bounded index scan.
+   * Query: from (ts ms, inclusive), to (ts ms, exclusive), tz_offset (min east of UTC, Bangkok=+420), session_id
+   */
+  router.get('/v1/agents/:agentId/chats/:chatId/messages/active-days', auth, (req: Request, res: Response) => {
+    const { agentId, chatId } = req.params as { agentId: string; chatId: string };
+    const apiKey = (req as AuthedRequest).apiKey;
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    const runner = agentRunners.get(agentId);
+    if (!runner) {
+      res.status(404).json({ error: `Agent '${agentId}' not found` });
+      return;
+    }
+    const query = req.query as Record<string, string>;
+    // Number(), not parseInt() — parseInt("100garbage") silently returns 100, masking a malformed
+    // client value the same way a case-sensitive/silently-defaulting enum param would (see order).
+    const from = query['from'] ? Number(query['from']) : NaN;
+    const to = query['to'] ? Number(query['to']) : NaN;
+    if (!Number.isFinite(from) || !Number.isFinite(to)) {
+      res.status(400).json({ error: 'from and to (ts ms) are required' });
+      return;
+    }
+    // Bound the window so a malformed client can't turn this into a near-full-history scan.
+    // 366 days is far wider than the one-month view the calendar sends, so it never bites
+    // legitimate navigation while still capping a pathological range (E5 in the design notes).
+    const MAX_ACTIVE_DAYS_SPAN_MS = 366 * 24 * 60 * 60 * 1000;
+    if (to - from > MAX_ACTIVE_DAYS_SPAN_MS) {
+      res.status(400).json({ error: 'window too large (max 366 days between from and to)' });
+      return;
+    }
+    let tzOffset = 0;
+    if (query['tz_offset'] !== undefined) {
+      const parsed = Number(query['tz_offset']);
+      if (!Number.isFinite(parsed)) {
+        res.status(400).json({ error: 'tz_offset must be a number (minutes east of UTC)' });
+        return;
+      }
+      tzOffset = parsed;
+    }
+    const sessionId = query['session_id'] ?? undefined;
+
+    const days = runner.getHistoryDb().getActiveDays(chatId, { from, to, tzOffset, sessionId });
+    res.json({ days });
+  });
+
+  /**
    * POST /api/v1/agents/:agentId/chats/:chatId/sessions/:sessionId/messages
    * Inject a message into an existing channel session (cross-channel continuation).
    * Streams the assistant response as SSE.

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2154,7 +2154,15 @@ export function createApiRouter(
       }
       tzOffset = parsed;
     }
-    const sessionId = query['session_id'] ?? undefined;
+    // session_id, like order, can arrive as an array when the param is repeated
+    // (?session_id=a&session_id=b). Guard so it can't reach the sqlite bind as an
+    // array and throw a 500 — surface a 400 instead. (Mirrors the order guard above.)
+    const rawSessionId = query['session_id'] as unknown;
+    if (rawSessionId !== undefined && typeof rawSessionId !== 'string') {
+      res.status(400).json({ error: 'session_id must be a single value' });
+      return;
+    }
+    const sessionId = rawSessionId ?? undefined;
 
     const days = runner.getHistoryDb().getActiveDays(chatId, { from, to, tzOffset, sessionId });
     res.json({ days });

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -9,6 +9,7 @@ import {
   MessageRole,
   PaginationOpts,
   SearchOpts,
+  ActiveDaysOpts,
   SearchPage,
   SearchResult,
   SessionSummary,
@@ -259,6 +260,44 @@ export class HistoryDB {
     } catch {
       return { results: [], total: 0, hasMore: false };
     }
+  }
+
+  /**
+   * Distinct local calendar days (YYYY-MM-DD) that have >= 1 message in [from, to).
+   *
+   * Rides the idx_messages_chat_ts index as a bounded range scan (chat_id + ts window),
+   * so a one-month window emits at most ~31 rows without a full-history scan.
+   *
+   * Timezone: tzOffset is minutes EAST of UTC (local = UTC + offset), matching the issue's
+   * SQL contract. Bangkok (UTC+7) => +420. The SQL adds (tzOffset * 60000) ms to ts before
+   * bucketing, so days match the viewer's local calendar. Omitted tzOffset defaults to 0 (UTC).
+   * (Clients computing this from JS should send -Date.prototype.getTimezoneOffset().)
+   */
+  getActiveDays(chatId: string, opts: ActiveDaysOpts): string[] {
+    // Short-circuit empty/inverted windows before touching SQLite.
+    if (!(opts.to > opts.from)) {
+      return [];
+    }
+
+    const conditions: string[] = ['chat_id = ?', 'ts >= ?', 'ts < ?'];
+    const params: (string | number)[] = [chatId, opts.from, opts.to];
+    if (opts.sessionId) {
+      conditions.push('session_id = ?');
+      params.push(opts.sessionId);
+    }
+
+    // offsetMs is bound FIRST because it appears first in the SQL text; keep ? order and bind
+    // order in lockstep. tzOffset is minutes east of UTC => local = UTC + offset => add offsetMs.
+    const offsetMs = (opts.tzOffset ?? 0) * 60000;
+    const sql = `
+      SELECT DISTINCT date((ts + ?) / 1000, 'unixepoch') AS day
+      FROM messages
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY day ASC
+    `;
+
+    const rows = this.db.prepare(sql).all(offsetMs, ...params) as Array<{ day: string }>;
+    return rows.map((r) => r.day);
   }
 
   listSessions(chatId?: string): SessionSummary[] {

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -53,6 +53,13 @@ export interface SearchOpts {
   offset?: number;
 }
 
+export interface ActiveDaysOpts {
+  from: number; // UTC ms, inclusive (ts >= from)
+  to: number; // UTC ms, exclusive (ts < to)
+  tzOffset?: number; // minutes EAST of UTC (local = UTC + offset); Bangkok = +420; default 0 (UTC)
+  sessionId?: string;
+}
+
 export interface SessionSummary {
   chatId: string | null;
   sessionId: string;

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -4,7 +4,8 @@
  * Spins up a real AgentRunner + GatewayRouter with a mock claude subprocess
  * and exercises all 7 Chat History / Media API endpoints via supertest.
  *
- * Test IDs: I-HIST-01 through I-HIST-12
+ * Test IDs: I-HIST-01 through I-HIST-27 (non-contiguous: I-HIST-14 is the `order` param
+ * test from #211/PR #213; active-days coverage is I-HIST-21 through I-HIST-27)
  */
 
 import * as fs from 'fs';
@@ -613,4 +614,195 @@ describe('Chat History API integration (planning-50)', () => {
     await router.stop();
     await runner.stop();
   }, 15000);
+
+  // ─── I-HIST-21: active-days — happy path with tz bucketing + session filter ─
+  it('I-HIST-21: GET /chats/:chatId/messages/active-days returns distinct local days', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-21-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-21-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    await waitFor(() => runner.isRunning());
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const sid = 'hist-21-session';
+    await sendMessage(router.getApp(), 'alfred', 'first day message', sid);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const chatId = `api-${sid}`;
+    const now = Date.now();
+    const res = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages/active-days?from=${now - 86400000}&to=${now + 86400000}&tz_offset=420&session_id=${sid}`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.days)).toBe(true);
+    expect(res.body.days.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.days[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-22: active-days — missing from/to returns 400 ────────────────
+  it('I-HIST-22: GET /messages/active-days with missing from/to returns 400', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-22-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-22-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const noFrom = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats/api-any/messages/active-days?to=1000')
+      .set('X-Api-Key', API_KEY_ADMIN);
+    const noTo = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats/api-any/messages/active-days?from=0')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(noFrom.status).toBe(400);
+    expect(noTo.status).toBe(400);
+    expect(noFrom.body.error).toBeDefined();
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-23: active-days — non-numeric from returns 400, not a silent truncation ─
+  it('I-HIST-23: GET /messages/active-days with non-numeric from/to returns 400', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-23-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-23-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // "100garbage" would silently truncate to 100 under parseInt() — must 400 instead.
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats/api-any/messages/active-days?from=100garbage&to=200')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(400);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-24: active-days — non-numeric tz_offset returns 400 ──────────
+  it('I-HIST-24: GET /messages/active-days with non-numeric tz_offset returns 400', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-24-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-24-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats/api-any/messages/active-days?from=0&to=1000&tz_offset=banana')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/tz_offset/i);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-25: active-days — 403 when key has no access to agent ────────
+  it('I-HIST-25: GET /messages/active-days returns 403 when key has no access to agent', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-25-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-25-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/alfred/chats/api-any/messages/active-days?from=0&to=1000')
+      .set('X-Api-Key', API_KEY_OTHER);
+
+    expect(res.status).toBe(403);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-26: active-days — 404 when agent not found ───────────────────
+  it('I-HIST-26: GET /messages/active-days returns 404 for unknown agent', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-26-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-26-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const res = await supertest(router.getApp())
+      .get('/api/v1/agents/nonexistent/chats/api-any/messages/active-days?from=0&to=1000')
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(404);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-27: active-days — window larger than 366 days returns 400 ─────
+  it('I-HIST-27: GET /messages/active-days with an over-long window returns 400', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-27-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-27-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // 400 days apart — beyond the 366-day cap that guards against a full-history scan.
+    const from = 0;
+    const to = 400 * 24 * 60 * 60 * 1000;
+    const res = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/api-any/messages/active-days?from=${from}&to=${to}`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/window too large/i);
+
+    // A window exactly at the boundary (366 days) is still accepted (200).
+    const okTo = 366 * 24 * 60 * 60 * 1000;
+    const ok = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/api-any/messages/active-days?from=${from}&to=${okTo}`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(ok.status).toBe(200);
+    expect(Array.isArray(ok.body.days)).toBe(true);
+
+    await router.stop();
+    await runner.stop();
+  });
 });

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -4,8 +4,8 @@
  * Spins up a real AgentRunner + GatewayRouter with a mock claude subprocess
  * and exercises all 7 Chat History / Media API endpoints via supertest.
  *
- * Test IDs: I-HIST-01 through I-HIST-27 (non-contiguous: I-HIST-14 is the `order` param
- * test from #211/PR #213; active-days coverage is I-HIST-21 through I-HIST-27)
+ * Test IDs: I-HIST-01 through I-HIST-28 (non-contiguous: I-HIST-14 is the `order` param
+ * test from #211/PR #213; active-days coverage is I-HIST-21 through I-HIST-28)
  */
 
 import * as fs from 'fs';
@@ -801,6 +801,34 @@ describe('Chat History API integration (planning-50)', () => {
 
     expect(ok.status).toBe(200);
     expect(Array.isArray(ok.body.days)).toBe(true);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-28: active-days — repeated session_id param returns 400, not 500 ─────
+  it('I-HIST-28: GET /messages/active-days with a repeated session_id returns 400', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-28-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-28-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // Express parses ?session_id=a&session_id=b as an array; without the guard it would
+    // reach the sqlite bind and throw a 500. Expect a clean 400 instead.
+    const from = 0;
+    const to = 24 * 60 * 60 * 1000;
+    const res = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/api-any/messages/active-days?from=${from}&to=${to}&session_id=a&session_id=b`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/session_id/i);
 
     await router.stop();
     await runner.stop();

--- a/tests/unit/api/active-days.test.ts
+++ b/tests/unit/api/active-days.test.ts
@@ -1,0 +1,162 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { HistoryDB } from '../../../src/history/db';
+import { HistoryMessage } from '../../../src/history/types';
+
+let tmpDir: string;
+const AGENT_ID = 'test-agent';
+const CHAT = 'telegram-12345';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'active-days-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeDb(): HistoryDB {
+  // Each test gets its own unique dir so the singleton cache does not interfere.
+  return HistoryDB.forAgent(tmpDir, AGENT_ID);
+}
+
+function insertAt(db: HistoryDB, ts: number, overrides: Partial<HistoryMessage> = {}): void {
+  const msg: HistoryMessage = {
+    chatId: CHAT,
+    sessionId: 'session-uuid-1',
+    source: 'telegram',
+    role: 'user',
+    content: 'msg',
+    senderName: 'testuser',
+    ts,
+    ...overrides,
+  };
+  db.insertMessage(msg);
+}
+
+// Fixed UTC timestamps — deterministic buckets, never Date.now().
+const JUL = 6; // month is 0-indexed in Date.UTC (6 = July)
+// tz_offset is minutes EAST of UTC (local = UTC + offset), matching the issue contract.
+const TZ_BANGKOK = 420; // UTC+7
+const TZ_NEPAL = 345; // UTC+5:45
+
+describe('HistoryDB.getActiveDays', () => {
+  // U-AD-01 — distinct days, deduped and ascending
+  it('returns distinct local days, deduped and sorted ascending', () => {
+    const db = makeDb();
+    insertAt(db, Date.UTC(2026, JUL, 2, 10, 0, 0));
+    insertAt(db, Date.UTC(2026, JUL, 2, 15, 0, 0)); // duplicate day
+    insertAt(db, Date.UTC(2026, JUL, 3, 9, 0, 0));
+    insertAt(db, Date.UTC(2026, JUL, 5, 20, 0, 0));
+
+    const days = db.getActiveDays(CHAT, {
+      from: Date.UTC(2026, JUL, 1),
+      to: Date.UTC(2026, JUL, 6),
+      tzOffset: 0,
+    });
+
+    expect(days).toEqual(['2026-07-02', '2026-07-03', '2026-07-05']);
+  });
+
+  // U-AD-02 — empty range and inverted window both return []
+  it('returns [] for a window with no messages', () => {
+    const db = makeDb();
+    insertAt(db, Date.UTC(2026, JUL, 2, 10, 0, 0));
+
+    const days = db.getActiveDays(CHAT, {
+      from: Date.UTC(2026, JUL, 10),
+      to: Date.UTC(2026, JUL, 20),
+      tzOffset: 0,
+    });
+
+    expect(days).toEqual([]);
+  });
+
+  it('short-circuits to [] when to <= from (inverted/empty window)', () => {
+    const db = makeDb();
+    insertAt(db, Date.UTC(2026, JUL, 2, 10, 0, 0));
+
+    const inverted = db.getActiveDays(CHAT, {
+      from: Date.UTC(2026, JUL, 5),
+      to: Date.UTC(2026, JUL, 1),
+    });
+    const equal = db.getActiveDays(CHAT, {
+      from: Date.UTC(2026, JUL, 2),
+      to: Date.UTC(2026, JUL, 2),
+    });
+
+    expect(inverted).toEqual([]);
+    expect(equal).toEqual([]);
+  });
+
+  // U-AD-03 — the critical timezone day-boundary test (a flipped sign fails this)
+  it('buckets a near-midnight message into the viewer local day (tz sign)', () => {
+    const db = makeDb();
+    // 2026-07-02T23:30:00Z — still Jul 2 in UTC, but Jul 3 in Bangkok (UTC+7).
+    const ts = Date.UTC(2026, JUL, 2, 23, 30, 0);
+    insertAt(db, ts);
+
+    const window = { from: Date.UTC(2026, JUL, 2), to: Date.UTC(2026, JUL, 4) };
+
+    const bangkok = db.getActiveDays(CHAT, { ...window, tzOffset: TZ_BANGKOK });
+    const utc = db.getActiveDays(CHAT, { ...window, tzOffset: 0 });
+
+    expect(bangkok).toEqual(['2026-07-03']); // UTC+7 pushes 23:30 into the next local day
+    expect(utc).toEqual(['2026-07-02']); // UTC bucketing keeps it on Jul 2
+  });
+
+  it('defaults to UTC bucketing when tzOffset is omitted', () => {
+    const db = makeDb();
+    insertAt(db, Date.UTC(2026, JUL, 2, 23, 30, 0));
+
+    const days = db.getActiveDays(CHAT, {
+      from: Date.UTC(2026, JUL, 2),
+      to: Date.UTC(2026, JUL, 4),
+    });
+
+    expect(days).toEqual(['2026-07-02']);
+  });
+
+  // U-AD-03b — a western offset must bucket the other way (guards the sign direction)
+  it('buckets a just-after-midnight UTC message into the previous local day for a western offset', () => {
+    const db = makeDb();
+    // 2026-07-03T02:00:00Z — Jul 3 in UTC, but still Jul 2 in New York (UTC-4).
+    insertAt(db, Date.UTC(2026, JUL, 3, 2, 0, 0));
+
+    const window = { from: Date.UTC(2026, JUL, 2), to: Date.UTC(2026, JUL, 4) };
+    const newYork = db.getActiveDays(CHAT, { ...window, tzOffset: -240 }); // UTC-4
+
+    expect(newYork).toEqual(['2026-07-02']);
+  });
+
+  // U-AD-04 — session_id filter (also exercises the full bind order)
+  it('filters by session_id', () => {
+    const db = makeDb();
+    insertAt(db, Date.UTC(2026, JUL, 2, 10, 0, 0), { sessionId: 'sess-A' });
+    insertAt(db, Date.UTC(2026, JUL, 3, 10, 0, 0), { sessionId: 'sess-B' });
+
+    const window = { from: Date.UTC(2026, JUL, 1), to: Date.UTC(2026, JUL, 6), tzOffset: 0 };
+
+    const onlyA = db.getActiveDays(CHAT, { ...window, sessionId: 'sess-A' });
+    const both = db.getActiveDays(CHAT, window);
+
+    expect(onlyA).toEqual(['2026-07-02']);
+    expect(both).toEqual(['2026-07-02', '2026-07-03']);
+  });
+
+  // U-AD-05 — half-hour / 45-min zone
+  it('buckets correctly for a 45-minute offset zone (Nepal UTC+5:45)', () => {
+    const db = makeDb();
+    // 2026-07-02T18:20:00Z + 5:45 = 2026-07-03T00:05 local => Jul 3 in Nepal.
+    insertAt(db, Date.UTC(2026, JUL, 2, 18, 20, 0));
+
+    const window = { from: Date.UTC(2026, JUL, 2), to: Date.UTC(2026, JUL, 4) };
+
+    const nepal = db.getActiveDays(CHAT, { ...window, tzOffset: TZ_NEPAL });
+    const utc = db.getActiveDays(CHAT, { ...window, tzOffset: 0 });
+
+    expect(nepal).toEqual(['2026-07-03']);
+    expect(utc).toEqual(['2026-07-02']);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a cheap, bounded `active-days` lookup so a jump-to-date calendar can mark which days have chat history without paging the whole thread into the client. One indexed range scan over `idx_messages_chat_ts` returns the distinct local calendar days with at least one message in a visible-month window.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor / Tech debt
- [ ] Documentation

## Related Issues
Closes #212

## Changes Made
- `src/history/db.ts`: new `getActiveDays(chatId, { from, to, tzOffset, sessionId })` — one `DISTINCT date(...)` range scan; short-circuits empty/inverted windows before touching SQLite.
- `src/history/types.ts`: new `ActiveDaysOpts` interface.
- `src/api/router.ts`: new `GET /api/v1/agents/:agentId/chats/:chatId/messages/active-days` route, registered next to `/messages/search`. Params parse with `Number()` (not `parseInt`) so `100garbage` is rejected with 400 instead of silently truncating; a non-numeric `tz_offset` is likewise rejected. A repeated `session_id` (parsed by Express as an array) is guarded to a 400 rather than a 500 at the SQLite bind — mirrors the `order` guard on the messages route.
- `API.md`: documents the endpoint, params, the `tz_offset` sign convention, the 400 cases, and a note that the `[from, to)` window is filtered in UTC while day labels are bucketed with `tz_offset` (callers should widen the window to the viewer's local month to avoid under-counting edge days).
- `tests/unit/api/active-days.test.ts`: 8 DB-level unit tests (distinct/sorted days, empty + inverted window, timezone day-boundary on eastern and western offsets, 45-minute zone, session filter).
- `tests/integration/chat-history-api.test.ts`: 8 HTTP-level integration tests (I-HIST-21..28: happy path, 400 missing/non-numeric `from`/`to`, 400 non-numeric `tz_offset`, 403 no access, 404 unknown agent, 400 over-long window, 400 repeated `session_id`).

## Timezone contract
`tz_offset` is minutes **east of UTC** (`local = UTC + offset`, Bangkok = `+420`), matching the SQL sketch in the issue. Documented in `API.md` with a note to send `-getTimezoneOffset()` from JS. The sign is pinned by day-boundary tests on both an eastern and a western offset — a flipped sign fails them.

## How to Test
1. Check out this branch and run `npm test`.
2. Or exercise the route: `GET /api/v1/agents/:agentId/chats/:chatId/messages/active-days?from=<ms>&to=<ms>&tz_offset=420&session_id=<id>`.

Expected: `{ "days": ["2026-07-02", "2026-07-03", ...] }` for a window with messages; `{ "days": [] }` (200) for an empty range; 400 for missing/non-numeric `from`/`to`/`tz_offset`.

## Checklist
- [x] Reviewed my own code
- [x] Tests pass (active-days unit + integration + api-router suites green; tsc clean)
- [x] No console errors

