### PR TITLE
fix(history): composite (ts, id) cursor to prevent pagination boundary skips

### DIFF
--- a/API.md
+++ b/API.md
@@ -2377,6 +2377,8 @@ Paginated message history (cursor-based). Returns messages in reverse chronologi
 | `limit` | Max messages to return (default 50, max 200) |
 | `before` | Return messages before this timestamp (ms) |
 | `after` | Return messages after this timestamp (ms) |
+| `before_id` | Id component of the cursor, paired with `before`. Echo back `nextCursorId` here to page correctly across messages that share a `ts` (see below). Ignored without `before`. |
+| `after_id` | Id component of the cursor, paired with `after` (the `order=asc` counterpart of `before_id`). Ignored without `after`. |
 | `session_id` | Filter to a specific session |
 | `order` | `asc` reads forward (oldest→newest) from `after`; `desc` (default) reads newest→oldest. Case-insensitive; any other value returns `400`. |
 
@@ -2391,9 +2393,13 @@ curl -H "X-Api-Key: my-secret-key-123" \
     { "role": "user", "content": "Hello!", "ts": 1775737709000, "sessionId": "abc-123" },
     { "role": "assistant", "content": "Hi there!", "ts": 1775737712000, "sessionId": "abc-123" }
   ],
-  "hasMore": false
+  "hasMore": true,
+  "nextCursor": 1775737709000,
+  "nextCursorId": 8412
 }
 ```
+
+When `hasMore` is `true`, the response carries a **composite cursor**: `nextCursor` (the boundary message's `ts`) and `nextCursorId` (its row id). `nextCursorId` is `null` whenever `nextCursor` is.
 
 **Seek-forward example** (jump to a date and read that day's first messages in one round-trip):
 
@@ -2403,6 +2409,8 @@ curl -H "X-Api-Key: my-secret-key-123" \
 ```
 
 `nextCursor` continues forward via `after` when `order=asc` (vs. `before` for the default `desc`).
+
+**Paging across equal-`ts` messages.** `ts` is millisecond-granular and not unique — an image burst coalesced into one turn, or rapid messages, can share a `ts`. To page a run of tied rows without skipping the remainder at the boundary, echo **both** cursor components back: `before=<nextCursor>&before_id=<nextCursorId>` for the default `desc`, or `after=<nextCursor>&after_id=<nextCursorId>` for `order=asc`. The query then matches the boundary as a composite `(ts, id)` tuple. Passing only `before`/`after` (the `ts`) remains valid and byte-for-byte backward compatible; it just retains the legacy behavior of dropping not-yet-shown rows that share the exact boundary `ts`.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2382,6 +2382,8 @@ Paginated message history (cursor-based). Returns messages in reverse chronologi
 | `session_id` | Filter to a specific session |
 | `order` | `asc` reads forward (oldest→newest) from `after`; `desc` (default) reads newest→oldest. Case-insensitive; any other value returns `400`. |
 
+`before`, `after`, `before_id`, and `after_id` must be numeric; a present-but-non-numeric value returns `400`.
+
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
   "http://localhost:10850/api/v1/agents/alfred/chats/telegram-<CHAT_ID>/messages?limit=20" | jq
