### PR TITLE
fix(security): require auth for dashboard/status/processes on non-loopback bind

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,7 +16,7 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 | `GET` | `/status` | Key or dashboard session¹ | Per-agent stats + heartbeat history |
 | `GET` | `/processes` | Key or dashboard session¹ | Host process tree for the dashboard |
 | `GET` | `/dashboard` | Session cookie¹ | Web UI dashboard (serves the login page when unauthenticated) |
-| `POST` | `/dashboard/login` | None (validates a key) | Exchange an API key for an `HttpOnly` `dash_session` cookie (8h) |
+| `POST` | `/dashboard/login` | None (validates a key) | Exchange an API key for an `HttpOnly; SameSite=Lax` `dash_session` cookie (8h). Brute-force throttled per IP (`429` after 10 failed attempts / 5 min) |
 | `POST` | `/dashboard/logout` | Session cookie | Revoke the dashboard session and clear the cookie |
 | `GET` | `/api/v1/commands` | None | List slash commands available in the chat UI |
 
@@ -213,8 +213,8 @@ each session of an agent is an isolated stream.
 | `POST` | `/api/v1/pty-stream-ticket` | Key *or* dashboard session | Exchange an API key **or** the `dash_session` cookie for a one-time, 30s-TTL ticket bound to a specific `{ agentId, sessionId }` |
 | `WS` | `/api/v1/agents/:agentId/pty-stream` | Ticket *or* Key | Subscribe to the live PTY stream for one session |
 
-> The browser dashboard authenticates with the `HttpOnly` `dash_session` cookie
-> (from `POST /dashboard/login`), which is sent automatically — it no longer embeds
+> The browser dashboard authenticates with the `HttpOnly; SameSite=Lax` `dash_session`
+> cookie (from `POST /dashboard/login`), which is sent automatically — it no longer embeds
 > any token in the page. `POST /api/v1/pty-stream-ticket` accepts that cookie, so
 > the ticket flow works without a token in the HTML or the WS URL.
 

--- a/API.md
+++ b/API.md
@@ -20,11 +20,14 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 | `POST` | `/dashboard/logout` | Session cookie | Revoke the dashboard session and clear the cookie |
 | `GET` | `/api/v1/commands` | None | List slash commands available in the chat UI |
 
-¹ **Auth applies only when `gateway.api.keys` is configured.** With no keys, these
-endpoints stay open (a keyless install has no credential to check). "Key or dashboard
-session" accepts an API key (`X-Api-Key` / `Authorization: Bearer`) **or** the
-`dash_session` cookie issued by `POST /dashboard/login`. When bound to a non-loopback
-interface (`gateway.bind = 0.0.0.0`), configure API keys so these are not world-readable.
+¹ **Auth applies when `gateway.api.keys` is configured.** "Key or dashboard session"
+accepts an API key (`X-Api-Key` / `Authorization: Bearer`) **or** the `dash_session`
+cookie issued by `POST /dashboard/login`. With **no** keys configured the behavior
+depends on the bind: on a **loopback** bind (`127.0.0.1`) they stay open (a keyless
+local install has no credential to check); on a **non-loopback** bind (`0.0.0.0` or a
+real IP) they **fail closed** — `/status`, `/processes`, and `/dashboard` return `503`
+until `gateway.api.keys` is set, so the surface is never exposed unauthenticated to the
+network. `/health` stays public in all cases.
 
 ### Agent API
 

--- a/API.md
+++ b/API.md
@@ -12,10 +12,19 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| `GET` | `/health` | None | Health check — status + agent list |
-| `GET` | `/status` | None | Per-agent stats + heartbeat history |
-| `GET` | `/ui` | None | Web UI dashboard |
+| `GET` | `/health` | None | Liveness only — returns `{"status":"ok"}` (no agent list) |
+| `GET` | `/status` | Key or dashboard session¹ | Per-agent stats + heartbeat history |
+| `GET` | `/processes` | Key or dashboard session¹ | Host process tree for the dashboard |
+| `GET` | `/dashboard` | Session cookie¹ | Web UI dashboard (serves the login page when unauthenticated) |
+| `POST` | `/dashboard/login` | None (validates a key) | Exchange an API key for an `HttpOnly` `dash_session` cookie (8h) |
+| `POST` | `/dashboard/logout` | Session cookie | Revoke the dashboard session and clear the cookie |
 | `GET` | `/api/v1/commands` | None | List slash commands available in the chat UI |
+
+¹ **Auth applies only when `gateway.api.keys` is configured.** With no keys, these
+endpoints stay open (a keyless install has no credential to check). "Key or dashboard
+session" accepts an API key (`X-Api-Key` / `Authorization: Bearer`) **or** the
+`dash_session` cookie issued by `POST /dashboard/login`. When bound to a non-loopback
+interface (`gateway.bind = 0.0.0.0`), configure API keys so these are not world-readable.
 
 ### Agent API
 
@@ -186,7 +195,8 @@ curl -s http://localhost:10850/api/v1/sessions/<sessionId>/screen \
 The `sessionId` is the gateway session UUID. Find it from the process list:
 
 ```bash
-curl -s http://localhost:10850/processes | grep -o 'sessions/[^/]*' | head -1
+# /processes requires an API key when gateway.api.keys is configured
+curl -s -H "X-Api-Key: $KEY" http://localhost:10850/processes | grep -o 'sessions/[^/]*' | head -1
 ```
 
 #### Live screen stream (WebSocket)
@@ -197,8 +207,13 @@ each session of an agent is an isolated stream.
 
 | Endpoint | Auth | Description |
 |----------|------|-------------|
-| `POST` | `/api/v1/pty-stream-ticket` | Key | Exchange an API key for a one-time, 30s-TTL ticket bound to a specific `{ agentId, sessionId }` |
+| `POST` | `/api/v1/pty-stream-ticket` | Key *or* dashboard session | Exchange an API key **or** the `dash_session` cookie for a one-time, 30s-TTL ticket bound to a specific `{ agentId, sessionId }` |
 | `WS` | `/api/v1/agents/:agentId/pty-stream` | Ticket *or* Key | Subscribe to the live PTY stream for one session |
+
+> The browser dashboard authenticates with the `HttpOnly` `dash_session` cookie
+> (from `POST /dashboard/login`), which is sent automatically — it no longer embeds
+> any token in the page. `POST /api/v1/pty-stream-ticket` accepts that cookie, so
+> the ticket flow works without a token in the HTML or the WS URL.
 
 **Auth path 1 — ephemeral ticket (used by the browser viewer):**
 
@@ -236,24 +251,29 @@ Closes with code `4404` if the session is not running in PTY mode.
 
 ### GET /health
 
-Health check. No auth required.
+Liveness check. No auth required. Intentionally minimal — it returns **only**
+liveness so it is safe to expose to external probes even when the gateway is bound
+to a non-loopback interface. Agent ids moved to `/status` (authenticated).
 
 ```bash
 curl http://localhost:10850/health
 ```
 
 ```json
-{ "status": "ok", "agents": ["alfred", "claude-founder"] }
+{ "status": "ok" }
 ```
 
 ---
 
 ### GET /status
 
