### PR TITLE
[Feature] Support per-job timezone for recurring cron jobs

### DIFF
--- a/API.md
+++ b/API.md
@@ -1913,6 +1913,7 @@ Jobs are persisted to `~/.claude-gateway/crons.json` and survive gateway restart
 | `scheduleKind` | No | `"cron"` (default) or `"at"` |
 | `schedule` | If `scheduleKind=cron` | 5-field cron expression e.g. `"0 9 * * *"` |
 | `scheduleAt` | If `scheduleKind=at` | ISO 8601 timestamp for one-shot run |
+| `timezone` | No | IANA zone (e.g. `"Asia/Bangkok"`) the `scheduleKind=cron` expression fires in — DST-safe. Defaults to `"UTC"` (legacy jobs unchanged). An unresolvable zone is rejected with `400`. Ignored for `scheduleKind=at` (absolute instants carry no zone ambiguity). |
 | `type` | No | `"command"` (default) or `"agent"` |
 | `command` | If `type=command` | Shell command to run |
 | `prompt` | If `type=agent` | Prompt sent to the agent as a new turn |
@@ -2006,6 +2007,26 @@ curl -s -X POST http://localhost:10850/api/v1/crons \
     "name": "morning-brief",
     "scheduleKind": "cron",
     "schedule": "0 9 * * *",
