### PR TITLE
fix(image): resolve endpoint config from ~/.claude/settings.json

### DIFF
--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as dns from 'node:dns';
 import * as net from 'node:net';
@@ -60,7 +61,8 @@ export class ImageModule implements ToolModule {
   toolVisibility: ToolVisibility = 'all-configured';
 
   isEnabled(): boolean {
-    // Enabled when the image service endpoint is configured (env-driven, like browser).
+    // Enabled when the image endpoint is configured in ~/.claude/settings.json (see
+    // baseUrl()) and not explicitly turned off.
     if (!this.baseUrl() || process.env.IMAGE_DISABLED === 'true') return false;
     // The Bearer proxy_secret rides every call — refuse a cleartext http URL to a
     // PUBLIC host (that would leak the secret). http to a local/internal host is a
@@ -106,18 +108,39 @@ export class ImageModule implements ToolModule {
   // ── config ────────────────────────────────────────────────────────────────
 
   private baseUrl(): string {
-    // Image generation can target any provider — not necessarily the same host as
-    // the LLM. IMAGE_BASE_URL overrides so an operator can point image at a separate
-    // endpoint; it falls back to ANTHROPIC_BASE_URL when they share one provider that
-    // fronts /v1/images/{generations,jobs} alongside /v1/messages.
-    const raw = process.env.IMAGE_BASE_URL || process.env.ANTHROPIC_BASE_URL || '';
-    return raw.replace(/\/+$/, '');
+    // Single source of truth: the Claude Code CLI config at ~/.claude/settings.json,
+    // whose `env` block carries ANTHROPIC_BASE_URL (the provider that also fronts
+    // /v1/images/{generations,jobs}). The CLI applies that block internally, not to
+    // the OS environment, so this MCP process can't inherit it — we read the file.
+    return (this.settingsEnv('ANTHROPIC_BASE_URL') || '').replace(/\/+$/, '');
   }
 
   private authToken(): string {
-    // Image API key overrides so a separate image endpoint can carry its own secret;
-    // falls back to ANTHROPIC_AUTH_TOKEN (the M2M proxy secret) when they share one.
-    return process.env.IMAGE_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN || '';
+    // Same source as baseUrl: the CLI's settings.json env carries the M2M token
+    // (CLAUDE_CODE_OAUTH_TOKEN) that authenticates to the provider.
+    return this.settingsEnv('CLAUDE_CODE_OAUTH_TOKEN') || '';
+  }
+
+  // Parsed `env` block of the CLI config, read once per instance (settings don't
+  // change within a session). undefined = not read yet; null = unreadable.
+  private settingsEnvCache?: Record<string, unknown> | null;
+
+  // settingsEnv reads a single key out of ~/.claude/settings.json's `env` block.
+  // CLAUDE_CONFIG_DIR overrides the ~/.claude location, matching Claude Code. Returns
+  // '' on any error (missing file, bad JSON, absent/non-string key) so callers degrade
+  // to "not configured" rather than throwing.
+  private settingsEnv(key: string): string {
+    if (this.settingsEnvCache === undefined) {
+      try {
+        const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+        this.settingsEnvCache =
+          JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf8'))?.env ?? null;
+      } catch {
+        this.settingsEnvCache = null;
+      }
+    }
+    const v = this.settingsEnvCache?.[key];
+    return typeof v === 'string' ? v : '';
   }
 
   private headers(): Record<string, string> {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -373,14 +373,9 @@ export class SessionProcess extends EventEmitter {
             GATEWAY_SESSION_MEDIA_DIR: this.source === 'api'
               ? path.resolve(this.agentConfig.workspace, '..', 'media', `api-${this.sessionId}`)
               : '',
-            // Image-generation tool (generate_image) — targets an image provider that
-            // may differ from the LLM: IMAGE_BASE_URL/IMAGE_API_KEY override, falling
-            // back to ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN when they share a provider.
-            // The MCP subprocess only sees the env we hand it, so every var module.ts
-            // reads must be forwarded explicitly. Empty base URL ⇒ tool disabled.
-            IMAGE_BASE_URL: process.env.IMAGE_BASE_URL ?? '',
-            ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL ?? '',
-            IMAGE_API_KEY: process.env.IMAGE_API_KEY ?? process.env.ANTHROPIC_AUTH_TOKEN ?? '',
+            // Image-generation tool (generate_image): its endpoint + token are read by
+            // module.ts straight from ~/.claude/settings.json (the CLI's config), so
+            // there is nothing to forward here. Only the operational knobs are env-driven:
             IMAGE_DISABLED: process.env.IMAGE_DISABLED ?? '',
             IMAGE_POLL_TIMEOUT_MS: process.env.IMAGE_POLL_TIMEOUT_MS ?? '',
           },

--- a/tests/unit/image-module.test.ts
+++ b/tests/unit/image-module.test.ts
@@ -1,109 +1,93 @@
 /**
  * Unit tests for the image MCP tool's endpoint resolution + https guard
- * (mcp/tools/image/module.ts). Two behaviors are locked in here:
+ * (mcp/tools/image/module.ts). Config comes from ONE place — the Claude Code CLI
+ * config at ~/.claude/settings.json (its `env` block carries ANTHROPIC_BASE_URL +
+ * CLAUDE_CODE_OAUTH_TOKEN). The CLI applies that block internally, not to the OS
+ * environment, so this MCP process reads the file directly. Two behaviors locked in:
  *
- *  1. baseUrl() resolves from IMAGE_BASE_URL first, then ANTHROPIC_BASE_URL —
- *     image generation may target a provider separate from the LLM, so an
- *     operator can override the endpoint (and secret via IMAGE_API_KEY) while
- *     still falling back to the ANTHROPIC_* pair when they share one provider.
- *  2. baseUrlIsSecure guard — the Bearer secret rides every call, so an http
- *     URL to a PUBLIC host is refused (isEnabled → false). https, or http to a
+ *  1. baseUrl() resolves from settings.json's env.ANTHROPIC_BASE_URL — absent file /
+ *     key ⇒ not configured ⇒ isEnabled() false.
+ *  2. baseUrlIsSecure guard — the Bearer secret rides every call, so an http URL to
+ *     a PUBLIC host is refused (isEnabled → false). https, or http to a
  *     local/internal host (a trusted hop like host.docker.internal in dev), is allowed.
  *
- * baseUrl() and baseUrlIsSecure are private/module-internal, so we assert their
- * OBSERVABLE effect via isEnabled() driven purely by env.
+ * baseUrl()/settingsEnv() are private, so we assert their OBSERVABLE effect via
+ * isEnabled(), driving it purely by the settings.json we write per test.
  */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { ImageModule } from '../../mcp/tools/image/module';
 
-const ENV_KEYS = [
-  'IMAGE_BASE_URL',
-  'ANTHROPIC_BASE_URL',
-  'IMAGE_DISABLED',
-  'IMAGE_API_KEY',
-  'ANTHROPIC_AUTH_TOKEN',
-] as const;
-
-describe('ImageModule.isEnabled() — endpoint resolution + https guard', () => {
-  const saved: Record<string, string | undefined> = {};
+describe('ImageModule.isEnabled() — endpoint resolution + https guard (config from ~/.claude/settings.json)', () => {
+  let cfgDir: string;
   let errSpy: jest.SpyInstance;
+  const savedCfgDir = process.env.CLAUDE_CONFIG_DIR;
+  const savedDisabled = process.env.IMAGE_DISABLED;
 
   beforeEach(() => {
-    for (const k of ENV_KEYS) {
-      saved[k] = process.env[k];
-      delete process.env[k];
-    }
+    // Point the module at a temp config dir via CLAUDE_CONFIG_DIR (real files — the
+    // os/fs builtins are non-configurable here, so they can't be spied).
+    cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'imgcfg-'));
+    process.env.CLAUDE_CONFIG_DIR = cfgDir;
     // isEnabled() logs to console.error the first time it refuses an insecure URL.
     errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env.IMAGE_DISABLED;
   });
 
   afterEach(() => {
-    for (const k of ENV_KEYS) {
-      if (saved[k] === undefined) delete process.env[k];
-      else process.env[k] = saved[k];
-    }
     errSpy.mockRestore();
+    fs.rmSync(cfgDir, { recursive: true, force: true });
+    if (savedCfgDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = savedCfgDir;
+    if (savedDisabled === undefined) delete process.env.IMAGE_DISABLED;
+    else process.env.IMAGE_DISABLED = savedDisabled;
   });
+
+  // Write the `env` block of settings.json — the single source baseUrl()/authToken() read.
+  const setSettings = (env: Record<string, string>) =>
+    fs.writeFileSync(path.join(cfgDir, 'settings.json'), JSON.stringify({ env }));
 
   const enabled = () => new ImageModule().isEnabled();
 
-  test('https ANTHROPIC_BASE_URL + token → enabled', () => {
-    process.env.ANTHROPIC_BASE_URL = 'https://provider.example.com';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+  test('https ANTHROPIC_BASE_URL in settings.json → enabled', () => {
+    setSettings({ ANTHROPIC_BASE_URL: 'https://provider.example.com', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
     expect(enabled()).toBe(true);
   });
 
-  test('ANTHROPIC_BASE_URL unset → disabled (no endpoint)', () => {
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+  test('no settings.json file → disabled (nothing configured)', () => {
+    expect(enabled()).toBe(false);
+  });
+
+  test('settings.json without ANTHROPIC_BASE_URL → disabled (no endpoint)', () => {
+    setSettings({ CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+    expect(enabled()).toBe(false);
+  });
+
+  test('malformed settings.json → disabled (degrades, does not throw)', () => {
+    fs.writeFileSync(path.join(cfgDir, 'settings.json'), '{ not valid json');
     expect(enabled()).toBe(false);
   });
 
   test('http to a local host (host.docker.internal) → enabled (trusted hop)', () => {
-    process.env.ANTHROPIC_BASE_URL = 'http://host.docker.internal:8080';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+    setSettings({ ANTHROPIC_BASE_URL: 'http://host.docker.internal:8080', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
     expect(enabled()).toBe(true);
   });
 
   test('http to localhost → enabled (trusted hop)', () => {
-    process.env.ANTHROPIC_BASE_URL = 'http://localhost:8080';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+    setSettings({ ANTHROPIC_BASE_URL: 'http://localhost:8080', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
     expect(enabled()).toBe(true);
   });
 
   test('http to a PUBLIC host → disabled (refuses to send Bearer secret in cleartext)', () => {
-    process.env.ANTHROPIC_BASE_URL = 'http://provider.example.com';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+    setSettings({ ANTHROPIC_BASE_URL: 'http://provider.example.com', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
     expect(enabled()).toBe(false);
     expect(errSpy).toHaveBeenCalled(); // the guard warns once
   });
 
   test('IMAGE_DISABLED=true → disabled even with a valid https URL', () => {
-    process.env.ANTHROPIC_BASE_URL = 'https://provider.example.com';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+    setSettings({ ANTHROPIC_BASE_URL: 'https://provider.example.com', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
     process.env.IMAGE_DISABLED = 'true';
     expect(enabled()).toBe(false);
-  });
-
-  describe('IMAGE_BASE_URL overrides ANTHROPIC_BASE_URL', () => {
-    test('IMAGE_BASE_URL set (https) with ANTHROPIC_BASE_URL unset → enabled', () => {
-      process.env.IMAGE_BASE_URL = 'https://image.example.com';
-      process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-      expect(enabled()).toBe(true);
-    });
-
-    test('a valid https IMAGE_BASE_URL overrides a public-http ANTHROPIC_BASE_URL (image wins)', () => {
-      // With only a public-http ANTHROPIC_BASE_URL the module is disabled; adding a
-      // valid https IMAGE_BASE_URL points image at a separate endpoint and enables it.
-      process.env.ANTHROPIC_BASE_URL = 'http://provider.example.com';
-      process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-      expect(enabled()).toBe(false);
-      process.env.IMAGE_BASE_URL = 'https://image.example.com';
-      expect(new ImageModule().isEnabled()).toBe(true);
-    });
-
-    test('IMAGE_API_KEY alone (no ANTHROPIC_AUTH_TOKEN) still enables with a valid URL', () => {
-      process.env.IMAGE_BASE_URL = 'https://image.example.com';
-      process.env.IMAGE_API_KEY = 'image-secret';
-      expect(enabled()).toBe(true);
-    });
   });
 });


### PR DESCRIPTION
## Summary

`generate_image` runs inside an MCP subprocess. Claude Code applies its
`~/.claude/settings.json` `env` block **internally** (for its own Anthropic API
calls), not to the OS process environment — so an MCP subprocess it spawns cannot
inherit `ANTHROPIC_BASE_URL` / the auth token from that block. On a real deployment
the `IMAGE_BASE_URL` / `ANTHROPIC_BASE_URL` / `IMAGE_API_KEY` env the image tool
reads are effectively never set in that subprocess, so `isEnabled()` returns false
and `generate_image` is silently absent from the toolset.

## Change

- `baseUrl()` / `authToken()` resolve from `~/.claude/settings.json`'s `env` block
  (`ANTHROPIC_BASE_URL` + `CLAUDE_CODE_OAUTH_TOKEN`), honouring `CLAUDE_CONFIG_DIR`
  the same way the CLI locates its config. Parsed once per instance.
- Drop the now-unused `IMAGE_*` env forwarding from the session MCP config
  (`src/session/process.ts`) — there is nothing to forward once config is read
  from the file.
- Rewrite the image-module unit test to drive config from a temp `settings.json`.

## Test

`tsc --noEmit` clean (src + mcp). `image-module` (8) + `session-process` (98) unit
tests pass.