-Per-agent stats and heartbeat history. No auth required.
+Per-agent stats and heartbeat history. **Requires an API key or a dashboard session
+cookie when `gateway.api.keys` is configured** (open otherwise). Returns 401 when
+keys are set and no valid credential is supplied.
 
 ```bash
-curl http://localhost:10850/status | jq
+# API key
+curl -H "X-Api-Key: $KEY" http://localhost:10850/status | jq
 ```
 
 ```json

--- a/README.md
+++ b/README.md
@@ -325,9 +325,11 @@ Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (l
 > dashboard session when keys are configured — the dashboard prompts for an API
 > key at `/dashboard` and stores an `HttpOnly` session cookie. `/health` stays
 > public but returns only `{"status":"ok"}` (no agent ids). With **no** keys
-> configured these endpoints stay open, so on a non-loopback bind always set keys.
-> The gateway serves plain HTTP; put TLS in front (reverse proxy) so credentials
-> are not sent in the clear.
+> configured the gateway **fails closed on a non-loopback bind**: `/status`,
+> `/processes`, and `/dashboard` return `503` until you set `gateway.api.keys`
+> (a startup warning is logged). On a loopback bind they stay open, so local
+> keyless installs are unaffected. The gateway serves plain HTTP; put TLS in
+> front (reverse proxy) so credentials are not sent in the clear.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -320,6 +320,15 @@ Recovery actions are clamped to a per-stage whitelist and a per-turn budget, and
 
 Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (localhost-only), so the dashboard and API are **not** exposed to the local network out of the box. Set to `0.0.0.0` to listen on all interfaces (for example when a containerized reverse proxy needs to reach the gateway). The `GATEWAY_BIND` environment variable, when set, takes precedence over this field.
 
+> **⚠️ Binding to `0.0.0.0`? Configure `gateway.api.keys`.** The monitoring
+> surface (`/status`, `/processes`) and the dashboard require an API key or a
+> dashboard session when keys are configured — the dashboard prompts for an API
+> key at `/dashboard` and stores an `HttpOnly` session cookie. `/health` stays
+> public but returns only `{"status":"ok"}` (no agent ids). With **no** keys
+> configured these endpoints stay open, so on a non-loopback bind always set keys.
+> The gateway serves plain HTTP; put TLS in front (reverse proxy) so credentials
+> are not sent in the clear.
+
 ```json
 {
   "gateway": {
@@ -336,8 +345,8 @@ The dashboard's **Terminal Viewer** opens read-only (a live mirror of the PTY). 
 
 Because interactive mode turns a read-only view into a remote-write surface, access is protected upstream rather than by a feature flag:
 
-- **Authentication** — the WebSocket requires a valid dashboard ticket or API key.
-- **`gateway.bind`** — the gateway binds to `127.0.0.1` (localhost) by default, so the dashboard is not reachable from the network out of the box. Expose a non-loopback bind (`0.0.0.0`) **only** behind a trusted authenticating reverse proxy.
+- **Authentication** — the WebSocket requires a valid dashboard ticket or API key. The ticket is minted at `POST /api/v1/pty-stream-ticket`, which itself requires an API key or a valid dashboard session cookie — so an unauthenticated caller cannot obtain one. The dashboard gets its session by logging in with an API key at `/dashboard` (`HttpOnly` cookie); no token is embedded in the page.
+- **`gateway.bind`** — the gateway binds to `127.0.0.1` (localhost) by default, so the dashboard is not reachable from the network out of the box. On a non-loopback bind (`0.0.0.0`), configure `gateway.api.keys` so the dashboard and monitoring endpoints require authentication, and prefer a TLS-terminating reverse proxy so credentials are not sent in the clear.
 
 Inbound frames are always bounded (text-only, size-capped) and are dropped for headless sessions (no PTY).
 

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -14,7 +14,7 @@ import { shouldRoutePtyInput, MAX_PTY_INPUT_BYTES } from '../shell/control-chann
 import { getWatcherHealth } from '../watch/factory';
 import { CronScheduler } from '../cron/scheduler';
 import { CronManager } from '../cron/manager';
-import { generateDashboardHtml } from '../ui/web-ui';
+import { generateDashboardHtml, generateLoginHtml } from '../ui/web-ui';
 import { createApiRouter } from './router';
 import { createCronRouter } from './cron-router';
 import { createWorkspaceRouter } from './workspace-router';
@@ -28,6 +28,52 @@ import { createAppsRouter } from './apps-router';
 import { ComposePort } from '../apps/compose-generator';
 
 const APP_NAME_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
+
+/** Name of the HttpOnly cookie carrying a dashboard session token. */
+const DASH_SESSION_COOKIE = 'dash_session';
+/** Dashboard session lifetime — long enough to avoid re-login mid-work. */
+const DASH_SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+
+/**
+ * Parse a Cookie request header into a name→value map. Manual parser so we take
+ * no new dependency (cookie-parser) just for a single cookie. Values are
+ * URL-decoded; malformed segments are skipped.
+ */
+function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const name = part.slice(0, eq).trim();
+    if (!name) continue;
+    try {
+      out[name] = decodeURIComponent(part.slice(eq + 1).trim());
+    } catch {
+      out[name] = part.slice(eq + 1).trim();
+    }
+  }
+  return out;
+}
+
+/**
+ * Timing-safe comparison of a presented token against the configured API keys.
+ * Mirrors createApiAuthMiddleware (auth.ts) so the inline auth on the
+ * dashboard-adjacent endpoints is not weaker than the /api middleware.
+ */
+function timingSafeKeyMatch(apiKeys: ApiKey[], token: string): boolean {
+  if (!token) return false;
+  const tokenBuf = Buffer.from(token);
+  return apiKeys.some((k) => {
+    try {
+      const keyBuf = Buffer.from(k.key);
+      if (keyBuf.length !== tokenBuf.length) return false;
+      return crypto.timingSafeEqual(keyBuf, tokenBuf);
+    } catch {
+      return false;
+    }
+  });
+}
 
 function getGatewayVersion(): string {
   try {
@@ -213,6 +259,48 @@ export class GatewayRouter {
     this.setupRoutes();
   }
 
+  /** Configured API keys ([] when none set — auth is then disabled/open). */
+  private get apiKeys(): ApiKey[] {
+    return this.gatewayConfig?.gateway?.api?.keys ?? [];
+  }
+
+  /** Extract a Bearer / X-Api-Key token from request headers. */
+  private extractApiToken(req: Request): string {
+    const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
+    const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
+    return authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
+  }
+
+  /** True when the request carries a live (unexpired) dashboard session cookie. */
+  private hasValidDashSession(req: Request): boolean {
+    const token = parseCookies(req.headers['cookie'])[DASH_SESSION_COOKIE];
+    if (!token) return false;
+    const exp = this.dashboardTokens.get(token) ?? 0;
+    return exp > Date.now();
+  }
+
+  /**
+   * Gate a dashboard-adjacent endpoint: accept a valid API key OR a live
+   * dashboard session cookie. When no API keys are configured, auth is disabled
+   * (open) — a keyless install has no credential to check and must not lock
+   * itself out. Writes 401 and returns false when unauthorized.
+   */
+  private requireDashOrApiKey(req: Request, res: Response): boolean {
+    const keys = this.apiKeys;
+    if (keys.length === 0) return true; // no auth configured → open, as before
+    if (timingSafeKeyMatch(keys, this.extractApiToken(req))) return true;
+    if (this.hasValidDashSession(req)) return true;
+    res.status(401).json({ error: 'Unauthorized' });
+    return false;
+  }
+
+  /** Build the Set-Cookie value for the dashboard session (Secure when TLS). */
+  private buildSessionCookie(req: Request, token: string, ttlMs: number): string {
+    const secure = req.secure || req.headers['x-forwarded-proto'] === 'https' ? '; Secure' : '';
+    const maxAge = Math.max(0, Math.floor(ttlMs / 1000));
+    return `${DASH_SESSION_COOKIE}=${token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=${maxAge}${secure}`;
+  }
+
   private setupRoutes(): void {
     if (process.env.DEV_MODE) {
       process.stderr.write('[gateway] DEV_MODE=1 active — module cache busted on every /dashboard request. Never enable in production.\n');
@@ -230,32 +318,14 @@ export class GatewayRouter {
 
     // Ephemeral WS ticket — exchange a short-lived token for PTY stream access.
     // MUST be registered before the apiRouter middleware so it handles its own auth
-    // (dashboard token or API key) without the apiRouter's auth gate intercepting first.
+    // without the apiRouter's auth gate intercepting first.
     // The ticket is one-time-use with a 30s TTL so neither the API key nor the
-    // dashboard token appears in WS URLs (server access logs / browser history).
-    // Accepts two credential types:
+    // dashboard session appears in WS URLs (server access logs / browser history).
+    // Accepts two credential types (via requireDashOrApiKey):
     //   • X-Api-Key / Bearer — full API key (programmatic clients)
-    //   • X-Dash-Token       — dashboard session token (browser, 10 min, issued at /dashboard)
+    //   • dash_session cookie — dashboard session (browser, issued at /dashboard/login)
     this.app.post('/api/v1/pty-stream-ticket', (req: Request, res: Response) => {
-      const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
-      const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
-      const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
-      const xDashToken = (req.headers['x-dash-token'] as string | undefined) ?? '';
-      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
-
-      // Validate: API key OR a live dashboard token.
-      const now = Date.now();
-      const dashExpiry = xDashToken ? (this.dashboardTokens.get(xDashToken) ?? 0) : 0;
-      const dashValid = dashExpiry > now;
-      if (dashValid) {
-        // Dashboard tokens are one-time-use: revoke immediately after auth so a
-        // leaked page source can't be replayed (each /dashboard visit gets a fresh one).
-        this.dashboardTokens.delete(xDashToken);
-      }
-      if (!dashValid && (!token || !apiKeys.some((k) => k.key === token))) {
-        res.status(401).json({ error: 'Unauthorized' });
-        return;
-      }
+      if (!this.requireDashOrApiKey(req, res)) return;
       const body = (req.body as { agentId?: string; sessionId?: string }) ?? {};
       const agentId = body.agentId ?? '';
       const sessionId = body.sessionId ?? '';
@@ -402,34 +472,67 @@ export class GatewayRouter {
       }
     });
 
-    // Health check
+    // Health check — intentionally minimal. Public (no auth) so external liveness
+    // probes work when bound to a non-loopback interface, but it leaks nothing:
+    // no agent ids, no version, just liveness.
     this.app.get('/health', (_req: Request, res: Response) => {
-      res.json({ status: 'ok', agents: [...this.agents.keys()] });
+      res.json({ status: 'ok' });
     });
 
-    // Web dashboard
-    this.app.get('/dashboard', (_req: Request, res: Response) => {
-      // Issue a short-lived dashboard token (10 min) instead of embedding the raw
-      // API key in the HTML. A view-source leak exposes only a token that can
-      // exclusively obtain PTY stream tickets — not make arbitrary API calls.
-      const dashToken = crypto.randomBytes(16).toString('hex');
-      this.dashboardTokens.set(dashToken, Date.now() + 10 * 60 * 1000);
+    // Web dashboard. When API keys are configured, require a live dashboard
+    // session cookie; otherwise serve the login page (API-key form). Keyless
+    // installs have no credential to check, so the dashboard stays open there —
+    // matching how the /api routers are only mounted when keys exist.
+    this.app.get('/dashboard', (req: Request, res: Response) => {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      if (this.apiKeys.length > 0 && !this.hasValidDashSession(req)) {
+        res.send(generateLoginHtml());
+        return;
+      }
       if (process.env.DEV_MODE) {
         // Hot-reload: bust module cache so each browser refresh picks up the latest compiled web-ui.js
         const webUiPath = require.resolve('../ui/web-ui');
         delete require.cache[webUiPath];
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { generateDashboardHtml: fresh } = require('../ui/web-ui') as typeof import('../ui/web-ui');
-        res.send(fresh(dashToken));
+        res.send(fresh());
       } else {
-        res.send(generateDashboardHtml(dashToken));
+        res.send(generateDashboardHtml());
       }
+    });
+
+    // Dashboard login — exchange a configured API key for an HttpOnly session
+    // cookie (multi-use, 8h). The cookie is never readable by page JS / view-source,
+    // so it can safely gate the dashboard reads and the PTY-ticket exchange.
+    this.app.post('/dashboard/login', (req: Request, res: Response) => {
+      const keys = this.apiKeys;
+      if (keys.length === 0) {
+        res.status(404).json({ error: 'Auth not configured' });
+        return;
+      }
+      const key = ((req.body as { key?: string })?.key ?? '').toString();
+      if (!timingSafeKeyMatch(keys, key)) {
+        res.status(401).json({ error: 'Invalid API key' });
+        return;
+      }
+      const token = crypto.randomBytes(32).toString('hex');
+      this.dashboardTokens.set(token, Date.now() + DASH_SESSION_TTL_MS);
+      res.setHeader('Set-Cookie', this.buildSessionCookie(req, token, DASH_SESSION_TTL_MS));
+      res.json({ ok: true });
+    });
+
+    // Dashboard logout — revoke the session token and clear the cookie.
+    this.app.post('/dashboard/logout', (req: Request, res: Response) => {
+      const token = parseCookies(req.headers['cookie'])[DASH_SESSION_COOKIE];
+      if (token) this.dashboardTokens.delete(token);
+      res.setHeader('Set-Cookie', this.buildSessionCookie(req, '', 0));
+      res.json({ ok: true });
     });
 
     // Process tree endpoint — returns raw ps data for dashboard.
     // Async exec + 3s cache: avoids blocking the event loop on every dashboard poll.
-    this.app.get('/processes', (_req: Request, res: Response) => {
+    this.app.get('/processes', (req: Request, res: Response) => {
+      if (!this.requireDashOrApiKey(req, res)) return;
       const now = Date.now();
       if (this.processesCache && now - this.processesCache.ts < GatewayRouter.PROCESSES_CACHE_TTL_MS) {
         res.json({ processes: this.processesCache.data, numCpus: GatewayRouter.NUM_CPUS });
@@ -462,17 +565,9 @@ export class GatewayRouter {
     // PTY screen snapshot — plain text, ANSI stripped. For agents that need to
     // observe what is currently displayed in the PTY shell to detect hangs, menu
     // states, or unexpected output without parsing escape codes.
-    // Auth: X-Api-Key or Authorization: Bearer header (API keys only — no dashboard token,
-    // as this endpoint is intended for programmatic/agent access, not the browser).
+    // Auth: X-Api-Key / Bearer (programmatic) OR dashboard session cookie (browser).
     this.app.get('/api/v1/sessions/:sessionId/screen', (req: Request, res: Response) => {
-      const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
-      const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
-      const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
-      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
-      if (!token || !apiKeys.some((k) => k.key === token)) {
-        res.status(401).json({ error: 'Unauthorized' });
-        return;
-      }
+      if (!this.requireDashOrApiKey(req, res)) return;
 
       const sessionId = req.params['sessionId'] ?? '';
       if (!sessionId) {
@@ -497,7 +592,8 @@ export class GatewayRouter {
     });
 
     // Status endpoint — per-agent stats + heartbeat history
-    this.app.get('/status', (_req: Request, res: Response) => {
+    this.app.get('/status', (req: Request, res: Response) => {
+      if (!this.requireDashOrApiKey(req, res)) return;
       const uptimeMs = Date.now() - this.startedAt.getTime();
 
       const agentsStatus = [...this.agents.entries()].map(([id, runner]) => {
@@ -644,7 +740,7 @@ export class GatewayRouter {
         const token = authHeader.startsWith('Bearer ')
           ? authHeader.slice(7).trim()
           : xApiKey.trim();
-        if (!token || !apiKeys.some((k) => k.key === token)) {
+        if (!timingSafeKeyMatch(apiKeys, token)) {
           socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
           socket.destroy();
           return;

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -272,6 +272,17 @@ export class GatewayRouter {
     return authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : xApiKey.trim();
   }
 
+  /**
+   * True when the resolved bind interface is NOT loopback — i.e. the gateway is
+   * reachable from beyond the local host. Used to fail closed: a keyless install
+   * is safe on localhost but must not expose the dashboard/monitoring surface
+   * unauthenticated on a non-loopback bind.
+   */
+  private isNonLoopbackBind(): boolean {
+    const host = resolveBindHost(process.env.GATEWAY_BIND, this.gatewayConfig?.gateway?.bind);
+    return !(host === '127.0.0.1' || host === '::1' || host === 'localhost' || host.startsWith('127.'));
+  }
+
   /** True when the request carries a live (unexpired) dashboard session cookie. */
   private hasValidDashSession(req: Request): boolean {
     const token = parseCookies(req.headers['cookie'])[DASH_SESSION_COOKIE];
@@ -288,7 +299,17 @@ export class GatewayRouter {
    */
   private requireDashOrApiKey(req: Request, res: Response): boolean {
     const keys = this.apiKeys;
-    if (keys.length === 0) return true; // no auth configured → open, as before
+    if (keys.length === 0) {
+      // No auth configured. Safe on loopback; on a non-loopback bind, refuse
+      // rather than expose the monitoring surface unauthenticated (fail closed).
+      if (this.isNonLoopbackBind()) {
+        res.status(503).json({
+          error: 'Dashboard/monitoring disabled: configure gateway.api.keys to expose it on a non-loopback bind (gateway.bind)',
+        });
+        return false;
+      }
+      return true; // keyless + loopback → open, as before
+    }
     if (timingSafeKeyMatch(keys, this.extractApiToken(req))) return true;
     if (this.hasValidDashSession(req)) return true;
     res.status(401).json({ error: 'Unauthorized' });
@@ -486,7 +507,15 @@ export class GatewayRouter {
     // matching how the /api routers are only mounted when keys exist.
     this.app.get('/dashboard', (req: Request, res: Response) => {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      if (this.apiKeys.length > 0 && !this.hasValidDashSession(req)) {
+      if (this.apiKeys.length === 0) {
+        // Keyless: open on loopback, but fail closed on a non-loopback bind.
+        if (this.isNonLoopbackBind()) {
+          res.status(503).send(generateLoginHtml(
+            'Dashboard disabled. Configure gateway.api.keys to enable access on a non-loopback bind (gateway.bind).',
+          ));
+          return;
+        }
+      } else if (!this.hasValidDashSession(req)) {
         res.send(generateLoginHtml());
         return;
       }
@@ -667,6 +696,13 @@ export class GatewayRouter {
     // are not exposed to the local network out of the box; operators opt into
     // wider exposure via config or the env var (e.g. "0.0.0.0" behind a proxy).
     const host = resolveBindHost(process.env.GATEWAY_BIND, this.gatewayConfig?.gateway?.bind);
+    // Fail-closed heads-up: a non-loopback bind with no API keys means the
+    // dashboard/monitoring endpoints refuse access (503) until keys are set.
+    if (this.isNonLoopbackBind() && this.apiKeys.length === 0) {
+      process.stderr.write(
+        `[gateway] WARNING: bound to ${host} with no gateway.api.keys — dashboard/status/processes are DISABLED (503) until you configure API keys. Set gateway.api.keys to enable access.\n`,
+      );
+    }
     return new Promise((resolve, reject) => {
       this.server = this.app.listen(port, host, () => {
         resolve();

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -103,6 +103,25 @@ export function resolveBindHost(
   return env || configured || '127.0.0.1';
 }
 
+/**
+ * True when a bind host refers to the local loopback interface only. Handles the
+ * common spellings: `localhost`, IPv4 loopback (`127.0.0.0/8`), IPv6 loopback
+ * (`::1`, its fully-expanded `0:0:...:1`), IPv4-mapped loopback (`::ffff:127.x`),
+ * and bracketed / zone-suffixed IPv6 forms. Anything else (`0.0.0.0`, `::`, a
+ * real IP, a hostname) is treated as non-loopback = potentially exposed.
+ */
+function isLoopbackHost(bind: string | undefined): boolean {
+  let host = (bind ?? '').trim().toLowerCase();
+  if (!host) return true; // empty resolves to the 127.0.0.1 default upstream
+  host = host.replace(/^\[/, '').replace(/\]$/, ''); // strip IPv6 brackets
+  host = host.split('%')[0]; // strip IPv6 zone id (fe80::1%eth0)
+  if (host.startsWith('::ffff:')) host = host.slice(7); // IPv4-mapped IPv6
+  if (host === 'localhost') return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true; // 127.0.0.0/8
+  return false;
+}
+
 // ─── Proxy types ──────────────────────────────────────────────────────────────
 
 interface ProxyRoute {
@@ -184,6 +203,12 @@ export class GatewayRouter {
    *  and carried by the HttpOnly `dash_session` cookie — never embedded in the HTML,
    *  so no token is exposed to view-source/XSS. token → expiresAt. */
   private readonly dashboardTokens = new Map<string, number>();
+
+  /** Failed-login throttle for /dashboard/login, keyed by client IP.
+   *  ip → { count, resetAt }. Blocks brute-forcing configured API keys. */
+  private readonly loginAttempts = new Map<string, { count: number; resetAt: number }>();
+  private static readonly LOGIN_MAX_ATTEMPTS = 10;
+  private static readonly LOGIN_WINDOW_MS = 5 * 60 * 1000;
 
   /** Per-agent message counters (output lines from subprocess) */
   private readonly messagesReceived: Map<string, number> = new Map();
@@ -276,11 +301,14 @@ export class GatewayRouter {
    * True when the resolved bind interface is NOT loopback — i.e. the gateway is
    * reachable from beyond the local host. Used to fail closed: a keyless install
    * is safe on localhost but must not expose the dashboard/monitoring surface
-   * unauthenticated on a non-loopback bind.
+   * unauthenticated on a non-loopback bind. Normalizes IPv6 brackets/zone,
+   * v4-mapped addresses, and the fully-expanded IPv6 loopback so an unusual but
+   * legitimate loopback bind is not mistaken for an exposed one.
    */
   private isNonLoopbackBind(): boolean {
-    const host = resolveBindHost(process.env.GATEWAY_BIND, this.gatewayConfig?.gateway?.bind);
-    return !(host === '127.0.0.1' || host === '::1' || host === 'localhost' || host.startsWith('127.'));
+    return !isLoopbackHost(
+      resolveBindHost(process.env.GATEWAY_BIND, this.gatewayConfig?.gateway?.bind),
+    );
   }
 
   /** True when the request carries a live (unexpired) dashboard session cookie. */
@@ -316,11 +344,45 @@ export class GatewayRouter {
     return false;
   }
 
-  /** Build the Set-Cookie value for the dashboard session (Secure when TLS). */
+  /** Client IP for throttling. Uses req.ip (Express; the socket peer unless
+   *  `trust proxy` is set) with a socket fallback. Behind an untrusted proxy all
+   *  clients share the proxy IP → a shared throttle, which fails safe. */
+  private clientIp(req: Request): string {
+    return req.ip || req.socket?.remoteAddress || 'unknown';
+  }
+
+  /** True when this IP has exceeded the failed-login budget for the window. */
+  private isLoginThrottled(req: Request): boolean {
+    const rec = this.loginAttempts.get(this.clientIp(req));
+    if (!rec || rec.resetAt < Date.now()) return false;
+    return rec.count >= GatewayRouter.LOGIN_MAX_ATTEMPTS;
+  }
+
+  /** Record a failed login for this IP (starts/extends the current window). */
+  private recordLoginFailure(req: Request): void {
+    const ip = this.clientIp(req);
+    const now = Date.now();
+    const rec = this.loginAttempts.get(ip);
+    if (!rec || rec.resetAt < now) {
+      this.loginAttempts.set(ip, { count: 1, resetAt: now + GatewayRouter.LOGIN_WINDOW_MS });
+    } else {
+      rec.count += 1;
+    }
+  }
+
+  /**
+   * Build the Set-Cookie value for the dashboard session (Secure when TLS).
+   * SameSite=Lax: the cookie is not sent on cross-site subresource requests
+   * (fetch/XHR/img) or cross-site POST — so it stays CSRF-safe for the
+   * state-changing POST routes (login/logout/pty-ticket) and the read endpoints'
+   * cross-site fetches — while still being sent on a top-level navigation to
+   * /dashboard, so opening the dashboard from a bookmark or link does not force
+   * a re-login (Strict would drop the cookie there).
+   */
   private buildSessionCookie(req: Request, token: string, ttlMs: number): string {
     const secure = req.secure || req.headers['x-forwarded-proto'] === 'https' ? '; Secure' : '';
     const maxAge = Math.max(0, Math.floor(ttlMs / 1000));
-    return `${DASH_SESSION_COOKIE}=${token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=${maxAge}${secure}`;
+    return `${DASH_SESSION_COOKIE}=${token}; HttpOnly; SameSite=Lax; Path=/; Max-Age=${maxAge}${secure}`;
   }
 
   private setupRoutes(): void {
@@ -540,11 +602,19 @@ export class GatewayRouter {
         res.status(404).json({ error: 'Auth not configured' });
         return;
       }
+      // Throttle brute-force attempts per client IP.
+      if (this.isLoginThrottled(req)) {
+        res.status(429).json({ error: 'Too many login attempts. Try again later.' });
+        return;
+      }
       const key = ((req.body as { key?: string })?.key ?? '').toString();
       if (!timingSafeKeyMatch(keys, key)) {
+        this.recordLoginFailure(req);
         res.status(401).json({ error: 'Invalid API key' });
         return;
       }
+      // Success: clear this IP's failure window.
+      this.loginAttempts.delete(this.clientIp(req));
       const token = crypto.randomBytes(32).toString('hex');
       this.dashboardTokens.set(token, Date.now() + DASH_SESSION_TTL_MS);
       res.setHeader('Set-Cookie', this.buildSessionCookie(req, token, DASH_SESSION_TTL_MS));
@@ -724,7 +794,7 @@ export class GatewayRouter {
       this.wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PTY_INPUT_BYTES * 8 });
       const apiKeys = this.gatewayConfig?.gateway?.api?.keys ?? [];
 
-      // Prune expired tickets and dashboard tokens every 60s.
+      // Prune expired tickets, dashboard tokens, and login-throttle windows every 60s.
       this.ticketPruner = setInterval(() => {
         const now = Date.now();
         for (const [k, v] of this.ptyStreamTickets) {
@@ -732,6 +802,9 @@ export class GatewayRouter {
         }
         for (const [k, exp] of this.dashboardTokens) {
           if (exp < now) this.dashboardTokens.delete(k);
+        }
+        for (const [ip, rec] of this.loginAttempts) {
+          if (rec.resetAt < now) this.loginAttempts.delete(ip);
         }
       }, 60_000);
       this.ticketPruner.unref();

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -180,9 +180,10 @@ export class GatewayRouter {
   private readonly ptyStreamTickets = new Map<string, { agentId: string; sessionId: string; expiresAt: number }>();
   private ticketPruner: ReturnType<typeof setInterval> | null = null;
 
-  /** Short-lived dashboard session tokens (10 min TTL). Issued at /dashboard serve time
-   *  so the raw API key is never embedded in the HTML page source. */
-  private readonly dashboardTokens = new Map<string, number>(); // token → expiresAt
+  /** Dashboard session tokens (DASH_SESSION_TTL_MS). Issued at POST /dashboard/login
+   *  and carried by the HttpOnly `dash_session` cookie — never embedded in the HTML,
+   *  so no token is exposed to view-source/XSS. token → expiresAt. */
+  private readonly dashboardTokens = new Map<string, number>();
 
   /** Per-agent message counters (output lines from subprocess) */
   private readonly messagesReceived: Map<string, number> = new Map();
@@ -773,11 +774,12 @@ export class GatewayRouter {
    * (server → browser); inbound keystrokes are opt-in per browser via the Shell
    * Process Viewer's mode toggle (client-side UX), so a viewer only sends bytes
    * while in input mode. Access to this socket is protected upstream: the caller
-   * has already authenticated (ticket or API key) and the gateway binds to
-   * localhost by default (`gateway.bind`) — set a non-loopback bind only behind
-   * a trusted proxy. Bytes are bounded (text-only, size-capped) and routed to
-   * the owning session; a headless session (no PTY) silently drops them
-   * (sendInputToSession → false).
+   * has already authenticated (one-time ticket or API key), and the ticket itself
+   * is only mintable with an API key or a valid dashboard session — so on a
+   * non-loopback `gateway.bind` an unauthenticated caller cannot reach this stream
+   * (provided `gateway.api.keys` is configured). Bytes are bounded (text-only,
+   * size-capped) and routed to the owning session; a headless session (no PTY)
+   * silently drops them (sendInputToSession → false).
    */
   private attachPtyStreamSocket(ws: WebSocket, agentId: string, sessionId: string): void {
     if (!ptyStreamRegistry.hasSockets(sessionId)) {

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -911,7 +911,22 @@ export function generateDashboardHtml(): string {
  * entered API key to POST /dashboard/login (JSON); on success the server sets the
  * HttpOnly session cookie and we reload into the dashboard. No external deps.
  */
-export function generateLoginHtml(): string {
+export function generateLoginHtml(disabledReason = ''): string {
+  const safeReason = disabledReason
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  // When a disabled reason is supplied (keyless install on a non-loopback bind),
+  // render a notice instead of the login form — there is no key to log in with.
+  const bodyInner = safeReason
+    ? `    <h1>Claude Gateway</h1>
+    <div class="sub">${safeReason}</div>`
+    : `    <h1>Claude Gateway</h1>
+    <div class="sub">Enter an API key to access the dashboard.</div>
+    <form id="login-form" autocomplete="off">
+      <label for="key">API key</label>
+      <input id="key" type="password" placeholder="sk-gateway-..." autofocus>
+      <button type="submit">Sign in</button>
+      <div id="err"></div>
+    </form>`;
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -947,14 +962,7 @@ export function generateLoginHtml(): string {
 </head>
 <body>
   <div class="card">
-    <h1>Claude Gateway</h1>
-    <div class="sub">Enter an API key to access the dashboard.</div>
-    <form id="login-form" autocomplete="off">
-      <label for="key">API key</label>
-      <input id="key" type="password" placeholder="sk-gateway-..." autofocus>
-      <button type="submit">Sign in</button>
-      <div id="err"></div>
-    </form>
+${bodyInner}
   </div>
   <script>
     function basePath() {
@@ -963,7 +971,8 @@ export function generateLoginHtml(): string {
       if (p.endsWith('/dashboard/')) return p.slice(0, -11);
       return p.endsWith('/') ? p.slice(0, -1) : p;
     }
-    document.getElementById('login-form').addEventListener('submit', async function(e) {
+    var loginForm = document.getElementById('login-form');
+    if (loginForm) loginForm.addEventListener('submit', async function(e) {
       e.preventDefault();
       var err = document.getElementById('err');
       err.textContent = '';

--- a/src/ui/web-ui.ts
+++ b/src/ui/web-ui.ts
@@ -2,14 +2,12 @@
  * Generates a self-contained HTML dashboard page for the gateway status UI.
  * No external dependencies except xterm.js CDN for PTY viewer.
  */
-export function generateDashboardHtml(dashToken = ''): string {
-  const safeToken = dashToken.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+export function generateDashboardHtml(): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="dash-token" content="${safeToken}">
   <title>Claude Gateway</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/css/xterm.min.css"
     integrity="sha384-eDYu/eBZQNhtqTaA7Wl3XighXKxm/9VYF+Chh3hQS+UUlKQIJ14hK2imKu4n99aR" crossorigin="anonymous"/>
@@ -222,7 +220,7 @@ export function generateDashboardHtml(dashToken = ''): string {
   </style>
 </head>
 <body>
-  <h1><span class="rainbow">Claude Gateway</span> <span id="gateway-version" style="font-size:0.75rem;color:#718096;"></span> <span id="refresh-indicator">refreshing...</span></h1>
+  <h1><span class="rainbow">Claude Gateway</span> <span id="gateway-version" style="font-size:0.75rem;color:#718096;"></span> <span id="refresh-indicator">refreshing...</span> <button id="logout-btn" style="float:right;font-size:0.7rem;background:#2d3748;color:#a0aec0;border:1px solid #4a5568;border-radius:4px;padding:2px 8px;cursor:pointer;">Logout</button></h1>
   <div class="meta">
     Uptime: <span id="uptime">&mdash;</span> &nbsp;|&nbsp;
     Started: <span id="started-at">&mdash;</span> &nbsp;|&nbsp;
@@ -288,9 +286,13 @@ export function generateDashboardHtml(dashToken = ''): string {
   <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/lib/xterm.min.js"
     integrity="sha384-pELe6ZHtFxFcuYBq3gMkqvmnNIqUWnAYjBG5gThqQQCjWp8PJ/65MLK4lMIfEK1e" crossorigin="anonymous"></script>
   <script>
-    // Read short-lived dashboard token from meta tag (10 min, server-issued at page load).
-    // The raw API key is never embedded in HTML — only this scoped, expiring token is.
-    const DASHBOARD_API_KEY = document.querySelector('meta[name="dash-token"]') ? document.querySelector('meta[name="dash-token"]').getAttribute('content') : '';
+    // Auth is carried by the HttpOnly 'dash_session' cookie the browser sends
+    // automatically on every same-origin request — no token is embedded in the
+    // page (nothing for view-source/XSS to steal). If any read returns 401 the
+    // session has expired or is missing, so bounce to /dashboard (login page).
+    function onUnauthorized() {
+      window.location.href = apiUrl('/dashboard');
+    }
 
     // Must match the server PTY size (src/shell/screen.ts ScreenModel defaults).
     const PTY_COLS = 200;
@@ -329,19 +331,19 @@ export function generateDashboardHtml(dashToken = ''): string {
     }
 
     async function wsPtyUrl(agentId, sessionId) {
-      // Exchange the API key for a short-lived ticket so the key never appears in
-      // the WS URL (which would expose it in server logs and browser history).
-      // Streams are per-session, so the session id is always part of the request.
+      // Exchange the dashboard session (HttpOnly cookie, sent automatically) for a
+      // short-lived ticket so no credential ever appears in the WS URL (which would
+      // expose it in server logs and browser history). Per-session, so the session
+      // id is always part of the request.
       const base = basePath() + '/api/v1/agents/' + encodeURIComponent(agentId) + '/pty-stream';
       const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      if (!DASHBOARD_API_KEY) {
-        return proto + '//' + window.location.host + base + '?session=' + encodeURIComponent(sessionId);
-      }
       const r = await fetch(apiUrl('/api/v1/pty-stream-ticket'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Dash-Token': DASHBOARD_API_KEY },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ agentId, sessionId }),
       });
+      if (r.status === 401) { onUnauthorized(); return null; }
+      if (!r.ok) throw new Error('ticket HTTP ' + r.status);
       const { ticket } = await r.json();
       return proto + '//' + window.location.host + base + '?ticket=' + ticket;
     }
@@ -457,6 +459,8 @@ export function generateDashboardHtml(dashToken = ''): string {
         schedulePtyReconnect(agentId, sessionId);
         return;
       }
+      // 401 → wsPtyUrl already bounced to the login page; stop here.
+      if (!url) return;
       // The session may have been closed/switched while awaiting the ticket.
       if (currentPtySession !== sessionId) return;
 
@@ -665,6 +669,7 @@ export function generateDashboardHtml(dashToken = ''): string {
       document.getElementById('refresh-indicator').textContent = 'refreshing...';
       try {
         const res = await fetch(apiUrl('/status'));
+        if (res.status === 401) { onUnauthorized(); return; }
         if (!res.ok) throw new Error('HTTP ' + res.status);
         const data = await res.json();
 
@@ -740,6 +745,7 @@ export function generateDashboardHtml(dashToken = ''): string {
     async function refreshProcesses() {
       try {
         const res = await fetch(apiUrl('/processes'));
+        if (res.status === 401) { onUnauthorized(); return; }
         if (!res.ok) return;
         const data = await res.json();
         renderProcessTree(data.processes || [], data.numCpus || 1);
@@ -881,11 +887,99 @@ export function generateDashboardHtml(dashToken = ''): string {
       document.getElementById('proc-tree').innerHTML = lines.join('\\n');
     }
 
+    // Logout — revoke the session cookie server-side, then land on the login page.
+    document.getElementById('logout-btn').addEventListener('click', async function() {
+      try {
+        await fetch(apiUrl('/dashboard/logout'), { method: 'POST' });
+      } catch (e) { /* best-effort; navigate regardless */ }
+      window.location.href = apiUrl('/dashboard');
+    });
+
     refresh();
     refreshProcesses();
     setInterval(refresh, 3000);
     // Process tree (with CPU/mem) is heavier (spawns ps) — refresh a bit slower.
     setInterval(refreshProcesses, 6000);
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * Minimal, self-contained login page served at GET /dashboard when API keys are
+ * configured and the request has no valid dashboard session cookie. Posts the
+ * entered API key to POST /dashboard/login (JSON); on success the server sets the
+ * HttpOnly session cookie and we reload into the dashboard. No external deps.
+ */
+export function generateLoginHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claude Gateway — Login</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
+      background: #0f1117; color: #e2e8f0;
+      min-height: 100vh; display: flex; align-items: center; justify-content: center;
+    }
+    .card {
+      background: #1a202c; border: 1px solid #2d3748; border-radius: 10px;
+      padding: 32px; width: 100%; max-width: 360px;
+    }
+    h1 { font-size: 1.25rem; margin-bottom: 4px; }
+    .sub { font-size: 0.8rem; color: #718096; margin-bottom: 20px; }
+    label { display: block; font-size: 0.75rem; color: #a0aec0; margin-bottom: 6px; }
+    input {
+      width: 100%; padding: 10px 12px; border-radius: 6px;
+      border: 1px solid #2d3748; background: #0f1117; color: #e2e8f0;
+      font-family: inherit; font-size: 0.9rem;
+    }
+    button {
+      width: 100%; margin-top: 16px; padding: 10px; border: none; border-radius: 6px;
+      background: #3182ce; color: #fff; font-weight: 600; font-size: 0.9rem; cursor: pointer;
+    }
+    button:hover { background: #2b6cb0; }
+    #err { color: #fc8181; font-size: 0.8rem; margin-top: 12px; min-height: 1em; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Claude Gateway</h1>
+    <div class="sub">Enter an API key to access the dashboard.</div>
+    <form id="login-form" autocomplete="off">
+      <label for="key">API key</label>
+      <input id="key" type="password" placeholder="sk-gateway-..." autofocus>
+      <button type="submit">Sign in</button>
+      <div id="err"></div>
+    </form>
+  </div>
+  <script>
+    function basePath() {
+      var p = window.location.pathname;
+      if (p.endsWith('/dashboard')) return p.slice(0, -10);
+      if (p.endsWith('/dashboard/')) return p.slice(0, -11);
+      return p.endsWith('/') ? p.slice(0, -1) : p;
+    }
+    document.getElementById('login-form').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      var err = document.getElementById('err');
+      err.textContent = '';
+      var key = document.getElementById('key').value;
+      try {
+        var res = await fetch(basePath() + '/dashboard/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: key }),
+        });
+        if (res.ok) { window.location.href = basePath() + '/dashboard'; return; }
+        err.textContent = res.status === 401 ? 'Invalid API key.' : ('Login failed (HTTP ' + res.status + ').');
+      } catch (e2) {
+        err.textContent = 'Network error.';
+      }
+    });
   </script>
 </body>
 </html>`;

--- a/tests/integration/gateway-e2e.test.ts
+++ b/tests/integration/gateway-e2e.test.ts
@@ -102,7 +102,11 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
     const res = await supertest(router.getApp()).get('/health');
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('ok');
-    expect(res.body.agents).toContain('agent-01');
+    // /health is intentionally minimal (no agent ids leaked); agent listing moved
+    // to /status, which is open here because no API keys are configured.
+    const statusRes = await supertest(router.getApp()).get('/status');
+    expect(statusRes.status).toBe(200);
+    expect(statusRes.body.agents.map((a: { id: string }) => a.id)).toContain('agent-01');
 
     await router.stop();
     await runner.stop();
@@ -247,11 +251,13 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
     const router = new GatewayRouter(agents, configs);
     await router.start(0);
 
-    // /health should list both agents
-    const res = await supertest(router.getApp()).get('/health');
+    // /status should list both agents (/health no longer leaks agent ids; open
+    // here because no API keys are configured).
+    const res = await supertest(router.getApp()).get('/status');
     expect(res.status).toBe(200);
-    expect(res.body.agents).toContain('agent-07a');
-    expect(res.body.agents).toContain('agent-07b');
+    const ids = res.body.agents.map((a: { id: string }) => a.id);
+    expect(ids).toContain('agent-07a');
+    expect(ids).toContain('agent-07b');
 
     await router.stop();
     await runner1.stop();
@@ -406,28 +412,46 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
       await router.stop(); await runner.stop();
     });
 
-    it('T-04: dashboard token (from /dashboard) → 200 with ticket, token is one-time-use', async () => {
+    it('T-04: dashboard session cookie (from /dashboard/login) → 200 with ticket, and is multi-use', async () => {
       const { router, runner } = await makeRouter('ticket-agent-04');
-      // Fetch the dashboard page — server issues a short-lived dashToken embedded in HTML.
+      // Unauthenticated /dashboard serves the login page, not the dashboard, and
+      // no longer embeds any token in the HTML.
       const dashRes = await supertest(router.getApp()).get('/dashboard');
       expect(dashRes.status).toBe(200);
-      const metaMatch = /name="dash-token" content="([0-9a-f]+)"/.exec(dashRes.text);
-      expect(metaMatch).not.toBeNull();
-      const dashToken = metaMatch![1];
+      expect(dashRes.text).toContain('Enter an API key');
+      expect(dashRes.text).not.toContain('name="dash-token"');
 
-      // First use: should succeed.
+      // Log in with a configured API key → HttpOnly session cookie.
+      const login = await supertest(router.getApp())
+        .post('/dashboard/login')
+        .send({ key: 'secret-key' });
+      expect(login.status).toBe(200);
+      const setCookie = login.headers['set-cookie'][0];
+      expect(setCookie).toMatch(/dash_session=/);
+      expect(setCookie).toMatch(/HttpOnly/);
+      expect(setCookie).toMatch(/SameSite=Strict/);
+      const cookie = setCookie.split(';')[0];
+
+      // First use with the cookie: should succeed.
       const first = await supertest(router.getApp())
         .post('/api/v1/pty-stream-ticket')
-        .set('X-Dash-Token', dashToken)
+        .set('Cookie', cookie)
         .send({ agentId: 'ticket-agent-04', sessionId: 'sess-x' });
       expect(first.status).toBe(200);
 
-      // Second use with the same token: must be rejected (one-time-use).
+      // Second use with the same cookie: session is multi-use (unlike the old
+      // one-time meta token), so it must succeed again.
       const second = await supertest(router.getApp())
         .post('/api/v1/pty-stream-ticket')
-        .set('X-Dash-Token', dashToken)
+        .set('Cookie', cookie)
         .send({ agentId: 'ticket-agent-04', sessionId: 'sess-x' });
-      expect(second.status).toBe(401);
+      expect(second.status).toBe(200);
+
+      // Wrong API key at login → 401, no cookie.
+      const bad = await supertest(router.getApp())
+        .post('/dashboard/login')
+        .send({ key: 'wrong-key' });
+      expect(bad.status).toBe(401);
 
       await router.stop(); await runner.stop();
     });

--- a/tests/integration/gateway-e2e.test.ts
+++ b/tests/integration/gateway-e2e.test.ts
@@ -429,7 +429,7 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
       const setCookie = login.headers['set-cookie'][0];
       expect(setCookie).toMatch(/dash_session=/);
       expect(setCookie).toMatch(/HttpOnly/);
-      expect(setCookie).toMatch(/SameSite=Strict/);
+      expect(setCookie).toMatch(/SameSite=Lax/);
       const cookie = setCookie.split(';')[0];
 
       // First use with the cookie: should succeed.

--- a/tests/integration/multi-agent.test.ts
+++ b/tests/integration/multi-agent.test.ts
@@ -320,7 +320,7 @@ describe('Multi-Agent (Option A)', () => {
   });
 
   // ─── I-MA-09: /health lists all running agents ────────────────────────────
-  it('I-MA-09: /health lists all running agents (replaces webhook routing test)', async () => {
+  it('I-MA-09: /status lists all running agents (replaces webhook routing test)', async () => {
     const ws1 = createTempWorkspace('ma09-a-');
     const ws2 = createTempWorkspace('ma09-b-');
     const logDir = createTempDir('ma09-log-');
@@ -345,10 +345,13 @@ describe('Multi-Agent (Option A)', () => {
     const router = new GatewayRouter(agents, configs);
     await router.start(0);
 
-    const res = await supertest(router.getApp()).get('/health');
+    // /health is now minimal (no agent ids); the agent listing lives on /status,
+    // which is open here because no API keys are configured.
+    const res = await supertest(router.getApp()).get('/status');
     expect(res.status).toBe(200);
-    expect(res.body.agents).toContain('ma09-alpha');
-    expect(res.body.agents).toContain('ma09-beta');
+    const ids = res.body.agents.map((a: { id: string }) => a.id);
+    expect(ids).toContain('ma09-alpha');
+    expect(ids).toContain('ma09-beta');
 
     await router.stop();
     await runner1.stop();

--- a/tests/unit/gateway-dashboard-auth.test.ts
+++ b/tests/unit/gateway-dashboard-auth.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression tests for the bind=0.0.0.0 hardening: with API keys configured, the
+ * dashboard-adjacent endpoints that used to be reachable with no credential
+ * (/status, /processes, /dashboard) now require an API key OR a dashboard session
+ * cookie, and /health leaks nothing beyond liveness. When no API keys are
+ * configured, behavior stays open (keyless installs must not lock themselves out).
+ *
+ * These exercise the real Express app built by GatewayRouter (getApp()) with
+ * supertest — no port binding, no WS.
+ */
+import supertest from 'supertest';
+import { GatewayRouter } from '../../src/api/gateway-router';
+import { AgentConfig, GatewayConfig, ApiKey } from '../../src/types';
+
+const KEY = 'sk-gateway-test-000000';
+
+function buildApp(apiKeys: ApiKey[] = []) {
+  const gatewayConfig: GatewayConfig = {
+    gateway: { logDir: '/tmp', timezone: 'UTC', ...(apiKeys.length ? { api: { keys: apiKeys } } : {}) },
+    agents: [],
+  };
+  const agents = new Map();
+  const configs = new Map<string, AgentConfig>();
+  const router = new GatewayRouter(agents, configs, undefined, gatewayConfig);
+  return router.getApp();
+}
+
+const WITH_KEYS = [{ key: KEY, description: 'test', agents: '*' as const }];
+
+/** Extract the `name=value` pair from a Set-Cookie header for reuse as a Cookie. */
+function cookieFrom(res: { headers: Record<string, string[] | string> }): string {
+  const setCookie = res.headers['set-cookie'] as unknown as string[];
+  return setCookie[0].split(';')[0];
+}
+
+describe('gateway dashboard auth hardening (bind 0.0.0.0)', () => {
+  describe('① /health is minimal and leaks nothing', () => {
+    it('returns exactly {status:ok} with no agents/version fields', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/health');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'ok' });
+      expect(res.body.agents).toBeUndefined();
+    });
+  });
+
+  describe('② /status + /processes require auth when keys are configured', () => {
+    it('/status → 401 without any credential', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/status');
+      expect(res.status).toBe(401);
+    });
+
+    it('/processes → 401 without any credential', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/processes');
+      expect(res.status).toBe(401);
+    });
+
+    it('/status → 200 with a valid API key (X-Api-Key)', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/status').set('X-Api-Key', KEY);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.agents)).toBe(true);
+    });
+
+    it('/status → 200 with a valid API key (Bearer)', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/status').set('Authorization', `Bearer ${KEY}`);
+      expect(res.status).toBe(200);
+    });
+
+    it('/status → 401 with a wrong API key', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/status').set('X-Api-Key', 'nope');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('③ dashboard session cookie flow', () => {
+    it('GET /dashboard unauthenticated serves the login page (no dashboard, no token in HTML)', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/dashboard');
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('Enter an API key');
+      expect(res.text).not.toContain('name="dash-token"');
+    });
+
+    it('POST /dashboard/login with a valid key sets an HttpOnly SameSite=Strict cookie', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).post('/dashboard/login').send({ key: KEY });
+      expect(res.status).toBe(200);
+      const setCookie = (res.headers['set-cookie'] as unknown as string[])[0];
+      expect(setCookie).toMatch(/dash_session=[0-9a-f]{64}/);
+      expect(setCookie).toMatch(/HttpOnly/);
+      expect(setCookie).toMatch(/SameSite=Strict/);
+      expect(setCookie).toMatch(/Path=\//);
+    });
+
+    it('POST /dashboard/login with a wrong key → 401, no cookie', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).post('/dashboard/login').send({ key: 'wrong' });
+      expect(res.status).toBe(401);
+      expect(res.headers['set-cookie']).toBeUndefined();
+    });
+
+    it('the session cookie authorizes /status and GET /dashboard (serves the real dashboard)', async () => {
+      const app = buildApp(WITH_KEYS);
+      const login = await supertest(app).post('/dashboard/login').send({ key: KEY });
+      const cookie = cookieFrom(login);
+
+      const status = await supertest(app).get('/status').set('Cookie', cookie);
+      expect(status.status).toBe(200);
+
+      const dash = await supertest(app).get('/dashboard').set('Cookie', cookie);
+      expect(dash.status).toBe(200);
+      expect(dash.text).toContain('Claude Gateway');
+      expect(dash.text).not.toContain('Enter an API key');
+    });
+
+    it('logout revokes the session — the same cookie no longer authorizes /status', async () => {
+      const app = buildApp(WITH_KEYS);
+      const login = await supertest(app).post('/dashboard/login').send({ key: KEY });
+      const cookie = cookieFrom(login);
+
+      await supertest(app).post('/dashboard/logout').set('Cookie', cookie).expect(200);
+
+      const status = await supertest(app).get('/status').set('Cookie', cookie);
+      expect(status.status).toBe(401);
+    });
+
+    it('a forged/unknown session cookie is rejected', async () => {
+      const res = await supertest(buildApp(WITH_KEYS))
+        .get('/status')
+        .set('Cookie', 'dash_session=deadbeefdeadbeef');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('keyless install stays open (no lock-out)', () => {
+    it('/status is reachable with no credential when no API keys are configured', async () => {
+      const res = await supertest(buildApp([])).get('/status');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /dashboard serves the dashboard directly (not the login page) with no keys', async () => {
+      const res = await supertest(buildApp([])).get('/dashboard');
+      expect(res.status).toBe(200);
+      expect(res.text).not.toContain('Enter an API key');
+    });
+
+    it('POST /dashboard/login → 404 when auth is not configured', async () => {
+      const res = await supertest(buildApp([])).post('/dashboard/login').send({ key: 'anything' });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/tests/unit/gateway-dashboard-auth.test.ts
+++ b/tests/unit/gateway-dashboard-auth.test.ts
@@ -84,13 +84,13 @@ describe('gateway dashboard auth hardening (bind 0.0.0.0)', () => {
       expect(res.text).not.toContain('name="dash-token"');
     });
 
-    it('POST /dashboard/login with a valid key sets an HttpOnly SameSite=Strict cookie', async () => {
+    it('POST /dashboard/login with a valid key sets an HttpOnly SameSite=Lax cookie', async () => {
       const res = await supertest(buildApp(WITH_KEYS)).post('/dashboard/login').send({ key: KEY });
       expect(res.status).toBe(200);
       const setCookie = (res.headers['set-cookie'] as unknown as string[])[0];
       expect(setCookie).toMatch(/dash_session=[0-9a-f]{64}/);
       expect(setCookie).toMatch(/HttpOnly/);
-      expect(setCookie).toMatch(/SameSite=Strict/);
+      expect(setCookie).toMatch(/SameSite=Lax/);
       expect(setCookie).toMatch(/Path=\//);
     });
 
@@ -187,6 +187,47 @@ describe('gateway dashboard auth hardening (bind 0.0.0.0)', () => {
       expect(status.status).toBe(401); // keyed → needs a credential, not 503
       const login = await supertest(app).post('/dashboard/login').send({ key: KEY });
       expect(login.status).toBe(200);
+    });
+
+    // Robust loopback detection — these unusual-but-legitimate loopback spellings
+    // must NOT be treated as exposed (keyless → still open), while bind-all forms must.
+    it.each(['localhost', '::1', '0:0:0:0:0:0:0:1', '127.0.0.5'])(
+      'keyless on loopback spelling %s stays open',
+      async (bind) => {
+        const res = await supertest(buildApp([], bind)).get('/status');
+        expect(res.status).toBe(200);
+      },
+    );
+
+    it.each(['::', '192.168.1.10'])('keyless on non-loopback %s fails closed (503)', async (bind) => {
+      const res = await supertest(buildApp([], bind)).get('/status');
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe('/dashboard/login brute-force throttle', () => {
+    it('blocks with 429 after 10 failed attempts — even with the correct key', async () => {
+      const app = buildApp(WITH_KEYS);
+      // 10 wrong attempts are allowed (each 401)…
+      for (let i = 0; i < 10; i++) {
+        const r = await supertest(app).post('/dashboard/login').send({ key: 'wrong' });
+        expect(r.status).toBe(401);
+      }
+      // …the 11th is throttled, and the throttle applies even to the correct key.
+      const blocked = await supertest(app).post('/dashboard/login').send({ key: KEY });
+      expect(blocked.status).toBe(429);
+    });
+
+    it('a successful login before the limit clears the failure window', async () => {
+      const app = buildApp(WITH_KEYS);
+      for (let i = 0; i < 5; i++) {
+        await supertest(app).post('/dashboard/login').send({ key: 'wrong' });
+      }
+      const ok = await supertest(app).post('/dashboard/login').send({ key: KEY });
+      expect(ok.status).toBe(200);
+      // Window was reset, so a fresh batch of wrong attempts is allowed again.
+      const afterReset = await supertest(app).post('/dashboard/login').send({ key: 'wrong' });
+      expect(afterReset.status).toBe(401);
     });
   });
 });

--- a/tests/unit/gateway-dashboard-auth.test.ts
+++ b/tests/unit/gateway-dashboard-auth.test.ts
@@ -14,9 +14,14 @@ import { AgentConfig, GatewayConfig, ApiKey } from '../../src/types';
 
 const KEY = 'sk-gateway-test-000000';
 
-function buildApp(apiKeys: ApiKey[] = []) {
+function buildApp(apiKeys: ApiKey[] = [], bind?: string) {
   const gatewayConfig: GatewayConfig = {
-    gateway: { logDir: '/tmp', timezone: 'UTC', ...(apiKeys.length ? { api: { keys: apiKeys } } : {}) },
+    gateway: {
+      logDir: '/tmp',
+      timezone: 'UTC',
+      ...(bind ? { bind } : {}),
+      ...(apiKeys.length ? { api: { keys: apiKeys } } : {}),
+    },
     agents: [],
   };
   const agents = new Map();
@@ -128,7 +133,8 @@ describe('gateway dashboard auth hardening (bind 0.0.0.0)', () => {
     });
   });
 
-  describe('keyless install stays open (no lock-out)', () => {
+  describe('keyless install on loopback stays open (no lock-out)', () => {
+    // No bind → resolves to the 127.0.0.1 default (loopback).
     it('/status is reachable with no credential when no API keys are configured', async () => {
       const res = await supertest(buildApp([])).get('/status');
       expect(res.status).toBe(200);
@@ -140,9 +146,47 @@ describe('gateway dashboard auth hardening (bind 0.0.0.0)', () => {
       expect(res.text).not.toContain('Enter an API key');
     });
 
+    it('explicit loopback bind (127.0.0.1) keyless is still open', async () => {
+      const res = await supertest(buildApp([], '127.0.0.1')).get('/status');
+      expect(res.status).toBe(200);
+    });
+
     it('POST /dashboard/login → 404 when auth is not configured', async () => {
       const res = await supertest(buildApp([])).post('/dashboard/login').send({ key: 'anything' });
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe('keyless install on a NON-loopback bind fails closed', () => {
+    it('/status → 503 (not open) when keyless and bound to 0.0.0.0', async () => {
+      const res = await supertest(buildApp([], '0.0.0.0')).get('/status');
+      expect(res.status).toBe(503);
+    });
+
+    it('/processes → 503 when keyless and bound to 0.0.0.0', async () => {
+      const res = await supertest(buildApp([], '0.0.0.0')).get('/processes');
+      expect(res.status).toBe(503);
+    });
+
+    it('GET /dashboard → 503 with a "configure gateway.api.keys" notice (no open dashboard)', async () => {
+      const res = await supertest(buildApp([], '0.0.0.0')).get('/dashboard');
+      expect(res.status).toBe(503);
+      expect(res.text).toContain('gateway.api.keys');
+      expect(res.text).not.toContain('id="pty-mode-toggle-btn"'); // not the real dashboard
+    });
+
+    it('/health stays public even keyless on 0.0.0.0 (liveness only)', async () => {
+      const res = await supertest(buildApp([], '0.0.0.0')).get('/health');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'ok' });
+    });
+
+    it('configuring an API key re-enables access on 0.0.0.0 (login works)', async () => {
+      const app = buildApp(WITH_KEYS, '0.0.0.0');
+      const status = await supertest(app).get('/status');
+      expect(status.status).toBe(401); // keyed → needs a credential, not 503
+      const login = await supertest(app).post('/dashboard/login').send({ key: KEY });
+      expect(login.status).toBe(200);
     });
   });
 });

--- a/tests/unit/interactive-shell-viewer.test.ts
+++ b/tests/unit/interactive-shell-viewer.test.ts
@@ -108,7 +108,7 @@ describe('dashboard HTML — mode toggle + embedded JS (Issue #201)', () => {
   }
 
   test('U-UI-01: the mode toggle button and swappable title are always in the markup', () => {
-    const html = generateDashboardHtml('tok')
+    const html = generateDashboardHtml()
     expect(html).toContain('id="pty-mode-toggle-btn"')
     expect(html).toContain('id="pty-title-text"')
     expect(html).toContain('Terminal Viewer')
@@ -117,26 +117,26 @@ describe('dashboard HTML — mode toggle + embedded JS (Issue #201)', () => {
   test('U-UI-02: the mode toggle ships visible (no inline display:none gate)', () => {
     // With no server flag, the toggle is always rendered — its button markup
     // must not be hidden with an inline style the way the gated version was.
-    const html = generateDashboardHtml('tok')
+    const html = generateDashboardHtml()
     const btn = html.match(/<button class="pty-mode-toggle"[^>]*>/)![0]
     expect(btn).not.toContain('display:none')
   })
 
   test('U-UI-03: the embedded dashboard script is syntactically valid', () => {
-    const body = scriptBody(generateDashboardHtml('tok'))
+    const body = scriptBody(generateDashboardHtml())
     // Parse-only: throws on a syntax error, does not execute (no DOM needed).
     expect(() => new Function(body)).not.toThrow()
   })
 
   test('U-UI-04: input-mode wiring references the shared send path', () => {
-    const body = scriptBody(generateDashboardHtml('tok'))
+    const body = scriptBody(generateDashboardHtml())
     expect(body).toContain('setPtyInputMode')
     expect(body).toContain('term.onData')
     expect(body).toContain('Interactive Terminal') // title in input mode
   })
 
   test('U-UI-05: physical PageUp/PageDown keys are forwarded to the PTY in view mode', () => {
-    const html = generateDashboardHtml('tok')
+    const html = generateDashboardHtml()
     // No on-screen page buttons — paging is driven by the real keyboard keys.
     expect(html).not.toContain('id="pty-pageup-btn"')
     expect(html).not.toContain('id="pty-pagedown-btn"')
@@ -157,7 +157,7 @@ describe('dashboard HTML — mode toggle + embedded JS (Issue #201)', () => {
     // and with disableStdin xterm rarely does, so a reconnect or stray click left
     // PageUp/PageDown dead. Verified end-to-end (headless Chromium) that a
     // document-level listener delivers the keys with focus OUTSIDE the terminal.
-    const body = scriptBody(generateDashboardHtml('tok'))
+    const body = scriptBody(generateDashboardHtml())
     expect(body).toContain("document.addEventListener('keydown', forwardPageKey)")
     // Must NOT be re-scoped back to the focus-dependent container.
     expect(body).not.toContain(


### PR DESCRIPTION
Closes #230

## What & why

With `gateway.bind` set to a non-loopback interface (`0.0.0.0`), the dashboard-adjacent endpoints were reachable **without any credential** — auth is applied only inside the `/api/*` sub-routers, not globally, so everything mounted directly on the app was gated solely by the localhost bind. The unauthenticated `/dashboard` minted a token that could be exchanged at `POST /api/v1/pty-stream-ticket` for a live PTY stream, which also routes inbound frames as **keystrokes into the agent shell** — effectively unauthenticated RCE on PTY-mode sessions (agents run with `--dangerously-skip-permissions`). `/status` disclosed the `sessionId` that chain needs, `/health` leaked the agent-id list, and `/processes` leaked host command-line args.

## Changes

Auth is gated on the existing `gateway.api.keys` — when **no** keys are configured it stays open, so keyless local installs are not locked out (mirrors how the `/api` routers are only mounted when keys exist).

- **`/health`** → returns only `{"status":"ok"}` (no agent ids). Still public for liveness probes.
- **`/status` + `/processes`** → require an API key (`X-Api-Key`/`Bearer`) **or** a dashboard session cookie; `401` otherwise.
- **Dashboard session via `HttpOnly` cookie:**
  - `GET /dashboard` serves a login page (API-key form) when there is no valid `dash_session` cookie, else the dashboard.
  - `POST /dashboard/login` validates a key (timing-safe) and sets `dash_session` (`HttpOnly; SameSite=Strict; Path=/`; `Secure` when TLS; 8h; multi-use).
  - `POST /dashboard/logout` revokes the session and clears the cookie.
  - `/status`, `/processes`, `/api/v1/sessions/:id/screen`, and `POST /api/v1/pty-stream-ticket` accept the API key **or** the cookie.
  - The page no longer embeds any auth token (`<meta name="dash-token">` removed); the browser sends the cookie automatically and the ticket exchange keeps credentials out of the WS URL. The client redirects to the login page on `401` and gains a **Logout** button.
- **WS header auth** now uses a timing-safe comparison, matching the `/api` middleware.

Cookies are parsed with a small manual helper — no new dependency.

## Out of scope

- The `/api/*` control API is already authenticated (`createApiAuthMiddleware` + `canAccessAgent`/`canWriteAgent`); LINE webhooks verify HMAC. Unchanged.
- The `/app/:name/:portName/*` reverse proxy remains unauthenticated (each app authenticates itself). Tracked separately — not part of this dashboard-hardening change.

## Testing

- New `tests/unit/gateway-dashboard-auth.test.ts` (15 cases): `/health` minimal, `/status`+`/processes` 401/200 (key + cookie), login/logout/forged-cookie, and the keyless-open path. **Proven to fail on the pre-fix code** (10/15 red when the `src` changes are reverted).
- Updated the existing `/health`-lists-agents assertions (e2e I-E2E-01/07, multi-agent I-MA-09) to read the agent list from `/status`.
- `npm run typecheck` clean; full suite `2532` tests pass (`workspace-loader` is a pre-existing parallel-race flake, green in isolation).
- `API.md` and `README.md` updated (endpoint table, `/health` + `/status` sections, `gateway.bind` + Terminal Viewer security notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