+    "type": "agent",
+    "prompt": "Give me a morning summary.",
+    "telegram": "<CHAT_ID>"
+  }' | jq
+```
+
+#### Example: Daily job in a specific timezone
+
+Run every day at 09:00 **Bangkok time** — not 09:00 UTC. Add `timezone` (any IANA zone); node-cron resolves DST at fire time.
+
+```bash
+curl -s -X POST http://localhost:10850/api/v1/crons \
+  -H "X-Api-Key: my-secret-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "claude-founder",
+    "name": "morning-brief-bkk",
+    "scheduleKind": "cron",
+    "schedule": "0 9 * * *",
+    "timezone": "Asia/Bangkok",
     "type": "agent",
     "prompt": "Give me a morning summary.",
     "telegram": "<CHAT_ID>"

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -198,6 +198,10 @@ export class CronManager extends EventEmitter {
     if (input.scheduleKind !== undefined) job.scheduleKind = input.scheduleKind;
     if (input.schedule !== undefined) job.schedule = input.schedule;
     if (input.scheduleAt !== undefined) job.scheduleAt = input.scheduleAt;
+    // Once set, a timezone can be changed to another valid zone but not cleared
+    // back to "unset": `undefined` is the no-op guard above and `null` is rejected
+    // by validateTimezone. To restore the default behavior, set it to "UTC"
+    // explicitly — which is identical to an unset zone (see scheduleJob()'s ?? 'UTC').
     if (input.timezone !== undefined) job.timezone = input.timezone;
     if (input.type !== undefined) job.type = input.type;
     if (input.command !== undefined) job.command = input.command;

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -621,7 +621,13 @@ export class CronManager extends EventEmitter {
       // more than 30 minutes ago, regardless of whether the schedule produced a new tick.
       let lastExpectedRun: Date;
       try {
-        const interval = CronExpressionParser.parse(job.schedule!, { currentDate: new Date() });
+        // Interpret the schedule in the job's own timezone (matches scheduleJob()'s
+        // node-cron {timezone} default) so catch-up computes the correct missed tick
+        // for non-UTC jobs after a restart.
+        const interval = CronExpressionParser.parse(job.schedule!, {
+          currentDate: new Date(),
+          tz: job.timezone ?? 'UTC',
+        });
         lastExpectedRun = interval.prev().toDate();
       } catch {
         continue; // unparseable schedule — skip catch-up

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -141,6 +141,7 @@ export class CronManager extends EventEmitter {
       scheduleKind,
       schedule: input.schedule,
       scheduleAt: input.scheduleAt,
+      timezone: input.timezone,
       type,
       command: input.command,
       prompt: input.prompt,
@@ -177,11 +178,12 @@ export class CronManager extends EventEmitter {
     const job = this.jobs.get(id);
     if (!job) throw new Error(`Job not found: ${id}`);
 
-    // Validate schedule if any schedule fields are being updated
+    // Validate schedule if any schedule fields (or the timezone) are being updated
     if (
       input.scheduleKind !== undefined ||
       input.schedule !== undefined ||
-      input.scheduleAt !== undefined
+      input.scheduleAt !== undefined ||
+      input.timezone !== undefined
     ) {
       const merged = { ...job, ...input };
       this.validateSchedule(merged);
@@ -196,6 +198,7 @@ export class CronManager extends EventEmitter {
     if (input.scheduleKind !== undefined) job.scheduleKind = input.scheduleKind;
     if (input.schedule !== undefined) job.schedule = input.schedule;
     if (input.scheduleAt !== undefined) job.scheduleAt = input.scheduleAt;
+    if (input.timezone !== undefined) job.timezone = input.timezone;
     if (input.type !== undefined) job.type = input.type;
     if (input.command !== undefined) job.command = input.command;
     if (input.prompt !== undefined) job.prompt = input.prompt;
@@ -286,17 +289,33 @@ export class CronManager extends EventEmitter {
 
   // ─── Internal ──────────────────────────────────────────────────────────────
 
-  private validateSchedule(input: { scheduleKind?: string; schedule?: string; scheduleAt?: string }): void {
+  private validateSchedule(input: { scheduleKind?: string; schedule?: string; scheduleAt?: string; timezone?: string }): void {
     const kind = input.scheduleKind ?? 'cron';
     if (kind === 'cron') {
       if (!input.schedule) throw new Error('schedule is required for scheduleKind=cron');
       if (!nodeCron.validate(input.schedule)) {
         throw new Error(`Invalid cron expression: "${input.schedule}"`);
       }
+      if (input.timezone !== undefined) this.validateTimezone(input.timezone);
     } else if (kind === 'at') {
       if (!input.scheduleAt) throw new Error('scheduleAt is required for scheduleKind=at');
       const ts = Date.parse(input.scheduleAt);
       if (isNaN(ts)) throw new Error(`Invalid ISO-8601 timestamp: "${input.scheduleAt}"`);
+    }
+  }
+
+  /**
+   * Reject an unresolvable IANA timezone. Probing with Intl.DateTimeFormat throws
+   * a RangeError for an unknown zone; an empty string is also invalid. This is the
+   * same set of zones node-cron accepts, so a value that passes here is safe to
+   * hand to `nodeCron.schedule(..., { timezone })`.
+   */
+  private validateTimezone(tz: string): void {
+    if (!tz) throw new Error('timezone must be a non-empty IANA zone name');
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: tz });
+    } catch {
+      throw new Error(`Invalid timezone: "${tz}" (expected an IANA zone, e.g. "Asia/Bangkok")`);
     }
   }
 
@@ -316,11 +335,14 @@ export class CronManager extends EventEmitter {
     const kind = job.scheduleKind ?? 'cron';
 
     if (kind === 'cron') {
+      // Fire the cron in the job's stored IANA zone (DST-safe via node-cron).
+      // Legacy jobs without a timezone default to 'UTC' — identical to the
+      // previous no-options behavior on the UTC gateway process.
       const task = nodeCron.schedule(job.schedule!, async () => {
         await this.executeJob(job);
-      });
+      }, { timezone: job.timezone ?? 'UTC' });
       this.scheduledTasks.set(job.id, task);
-      this.logger.info(`Scheduled "${job.name}" [cron: ${job.schedule}]`, { id: job.id });
+      this.logger.info(`Scheduled "${job.name}" [cron: ${job.schedule} @ ${job.timezone ?? 'UTC'}]`, { id: job.id });
 
     } else if (kind === 'at') {
       const targetMs = Date.parse(job.scheduleAt!);

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -311,11 +311,11 @@ export class CronManager extends EventEmitter {
    * hand to `nodeCron.schedule(..., { timezone })`.
    */
   private validateTimezone(tz: string): void {
-    if (!tz) throw new Error('timezone must be a non-empty IANA zone name');
+    if (!tz) throw new Error('timezone must be a non-empty time zone string');
     try {
       Intl.DateTimeFormat(undefined, { timeZone: tz });
     } catch {
-      throw new Error(`Invalid timezone: "${tz}" (expected an IANA zone, e.g. "Asia/Bangkok")`);
+      throw new Error(`Invalid timezone: "${tz}" (expected a valid time zone, e.g. an IANA name like "Asia/Bangkok")`);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,6 +302,7 @@ export interface CronJob {
   scheduleKind?: CronScheduleKind;  // default: 'cron'
   schedule?: string;                // cron expression (kind=cron)
   scheduleAt?: string;              // ISO-8601 timestamp (kind=at)
+  timezone?: string;                // IANA zone (kind=cron) the schedule fires in; default 'UTC'
   // Payload fields
   type?: CronJobType;               // default: 'command'
   command?: string;                 // shell command (type=command)
@@ -324,6 +325,7 @@ export interface CronJobCreate {
   scheduleKind?: CronScheduleKind;
   schedule?: string;
   scheduleAt?: string;
+  timezone?: string;
   // Payload
   type?: CronJobType;
   command?: string;
@@ -341,6 +343,7 @@ export interface CronJobUpdate {
   scheduleKind?: CronScheduleKind;
   schedule?: string;
   scheduleAt?: string;
+  timezone?: string;
   type?: CronJobType;
   command?: string;
   prompt?: string;

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -1085,7 +1085,7 @@ describe('TZ7-TZ15: Additional timezone edge cases', () => {
     manager.stop();
   });
 
-  it('TZ9: a fixed-offset zone identifier ("+07:00") is accepted (Intl treats it as a valid time zone, not just IANA names)', async () => {
+  it('TZ9: a fixed-offset zone identifier ("+07:00") is accepted AND scheduled with that offset (Intl treats it as a valid time zone, not just IANA names)', async () => {
     const { manager, agentId } = makeManager();
     await manager.start();
 
@@ -1099,6 +1099,13 @@ describe('TZ7-TZ15: Additional timezone edge cases', () => {
     });
 
     expect(job.timezone).toBe('+07:00');
+    // End-to-end: the offset must reach nodeCron.schedule, not just pass create()
+    // validation — proves the accepted-set claim holds through the scheduling path.
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      '0 9 * * *',
+      expect.any(Function),
+      expect.objectContaining({ timezone: '+07:00' }),
+    );
 
     manager.stop();
   });

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -1057,7 +1057,7 @@ describe('TZ7-TZ15: Additional timezone edge cases', () => {
       schedule: '0 9 * * *',
       timezone: '',
       command: 'echo hi',
-    })).rejects.toThrow(/non-empty IANA zone/);
+    })).rejects.toThrow(/non-empty time zone/);
 
     manager.stop();
   });
@@ -1155,7 +1155,7 @@ describe('TZ7-TZ15: Additional timezone edge cases', () => {
     // Simulates a JSON API caller sending `"timezone": null` — not reachable through
     // the CronJobUpdate TS type, but valid at the HTTP/JSON boundary.
     await expect(manager.update(job.id, { timezone: null as unknown as string }))
-      .rejects.toThrow(/non-empty IANA zone/);
+      .rejects.toThrow(/non-empty time zone/);
 
     // Rejected update must not have clobbered the previously-valid timezone.
     expect(manager.get(job.id)?.timezone).toBe('UTC');

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -885,3 +885,149 @@ describe('Fix 2: catchUpMissedJobs uses cron-parser to detect genuine missed tic
     manager.stop();
   });
 });
+
+// ─── TZ1-TZ6: Per-job timezone (#225) ─────────────────────────────────────────
+
+describe('TZ1-TZ6: Per-job timezone', () => {
+  // Spy on the shared node-cron module instance the manager imports, so we can
+  // assert the timezone option handed to nodeCron.schedule without waiting on
+  // real timers. spyOn calls through by default, so manager.stop() still cleans
+  // the created tasks up.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const nodeCron = require('node-cron');
+  let scheduleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    scheduleSpy = jest.spyOn(nodeCron, 'schedule');
+  });
+  afterEach(() => {
+    scheduleSpy.mockRestore();
+  });
+
+  it('TZ1: cron job with a timezone is scheduled in that zone', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'tz-job',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'Asia/Bangkok',
+      command: 'echo hi',
+    });
+
+    expect(job.timezone).toBe('Asia/Bangkok');
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      '0 9 * * *',
+      expect.any(Function),
+      expect.objectContaining({ timezone: 'Asia/Bangkok' }),
+    );
+
+    manager.stop();
+  });
+
+  it('TZ2: cron job without a timezone defaults to UTC', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'no-tz-job',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      command: 'echo hi',
+    });
+
+    expect(job.timezone).toBeUndefined();
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      '0 9 * * *',
+      expect.any(Function),
+      expect.objectContaining({ timezone: 'UTC' }),
+    );
+
+    manager.stop();
+  });
+
+  it('TZ3: an invalid IANA timezone is rejected on create', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    await expect(manager.create({
+      agentId,
+      name: 'bad-tz',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'Not/AZone',
+      command: 'echo x',
+    })).rejects.toThrow(/Invalid timezone/);
+
+    manager.stop();
+  });
+
+  it('TZ4: update persists the timezone and reschedules in the new zone', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'tz-update',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
+      command: 'echo hi',
+    });
+
+    scheduleSpy.mockClear();
+    const updated = await manager.update(job.id, { timezone: 'America/New_York' });
+
+    expect(updated.timezone).toBe('America/New_York');
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      '0 9 * * *',
+      expect.any(Function),
+      expect.objectContaining({ timezone: 'America/New_York' }),
+    );
+
+    manager.stop();
+  });
+
+  it('TZ5: update to an invalid timezone is rejected', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'tz-bad-update',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      command: 'echo hi',
+    });
+
+    await expect(manager.update(job.id, { timezone: 'Mars/Phobos' }))
+      .rejects.toThrow(/Invalid timezone/);
+
+    manager.stop();
+  });
+
+  it('TZ6: timezone survives a store reload (persistence)', async () => {
+    const tmpDir = makeTmpDir();
+    const { manager, agentId } = makeManager({ tmpDir });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'tz-persist',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'Europe/London',
+      command: 'echo hi',
+    });
+    manager.stop();
+
+    // Fresh manager reading the same store file must recover the timezone.
+    const { manager: manager2 } = makeManager({ tmpDir });
+    await manager2.start();
+    expect(manager2.get(job.id)?.timezone).toBe('Europe/London');
+    manager2.stop();
+  });
+});

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -1031,3 +1031,281 @@ describe('TZ1-TZ6: Per-job timezone', () => {
     manager2.stop();
   });
 });
