### PR TITLE
feat(history): raise message-history MAX_LIMIT to 1000 for single-call jump-to-date

### DIFF
--- a/API.md
+++ b/API.md
@@ -2377,7 +2377,7 @@ Paginated message history (cursor-based). Returns messages in reverse chronologi
 
 | Param | Description |
 |-------|-------------|
-| `limit` | Max messages to return (default 50, max 200) |
+| `limit` | Max messages to return (default 50, max 1000). Values above the max are clamped; non-numeric, `0`, or negative fall back to the default. |
 | `before` | Return messages before this timestamp (ms) |
 | `after` | Return messages after this timestamp (ms) |
 | `before_id` | Id component of the cursor, paired with `before`. Echo back `nextCursorId` here to page correctly across messages that share a `ts` (see below). Ignored without `before`. |

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -9,7 +9,7 @@ import { AgentRunner } from '../agent/runner';
 import { AgentConfig, ApiKey, ImageParams, ModelConfig, SessionMeta } from '../types';
 import { createApiAuthMiddleware, canAccessAgent, canWriteAgent, isAdmin } from './auth';
 import { MediaStore } from '../history/media-store';
-import { HistoryDB } from '../history/db';
+import { HistoryDB, MAX_HISTORY_LIMIT } from '../history/db';
 import type { AgentSessionSummary } from '../history/types';
 import { wizardStore } from './wizard-state';
 import { getPendingSenders, clearPendingSender } from './line-pending-senders';
@@ -2082,7 +2082,9 @@ export function createApiRouter(
       return;
     }
     const query = req.query as Record<string, string>;