@@ -2390,8 +2392,8 @@ curl -H "X-Api-Key: my-secret-key-123" \
 ```json
 {
   "messages": [
-    { "role": "user", "content": "Hello!", "ts": 1775737709000, "sessionId": "abc-123" },
-    { "role": "assistant", "content": "Hi there!", "ts": 1775737712000, "sessionId": "abc-123" }
+    { "role": "assistant", "content": "Hi there!", "ts": 1775737712000, "sessionId": "abc-123" },
+    { "role": "user", "content": "Hello!", "ts": 1775737709000, "sessionId": "abc-123" }
   ],
   "hasMore": true,
   "nextCursor": 1775737709000,

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2052,6 +2052,11 @@ export function createApiRouter(
     const limit = query['limit'] ? Math.min(parseInt(query['limit'], 10) || 50, 200) : 50;
     const before = query['before'] ? parseInt(query['before'], 10) : undefined;
     const after = query['after'] ? parseInt(query['after'], 10) : undefined;
+    // Optional id component of the cursor, echoed from a prior page's nextCursorId. Paired
+    // with before/after, it forms a composite (ts, id) cursor so paging across messages that
+    // share a ts doesn't skip the tied remainder. Ignored unless its before/after is present.
+    const beforeId = query['before_id'] ? parseInt(query['before_id'], 10) : undefined;
+    const afterId = query['after_id'] ? parseInt(query['after_id'], 10) : undefined;
     const sessionId = query['session_id'] ?? undefined;
 
     // order: case-insensitive; 'asc' seeks forward, 'desc' (or omitted) is the db default.
@@ -2076,7 +2081,7 @@ export function createApiRouter(
       }
     }
 
-    const page = runner.getHistoryDb().getMessages(chatId, { limit, before, after, sessionId, order });
+    const page = runner.getHistoryDb().getMessages(chatId, { limit, before, after, beforeId, afterId, sessionId, order });
     res.json(page);
   });
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -2050,13 +2050,28 @@ export function createApiRouter(
     }
     const query = req.query as Record<string, string>;
     const limit = query['limit'] ? Math.min(parseInt(query['limit'], 10) || 50, 200) : 50;
-    const before = query['before'] ? parseInt(query['before'], 10) : undefined;
-    const after = query['after'] ? parseInt(query['after'], 10) : undefined;
-    // Optional id component of the cursor, echoed from a prior page's nextCursorId. Paired
-    // with before/after, it forms a composite (ts, id) cursor so paging across messages that
-    // share a ts doesn't skip the tied remainder. Ignored unless its before/after is present.
-    const beforeId = query['before_id'] ? parseInt(query['before_id'], 10) : undefined;
-    const afterId = query['after_id'] ? parseInt(query['after_id'], 10) : undefined;
+    // Numeric cursor params. before/after are ms timestamps; before_id/after_id are the id
+    // component of the composite (ts, id) cursor, echoed from a prior page's nextCursorId —
+    // paired with before/after they stop paging from skipping messages that share a ts
+    // (ignored unless the matching before/after is present). A present-but-non-numeric value
+    // (?before=abc, or a duplicate/structured param) is a malformed request: reject with 400
+    // so client bugs surface, mirroring the `order` guard below, rather than coercing to NaN
+    // and silently returning an empty page.
+    const cursorInts: Record<string, number | undefined> = {};
+    for (const name of ['before', 'after', 'before_id', 'after_id']) {
+      const raw = query[name] as unknown;
+      if (raw === undefined) continue;
+      const n = typeof raw === 'string' ? parseInt(raw, 10) : NaN;
+      if (!Number.isFinite(n)) {
+        res.status(400).json({ error: `${name} must be a number` });
+        return;
+      }
+      cursorInts[name] = n;
+    }
+    const before = cursorInts['before'];
+    const after = cursorInts['after'];
+    const beforeId = cursorInts['before_id'];
+    const afterId = cursorInts['after_id'];
     const sessionId = query['session_id'] ?? undefined;
 
     // order: case-insensitive; 'asc' seeks forward, 'desc' (or omitted) is the db default.

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -176,13 +176,29 @@ export class HistoryDB {
       conditions.push('session_id = ?');
       params.push(opts.sessionId);
     }
+    // Composite (ts, id) cursor: when the caller pairs before/after with its id component,
+    // match the boundary as a tuple so a page edge landing between equal-ts rows doesn't
+    // skip the tied remainder. Without the id it falls back to the legacy ts-only filter,
+    // keeping existing clients byte-for-byte compatible. before pages toward older rows
+    // (uses <), after pages toward newer rows (uses >) — the id comparison follows the
+    // same direction as its ts.
     if (opts.before !== undefined) {
-      conditions.push('ts < ?');
-      params.push(opts.before);
+      if (opts.beforeId !== undefined) {
+        conditions.push('(ts < ? OR (ts = ? AND id < ?))');
+        params.push(opts.before, opts.before, opts.beforeId);
+      } else {
+        conditions.push('ts < ?');
+        params.push(opts.before);
+      }
     }
     if (opts.after !== undefined) {
-      conditions.push('ts > ?');
-      params.push(opts.after);
+      if (opts.afterId !== undefined) {
+        conditions.push('(ts > ? OR (ts = ? AND id > ?))');
+        params.push(opts.after, opts.after, opts.afterId);
+      } else {
+        conditions.push('ts > ?');
+        params.push(opts.after);
+      }
     }
 
     // Fetch limit+1 to determine hasMore
@@ -190,9 +206,9 @@ export class HistoryDB {
     const order = opts.order === 'asc' ? 'ASC' : 'DESC'; // whitelist; never interpolate raw input
     // Tiebreak on id (AUTOINCREMENT, monotonic with insertion) so rows sharing a
     // ts have a deterministic, chronology-consistent order instead of relying on
-    // SQLite's unspecified default. NOTE: nextCursor is ts-only, so a page
-    // boundary landing between equal-ts rows can still skip the tied remainder —
-    // fully closing that needs a composite (ts,id) cursor (tracked separately).
+    // SQLite's unspecified default. Paired with the composite (ts, id) cursor above,
+    // a page boundary between equal-ts rows is expressible exactly, so no tied row is
+    // skipped or repeated when the caller passes the cursor's id component back.
     const sql = `
       SELECT id, chat_id, session_id, source, role, content, sender_name, sender_id,
              platform_message_id, media_files, ts