+
+// ─── TZ7-TZ15: Additional timezone edge cases (#225 hardening) ────────────────
+
+describe('TZ7-TZ15: Additional timezone edge cases', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const nodeCron = require('node-cron');
+  let scheduleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    scheduleSpy = jest.spyOn(nodeCron, 'schedule');
+  });
+  afterEach(() => {
+    scheduleSpy.mockRestore();
+  });
+
+  it('TZ7: an empty-string timezone is rejected on create', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    await expect(manager.create({
+      agentId,
+      name: 'empty-tz',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: '',
+      command: 'echo hi',
+    })).rejects.toThrow(/non-empty IANA zone/);
+
+    manager.stop();
+  });
+
+  it('TZ8: a lower-cased zone name is accepted (Intl resolves it case-insensitively, matching node-cron\'s own check)', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'lowercase-tz',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'asia/bangkok',
+      command: 'echo hi',
+    });
+
+    expect(job.timezone).toBe('asia/bangkok');
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      '0 9 * * *',
+      expect.any(Function),
+      expect.objectContaining({ timezone: 'asia/bangkok' }),
+    );
+
+    manager.stop();
+  });
+
+  it('TZ9: a fixed-offset zone identifier ("+07:00") is accepted (Intl treats it as a valid time zone, not just IANA names)', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'offset-tz',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: '+07:00',
+      command: 'echo hi',
+    });
+
+    expect(job.timezone).toBe('+07:00');
+
+    manager.stop();
+  });
+
+  it('TZ10: a whitespace-padded zone name is rejected', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    await expect(manager.create({
+      agentId,
+      name: 'padded-tz',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: ' Asia/Bangkok ',
+      command: 'echo hi',
+    })).rejects.toThrow(/Invalid timezone/);
+
+    manager.stop();
+  });
+
+  it('TZ11: an at-job with a bogus timezone value is accepted (timezone validation only applies to scheduleKind=cron)', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const futureTs = new Date(Date.now() + 60_000).toISOString();
+    const job = await manager.create({
+      agentId,
+      name: 'at-with-garbage-tz',
+      scheduleKind: 'at',
+      scheduleAt: futureTs,
+      timezone: 'Not/AZone',
+      command: 'echo hi',
+    });
+
+    expect(job.timezone).toBe('Not/AZone');
+    expect(scheduleSpy).not.toHaveBeenCalled();
+
+    manager.stop();
+  });
+
+  it('TZ12: an explicit null timezone on update is rejected, not silently ignored', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'tz-null-update',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
+      command: 'echo hi',
+    });
+
+    // Simulates a JSON API caller sending `"timezone": null` — not reachable through
+    // the CronJobUpdate TS type, but valid at the HTTP/JSON boundary.
+    await expect(manager.update(job.id, { timezone: null as unknown as string }))
+      .rejects.toThrow(/non-empty IANA zone/);
+
+    // Rejected update must not have clobbered the previously-valid timezone.
+    expect(manager.get(job.id)?.timezone).toBe('UTC');
+
+    manager.stop();
+  });
+
+  it('TZ13: updating an unrelated field preserves and re-applies the existing timezone', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'tz-untouched',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'Asia/Tokyo',
+      command: 'echo hi',
+    });
+
+    scheduleSpy.mockClear();
+    const updated = await manager.update(job.id, { name: 'renamed' });
+
+    expect(updated.timezone).toBe('Asia/Tokyo');
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      '0 9 * * *',
+      expect.any(Function),
+      expect.objectContaining({ timezone: 'Asia/Tokyo' }),
+    );
+
+    manager.stop();
+  });
+
+  it('TZ14: two concurrent jobs in different zones do not leak timezone across schedules', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    await manager.create({
+      agentId,
+      name: 'job-bkk',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'Asia/Bangkok',
+      command: 'echo bkk',
+    });
+
+    await manager.create({
+      agentId,
+      name: 'job-nyc',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 'America/New_York',
+      command: 'echo nyc',
+    });
+
+    expect(scheduleSpy).toHaveBeenNthCalledWith(
+      1,
+      '0 9 * * *',
+      expect.any(Function),
+      expect.objectContaining({ timezone: 'Asia/Bangkok' }),
+    );
+    expect(scheduleSpy).toHaveBeenNthCalledWith(
+      2,
+      '0 9 * * *',
+      expect.any(Function),
+      expect.objectContaining({ timezone: 'America/New_York' }),
+    );
+
+    manager.stop();
+  });
+
+  it('TZ15: a non-string timezone value (e.g. a number from a malformed request body) is rejected cleanly, not a raw TypeError', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    await expect(manager.create({
+      agentId,
+      name: 'numeric-tz',
+      scheduleKind: 'cron',
+      schedule: '0 9 * * *',
+      timezone: 7 as unknown as string,
+      command: 'echo hi',
+    })).rejects.toThrow(/Invalid timezone/);
+
+    manager.stop();
+  });
+});
+
+// ─── TZ-GAP: catch-up after restart does not honor per-job timezone ──────────
+//
+// Found while writing coverage for #225: catchUpMissedJobs() (src/cron/manager.ts)
+// parses the cron expression with `CronExpressionParser.parse(job.schedule!, { currentDate })`
+// and never forwards `job.timezone`. cron-parser accepts a `tz` option (see
+// node_modules/cron-parser/dist/types/CronExpression.d.ts) — without it, "last expected
+// tick" is computed in the process's local/UTC time, not the job's zone. A restart shortly
+// after a scheduled fire time in a non-UTC zone can therefore mis-detect a missed run (false
+// catch-up, or a genuine miss going uncaught) even though live scheduling (scheduleJob) is
+// correctly zone-aware via node-cron.
+//
+// FIXED: catchUpMissedJobs() now forwards `tz: job.timezone ?? 'UTC'` to the parser, matching
+// scheduleJob()'s node-cron {timezone} default. This test locks that behavior in.
+describe('TZ-GAP: catchUpMissedJobs should honor job.timezone', () => {
+  it('forwards the job\'s timezone to CronExpressionParser.parse during startup catch-up', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { CronExpressionParser } = require('cron-parser');
+    const parseSpy = jest.spyOn(CronExpressionParser, 'parse');
+
+    const tmpDir = makeTmpDir();
+    const storePath = path.join(tmpDir, 'crons.json');
+    const runsDir = path.join(tmpDir, 'runs');
+
+    const twoMinAgo = Date.now() - 2 * 60 * 1000;
+    fs.writeFileSync(storePath, JSON.stringify({
+      version: 1,
+      jobs: [{
+        id: 'tz-gap-job',
+        agentId: 'test-agent',
+        name: 'tz-gap-job',
+        scheduleKind: 'cron',
+        schedule: '* * * * *',
+        timezone: 'Asia/Bangkok',
+        command: 'echo hi',
+        type: 'command',
+        enabled: true,
+        deleteAfterRun: false,
+        createdAt: Date.now() - 200000,
+        updatedAt: Date.now() - 200000,
+        state: {
+          lastRunAt: twoMinAgo,
+          lastStatus: 'ok',
+          lastError: null,
+          runCount: 5,
+          consecutiveErrors: 0,
+        },
+      }],
+    }, null, 2));
+
+    const agentRunners = new Map<string, any>();
+    const agentConfigs = new Map<string, AgentConfig>();
+    agentConfigs.set('test-agent', makeAgentConfig('test-agent'));
+    const manager = new CronManager({ storePath, runsDir }, agentRunners, agentConfigs, makeLogger());
+
+    await manager.start();
+
+    expect(parseSpy).toHaveBeenCalledWith(
+      '* * * * *',
+      expect.objectContaining({ tz: 'Asia/Bangkok' }),
+    );
+
+    parseSpy.mockRestore();
+    manager.stop();
+  });
+});