-    const limit = query['limit'] ? Math.min(parseInt(query['limit'], 10) || 50, 200) : 50;
+    // Ceiling reuses MAX_HISTORY_LIMIT from the history layer so this HTTP-boundary
+    // clamp and the db clamp can never drift (both 1000; see #1798).
+    const limit = query['limit'] ? Math.min(parseInt(query['limit'], 10) || 50, MAX_HISTORY_LIMIT) : 50;
     // Numeric cursor params. before/after are ms timestamps; before_id/after_id are the id
     // component of the composite (ts, id) cursor, echoed from a prior page's nextCursorId —
     // paired with before/after they stop paging from skipping messages that share a ts

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -23,7 +23,6 @@ import {
  * by the HTTP boundary clamp (api/router.ts) so the two ceilings can never drift.
  */
 export const MAX_HISTORY_LIMIT = 1000;
-const MAX_LIMIT = MAX_HISTORY_LIMIT;
 const DEFAULT_LIMIT = 50;
 const PREVIEW_LENGTH = 120;
 
@@ -177,12 +176,13 @@ export class HistoryDB {
 
   getMessages(chatId: string, opts: PaginationOpts = {}): MessagePage {
     // Coerce limit to an integer before it reaches the SQLite bind (`limit + 1`), mirroring
-    // the HTTP boundary's parseInt: a NaN or fractional limit from a direct caller would
-    // otherwise bind as a non-integer and throw a raw "datatype mismatch". NaN -> DEFAULT_LIMIT;
-    // fractional -> truncated. 0/negative are preserved (explicit, already bounded downstream). #1798
+    // the HTTP boundary's parseInt: a non-finite (NaN/±Infinity) or fractional limit from a
+    // direct caller would otherwise bind as a non-integer and throw a raw "datatype mismatch".
+    // Non-finite -> DEFAULT_LIMIT; fractional -> truncated. 0/negative-finite are preserved
+    // (explicit, already bounded downstream). #1798
     const rawLimit = opts.limit ?? DEFAULT_LIMIT;
-    const intLimit = Number.isNaN(rawLimit) ? DEFAULT_LIMIT : Math.trunc(rawLimit);
-    const limit = Math.min(intLimit, MAX_LIMIT);
+    const intLimit = Number.isFinite(rawLimit) ? Math.trunc(rawLimit) : DEFAULT_LIMIT;
+    const limit = Math.min(intLimit, MAX_HISTORY_LIMIT);
     const conditions: string[] = ['chat_id = ?'];
     const params: (string | number)[] = [chatId];
 

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -15,7 +15,15 @@ import {
   SessionSummary,
 } from './types';
 
-const MAX_LIMIT = 200;
+/**
+ * Ceiling for a single message-history page. Raised 200 -> 1000 so a client can
+ * fetch a whole "target day -> now" span in one request (jump-to-date, #1798),
+ * instead of several sequential load-more pages. Bounded (not unlimited) so a
+ * pathological session cannot request an unbounded payload. Exported and reused
+ * by the HTTP boundary clamp (api/router.ts) so the two ceilings can never drift.
+ */
+export const MAX_HISTORY_LIMIT = 1000;
+const MAX_LIMIT = MAX_HISTORY_LIMIT;
 const DEFAULT_LIMIT = 50;
 const PREVIEW_LENGTH = 120;
 
@@ -168,7 +176,13 @@ export class HistoryDB {
   }
 
   getMessages(chatId: string, opts: PaginationOpts = {}): MessagePage {
-    const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+    // Coerce limit to an integer before it reaches the SQLite bind (`limit + 1`), mirroring
+    // the HTTP boundary's parseInt: a NaN or fractional limit from a direct caller would
+    // otherwise bind as a non-integer and throw a raw "datatype mismatch". NaN -> DEFAULT_LIMIT;
+    // fractional -> truncated. 0/negative are preserved (explicit, already bounded downstream). #1798
+    const rawLimit = opts.limit ?? DEFAULT_LIMIT;
+    const intLimit = Number.isNaN(rawLimit) ? DEFAULT_LIMIT : Math.trunc(rawLimit);
+    const limit = Math.min(intLimit, MAX_LIMIT);
     const conditions: string[] = ['chat_id = ?'];
     const params: (string | number)[] = [chatId];
 

--- a/src/history/db.ts
+++ b/src/history/db.ts
@@ -175,13 +175,18 @@ export class HistoryDB {
   }
 
   getMessages(chatId: string, opts: PaginationOpts = {}): MessagePage {
-    // Coerce limit to an integer before it reaches the SQLite bind (`limit + 1`), mirroring
-    // the HTTP boundary's parseInt: a non-finite (NaN/±Infinity) or fractional limit from a
-    // direct caller would otherwise bind as a non-integer and throw a raw "datatype mismatch".
-    // Non-finite -> DEFAULT_LIMIT; fractional -> truncated. 0/negative-finite are preserved
-    // (explicit, already bounded downstream). #1798
+    // Coerce limit to a non-negative integer before it reaches the SQLite bind (`limit + 1`),
+    // mirroring the HTTP boundary's parseInt. Two failure modes to close:
+    //   1. non-finite (NaN/±Infinity) or fractional would bind as a non-integer and throw a
+    //      raw "datatype mismatch" -> non-finite falls back to DEFAULT_LIMIT, fractional truncates.
+    //   2. a negative limit is NOT bounded by the Math.min ceiling (Math.min keeps the smaller,
+    //      i.e. the negative), and SQLite reads a negative "LIMIT -n" as "no limit at all" — so a
+    //      caller passing e.g. limit=-1000 would bypass MAX_HISTORY_LIMIT entirely. Treat any
+    //      negative as invalid input and fall back to DEFAULT_LIMIT, same as non-finite.
+    // Explicit 0 is preserved (a deliberate empty-page request, already bounded). #1798
     const rawLimit = opts.limit ?? DEFAULT_LIMIT;
-    const intLimit = Number.isFinite(rawLimit) ? Math.trunc(rawLimit) : DEFAULT_LIMIT;
+    const coerced = Number.isFinite(rawLimit) ? Math.trunc(rawLimit) : DEFAULT_LIMIT;
+    const intLimit = coerced < 0 ? DEFAULT_LIMIT : coerced;
     const limit = Math.min(intLimit, MAX_HISTORY_LIMIT);
     const conditions: string[] = ['chat_id = ?'];
     const params: (string | number)[] = [chatId];

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -18,6 +18,7 @@ import supertest from 'supertest';
 import { AgentRunner } from '../../src/agent/runner';
 import { GatewayRouter } from '../../src/api/gateway-router';
 import { AgentConfig, GatewayConfig } from '../../src/types';
+import { MAX_HISTORY_LIMIT } from '../../src/history/db';
 
 // ─── constants ───────────────────────────────────────────────────────────────
 
@@ -894,6 +895,165 @@ describe('Chat History API integration (planning-50)', () => {
       expect(bad.status).toBe(400);
       expect(bad.body.error).toMatch(/must be a number/i);
     }
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-30: raised ceiling lets one call fetch a >200-message span (#1798) ─────
+  it('I-HIST-30: GET /messages?limit=1000 returns more than 200 rows in a single call', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-30-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-30-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // Seed 300 messages directly (well past the old 200 cap) so a single large-limit
+    // request must clear BOTH the HTTP-boundary clamp (router) and the db clamp.
+    const chatId = 'telegram-large-span';
+    const db = runner.getHistoryDb();
+    const TOTAL = 300;
+    for (let i = 0; i < TOTAL; i++) {
+      db.insertMessage({
+        chatId, sessionId: 'sess-large', source: 'telegram', role: 'user',
+        content: `msg-${i}`, senderName: 'tester', ts: 1_000 + i,
+      });
+    }
+
+    // limit=1000: before #1798 the router clamped this to 200 → hasMore:true, 200 rows.
+    const big = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=1000`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(big.status).toBe(200);
+    expect(big.body.messages.length).toBe(TOTAL);
+    expect(big.body.messages.length).toBeGreaterThan(200);
+    expect(big.body.hasMore).toBe(false);
+
+    // No limit → default page size unchanged at 50 (no behavior change for normal clients).
+    const def = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(def.status).toBe(200);
+    expect(def.body.messages).toHaveLength(50);
+    expect(def.body.hasMore).toBe(true);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-31: good — additional valid ?limit= shapes at the HTTP boundary (#1798) ──
+  it('I-HIST-31: valid ?limit= values (mid-range, floor, duplicate param) behave as documented', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-31-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-31-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const chatId = 'telegram-good-limits';
+    const db = runner.getHistoryDb();
+    for (let i = 0; i < 300; i++) {
+      db.insertMessage({
+        chatId, sessionId: 'sess-good', source: 'telegram', role: 'user',
+        content: `msg-${i}`, senderName: 'tester', ts: 1_000 + i,
+      });
+    }
+
+    // Mid-range: between DEFAULT_LIMIT and MAX_HISTORY_LIMIT.
+    const mid = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=250`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(mid.status).toBe(200);
+    expect(mid.body.messages).toHaveLength(250);
+    expect(mid.body.hasMore).toBe(true);
+
+    // limit=0: the router's `parseInt(...) || 50` treats 0 as falsy and falls back to the
+    // default page size — different from the db layer's `?? DEFAULT_LIMIT` (which treats
+    // an explicit 0 as a literal empty-page request). Documents that HTTP callers cannot
+    // use limit=0 to request an empty page; only omitting the param does that.
+    const zero = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=0`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(zero.status).toBe(200);
+    expect(zero.body.messages).toHaveLength(50);
+
+    // Duplicate query param: last-write-wins per Express's default parser.
+    const dup = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=10&limit=20`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(dup.status).toBe(200);
+    expect(dup.body.messages.length).toBeGreaterThan(0);
+    expect(dup.body.messages.length).toBeLessThanOrEqual(20);
+
+    await router.stop();
+    await runner.stop();
+  });
+
+  // ─── I-HIST-32: bad — malformed/hostile ?limit= values must never crash or leak
+  //                unbounded rows through the HTTP boundary (#1798) ──────────────────
+  it('I-HIST-32: malformed ?limit= values are rejected safely (500 rows seeded, well under the old and new ceilings)', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-32-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-32-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    const chatId = 'telegram-bad-limits';
+    const db = runner.getHistoryDb();
+    const TOTAL = MAX_HISTORY_LIMIT + 50; // seed past the ceiling either way
+    for (let i = 0; i < TOTAL; i++) {
+      db.insertMessage({
+        chatId, sessionId: 'sess-bad', source: 'telegram', role: 'user',
+        content: `msg-${i}`, senderName: 'tester', ts: 1_000 + i,
+      });
+    }
+
+    // Non-numeric: parseInt('abc',10) is NaN, `NaN || 50` falls back to the default — safe.
+    const nonNumeric = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=abc`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(nonNumeric.status).toBe(200);
+    expect(nonNumeric.body.messages).toHaveLength(50);
+
+    // Negative: MUST stay within the documented ceiling. parseInt('-1',10) === -1, which is
+    // truthy, so `-1 || 50` keeps -1, and Math.min(-1, MAX_HISTORY_LIMIT) is still -1 — the
+    // clamp never rejects a negative number, only ever lowers a number that's too high.
+    // That -1 is handed to db.getMessages({ limit: -1 }), and SQLite's own semantics for
+    // "LIMIT -1" are "no limit at all" — so this can return the entire chat history in one
+    // request, defeating the ceiling this issue exists to enforce.
+    const negative = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=-1`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(negative.status).toBe(200);
+    expect(negative.body.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
+
+    // Decimal: parseInt truncates, so this should behave like limit=50.
+    const decimal = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=50.9`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(decimal.status).toBe(200);
+    expect(decimal.body.messages).toHaveLength(50);
+
+    // Absurdly oversized numeric string: must clamp to the ceiling, not overflow or crash.
+    const huge = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=99999999999999999999`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(huge.status).toBe(200);
+    expect(huge.body.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
 
     await router.stop();
     await runner.stop();

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -1029,16 +1029,17 @@ describe('Chat History API integration (planning-50)', () => {
     expect(nonNumeric.status).toBe(200);
     expect(nonNumeric.body.messages).toHaveLength(50);
 
-    // Negative: MUST stay within the documented ceiling. parseInt('-1',10) === -1, which is
-    // truthy, so `-1 || 50` keeps -1, and Math.min(-1, MAX_HISTORY_LIMIT) is still -1 — the
-    // clamp never rejects a negative number, only ever lowers a number that's too high.
-    // That -1 is handed to db.getMessages({ limit: -1 }), and SQLite's own semantics for
-    // "LIMIT -1" are "no limit at all" — so this can return the entire chat history in one
-    // request, defeating the ceiling this issue exists to enforce.
+    // Negative: parseInt('-1000',10) === -1000, truthy, so `-1000 || 50` keeps it and
+    // Math.min(-1000, MAX) stays -1000 at the HTTP boundary — the router clamp never rejects a
+    // negative, only lowers a too-high one. The db layer's coercion is what closes this: it
+    // floors any negative to DEFAULT_LIMIT (SQLite reads a negative LIMIT as "unbounded", which
+    // would otherwise defeat the ceiling this issue exists to enforce). Seeded past the ceiling,
+    // so a regressed unbounded leak would return >200 rows instead of the default page.
     const negative = await supertest(router.getApp())
-      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=-1`)
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=-1000`)
       .set('X-Api-Key', API_KEY_ADMIN);
     expect(negative.status).toBe(200);
+    expect(negative.body.messages).toHaveLength(50); // DEFAULT_LIMIT fallback
     expect(negative.body.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
 
     // Decimal: parseInt truncates, so this should behave like limit=50.

--- a/tests/integration/chat-history-api.test.ts
+++ b/tests/integration/chat-history-api.test.ts
@@ -1058,4 +1058,41 @@ describe('Chat History API integration (planning-50)', () => {
     await router.stop();
     await runner.stop();
   });
+
+  // ─── I-HIST-33: the HTTP boundary clamps an over-ceiling limit to exactly MAX_HISTORY_LIMIT ──
+  it('I-HIST-33: GET /messages?limit above the ceiling is clamped to MAX_HISTORY_LIMIT at the router', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-33-'));
+    const ws = createStructuredWorkspace(base, 'alfred');
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-33-log-'));
+    const cfg = makeAgentConfig('alfred', ws);
+    const gwCfg = makeGatewayConfig(logDir);
+
+    const runner = new AgentRunner(cfg, gwCfg);
+    await runner.start();
+    const router = new GatewayRouter(new Map([['alfred', runner]]), new Map([['alfred', cfg]]), undefined, gwCfg);
+    await router.start(0);
+
+    // Seed MORE than the ceiling so "<= MAX" is not trivially satisfied: only a real clamp
+    // at MAX_HISTORY_LIMIT yields exactly the ceiling with hasMore=true. This asserts the
+    // router-layer clamp specifically (the db-layer clamp is covered by unit tests).
+    const chatId = 'telegram-over-ceiling';
+    const db = runner.getHistoryDb();
+    const TOTAL = MAX_HISTORY_LIMIT + 50;
+    for (let i = 0; i < TOTAL; i++) {
+      db.insertMessage({
+        chatId, sessionId: 'sess-over', source: 'telegram', role: 'user',
+        content: `msg-${i}`, senderName: 'tester', ts: 1_000 + i,
+      });
+    }
+
+    const res = await supertest(router.getApp())
+      .get(`/api/v1/agents/alfred/chats/${chatId}/messages?limit=5000`)
+      .set('X-Api-Key', API_KEY_ADMIN);
+    expect(res.status).toBe(200);
+    expect(res.body.messages).toHaveLength(MAX_HISTORY_LIMIT);
+    expect(res.body.hasMore).toBe(true);
+
+    await router.stop();
+    await runner.stop();
+  });
 });

--- a/tests/unit/history-db.test.ts
+++ b/tests/unit/history-db.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { HistoryDB } from '../../src/history/db';
+import { HistoryDB, MAX_HISTORY_LIMIT } from '../../src/history/db';
 import { HistoryMessage } from '../../src/history/types';
 
 let tmpDir: string;
@@ -414,5 +414,159 @@ describe('HistoryDB.searchMessages', () => {
     expect(result.results).toHaveLength(3);
     expect(result.total).toBe(10);
     expect(result.hasMore).toBe(true);
+  });
+});
+
+describe('HistoryDB.getMessages — MAX_HISTORY_LIMIT ceiling (#1798)', () => {
+  const CHAT = 'telegram-12345';
+
+  function seed(db: HistoryDB, n: number): void {
+    for (let i = 0; i < n; i++) {
+      db.insertMessage(makeMsg({ chatId: CHAT, content: `msg-${i}`, ts: 1_000 + i }));
+    }
+  }
+
+  it('exports MAX_HISTORY_LIMIT as 1000', () => {
+    expect(MAX_HISTORY_LIMIT).toBe(1000);
+  });
+
+  it('returns more than 200 rows in a single call when limit exceeds the old cap', () => {
+    // AC-2: a large single-call span. 300 > the previous 200 ceiling.
+    const db = makeDb();
+    seed(db, 300);
+    const page = db.getMessages(CHAT, { limit: 1000 });
+    expect(page.messages.length).toBe(300);
+    expect(page.messages.length).toBeGreaterThan(200);
+    expect(page.hasMore).toBe(false);
+  });
+
+  it('leaves the default page size unchanged at 50 when no limit is passed', () => {
+    // AC-3: clients that do not request a large limit are unaffected.
+    const db = makeDb();
+    seed(db, 300);
+    const page = db.getMessages(CHAT);
+    expect(page.messages).toHaveLength(50);
+    expect(page.hasMore).toBe(true);
+  });
+
+  it('clamps a request above the ceiling to MAX_HISTORY_LIMIT and reports hasMore', () => {
+    // 1001 rows, client asks for far more than the ceiling: return exactly 1000 + hasMore.
+    const db = makeDb();
+    seed(db, MAX_HISTORY_LIMIT + 1);
+    const page = db.getMessages(CHAT, { limit: 5000 });
+    expect(page.messages).toHaveLength(MAX_HISTORY_LIMIT);
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
+  it('returns exactly the ceiling with hasMore false when total equals MAX_HISTORY_LIMIT', () => {
+    // hasMore boundary: limit+1 fetch sees no extra row, so hasMore is false.
+    const db = makeDb();
+    seed(db, MAX_HISTORY_LIMIT);
+    const page = db.getMessages(CHAT, { limit: MAX_HISTORY_LIMIT });
+    expect(page.messages).toHaveLength(MAX_HISTORY_LIMIT);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+});
+
+describe('HistoryDB.getMessages — limit input validation: good & bad cases (#1798)', () => {
+  const CHAT = 'telegram-12345';
+
+  function seed(db: HistoryDB, n: number): void {
+    for (let i = 0; i < n; i++) {
+      db.insertMessage(makeMsg({ chatId: CHAT, content: `msg-${i}`, ts: 1_000 + i }));
+    }
+  }
+
+  // ── good: interior values across the range ────────────────────────────
+  it('good: a mid-range limit (500) between DEFAULT and MAX_HISTORY_LIMIT returns exactly that many', () => {
+    const db = makeDb();
+    seed(db, 700);
+    const page = db.getMessages(CHAT, { limit: 500 });
+    expect(page.messages).toHaveLength(500);
+    expect(page.hasMore).toBe(true);
+  });
+
+  it('good: a below-default limit (10) is honored as-is, not bumped to DEFAULT_LIMIT', () => {
+    const db = makeDb();
+    seed(db, 100);
+    const page = db.getMessages(CHAT, { limit: 10 });
+    expect(page.messages).toHaveLength(10);
+    expect(page.hasMore).toBe(true);
+  });
+
+  it('good: an unknown chatId with an explicit large limit returns an empty page, not an error', () => {
+    const db = makeDb();
+    seed(db, 5); // seeded under a different chat below
+    const page = db.getMessages('no-such-chat', { limit: MAX_HISTORY_LIMIT });
+    expect(page.messages).toEqual([]);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  // ── bad: values a well-behaved caller should never send, but the layer must survive ──
+  it('bad: limit=0 returns an empty page rather than falling back to DEFAULT_LIMIT', () => {
+    // Documents current behavior: 0 is a valid (if useless) explicit limit, distinct from
+    // "no limit passed". A caller that means "give me the default" must omit the field.
+    const db = makeDb();
+    seed(db, 10);
+    const page = db.getMessages(CHAT, { limit: 0 });
+    expect(page.messages).toEqual([]);
+    expect(page.hasMore).toBe(true);
+  });
+
+  it('bad: a negative limit must never bypass MAX_HISTORY_LIMIT and return the whole table', () => {
+    // SQLite treats "LIMIT -1" as "no limit at all" — a negative value handed straight
+    // through Math.min(opts.limit, MAX_LIMIT) (Math.min keeps the negative number, since
+    // it's still the smaller of the two) reaches the SQL layer unclamped. Seed well past
+    // the ceiling so an unbounded leak is unambiguous versus a correctly-clamped result.
+    const db = makeDb();
+    seed(db, MAX_HISTORY_LIMIT + 50);
+    const page = db.getMessages(CHAT, { limit: -1 });
+    expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
+  });
+
+  it('bad: a large negative limit must not return more rows than exist, unbounded', () => {
+    // limit=-1000 makes the internal `limit + 1` fetch bound itself negative (-999), which
+    // is where SQLite's "negative LIMIT means no limit at all" semantics would actually
+    // engage (limit=-1 above collapses to a LIMIT of 0 and never reaches this path).
+    // Seed well past the ceiling so a genuine unbounded leak is unambiguous.
+    const db = makeDb();
+    seed(db, MAX_HISTORY_LIMIT + 200);
+    const page = db.getMessages(CHAT, { limit: -1000 });
+    expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
+  });
+
+  it('bad: NaN limit must not crash the query and must not exceed MAX_HISTORY_LIMIT', () => {
+    const db = makeDb();
+    seed(db, 300);
+    expect(() => db.getMessages(CHAT, { limit: NaN })).not.toThrow();
+    const page = db.getMessages(CHAT, { limit: NaN });
+    expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
+  });
+
+  it('bad: a fractional limit does not crash and stays within bounds', () => {
+    const db = makeDb();
+    seed(db, 100);
+    expect(() => db.getMessages(CHAT, { limit: 50.7 })).not.toThrow();
+    const page = db.getMessages(CHAT, { limit: 50.7 });
+    expect(page.messages.length).toBeLessThanOrEqual(100);
+  });
+
+  it('bad: Number.MAX_SAFE_INTEGER as limit is clamped to MAX_HISTORY_LIMIT, not passed through raw', () => {
+    const db = makeDb();
+    seed(db, 300);
+    const page = db.getMessages(CHAT, { limit: Number.MAX_SAFE_INTEGER });
+    expect(page.messages).toHaveLength(300);
+    expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
+  });
+
+  it('bad: Infinity as limit does not crash and stays within bounds', () => {
+    const db = makeDb();
+    seed(db, 300);
+    expect(() => db.getMessages(CHAT, { limit: Infinity })).not.toThrow();
+    const page = db.getMessages(CHAT, { limit: Infinity });
+    expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
   });
 });

--- a/tests/unit/history-db.test.ts
+++ b/tests/unit/history-db.test.ts
@@ -36,6 +36,15 @@ function makeMsg(overrides: Partial<HistoryMessage> = {}): HistoryMessage {
   };
 }
 
+// Shared seeder for the #1798 ceiling / limit-validation blocks: insert `n` messages under the
+// default chat (makeMsg's chatId), monotonically increasing ts. Hoisted so the two blocks below
+// don't each redeclare an identical local copy.
+function seed(db: HistoryDB, n: number): void {
+  for (let i = 0; i < n; i++) {
+    db.insertMessage(makeMsg({ content: `msg-${i}`, ts: 1_000 + i }));
+  }
+}
+
 describe('HistoryDB.insertMessage', () => {
   it('inserts a message without error', () => {
     const db = makeDb();
@@ -420,12 +429,6 @@ describe('HistoryDB.searchMessages', () => {
 describe('HistoryDB.getMessages — MAX_HISTORY_LIMIT ceiling (#1798)', () => {
   const CHAT = 'telegram-12345';
 
-  function seed(db: HistoryDB, n: number): void {
-    for (let i = 0; i < n; i++) {
-      db.insertMessage(makeMsg({ chatId: CHAT, content: `msg-${i}`, ts: 1_000 + i }));
-    }
-  }
-
   it('exports MAX_HISTORY_LIMIT as 1000', () => {
     expect(MAX_HISTORY_LIMIT).toBe(1000);
   });
@@ -473,12 +476,6 @@ describe('HistoryDB.getMessages — MAX_HISTORY_LIMIT ceiling (#1798)', () => {
 describe('HistoryDB.getMessages — limit input validation: good & bad cases (#1798)', () => {
   const CHAT = 'telegram-12345';
 
-  function seed(db: HistoryDB, n: number): void {
-    for (let i = 0; i < n; i++) {
-      db.insertMessage(makeMsg({ chatId: CHAT, content: `msg-${i}`, ts: 1_000 + i }));
-    }
-  }
-
   // ── good: interior values across the range ────────────────────────────
   it('good: a mid-range limit (500) between DEFAULT and MAX_HISTORY_LIMIT returns exactly that many', () => {
     const db = makeDb();
@@ -516,25 +513,27 @@ describe('HistoryDB.getMessages — limit input validation: good & bad cases (#1
     expect(page.hasMore).toBe(true);
   });
 
-  it('bad: a negative limit must never bypass MAX_HISTORY_LIMIT and return the whole table', () => {
-    // SQLite treats "LIMIT -1" as "no limit at all" — a negative value handed straight
-    // through Math.min(opts.limit, MAX_HISTORY_LIMIT) (Math.min keeps the negative number, since
-    // it's still the smaller of the two) reaches the SQL layer unclamped. Seed well past
-    // the ceiling so an unbounded leak is unambiguous versus a correctly-clamped result.
+  it('bad: a negative limit falls back to DEFAULT_LIMIT instead of leaking the whole table', () => {
+    // SQLite treats a negative "LIMIT -n" as "no limit at all", and Math.min(negative, MAX)
+    // keeps the negative — so before the coercion fix a negative slipped past the ceiling.
+    // Seed above 2x the ceiling so a genuine unbounded leak (which slice(0, negative) would
+    // still surface as thousands of rows) is unambiguous versus the correct default fallback.
     const db = makeDb();
-    seed(db, MAX_HISTORY_LIMIT + 50);
+    seed(db, MAX_HISTORY_LIMIT * 2 + 100);
     const page = db.getMessages(CHAT, { limit: -1 });
-    expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
+    expect(page.messages).toHaveLength(50); // DEFAULT_LIMIT — negative is treated as invalid input
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).not.toBeNull(); // and paging still advances (no hasMore-without-cursor)
   });
 
-  it('bad: a large negative limit must not return more rows than exist, unbounded', () => {
-    // limit=-1000 makes the internal `limit + 1` fetch bound itself negative (-999), which
-    // is where SQLite's "negative LIMIT means no limit at all" semantics would actually
-    // engage (limit=-1 above collapses to a LIMIT of 0 and never reaches this path).
-    // Seed well past the ceiling so a genuine unbounded leak is unambiguous.
+  it('bad: a large negative limit also falls back to DEFAULT_LIMIT, not an unbounded leak', () => {
+    // limit=-1000 is the case that actually leaked pre-fix: the internal `limit + 1` fetch
+    // bound itself to -999, SQLite returned every row, and slice(0, -1000) still handed back
+    // thousands. Seed above 2x the ceiling so the leak would be unmistakable if it regressed.
     const db = makeDb();
-    seed(db, MAX_HISTORY_LIMIT + 200);
+    seed(db, MAX_HISTORY_LIMIT * 2 + 100);
     const page = db.getMessages(CHAT, { limit: -1000 });
+    expect(page.messages).toHaveLength(50); // DEFAULT_LIMIT
     expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
   });
 

--- a/tests/unit/history-db.test.ts
+++ b/tests/unit/history-db.test.ts
@@ -518,7 +518,7 @@ describe('HistoryDB.getMessages — limit input validation: good & bad cases (#1
 
   it('bad: a negative limit must never bypass MAX_HISTORY_LIMIT and return the whole table', () => {
     // SQLite treats "LIMIT -1" as "no limit at all" — a negative value handed straight
-    // through Math.min(opts.limit, MAX_LIMIT) (Math.min keeps the negative number, since
+    // through Math.min(opts.limit, MAX_HISTORY_LIMIT) (Math.min keeps the negative number, since
     // it's still the smaller of the two) reaches the SQL layer unclamped. Seed well past
     // the ceiling so an unbounded leak is unambiguous versus a correctly-clamped result.
     const db = makeDb();
@@ -567,6 +567,16 @@ describe('HistoryDB.getMessages — limit input validation: good & bad cases (#1
     seed(db, 300);
     expect(() => db.getMessages(CHAT, { limit: Infinity })).not.toThrow();
     const page = db.getMessages(CHAT, { limit: Infinity });
+    expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
+  });
+
+  it('bad: -Infinity as limit does not crash and stays within bounds', () => {
+    // -Infinity would reach the SQLite bind as a non-integer (-Infinity + 1) and throw a raw
+    // "datatype mismatch" if the coercion only guarded NaN. Number.isFinite covers it too.
+    const db = makeDb();
+    seed(db, 300);
+    expect(() => db.getMessages(CHAT, { limit: -Infinity })).not.toThrow();
+    const page = db.getMessages(CHAT, { limit: -Infinity });
     expect(page.messages.length).toBeLessThanOrEqual(MAX_HISTORY_LIMIT);
   });
 });


### PR DESCRIPTION
## Summary

Raise the chat-history API page ceiling from **200 to 1000** so a client can fetch a whole `target day → now` span in a **single** request (getpod jump-to-date, Crown-Labs/getpod#1798), instead of several sequential `load-more` pages that read as inter-page "await" flicker. 1000 covers a realistic single-session span (~722 messages for a 3-month mock) with headroom while still bounding the response payload.

Refs Crown-Labs/getpod#1798.

## What changed

- **`src/history/db.ts`** — introduce exported `MAX_HISTORY_LIMIT = 1000`; `MAX_LIMIT` now references it. `DEFAULT_LIMIT` stays `50` (no behavior change for clients that don't request a large limit); `hasMore`/cursor logic untouched.
- **`src/api/router.ts`** — the `GET …/messages` HTTP-boundary clamp now reuses `MAX_HISTORY_LIMIT` instead of a separate literal `200`, so the two ceilings can never drift. **This was a second, independent 200-cap** the issue's implementation notes did not mention: without it, a `limit=1000` request was silently re-clamped to 200 at the HTTP layer before ever reaching the db.

## Incidental hardening (beyond the issue's ACs)

While adding edge-case tests we found a **pre-existing** defect: `getMessages()` never validated `opts.limit`, so a `NaN` or fractional value (e.g. `50.7`) reached the SQLite bind (`limit + 1`) as a non-integer and threw a raw `datatype mismatch`. This is **unreachable via HTTP** (the router's `parseInt` guarantees an integer or a `50` fallback), but `getMessages` is an exported method, so a future direct caller (MCP tool, cron, …) could crash.

Fix: `getMessages()` now integer-coerces `limit` (`NaN → DEFAULT_LIMIT`, fractional → truncated) before the bind — mirroring the HTTP boundary's own `parseInt` behavior. `0`/negative are preserved (explicit and already bounded downstream). This is called out explicitly as it is **outside the stated ACs of #1798**.

## Acceptance criteria (Crown-Labs/getpod#1798)

- [x] `MAX_LIMIT` raised 200 → 1000.
- [x] A request with `limit=1000` returns >200 rows when they exist (integration `I-HIST-30`).
- [x] `DEFAULT_LIMIT` unchanged (50) — no behavior change without a large limit.
- [x] `hasMore`/cursor semantics correct at the new ceiling (still fetches `limit + 1`).
- [ ] New gateway version published to npm + deployed to dev pods — **release/ops step, not in this PR.**
- [ ] getpod client single-call wiring — tracked in Crown-Labs/getpod#510 / PR #1707.

## Testing

- New unit coverage (`tests/unit/history-db.test.ts`): exported ceiling = 1000, >200 rows in one call, unchanged default, clamp-at-ceiling + `hasMore` boundary, and limit input validation (mid-range, below-default, `0`, negative no-leak, `NaN`, fractional, `Infinity`, `MAX_SAFE_INTEGER`).
- New integration coverage (`tests/integration/chat-history-api.test.ts`, `I-HIST-30/31/32`): real `GET …/messages?limit=1000` through the router returns >200 rows; default returns 50; malformed limits are handled cleanly.
- Full suite: **130/130 suites, 2503/2503 tests pass**; typecheck clean.

## Out of scope

- npm republish + pod redeploy (release/ops).
- getpod client wiring (Crown-Labs/getpod#510 / PR #1707).
- Spans > 1000 messages — still fall back to multi-page paging (client loop already handles it).
