### PR TITLE
fix(skills): guard skills hot-reload against the self-restart footgun

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -351,9 +351,14 @@ async function startAgent(
           updated.systemPrompt,
           'utf8',
         );
-        // Stop idle subprocesses now; busy sessions are deferred until
-        // their current turn completes, then restarted automatically.
-        await runner.restartOrDefer();
+        // Stop idle subprocesses now so they pick up the new registry on
+        // next spawn. Busy sessions are left running (skipBusy) rather than
+        // marked for a deferred restart: a session that triggers a SKILL.md
+        // change mid-turn would otherwise stop itself the instant its turn
+        // completes (the self-restart footgun — same guard the workspace
+        // watcher applies above). The recomposed CLAUDE.md is already on disk,
+        // so a skipped busy session picks up the change on its next spawn.
+        await runner.restartOrDefer({ skipBusy: true });
         logger.info('Skills registry updated', {
           count: updated.skillRegistry?.skills.size ?? 0,
         });

--- a/tests/integration/skills-hot-reload.test.ts
+++ b/tests/integration/skills-hot-reload.test.ts
@@ -13,6 +13,10 @@
  * HR3 — delete shared skill triggers restart
  * HR4 — busy session is NOT stopped; CLAUDE.md still refreshed
  * HR5 — module-dir skill change behaves the same as shared-dir change
+ * HR6 — busy session survives EVEN AFTER its turn completes (no self-restart
+ *       footgun): the skills-reload path must pass skipBusy:true, otherwise a
+ *       session that triggered the SKILL.md change is stopped the instant its
+ *       turn ends. Regression guard for the missing skipBusy on src/index.ts.
  */
 
 import { EventEmitter } from 'events';
@@ -142,7 +146,9 @@ function deleteSkillFile(dir: string, name: string): void {
 
 // Replicates the inline watcher callback in src/index.ts so the integration
 // test exercises the same sequence (reload -> setSkillRegistry ->
-// write CLAUDE.md -> restartOrDefer).
+// write CLAUDE.md -> restartOrDefer). Must stay a faithful mirror of the
+// production callback, including the skipBusy:true guard on the skills path
+// (skipping busy sessions avoids the self-restart footgun — see HR6).
 function wireSkillsWatcher(
   runner: AgentRunner,
   workspaceDir: string,
@@ -166,7 +172,7 @@ function wireSkillsWatcher(
         updated.systemPrompt,
         'utf8',
       );
-      await runner.restartOrDefer();
+      await runner.restartOrDefer({ skipBusy: true });
     },
   });
 }
@@ -314,7 +320,8 @@ describe('Skills hot-reload end-to-end', () => {
     await sendChannelPost(port, 'chat:hr4', 'hi');
     await new Promise((r) => setTimeout(r, 100));
     const sess = getSessions(runner).get('chat:hr4')!;
-    // Session is processing (isProcessing === true from sendChannelPost) — will be deferred, not stopped.
+    // Session is processing (isProcessing === true from sendChannelPost) — with
+    // skipBusy:true it is left running (skipped), not deferred and not stopped.
 
     watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
     await new Promise((r) => setTimeout(r, 150));
@@ -349,5 +356,48 @@ describe('Skills hot-reload end-to-end', () => {
     const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
     expect(claudeMd).toContain('/hr5-skill');
     expect(claudeMd).toContain('**Workspace Skills**');
+  }, 10000);
+
+  // --------------------------------------------------------------------------
+  // HR6 — busy session survives EVEN AFTER its turn completes (footgun guard)
+  //
+  // This is the regression test for the self-restart footgun: a session that
+  // triggers a SKILL.md change while busy must NOT be marked for a deferred
+  // restart, otherwise it is stopped the instant its turn ends. HR4 only checks
+  // survival *during* the turn (which passes even on the buggy code, since the
+  // deferred restart hasn't fired yet); HR6 completes the turn and asserts the
+  // session is still alive — which only holds when the skills-reload path passes
+  // skipBusy:true.
+  // --------------------------------------------------------------------------
+  it('HR6: busy session survives after its turn completes (no deferred restart)', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:hr6', 'hi');
+    await new Promise((r) => setTimeout(r, 100));
+    const sess = getSessions(runner).get('chat:hr6')!;
+    expect(sess).toBeDefined();
+    // Session is busy (isProcessing === true from sendChannelPost), as if it is
+    // mid-turn editing its own SKILL.md.
+
+    watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
+    await new Promise((r) => setTimeout(r, 150));
+
+    writeSkillFile(sharedSkillsDir, 'hr6-skill');
+
+    // Wait for the reload to land (CLAUDE.md rewritten).
+    await waitForCondition(() =>
+      fs
+        .readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8')
+        .includes('/hr6-skill'),
+    );
+
+    // The turn now completes. On the buggy path (no skipBusy) the session was
+    // marked pendingRestart and this stops it; with skipBusy:true it survives.
+    sess.setProcessing(false);
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(getSessions(runner).has('chat:hr6')).toBe(true);
+    expect(sess.isRunning()).toBe(true);
   }, 10000);
 });