@@ -207,11 +223,11 @@ export class HistoryDB {
     const slice = hasMore ? rows.slice(0, limit) : rows;
 
     const messages = slice.map((r) => this._rowToMessage(r));
-    const nextCursor = hasMore && slice.length > 0
-      ? (slice[slice.length - 1]!['ts'] as number)
-      : null;
+    const boundary = hasMore && slice.length > 0 ? slice[slice.length - 1]! : null;
+    const nextCursor = boundary ? (boundary['ts'] as number) : null;
+    const nextCursorId = boundary ? (boundary['id'] as number) : null;
 
-    return { messages, hasMore, nextCursor };
+    return { messages, hasMore, nextCursor, nextCursorId };
   }
 
   searchMessages(chatId: string, query: string, opts: SearchOpts = {}): SearchPage {

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -19,6 +19,10 @@ export interface MessagePage {
   messages: HistoryMessage[];
   hasMore: boolean;
   nextCursor: number | null;
+  // Row id of the boundary message, paired with nextCursor (ts). Pass both back as
+  // before_id/after_id to page across a run of equal-ts messages without skipping the
+  // tied remainder. null whenever nextCursor is null. See PaginationOpts.beforeId.
+  nextCursorId: number | null;
 }
 
 export interface SearchResult extends HistoryMessage {
@@ -44,6 +48,12 @@ export interface PaginationOpts {
   limit?: number;
   before?: number;
   after?: number;
+  // Optional id component of the cursor, paired with before/after (ts). When supplied,
+  // the boundary is matched as a composite (ts, id) tuple so a page edge landing between
+  // messages that share a ts no longer skips the tied remainder. Ignored unless its
+  // matching before/after is also set. Omitting it preserves the legacy ts-only behavior.
+  beforeId?: number;
+  afterId?: number;
   sessionId?: string;
   order?: 'asc' | 'desc'; // default 'desc' (reverse-chronological)
 }

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -885,6 +885,16 @@ describe('Chat History API integration (planning-50)', () => {
     expect(collected).toEqual(['e', 'd', 'c', 'b', 'a']);
     expect(new Set(collected).size).toBe(5);
 
+    // A present-but-non-numeric cursor component is a malformed request → 400 (not a
+    // silent empty page). Covers before/after and both id companions uniformly.
+    for (const badParam of ['before=abc', 'after=xyz', 'before_id=nope', 'after_id=nan']) {
+      const bad = await supertest(router.getApp())
+        .get(`/api/v1/agents/alfred/chats/${chatId}/messages?${badParam}`)
+        .set('X-Api-Key', API_KEY_ADMIN);
+      expect(bad.status).toBe(400);
+      expect(bad.body.error).toMatch(/must be a number/i);
+    }
+
     await router.stop();
     await runner.stop();
   });

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -4,8 +4,9 @@
  * Spins up a real AgentRunner + GatewayRouter with a mock claude subprocess
  * and exercises all 7 Chat History / Media API endpoints via supertest.
  *
- * Test IDs: I-HIST-01 through I-HIST-28 (non-contiguous: I-HIST-14 is the `order` param
- * test from #211/PR #213; active-days coverage is I-HIST-21 through I-HIST-28)
+ * Test IDs: I-HIST-01 through I-HIST-29 (non-contiguous: I-HIST-14 is the `order` param
+ * test from #211/PR #213; active-days coverage is I-HIST-21 through I-HIST-28; I-HIST-29
+ * covers the composite (ts,id) cursor)
  */
 
 import * as fs from 'fs';
@@ -829,6 +830,60 @@ describe('Chat History API integration (planning-50)', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/session_id/i);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-29: composite (ts,id) cursor pages an equal-ts burst without skipping ─────
+  it('I-HIST-29: GET /messages before_id/after_id cursor covers an equal-ts burst end-to-end', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-29-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-29-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // Seed a burst where three messages share ts=200, flanked by a lower and a higher ts,
+    // directly through the history DB so the tie is deterministic (sendMessage stamps wall-clock ts).
+    const chatId = 'telegram-tie-burst';
+    const db = runner.getHistoryDb();
+    const seed: ReadonlyArray<readonly [string, number]> = [
+      ['a', 100], ['b', 200], ['c', 200], ['d', 200], ['e', 300],
+    ];
+    for (const [content, ts] of seed) {
+      db.insertMessage({
+        chatId, sessionId: 'sess-tie', source: 'telegram', role: 'user',
+        content, senderName: 'tester', ts,
+      });
+    }
+
+    // Page desc, 2 at a time, feeding BOTH nextCursor and nextCursorId back each round.
+    const collected: string[] = [];
+    let before: number | undefined;
+    let beforeId: number | undefined;
+    for (let guard = 0; guard < 10; guard++) {
+      const qs = new URLSearchParams({ limit: '2' });
+      if (before !== undefined) qs.set('before', String(before));
+      if (beforeId !== undefined) qs.set('before_id', String(beforeId));
+      const res = await supertest(router.getApp())
+        .get(`/api/v1/agents/alfred/chats/${chatId}/messages?${qs.toString()}`)
+        .set('X-Api-Key', API_KEY_ADMIN);
+      expect(res.status).toBe(200);
+      collected.push(...res.body.messages.map((m: { content: string }) => m.content));
+      if (!res.body.hasMore) break;
+      before = res.body.nextCursor as number;
+      beforeId = res.body.nextCursorId as number;
+    }
+
+    // Every message exactly once, full desc order — the tied 'b'/'c' are NOT skipped,
+    // which a ts-only cursor (before without before_id) would drop at the ts=200 boundary.
+    expect(collected).toEqual(['e', 'd', 'c', 'b', 'a']);
+    expect(new Set(collected).size).toBe(5);
 
     await router.stop();
     await runner.stop();

--- a/tests/unit/history-db.test.ts
+++ b/tests/unit/history-db.test.ts
@@ -246,6 +246,93 @@ describe('HistoryDB.getMessages — order (asc/desc seek-forward)', () => {
   });
 });
 
+describe('HistoryDB.getMessages — composite (ts,id) cursor (boundary skip)', () => {
+  const CHAT = 'telegram-12345';
+
+  // A run where three messages share ts=200, flanked by a lower and a higher ts.
+  // Inserted a..e into an empty db => AUTOINCREMENT ids 1..5 in that order.
+  // desc row order: e,d,c,b,a ; asc row order: a,b,c,d,e.
+  function seedTie(db: HistoryDB): void {
+    db.insertMessage(makeMsg({ chatId: CHAT, content: 'a', ts: 100 }));
+    db.insertMessage(makeMsg({ chatId: CHAT, content: 'b', ts: 200 }));
+    db.insertMessage(makeMsg({ chatId: CHAT, content: 'c', ts: 200 }));
+    db.insertMessage(makeMsg({ chatId: CHAT, content: 'd', ts: 200 }));
+    db.insertMessage(makeMsg({ chatId: CHAT, content: 'e', ts: 300 }));
+  }
+
+  // U-HDB-TIE-01 — documents the legacy skip the id component closes: a ts-only
+  // continuation drops the not-yet-shown rows that share the boundary ts.
+  it('desc: ts-only cursor (no id) still skips messages sharing the boundary ts', () => {
+    const db = makeDb();
+    seedTie(db);
+    const page1 = db.getMessages(CHAT, { limit: 2 }); // desc => e(300), d(200)
+    expect(page1.messages.map((m) => m.content)).toEqual(['e', 'd']);
+    expect(page1.nextCursor).toBe(200);
+
+    // ts-only continuation: WHERE ts < 200 => only 'a'; 'b' and 'c' (ts=200) vanish.
+    const page2 = db.getMessages(CHAT, { limit: 2, before: page1.nextCursor! });
+    expect(page2.messages.map((m) => m.content)).toEqual(['a']);
+  });
+
+  // U-HDB-TIE-02 — composite cursor pages desc across the tie with no skip, no dup.
+  it('desc: composite (ts,id) cursor returns every message exactly once across the tie', () => {
+    const db = makeDb();
+    seedTie(db);
+    const collected: string[] = [];
+    let before: number | undefined;
+    let beforeId: number | undefined;
+    for (let guard = 0; guard < 10; guard++) {
+      const page = db.getMessages(CHAT, { limit: 2, before, beforeId });
+      collected.push(...page.messages.map((m) => m.content));
+      if (!page.hasMore) break;
+      before = page.nextCursor!;
+      beforeId = page.nextCursorId!;
+    }
+    expect(collected).toEqual(['e', 'd', 'c', 'b', 'a']); // full desc, in order
+    expect(new Set(collected).size).toBe(5); // no duplicates
+  });
+
+  // U-HDB-TIE-03 — mirror for asc via after/afterId.
+  it('asc: composite (ts,id) cursor returns every message exactly once across the tie', () => {
+    const db = makeDb();
+    seedTie(db);
+    const collected: string[] = [];
+    let after: number | undefined;
+    let afterId: number | undefined;
+    for (let guard = 0; guard < 10; guard++) {
+      const page = db.getMessages(CHAT, { order: 'asc', limit: 2, after, afterId });
+      collected.push(...page.messages.map((m) => m.content));
+      if (!page.hasMore) break;
+      after = page.nextCursor!;
+      afterId = page.nextCursorId!;
+    }
+    expect(collected).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(new Set(collected).size).toBe(5);
+  });
+
+  // U-HDB-TIE-04 — nextCursorId travels with nextCursor and is null on the final page.
+  it('exposes nextCursorId alongside nextCursor, both null when there is no next page', () => {
+    const db = makeDb();
+    seedTie(db);
+    const page1 = db.getMessages(CHAT, { limit: 2 });
+    expect(page1.hasMore).toBe(true);
+    expect(typeof page1.nextCursorId).toBe('number');
+
+    const last = db.getMessages(CHAT, { limit: 100 });
+    expect(last.hasMore).toBe(false);
+    expect(last.nextCursor).toBeNull();
+    expect(last.nextCursorId).toBeNull();
+  });
+
+  // U-HDB-TIE-05 — an id component without its ts partner is inert (no accidental filter).
+  it('beforeId is ignored when before is absent', () => {
+    const db = makeDb();
+    seedTie(db);
+    const page = db.getMessages(CHAT, { limit: 100, beforeId: 3 });
+    expect(page.messages).toHaveLength(5);
+  });
+});
+
 describe('HistoryDB.listChats', () => {
   it('returns empty array when no messages', () => {
     const db = makeDb();


### PR DESCRIPTION
## Summary
Fixes the timestamp-only cursor boundary skip described in #214. When several messages share the exact same `ts` and a page boundary falls among them, the previous `ts < cursor` / `ts > cursor` filter dropped the tied remainder. This moves pagination to a composite `(ts, id)` cursor so a boundary is fully identified by row.

Closes #214.

## Design — Option A (additive, non-breaking)
Existing `before` / `after` / `nextCursor` (ts-only) behavior is unchanged. New optional companions are added:
- Request: `before_id` / `after_id` (the row id at the boundary)
- Response: `nextCursorId` (id of the last row in the page)

Old clients keep working exactly as before; new clients pass both `before`+`before_id` (or `after`+`after_id`) and get correct paging across equal-`ts` runs.

**DB filter** (`src/history/db.ts`): when a tiebreak id is supplied, the strict `ts` comparison becomes a tuple comparison consistent with sort direction:
- desc: `WHERE (ts < :ts) OR (ts = :ts AND id < :id)`
- asc:  `WHERE (ts > :ts) OR (ts = :ts AND id > :id)`

## Changes
| File | Change |
|------|--------|
| `src/history/types.ts` | `PaginationOpts` gains `beforeId?`/`afterId?`; `MessagePage` gains `nextCursorId` |
| `src/history/db.ts` | composite tuple comparison + emit `nextCursorId` |
| `src/api/router.ts` | parse `before_id`/`after_id`, echo `nextCursorId` |
| `API.md` | new params + `nextCursorId` + equal-`ts` paging note |
| `tests/unit/history-db.test.ts` | +5 unit (U-HDB-TIE-01..05) |
| `tests/integration/chat-history-api.test.ts` | +1 integration (I-HIST-29) — equal-`ts` burst via HTTP cursor |

**6 files, +196/−15**

## Test coverage
- Unit: composite cursor pages through an equal-`ts` run with no skip/duplicate in both `asc` and `desc`.
- Integration: seed an equal-`ts` burst, paginate end-to-end via the HTTP cursor, assert every message returned exactly once.
- Build clean · affected suites green.
