### PR TITLE
[Feature] Default allow_tools to true when creating an agent via POST /v1/agents

### DIFF
--- a/API.md
+++ b/API.md
@@ -389,6 +389,7 @@ Create a new agent entry in `config.json`. Requires admin key. Also creates the 
 | `id` | Yes | Agent ID — pattern `[a-z][a-z0-9_-]{1,31}` |
 | `description` | Yes | Human-readable description |
 | `model` | No | Claude model ID (default: `claude-sonnet-4-6`) |
+| `allow_tools` | No | Whether the agent may invoke tools when accessed via the API channel (default: `true`). Pass `false` to create a conversational-only agent. |
 
 ```bash
 curl -X POST \
@@ -399,14 +400,14 @@ curl -X POST \
 ```
 
 ```json
-{ "agent": { "id": "my-bot", "description": "My new bot", "model": "claude-sonnet-4-6" } }
+{ "agent": { "id": "my-bot", "description": "My new bot", "model": "claude-sonnet-4-6", "allow_tools": true } }
 ```
 
 **Error responses:**
 
 | Status | When |
 |--------|------|
-| 400 | Invalid `id` format or missing `description` |
+| 400 | Invalid `id` format, missing `description`, or non-boolean `allow_tools` |
 | 403 | Not an admin key |
 | 409 | Agent ID already exists |
 | 501 | Gateway started without a config path |

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1073,6 +1073,7 @@ export function createApiRouter(
       description: wizard.prompt.slice(0, 200).trim(),
       workspace: absToTildePath(workspaceDirAbs),
       env: absToTildePath(path.join(workspaceDirAbs, '.env')),
+      allow_tools: true,
       claude: { model: defaultModel, extraFlags: [] },
     };
     if (wizard.signatureEmoji) newAgent.signatureEmoji = wizard.signatureEmoji;