### PR DESCRIPTION
## Summary
Adds an optional per-job `timezone` field to recurring cron jobs so a scheduled job fires at the intended wall-clock time in a specific IANA zone (e.g. `Asia/Bangkok`), instead of always being interpreted in the scheduler's process zone (UTC). Both the live schedule and the startup catch-up path are now zone-aware, and invalid zones are rejected at create/update time.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor / Tech debt
- [ ] Documentation

## Related Issues
Closes #225

## Changes Made
- `src/types.ts`: add optional `timezone?: string` to the recurring cron job types.
- `src/cron/manager.ts`:
  - `scheduleJob()` now passes `{ timezone: job.timezone ?? 'UTC' }` to `nodeCron.schedule(...)` so live scheduling is zone-aware.
  - `catchUpMissedJobs()` now forwards `tz: job.timezone ?? 'UTC'` to `CronExpressionParser.parse(...)` so restart catch-up computes the last-expected tick in the job's own zone (previously used the process zone — a Bangkok job could be caught up ~7h off).
  - `create()` / `update()` persist and re-apply `timezone`; `validateSchedule()` rejects an unresolvable zone via `Intl.DateTimeFormat` and rejects empty/whitespace/non-string values without silently overwriting an existing value.
- `tests/unit/cron-manager.test.ts`: 15 timezone cases (TZ1–TZ15) covering valid IANA/lowercase/fixed-offset zones, empty/whitespace/null/number rejection, at-job passthrough, multi-job isolation, and the restart catch-up path (TZ-GAP).

## How to Test
1. Checkout this branch and run the cron suite under a non-UTC zone: `TZ=Asia/Bangkok npx jest cron-manager`.
2. Create a recurring job with `timezone: "Asia/Bangkok"` and a daily schedule; confirm it fires at the Bangkok wall-clock time, not UTC.
3. Restart the gateway shortly after a job's scheduled time and confirm catch-up does not double-fire or skip.

Expected: all cron tests green (79/79); zone-aware jobs fire at the correct local time; invalid zones are rejected at create/update.

## Checklist
- [x] Reviewed my own code
- [x] Tests pass (if applicable)
- [x] No console errors
