### PR TITLE
fix(cron): honor agent allow_tools for scheduled agent jobs

### DIFF
--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -512,8 +512,13 @@ export class CronManager extends EventEmitter {
 
     const sessionId = `cron-${job.id}`;
     const timeoutMs = job.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    // Resolve the agent's tool policy the same way the API request path does
+    // (src/api/router.ts) so a cron job honors the agent's `allow_tools` setting.
+    // Without this, sendApiMessage() defaults a missing option to `false` and every
+    // cron turn runs with tools disabled regardless of the agent's configuration.
+    const allowTools = this.agentConfigs.get(job.agentId)?.allow_tools ?? false;
 
-    const { text } = await runner.sendApiMessage(sessionId, `cron-${job.id}`, job.prompt!, { timeoutMs });
+    const { text } = await runner.sendApiMessage(sessionId, `cron-${job.id}`, job.prompt!, { timeoutMs, allowTools });
     return text;
   }
 

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -512,10 +512,11 @@ export class CronManager extends EventEmitter {
 
     const sessionId = `cron-${job.id}`;
     const timeoutMs = job.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    // Resolve the agent's tool policy the same way the API request path does
-    // (src/api/router.ts) so a cron job honors the agent's `allow_tools` setting.
-    // Without this, sendApiMessage() defaults a missing option to `false` and every
-    // cron turn runs with tools disabled regardless of the agent's configuration.
+    // Honor the agent's `allow_tools` setting for cron turns, mirroring the API
+    // request path (src/api/router.ts). Cron has no API key, so an unset value
+    // falls back to the secure default (false) rather than the router's apiKey
+    // fallback. Without this, sendApiMessage() defaults the missing option to
+    // `false` and every cron turn runs with tools disabled regardless of config.
     const allowTools = this.agentConfigs.get(job.agentId)?.allow_tools ?? false;
 
     const { text } = await runner.sendApiMessage(sessionId, `cron-${job.id}`, job.prompt!, { timeoutMs, allowTools });

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -283,6 +283,48 @@ describe('T6-T10: Agent type payload', () => {
   });
 });
 
+// ─── T-allowTools: agent tool policy is honored (regression for allow_tools bug) ─
+
+describe('T-allowTools: cron honors the agent allow_tools setting', () => {
+  async function runAgentJob(allowTools: boolean | undefined) {
+    const runner = makeRunner('ok');
+    const { manager, agentId, agentConfigs } = makeManager({ runner, botToken: 'BOT' });
+    // Set the agent's tool policy the same way the UI toggle persists it to config.
+    agentConfigs.get(agentId)!.allow_tools = allowTools;
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'tool-policy',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'do work',
+      telegram: '12345',
+    });
+
+    await manager.run(job.id);
+    const opts = (runner.sendApiMessage as jest.Mock).mock.calls[0][3];
+    manager.stop();
+    return opts;
+  }
+
+  it('forwards allowTools: true when agent.allow_tools is true', async () => {
+    const opts = await runAgentJob(true);
+    expect(opts).toEqual(expect.objectContaining({ allowTools: true }));
+  });
+
+  it('forwards allowTools: false when agent.allow_tools is false', async () => {
+    const opts = await runAgentJob(false);
+    expect(opts).toEqual(expect.objectContaining({ allowTools: false }));
+  });
+
+  it('defaults allowTools to false when agent.allow_tools is unset', async () => {
+    const opts = await runAgentJob(undefined);
+    expect(opts).toEqual(expect.objectContaining({ allowTools: false }));
+  });
+});
+
 // ─── T11-T13: Telegram delivery ───────────────────────────────────────────────
 
 describe('T11-T13: Telegram delivery', () => {


### PR DESCRIPTION
## Summary
Cron jobs of `type: agent` were dispatched through `sendApiMessage()` without an `allowTools` option, so it defaulted to `false` on every cron turn — scheduled agent tasks always ran with tools disabled, ignoring the agent's `allow_tools` setting (and the UI "Allow Tools (API)" toggle that persists it). This resolves `allowTools` from the agent config in `runAgentTurn()` and forwards it, mirroring the direct API request path.

## Related Issue
Closes #228

## Changes Made
- `src/cron/manager.ts`: in `runAgentTurn()`, resolve `allowTools` from `this.agentConfigs.get(job.agentId)?.allow_tools ?? false` and pass it to `sendApiMessage`. The `agentConfigs` map was already available (used for the bot-token lookup). Secure default (`false` when unset) is preserved.
- `tests/unit/cron-manager.test.ts`: add regression tests asserting the resolved `allowTools` is forwarded for the `true` / `false` / unset cases.

## Testing
- `npm run typecheck`: pass
- `npm test`: 131 suites / 2537 tests pass (the `workspace-loader` suite is flaky under parallel load due to a temp-dir race unrelated to this change — it passes in isolation and on a clean re-run)
- Regression proof: reverting the one-line call-site change makes all three new tests fail (no `allowTools` key forwarded), confirming they exercise the bug.