@@ -1095,6 +1096,7 @@ export function createApiRouter(
       description: wizard.prompt.slice(0, 200).trim(),
       workspace: workspaceDirAbs,
       env: path.join(workspaceDirAbs, '.env'),
+      allow_tools: true,
       claude: { model: defaultModel, extraFlags: [] },
       ...(wizard.signatureEmoji ? { signatureEmoji: wizard.signatureEmoji } : {}),
       ...(avatarFilename ? { avatar: avatarFilename } : {}),

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -602,8 +602,8 @@ export function createApiRouter(
       res.status(501).json({ error: 'Agent management not available (no configPath)' });
       return;
     }
-    const body = req.body as { id?: unknown; description?: unknown; model?: unknown };
-    const { id, description, model } = body;
+    const body = req.body as { id?: unknown; description?: unknown; model?: unknown; allow_tools?: unknown };
+    const { id, description, model, allow_tools } = body;
 
     if (!id || typeof id !== 'string' || !AGENT_ID_RE.test(id)) {
       res.status(400).json({ error: 'id must match pattern [a-z][a-z0-9_-]{1,31}' });
@@ -613,10 +613,18 @@ export function createApiRouter(
       res.status(400).json({ error: 'description is required' });
       return;
     }
+    if (allow_tools !== undefined && typeof allow_tools !== 'boolean') {
+      res.status(400).json({ error: 'allow_tools must be a boolean' });
+      return;
+    }
     if (agentConfigs.has(id)) {
       res.status(409).json({ error: `Agent '${id}' already exists` });
       return;
     }
+
+    // Default new agents to tool-enabled so they work out of the box; an explicit
+    // `false` in the request body is respected. Mirrors the MCP agent-create path.
+    const allowTools = typeof allow_tools === 'boolean' ? allow_tools : true;
 
     const workspace = path.join('~', '.claude-gateway', 'agents', id, 'workspace');
     const workspaceAbs = path.join(os.homedir(), '.claude-gateway', 'agents', id, 'workspace');
@@ -625,6 +633,7 @@ export function createApiRouter(
       description: (description as string).trim(),
       workspace,
       env: path.join('~', '.claude-gateway', 'agents', id, 'workspace', '.env'),
+      allow_tools: allowTools,
       claude: {
         model: typeof model === 'string' && model.trim() ? model.trim() : 'claude-sonnet-4-6',
         extraFlags: [],
@@ -651,6 +660,7 @@ export function createApiRouter(
       description: (description as string).trim(),
       workspace: workspaceAbs,
       env: path.join(workspaceAbs, '.env'),
+      allow_tools: allowTools,
       claude: {
         model: typeof model === 'string' && model.trim() ? model.trim() : 'claude-sonnet-4-6',
         extraFlags: [],
@@ -678,7 +688,7 @@ export function createApiRouter(
       console.error(`[api] Warning: agent '${id}' created in config but workspace setup failed: ${(err as Error).message}`);
     }
 
-    res.status(201).json({ agent: { id, description: newAgent.description, model: (newAgent.claude as Record<string, unknown>).model } });
+    res.status(201).json({ agent: { id, description: newAgent.description, model: (newAgent.claude as Record<string, unknown>).model, allow_tools: allowTools } });
   });
 
   // ──────────────────────────────────────────────────────────────

--- a/tests/unit/api-agent-create-allow-tools.test.ts
+++ b/tests/unit/api-agent-create-allow-tools.test.ts
@@ -1,0 +1,147 @@
+/**
+ * HTTP-level tests for the `allow_tools` default on agent creation:
+ *  - POST /api/v1/agents with no `allow_tools` defaults the new agent to
+ *    `allow_tools: true`, both persisted to config.json and reflected in the
+ *    in-memory config immediately (no file-watcher round-trip / restart).
+ *  - An explicit `allow_tools: false` in the body is respected, not overridden.
+ *  - A non-boolean `allow_tools` is rejected with 400.
+ *  - Pre-existing agents are untouched (no migration of their config entry).
+ *
+ * Regression coverage for the bug where POST /v1/agents never set `allow_tools`,
+ * so every downstream read fell back to a falsy default and brand-new agents
+ * were tool-disabled until an explicit PATCH. Mirrors the real-router + temp
+ * config.json setup in api-agent-name.test.ts.
+ */
+import express from 'express';
+import * as supertest from 'supertest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createApiRouter } from '../../src/api/router';
+import { AgentConfig, ApiKey } from '../../src/types';
+
+const EXISTING_ID = 'alfred';
+const ADMIN = { Authorization: 'Bearer sk-test-admin' };
+
+function makeExistingAgent(): AgentConfig {
+  return {
+    id: EXISTING_ID,
+    description: 'Personal assistant',
+    workspace: '/tmp/alfred',
+    env: '',
+    claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+  };
+}
+
+describe('POST /api/v1/agents — allow_tools default', () => {
+  let tmpDir: string;
+  let configPath: string;
+  let configs: Map<string, AgentConfig>;
+  let app: express.Express;
+  // Track workspace dirs the handler creates under $HOME so we can clean them up.
+  const createdAgentIds: string[] = [];
+
+  const apiKeys: ApiKey[] = [{ key: 'sk-test-admin', agents: '*', admin: true }];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-allowtools-api-'));
+    configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          gateway: { logDir: '~/logs', timezone: 'UTC' },
+          agents: [makeExistingAgent()],
+        },
+        null,
+        2,
+      ),
+    );
+    configs = new Map([[EXISTING_ID, makeExistingAgent()]]);
+    const runners = new Map();
+    app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter(runners, configs, apiKeys, configPath));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    // The create handler writes a workspace under ~/.claude-gateway/agents/<id>.
+    for (const id of createdAgentIds) {
+      fs.rmSync(path.join(os.homedir(), '.claude-gateway', 'agents', id), {
+        recursive: true,
+        force: true,
+      });
+    }
+    createdAgentIds.length = 0;
+  });
+
+  const create = (body: Record<string, unknown>) => {
+    if (typeof body.id === 'string') createdAgentIds.push(body.id);
+    return supertest.default(app).post('/api/v1/agents').set(ADMIN).send(body);
+  };
+
+  const readDisk = () => JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+  it('defaults allow_tools to true in config.json when omitted', async () => {
+    const res = await create({ id: 'toolbot', description: 'A new bot' });
+    expect(res.status).toBe(201);
+    expect(res.body.agent.allow_tools).toBe(true);
+
+    const onDisk = readDisk();
+    const entry = onDisk.agents.find((a: { id: string }) => a.id === 'toolbot');
+    expect(entry).toBeDefined();
+    expect(entry.allow_tools).toBe(true);
+  });
+
+  it('reflects allow_tools: true on GET /agents immediately (no restart)', async () => {
+    await create({ id: 'toolbot', description: 'A new bot' });
+    const res = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+    expect(res.status).toBe(200);
+    const agent = res.body.agents.find((a: { id: string }) => a.id === 'toolbot');
+    expect(agent).toBeDefined();
+    expect(agent.allow_tools).toBe(true);
+    // In-memory config map is updated synchronously, not via the file watcher.
+    expect(configs.get('toolbot')!.allow_tools).toBe(true);
+  });
+
+  it('respects an explicit allow_tools: false and does not override it', async () => {
+    const res = await create({ id: 'chatbot', description: 'Conversational only', allow_tools: false });
+    expect(res.status).toBe(201);
+    expect(res.body.agent.allow_tools).toBe(false);
+
+    const onDisk = readDisk();
+    const entry = onDisk.agents.find((a: { id: string }) => a.id === 'chatbot');
+    expect(entry.allow_tools).toBe(false);
+    expect(configs.get('chatbot')!.allow_tools).toBe(false);
+
+    const get = await supertest.default(app).get('/api/v1/agents').set(ADMIN);
+    const agent = get.body.agents.find((a: { id: string }) => a.id === 'chatbot');
+    expect(agent.allow_tools).toBe(false);
+  });
+
+  it('honors an explicit allow_tools: true', async () => {
+    const res = await create({ id: 'toolbot2', description: 'Explicit true', allow_tools: true });
+    expect(res.status).toBe(201);
+    expect(res.body.agent.allow_tools).toBe(true);
+    expect(readDisk().agents.find((a: { id: string }) => a.id === 'toolbot2').allow_tools).toBe(true);
+  });
+
+  it('rejects a non-boolean allow_tools with 400', async () => {
+    const res = await create({ id: 'badbot', description: 'Invalid flag', allow_tools: 'yes' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/allow_tools must be a boolean/i);
+    // Nothing persisted on validation failure.
+    const onDisk = readDisk();
+    expect(onDisk.agents.find((a: { id: string }) => a.id === 'badbot')).toBeUndefined();
+  });
+
+  it('leaves pre-existing agents untouched (no migration)', async () => {
+    await create({ id: 'toolbot', description: 'A new bot' });
+    const onDisk = readDisk();
+    const existing = onDisk.agents.find((a: { id: string }) => a.id === EXISTING_ID);
+    // The pre-existing agent had no allow_tools field; it must stay absent.
+    expect(existing).toBeDefined();
+    expect(existing.allow_tools).toBeUndefined();
+  });
+});

