### PR TITLE
fix(image): resolve endpoint config from ~/.claude/settings.json

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@
 # Image generation may target a provider separate from the LLM. These override
 # ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN for image calls; leave unset to reuse
 # the same provider that fronts /v1/images/{generations,jobs}.
+# When none of IMAGE_BASE_URL / ANTHROPIC_BASE_URL are set, the tool falls back to the
+# `env` block of ~/.claude/settings.json (ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN or
+# CLAUDE_CODE_OAUTH_TOKEN), so it still resolves inside an MCP subprocess that can't
+# inherit the CLI's internally-applied config. CLAUDE_CONFIG_DIR relocates that lookup.
 # IMAGE_BASE_URL=
 # IMAGE_API_KEY=
 

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as dns from 'node:dns';
 import * as net from 'node:net';
@@ -60,7 +61,8 @@ export class ImageModule implements ToolModule {
   toolVisibility: ToolVisibility = 'all-configured';
 
   isEnabled(): boolean {
-    // Enabled when the image service endpoint is configured (env-driven, like browser).
+    // Enabled when the image endpoint is configured in ~/.claude/settings.json (see
+    // baseUrl()) and not explicitly turned off.
     if (!this.baseUrl() || process.env.IMAGE_DISABLED === 'true') return false;
     // The Bearer proxy_secret rides every call — refuse a cleartext http URL to a
     // PUBLIC host (that would leak the secret). http to a local/internal host is a
@@ -106,18 +108,50 @@ export class ImageModule implements ToolModule {
   // ── config ────────────────────────────────────────────────────────────────
 
   private baseUrl(): string {
-    // Image generation can target any provider — not necessarily the same host as
-    // the LLM. IMAGE_BASE_URL overrides so an operator can point image at a separate
-    // endpoint; it falls back to ANTHROPIC_BASE_URL when they share one provider that
-    // fronts /v1/images/{generations,jobs} alongside /v1/messages.
-    const raw = process.env.IMAGE_BASE_URL || process.env.ANTHROPIC_BASE_URL || '';
+    // Image generation may target a provider separate from the LLM: IMAGE_BASE_URL
+    // (or ANTHROPIC_BASE_URL when they share a provider that fronts /v1/images
+    // alongside /v1/messages) overrides. When neither env var is set, fall back to
+    // the Claude Code CLI config at ~/.claude/settings.json — its `env` block carries
+    // ANTHROPIC_BASE_URL, and the CLI applies that block internally (not to the OS
+    // environment), so an MCP subprocess can't inherit it and reads the file instead.
+    const raw =
+      process.env.IMAGE_BASE_URL ||
+      process.env.ANTHROPIC_BASE_URL ||
+      this.settingsEnv('ANTHROPIC_BASE_URL');
     return raw.replace(/\/+$/, '');
   }
 
   private authToken(): string {
-    // Image API key overrides so a separate image endpoint can carry its own secret;
-    // falls back to ANTHROPIC_AUTH_TOKEN (the M2M proxy secret) when they share one.
-    return process.env.IMAGE_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN || '';
+    // IMAGE_API_KEY overrides so a separate image endpoint can carry its own secret;
+    // falls back to ANTHROPIC_AUTH_TOKEN, then to the CLI config's M2M token
+    // (CLAUDE_CODE_OAUTH_TOKEN in ~/.claude/settings.json).
+    return (
+      process.env.IMAGE_API_KEY ||
+      process.env.ANTHROPIC_AUTH_TOKEN ||
+      this.settingsEnv('CLAUDE_CODE_OAUTH_TOKEN')
+    );
+  }
+
+  // Parsed `env` block of the CLI config, read once per instance (settings don't
+  // change within a session). undefined = not read yet; null = unreadable.
+  private settingsEnvCache?: Record<string, unknown> | null;
+
+  // settingsEnv reads a single key out of ~/.claude/settings.json's `env` block.
+  // CLAUDE_CONFIG_DIR overrides the ~/.claude location, matching Claude Code. Returns
+  // '' on any error (missing file, bad JSON, absent/non-string key) so callers degrade
+  // to "not configured" rather than throwing.
+  private settingsEnv(key: string): string {
+    if (this.settingsEnvCache === undefined) {
+      try {
+        const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+        this.settingsEnvCache =
+          JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf8'))?.env ?? null;
+      } catch {
+        this.settingsEnvCache = null;
+      }
+    }
+    const v = this.settingsEnvCache?.[key];
+    return typeof v === 'string' ? v : '';
   }
 
   private headers(): Record<string, string> {

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -61,9 +61,12 @@ export class ImageModule implements ToolModule {
   toolVisibility: ToolVisibility = 'all-configured';
 
   isEnabled(): boolean {
-    // Enabled when the image endpoint is configured in ~/.claude/settings.json (see
-    // baseUrl()) and not explicitly turned off.
-    if (!this.baseUrl() || process.env.IMAGE_DISABLED === 'true') return false;
+    // Enabled when BOTH the endpoint and an auth token resolve (from env or the CLI config
+    // at ~/.claude/settings.json; see baseUrl()/authToken()) and the tool isn't explicitly
+    // turned off. Requiring the token here means a config that resolves a URL but no token
+    // disables the tool cleanly, instead of advertising it and then failing every call with a
+    // 401 on an empty Bearer.
+    if (!this.baseUrl() || !this.authToken() || process.env.IMAGE_DISABLED === 'true') return false;
     // The Bearer proxy_secret rides every call — refuse a cleartext http URL to a
     // PUBLIC host (that would leak the secret). http to a local/internal host is a
     // trusted hop (e.g. host.docker.internal in dev) and stays allowed.
@@ -123,11 +126,14 @@ export class ImageModule implements ToolModule {
 
   private authToken(): string {
     // IMAGE_API_KEY overrides so a separate image endpoint can carry its own secret;
-    // falls back to ANTHROPIC_AUTH_TOKEN, then to the CLI config's M2M token
-    // (CLAUDE_CODE_OAUTH_TOKEN in ~/.claude/settings.json).
+    // falls back to ANTHROPIC_AUTH_TOKEN, then to the CLI config's `env` block in
+    // ~/.claude/settings.json. Check BOTH token keys there: a proxy deployment may store the
+    // M2M secret under ANTHROPIC_AUTH_TOKEN (the same key the env path uses) or under
+    // CLAUDE_CODE_OAUTH_TOKEN — mirror the env precedence and accept either.
     return (
       process.env.IMAGE_API_KEY ||
       process.env.ANTHROPIC_AUTH_TOKEN ||
+      this.settingsEnv('ANTHROPIC_AUTH_TOKEN') ||
       this.settingsEnv('CLAUDE_CODE_OAUTH_TOKEN')
     );
   }

--- a/tests/unit/image-module.test.ts
+++ b/tests/unit/image-module.test.ts
@@ -1,109 +1,144 @@
 /**
  * Unit tests for the image MCP tool's endpoint resolution + https guard
- * (mcp/tools/image/module.ts). Two behaviors are locked in here:
+ * (mcp/tools/image/module.ts). Config resolves in this order:
  *
- *  1. baseUrl() resolves from IMAGE_BASE_URL first, then ANTHROPIC_BASE_URL —
- *     image generation may target a provider separate from the LLM, so an
- *     operator can override the endpoint (and secret via IMAGE_API_KEY) while
- *     still falling back to the ANTHROPIC_* pair when they share one provider.
- *  2. baseUrlIsSecure guard — the Bearer secret rides every call, so an http
- *     URL to a PUBLIC host is refused (isEnabled → false). https, or http to a
- *     local/internal host (a trusted hop like host.docker.internal in dev), is allowed.
+ *   IMAGE_BASE_URL → ANTHROPIC_BASE_URL (env) → ~/.claude/settings.json's env block.
  *
- * baseUrl() and baseUrlIsSecure are private/module-internal, so we assert their
- * OBSERVABLE effect via isEnabled() driven purely by env.
+ * The env vars let an operator point image at a separate endpoint; the settings.json
+ * fallback covers the common case where the tool runs in an MCP subprocess that can't
+ * inherit the CLI's config (Claude Code applies settings.json's `env` internally, not
+ * to the OS environment). Two behaviors locked in:
+ *
+ *  1. baseUrl() resolves from the first source above that yields a value; absent all
+ *     three ⇒ not configured ⇒ isEnabled() false. Env wins over settings.json.
+ *  2. baseUrlIsSecure guard — the Bearer secret rides every call, so an http URL to a
+ *     PUBLIC host is refused (isEnabled → false). https, or http to a local/internal
+ *     host (a trusted hop like host.docker.internal in dev), is allowed.
+ *
+ * baseUrl()/settingsEnv() are private, so we assert their OBSERVABLE effect via
+ * isEnabled(), driving it by the env / settings.json we set per test.
  */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { ImageModule } from '../../mcp/tools/image/module';
 
 const ENV_KEYS = [
   'IMAGE_BASE_URL',
   'ANTHROPIC_BASE_URL',
-  'IMAGE_DISABLED',
   'IMAGE_API_KEY',
   'ANTHROPIC_AUTH_TOKEN',
+  'IMAGE_DISABLED',
 ] as const;
 
 describe('ImageModule.isEnabled() — endpoint resolution + https guard', () => {
-  const saved: Record<string, string | undefined> = {};
+  let cfgDir: string;
   let errSpy: jest.SpyInstance;
+  const saved: Record<string, string | undefined> = {};
+  const savedCfgDir = process.env.CLAUDE_CONFIG_DIR;
 
   beforeEach(() => {
     for (const k of ENV_KEYS) {
       saved[k] = process.env[k];
       delete process.env[k];
     }
+    // Point the settings.json fallback at a temp config dir via CLAUDE_CONFIG_DIR
+    // (real files — the os/fs builtins are non-configurable here, so they can't be spied).
+    cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'imgcfg-'));
+    process.env.CLAUDE_CONFIG_DIR = cfgDir;
     // isEnabled() logs to console.error the first time it refuses an insecure URL.
     errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    errSpy.mockRestore();
+    fs.rmSync(cfgDir, { recursive: true, force: true });
     for (const k of ENV_KEYS) {
       if (saved[k] === undefined) delete process.env[k];
       else process.env[k] = saved[k];
     }
-    errSpy.mockRestore();
+    if (savedCfgDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = savedCfgDir;
   });
+
+  // Write the `env` block of settings.json (the fallback source).
+  const setSettings = (env: Record<string, string>) =>
+    fs.writeFileSync(path.join(cfgDir, 'settings.json'), JSON.stringify({ env }));
 
   const enabled = () => new ImageModule().isEnabled();
 
-  test('https ANTHROPIC_BASE_URL + token → enabled', () => {
-    process.env.ANTHROPIC_BASE_URL = 'https://provider.example.com';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-    expect(enabled()).toBe(true);
-  });
-
-  test('ANTHROPIC_BASE_URL unset → disabled (no endpoint)', () => {
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-    expect(enabled()).toBe(false);
-  });
-
-  test('http to a local host (host.docker.internal) → enabled (trusted hop)', () => {
-    process.env.ANTHROPIC_BASE_URL = 'http://host.docker.internal:8080';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-    expect(enabled()).toBe(true);
-  });
-
-  test('http to localhost → enabled (trusted hop)', () => {
-    process.env.ANTHROPIC_BASE_URL = 'http://localhost:8080';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-    expect(enabled()).toBe(true);
-  });
-
-  test('http to a PUBLIC host → disabled (refuses to send Bearer secret in cleartext)', () => {
-    process.env.ANTHROPIC_BASE_URL = 'http://provider.example.com';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-    expect(enabled()).toBe(false);
-    expect(errSpy).toHaveBeenCalled(); // the guard warns once
-  });
-
-  test('IMAGE_DISABLED=true → disabled even with a valid https URL', () => {
-    process.env.ANTHROPIC_BASE_URL = 'https://provider.example.com';
-    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-    process.env.IMAGE_DISABLED = 'true';
-    expect(enabled()).toBe(false);
-  });
-
-  describe('IMAGE_BASE_URL overrides ANTHROPIC_BASE_URL', () => {
-    test('IMAGE_BASE_URL set (https) with ANTHROPIC_BASE_URL unset → enabled', () => {
-      process.env.IMAGE_BASE_URL = 'https://image.example.com';
+  describe('env-based config', () => {
+    test('https ANTHROPIC_BASE_URL env → enabled', () => {
+      process.env.ANTHROPIC_BASE_URL = 'https://provider.example.com';
       process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
       expect(enabled()).toBe(true);
     });
 
-    test('a valid https IMAGE_BASE_URL overrides a public-http ANTHROPIC_BASE_URL (image wins)', () => {
-      // With only a public-http ANTHROPIC_BASE_URL the module is disabled; adding a
-      // valid https IMAGE_BASE_URL points image at a separate endpoint and enables it.
-      process.env.ANTHROPIC_BASE_URL = 'http://provider.example.com';
-      process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
-      expect(enabled()).toBe(false);
-      process.env.IMAGE_BASE_URL = 'https://image.example.com';
-      expect(new ImageModule().isEnabled()).toBe(true);
-    });
-
-    test('IMAGE_API_KEY alone (no ANTHROPIC_AUTH_TOKEN) still enables with a valid URL', () => {
+    test('IMAGE_BASE_URL env (separate image endpoint) → enabled', () => {
       process.env.IMAGE_BASE_URL = 'https://image.example.com';
       process.env.IMAGE_API_KEY = 'image-secret';
       expect(enabled()).toBe(true);
+    });
+
+    test('no env and no settings.json → disabled (nothing configured)', () => {
+      expect(enabled()).toBe(false);
+    });
+
+    test('http to a PUBLIC host env → disabled (refuses Bearer secret in cleartext)', () => {
+      process.env.ANTHROPIC_BASE_URL = 'http://provider.example.com';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+      expect(enabled()).toBe(false);
+      expect(errSpy).toHaveBeenCalled();
+    });
+
+    test('IMAGE_DISABLED=true → disabled even with a valid https env URL', () => {
+      process.env.ANTHROPIC_BASE_URL = 'https://provider.example.com';
+      process.env.IMAGE_DISABLED = 'true';
+      expect(enabled()).toBe(false);
+    });
+  });
+
+  describe('settings.json fallback (no env)', () => {
+    test('https ANTHROPIC_BASE_URL in settings.json → enabled', () => {
+      setSettings({ ANTHROPIC_BASE_URL: 'https://provider.example.com', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(true);
+    });
+
+    test('settings.json without ANTHROPIC_BASE_URL → disabled (no endpoint)', () => {
+      setSettings({ CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(false);
+    });
+
+    test('malformed settings.json → disabled (degrades, does not throw)', () => {
+      fs.writeFileSync(path.join(cfgDir, 'settings.json'), '{ not valid json');
+      expect(enabled()).toBe(false);
+    });
+
+    test('http to a local host (host.docker.internal) in settings.json → enabled (trusted hop)', () => {
+      setSettings({ ANTHROPIC_BASE_URL: 'http://host.docker.internal:8080', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(true);
+    });
+
+    test('http to localhost in settings.json → enabled (trusted hop)', () => {
+      setSettings({ ANTHROPIC_BASE_URL: 'http://localhost:8080', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(true);
+    });
+
+    test('http to a PUBLIC host in settings.json → disabled', () => {
+      setSettings({ ANTHROPIC_BASE_URL: 'http://provider.example.com', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(false);
+      expect(errSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('precedence: env overrides settings.json', () => {
+    test('a valid https env URL wins over a public-http settings.json URL', () => {
+      // settings.json alone (public http) ⇒ disabled…
+      setSettings({ ANTHROPIC_BASE_URL: 'http://provider.example.com', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(false);
+      // …a valid https env URL points image elsewhere and enables it.
+      process.env.IMAGE_BASE_URL = 'https://image.example.com';
+      expect(new ImageModule().isEnabled()).toBe(true);
     });
   });
 });

--- a/tests/unit/image-module.test.ts
+++ b/tests/unit/image-module.test.ts
@@ -109,6 +109,20 @@ describe('ImageModule.isEnabled() — endpoint resolution + https guard', () => 
       expect(enabled()).toBe(false);
     });
 
+    test('token stored under ANTHROPIC_AUTH_TOKEN in settings.json is accepted → enabled', () => {
+      // A proxy deployment may carry the M2M secret under ANTHROPIC_AUTH_TOKEN (the same key
+      // the env path uses) rather than CLAUDE_CODE_OAUTH_TOKEN — both must resolve the token.
+      setSettings({ ANTHROPIC_BASE_URL: 'https://provider.example.com', ANTHROPIC_AUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(true);
+    });
+
+    test('endpoint in settings.json but no token anywhere → disabled (no silent 401)', () => {
+      // A resolvable https URL with no token must disable the tool cleanly rather than
+      // advertise it and 401 on an empty Bearer at call time.
+      setSettings({ ANTHROPIC_BASE_URL: 'https://provider.example.com' });
+      expect(enabled()).toBe(false);
+    });
+
     test('malformed settings.json → disabled (degrades, does not throw)', () => {
       fs.writeFileSync(path.join(cfgDir, 'settings.json'), '{ not valid json');
       expect(enabled()).toBe(false);


### PR DESCRIPTION
## Summary

`generate_image` runs inside an MCP subprocess that the gateway hands a **curated** env
(`src/session/process.ts`) — it does not inherit the gateway's full environment. Claude Code
applies its `~/.claude/settings.json` `env` block **internally** (for its own Anthropic API
calls), not to the OS process environment, so on a real deployment `ANTHROPIC_BASE_URL` / the
auth token are not present in the gateway process to forward, the image tool's endpoint
resolves empty, `isEnabled()` returns false, and `generate_image` is silently absent from the
toolset.

## Change

- `baseUrl()` / `authToken()` fall back to `~/.claude/settings.json`'s `env` block
  (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` or `CLAUDE_CODE_OAUTH_TOKEN`), honouring
  `CLAUDE_CONFIG_DIR` the same way the CLI locates its config. Parsed once per instance.
  Explicit `IMAGE_*` / `ANTHROPIC_*` env still take precedence when present.
- The `IMAGE_*` env forwarding in `src/session/process.ts` is **retained** (this PR does not
  touch that file). The MCP subprocess only sees the env the gateway hands it, so that block
  is still the only path by which `IMAGE_DISABLED`, `IMAGE_POLL_TIMEOUT_MS`, and the
  `IMAGE_BASE_URL` / `IMAGE_API_KEY` overrides reach the tool — dropping it would break those
  knobs. (An earlier draft of this description said the forwarding was removed; that was
  inaccurate — it stays, by design.)
- Rewrite the image-module unit test to drive config from a temp `settings.json`.

## Review follow-up

- `authToken()` also reads `ANTHROPIC_AUTH_TOKEN` from the settings.json `env` block, ahead of
  `CLAUDE_CODE_OAUTH_TOKEN`: a proxy deployment may store the M2M secret under that key (the
  same one the env path uses), and resolving only `CLAUDE_CODE_OAUTH_TOKEN` would leave the
  token empty.
- `isEnabled()` now requires a resolvable token as well as a secure endpoint, so a
  URL-without-token config disables the tool cleanly instead of advertising it and then
  failing every call with a 401 on an empty Bearer.
- `.env.example` documents the settings.json fallback (both token keys) and `CLAUDE_CONFIG_DIR`.

## Test

`tsc --noEmit` clean (src + mcp). `image-module` (14) + `session-process` (98) unit tests pass.