### PR DESCRIPTION
## Summary
The skills hot-reload watcher called `runner.restartOrDefer()` with **no options** (`src/index.ts:356`), so `skipBusy` defaulted to `false`. A busy session that triggers a `SKILL.md` change mid-turn (e.g. an agent renaming its own skill) was marked for a **deferred restart** (`runner.ts:1845`) and stopped the instant its turn completed — appearing to the user as "the process dies right after finishing a turn."

The **workspace** watcher one call above (`src/index.ts:326`) already guards this exact footgun with `skipBusy: agentWritableOnly`; the skills path never got the same treatment.

## Fix
Pass `skipBusy: true` on the skills-reload path (one line + corrected comment):
- Idle sessions still stop/refresh and pick up the new registry on next spawn.
- Busy sessions are left running instead of armed for a deferred restart — the recomposed `CLAUDE.md` is already written to disk before the restart decision, so a skipped busy session picks up the skill change on its own next natural spawn (the rationale documented at `runner.ts:1820-1832`).

The runner-level mechanism was already fully unit-tested (`agent-runner.test.ts` RS7, including "completing its turn must NOT stop it"). The gap was purely the **production wiring** — this PR closes it and locks it with an integration regression test.

## Regression test
`tests/integration/skills-hot-reload.test.ts`:
- The `wireSkillsWatcher` mirror (a faithful copy of the production callback) now passes `skipBusy: true`, matching the fixed `src/index.ts`.
- New **HR6**: a busy session survives **even after its turn completes**. The pre-existing HR4 only asserted survival *during* the turn — which passes even on the buggy code, because the deferred restart hasn't fired yet. HR6 completes the turn and asserts the session is still alive.
- **Proven to fail on the pre-fix path**: with the mirror reverted to `restartOrDefer()`, HR6 fails (`Expected: true, Received: false` — the busy session is stopped after its turn). Restored, it passes.

## Acceptance Criteria
- [x] A busy session that triggers a `SKILL.md` change is NOT stopped when its turn completes (no deferred restart on the skills path)
- [x] Idle sessions still stop/refresh on a skills change so they pick up the new registry on next spawn (HR1/HR2/HR3/HR5 unchanged, still green)
- [x] The recomposed `CLAUDE.md` is still written to disk before the restart decision (unchanged)
- [x] An integration test asserts a busy session survives a skills reload (HR6), proven to fail on the old code

## Known tradeoff (matches the issue's Out-of-Scope note)
With `skipBusy: true` always on the skills path, a busy session that did *not* trigger the change also keeps its old registry until its next natural spawn (instead of a deferred restart). This is the same tradeoff the workspace watcher already makes for agent-writable files, and is strictly safer than killing active turns. The cross-agent blast radius ("mark stale instead of stop") remains a separate, out-of-scope concern.

## Gates
- `npm run typecheck` clean
- `npm test` — 2511/2511 tests pass. The lone `watch-factory.test.ts` suite flag is a pre-existing parallel-run teardown/open-handle artifact (7/7 in isolation), unrelated to this change (only `src/index.ts` + the integration test are touched).

Closes #223