--- a/tests/unit/api-avatar-wizard.test.ts
+++ b/tests/unit/api-avatar-wizard.test.ts
@@ -990,3 +990,39 @@ describe('POST /api/v1/agents/wizard/:wizardId/complete', () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/v1/agents/wizard/:wizardId/confirm — allow_tools default
+// Regression: the wizard finalize path must default new agents to tool-enabled,
+// matching POST /v1/agents. Previously it never set allow_tools, so wizard-made
+// agents were tool-disabled by the downstream falsy fallback.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/agents/wizard/:wizardId/confirm — allow_tools default', () => {
+  it('defaults allow_tools to true in config.json and in memory', async () => {
+    const { app, tmpDir, configPath, agentConfigs } = buildCtx();
+    const state = wizardStore.create('wizardtoolbot', 'A wizard-made bot', {
+      'AGENTS.md': '# Agent: wizardtoolbot\nHello',
+    });
+    try {
+      const res = await supertest.default(app)
+        .post(`/api/v1/agents/wizard/${state.wizardId}/confirm`)
+        .set('Authorization', `Bearer ${ADMIN_KEY}`)
+        .send({});
+      expect(res.status).toBe(200);
+      expect(res.body.agentId).toBe('wizardtoolbot');
+
+      const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        agents: { id: string; allow_tools?: boolean }[];
+      };
+      const entry = onDisk.agents.find((a) => a.id === 'wizardtoolbot');
+      expect(entry).toBeDefined();
+      expect(entry!.allow_tools).toBe(true);
+
+      // In-memory config is updated synchronously (no file-watcher round-trip).
+      expect(agentConfigs.get('wizardtoolbot')!.allow_tools).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
`POST /v1/agents` never set `allow_tools`, so every downstream read fell back to a falsy default and brand-new agents were tool-disabled until an explicit `PATCH`. This sets `allow_tools` at creation time (default `true`), accepts an optional `allow_tools` in the request body so callers can opt out, and surfaces the effective value in the response. The same latent gap in the wizard finalize path is fixed too, so agents created through the UI wizard are also tool-enabled by default.

## Related Issue
Closes #222

## Changes Made
- `src/api/router.ts` — `POST /v1/agents` handler:
  - Accepts and validates an optional `allow_tools` in the request body (non-boolean → `400`).
  - Defaults `allow_tools` to `true`; an explicit `false` is respected.
  - Sets `allow_tools` on both the persisted `config.json` entry and the in-memory `agentConfigs` map, so `GET /v1/agents` reflects it immediately without waiting for the file watcher / a restart.
  - Includes `allow_tools` in the `201` response.
- `src/api/router.ts` — wizard finalize handler (`POST /v1/agents/wizard/:wizardId/confirm`):
  - Defaults `allow_tools` to `true` on both the persisted config entry and the in-memory config, matching the direct create path (previously this path had the identical tool-disabled default bug).
  - Mirrors the MCP agent-create path (`src/apps/agent-manager.ts`), which already defaults to `true`.
- `API.md` — documents the new `allow_tools` field, the `true` default, the `400` condition, and the response shape for `POST /api/v1/agents`.
- `tests/unit/api-agent-create-allow-tools.test.ts` (new) — 6 HTTP-level tests against the real router + a temp `config.json`, covering all four acceptance criteria (default true persisted, GET reflects immediately, explicit `false` respected, pre-existing agents untouched) plus the `400` validation path.
- `tests/unit/api-avatar-wizard.test.ts` — adds a test proving the wizard finalize path defaults `allow_tools` to `true` in both `config.json` and the in-memory config.

## Testing
- `npm run typecheck`: pass
- `npm run test:unit`: 2134/2134 tests pass (the lone `pty-shell.test.ts` suite flag is a pre-existing parallel-run teardown/open-handle flake — it passes 116/116 in isolation and is unrelated to this change).
- Affected suites after the wizard fix: `api-avatar-wizard`, `api-agent-create-allow-tools`, `api-router`, `api-agent-name` — 115/115 pass.
- Regression proof: reverting each fix makes the corresponding new test fail (direct path: 5/6 fail; wizard path: the finalize test fails); restoring passes.
