### PR TITLE
[Security] Require an admin key for dashboard/monitoring auth (#232)

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,21 +13,26 @@ All API endpoints require an API key configured in `config.json`. Pass it via:
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/health` | None | Liveness only — returns `{"status":"ok"}` (no agent list) |
-| `GET` | `/status` | Key or dashboard session¹ | Per-agent stats + heartbeat history |
-| `GET` | `/processes` | Key or dashboard session¹ | Host process tree for the dashboard |
+| `GET` | `/status` | Admin key or dashboard session¹ | Per-agent stats + heartbeat history |
+| `GET` | `/processes` | Admin key or dashboard session¹ | Host process tree for the dashboard |
 | `GET` | `/dashboard` | Session cookie¹ | Web UI dashboard (serves the login page when unauthenticated) |
-| `POST` | `/dashboard/login` | None (validates a key) | Exchange an API key for an `HttpOnly; SameSite=Lax` `dash_session` cookie (8h). Brute-force throttled per IP (`429` after 10 failed attempts / 5 min) |
+| `POST` | `/dashboard/login` | None (validates an admin key) | Exchange an **admin** API key for an `HttpOnly; SameSite=Lax` `dash_session` cookie (8h). Brute-force throttled per IP (`429` after 10 failed attempts / 5 min) |
 | `POST` | `/dashboard/logout` | Session cookie | Revoke the dashboard session and clear the cookie |
 | `GET` | `/api/v1/commands` | None | List slash commands available in the chat UI |
 
-¹ **Auth applies when `gateway.api.keys` is configured.** "Key or dashboard session"
-accepts an API key (`X-Api-Key` / `Authorization: Bearer`) **or** the `dash_session`
-cookie issued by `POST /dashboard/login`. With **no** keys configured the behavior
+¹ **Auth applies when `gateway.api.keys` is configured, and requires an _admin_ key**
+(`admin: true`). The dashboard/monitoring surface grants cross-agent, host-wide power
+(session list, process tree, and PTY keystroke injection into any session), so it
+intentionally requires more than a scoped or write key. "Admin key or dashboard session"
+accepts an admin API key (`X-Api-Key` / `Authorization: Bearer`) **or** the `dash_session`
+cookie issued by `POST /dashboard/login` (which is itself only issued to an admin key). A
+valid but non-admin key is rejected (`401`). With **no** keys configured the behavior
 depends on the bind: on a **loopback** bind (`127.0.0.1`) they stay open (a keyless
 local install has no credential to check); on a **non-loopback** bind (`0.0.0.0` or a
 real IP) they **fail closed** — `/status`, `/processes`, and `/dashboard` return `503`
 until `gateway.api.keys` is set, so the surface is never exposed unauthenticated to the
-network. `/health` stays public in all cases.
+network. If keys are configured but **none is admin**, the dashboard is inaccessible
+(login returns `401`) and a startup warning is emitted. `/health` stays public in all cases.
 
 ### Agent API
 
@@ -198,7 +203,7 @@ curl -s http://localhost:10850/api/v1/sessions/<sessionId>/screen \
 The `sessionId` is the gateway session UUID. Find it from the process list:
 
 ```bash
-# /processes requires an API key when gateway.api.keys is configured
+# /processes requires an admin API key when gateway.api.keys is configured
 curl -s -H "X-Api-Key: $KEY" http://localhost:10850/processes | grep -o 'sessions/[^/]*' | head -1
 ```
 
@@ -210,7 +215,7 @@ each session of an agent is an isolated stream.
 
 | Endpoint | Auth | Description |
 |----------|------|-------------|
-| `POST` | `/api/v1/pty-stream-ticket` | Key *or* dashboard session | Exchange an API key **or** the `dash_session` cookie for a one-time, 30s-TTL ticket bound to a specific `{ agentId, sessionId }` |
+| `POST` | `/api/v1/pty-stream-ticket` | Admin key *or* dashboard session | Exchange an **admin** API key **or** the `dash_session` cookie for a one-time, 30s-TTL ticket bound to a specific `{ agentId, sessionId }` |
 | `WS` | `/api/v1/agents/:agentId/pty-stream` | Ticket *or* Key | Subscribe to the live PTY stream for one session |
 
 > The browser dashboard authenticates with the `HttpOnly; SameSite=Lax` `dash_session`
@@ -270,9 +275,10 @@ curl http://localhost:10850/health
 
 ### GET /status
 
-Per-agent stats and heartbeat history. **Requires an API key or a dashboard session
-cookie when `gateway.api.keys` is configured** (open otherwise). Returns 401 when
-keys are set and no valid credential is supplied.
+Per-agent stats and heartbeat history. **Requires an _admin_ API key or a dashboard
+session cookie when `gateway.api.keys` is configured** (open otherwise). Returns 401
+when keys are set and no valid admin credential is supplied (a valid non-admin key is
+also rejected).
 
 ```bash
 # API key

--- a/README.md
+++ b/README.md
@@ -320,15 +320,20 @@ Recovery actions are clamped to a per-stage whitelist and a per-turn budget, and
 
 Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (localhost-only), so the dashboard and API are **not** exposed to the local network out of the box. Set to `0.0.0.0` to listen on all interfaces (for example when a containerized reverse proxy needs to reach the gateway). The `GATEWAY_BIND` environment variable, when set, takes precedence over this field.
 
-> **⚠️ Binding to `0.0.0.0`? Configure `gateway.api.keys`.** The monitoring
-> surface (`/status`, `/processes`) and the dashboard require an API key or a
-> dashboard session when keys are configured — the dashboard prompts for an API
-> key at `/dashboard` and stores an `HttpOnly` session cookie. `/health` stays
-> public but returns only `{"status":"ok"}` (no agent ids). With **no** keys
+> **⚠️ Binding to `0.0.0.0`? Configure an admin key in `gateway.api.keys`.** The
+> monitoring surface (`/status`, `/processes`) and the dashboard require an
+> **admin** API key (`admin: true`) or a dashboard session when keys are
+> configured — a scoped or write-only key is rejected (`401`), because the
+> dashboard grants cross-agent, host-wide power (including PTY keystroke injection
+> into any session). The dashboard prompts for an admin key at `/dashboard` and
+> stores an `HttpOnly` session cookie (issued only to an admin key). `/health`
+> stays public but returns only `{"status":"ok"}` (no agent ids). With **no** keys
 > configured the gateway **fails closed on a non-loopback bind**: `/status`,
 > `/processes`, and `/dashboard` return `503` until you set `gateway.api.keys`
-> (a startup warning is logged). On a loopback bind they stay open, so local
-> keyless installs are unaffected. The gateway serves plain HTTP; put TLS in
+> (a startup warning is logged); if keys are set but **none is admin**, the
+> dashboard is inaccessible and a startup warning is logged. On a loopback bind
+> they stay open, so local keyless installs are unaffected. The gateway serves
+> plain HTTP; put TLS in
 > front (reverse proxy) so credentials are not sent in the clear.
 
 ```json
@@ -347,8 +352,8 @@ The dashboard's **Terminal Viewer** opens read-only (a live mirror of the PTY). 
 
 Because interactive mode turns a read-only view into a remote-write surface, access is protected upstream rather than by a feature flag:
 
-- **Authentication** — the WebSocket requires a valid dashboard ticket or API key. The ticket is minted at `POST /api/v1/pty-stream-ticket`, which itself requires an API key or a valid dashboard session cookie — so an unauthenticated caller cannot obtain one. The dashboard gets its session by logging in with an API key at `/dashboard` (`HttpOnly` cookie); no token is embedded in the page.
-- **`gateway.bind`** — the gateway binds to `127.0.0.1` (localhost) by default, so the dashboard is not reachable from the network out of the box. On a non-loopback bind (`0.0.0.0`), configure `gateway.api.keys` so the dashboard and monitoring endpoints require authentication, and prefer a TLS-terminating reverse proxy so credentials are not sent in the clear.
+- **Authentication** — the WebSocket requires a valid dashboard ticket or **admin** API key. The ticket is minted at `POST /api/v1/pty-stream-ticket`, which itself requires an admin API key or a valid dashboard session cookie — so an unauthenticated (or non-admin) caller cannot obtain one. The dashboard gets its session by logging in with an admin key at `/dashboard` (`HttpOnly` cookie); no token is embedded in the page.
+- **`gateway.bind`** — the gateway binds to `127.0.0.1` (localhost) by default, so the dashboard is not reachable from the network out of the box. On a non-loopback bind (`0.0.0.0`), configure an admin key in `gateway.api.keys` so the dashboard and monitoring endpoints require an admin credential, and prefer a TLS-terminating reverse proxy so credentials are not sent in the clear.
 
 Inbound frames are always bounded (text-only, size-capped) and are dropped for headless sessions (no PTY).
 

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -75,6 +75,21 @@ function timingSafeKeyMatch(apiKeys: ApiKey[], token: string): boolean {
   });
 }
 
+/**
+ * Timing-safe match restricted to admin keys (`admin: true`). The dashboard and
+ * monitoring surface (session list, process tree, screen, and PTY keystroke
+ * injection) grants cross-agent, host-wide power that intentionally transcends a
+ * key's `agents` scope — so it requires an admin key, not merely any configured
+ * key. A scoped or write-only key must not reach it. Pre-filters to admin keys,
+ * then reuses the same timing-safe comparison.
+ */
+function timingSafeAdminKeyMatch(apiKeys: ApiKey[], token: string): boolean {
+  return timingSafeKeyMatch(
+    apiKeys.filter((k) => k.admin === true),
+    token,
+  );
+}
+
 function getGatewayVersion(): string {
   try {
     const pkgPath = path.join(__dirname, '..', '..', 'package.json');
@@ -320,10 +335,12 @@ export class GatewayRouter {
   }
 
   /**
-   * Gate a dashboard-adjacent endpoint: accept a valid API key OR a live
-   * dashboard session cookie. When no API keys are configured, auth is disabled
-   * (open) — a keyless install has no credential to check and must not lock
-   * itself out. Writes 401 and returns false when unauthorized.
+   * Gate a dashboard-adjacent endpoint: accept an admin API key OR a live
+   * dashboard session cookie (which is itself only issued to an admin key). The
+   * dashboard grants cross-agent, host-wide power, so a non-admin (scoped or
+   * write-only) key is rejected. When no API keys are configured, auth is
+   * disabled (open) — a keyless install has no credential to check and must not
+   * lock itself out. Writes 401 and returns false when unauthorized.
    */
   private requireDashOrApiKey(req: Request, res: Response): boolean {
     const keys = this.apiKeys;
@@ -338,7 +355,7 @@ export class GatewayRouter {
       }
       return true; // keyless + loopback → open, as before
     }
-    if (timingSafeKeyMatch(keys, this.extractApiToken(req))) return true;
+    if (timingSafeAdminKeyMatch(keys, this.extractApiToken(req))) return true;
     if (this.hasValidDashSession(req)) return true;
     res.status(401).json({ error: 'Unauthorized' });
     return false;
@@ -608,7 +625,10 @@ export class GatewayRouter {
         return;
       }
       const key = ((req.body as { key?: string })?.key ?? '').toString();
-      if (!timingSafeKeyMatch(keys, key)) {
+      // Admin only: the session cookie this issues unlocks cross-agent, host-wide
+      // dashboard power, so a valid-but-non-admin key must not obtain one. The 401
+      // body stays generic (does not confirm the key exists but lacks admin).
+      if (!timingSafeAdminKeyMatch(keys, key)) {
         this.recordLoginFailure(req);
         res.status(401).json({ error: 'Invalid API key' });
         return;
@@ -772,6 +792,13 @@ export class GatewayRouter {
       process.stderr.write(
         `[gateway] WARNING: bound to ${host} with no gateway.api.keys — dashboard/status/processes are DISABLED (503) until you configure API keys. Set gateway.api.keys to enable access.\n`,
       );
+    } else if (this.isNonLoopbackBind() && !this.apiKeys.some((k) => k.admin === true)) {
+      // Keys exist but none is admin: the dashboard requires an admin key, so
+      // login/status/processes will reject every configured key (401). Warn so
+      // the operator knows why access is refused and marks a key `admin: true`.
+      process.stderr.write(
+        `[gateway] WARNING: bound to ${host} with API keys but none is admin — dashboard/status/processes require an admin key, so login will be refused (401). Mark a key "admin": true in gateway.api.keys to enable dashboard access.\n`,
+      );
     }
     return new Promise((resolve, reject) => {
       this.server = this.app.listen(port, host, () => {
@@ -845,12 +872,14 @@ export class GatewayRouter {
         }
 
         // Auth path 2: Bearer token or X-Api-Key header (for non-browser clients).
+        // Admin only — this path grants direct PTY keystroke injection into the
+        // agent's session, so a non-admin key must not pass.
         const authHeader = (req.headers['authorization'] as string | undefined) ?? '';
         const xApiKey = (req.headers['x-api-key'] as string | undefined) ?? '';
         const token = authHeader.startsWith('Bearer ')
           ? authHeader.slice(7).trim()
           : xApiKey.trim();
-        if (!timingSafeKeyMatch(apiKeys, token)) {
+        if (!timingSafeAdminKeyMatch(apiKeys, token)) {
           socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
           socket.destroy();
           return;

--- a/tests/integration/gateway-e2e.test.ts
+++ b/tests/integration/gateway-e2e.test.ts
@@ -366,7 +366,8 @@ describe('Gateway E2E (Option A — monitoring only)', () => {
       const workspace = createTempWorkspace(`e2e-ticket-${agentId}-`);
       const logDir = createTempDir(`e2e-ticket-${agentId}-log-`);
       const agentCfg = makeAgentConfig(agentId, `token-${agentId}`, workspace);
-      const gatewayCfg = makeGatewayConfig(logDir, [{ key: 'secret-key', agents: '*' }]);
+      // Admin key: the pty-ticket / dashboard surface requires admin (Issue #232).
+      const gatewayCfg = makeGatewayConfig(logDir, [{ key: 'secret-key', agents: '*', admin: true }]);
       const runner = new AgentRunner(agentCfg, gatewayCfg);
       await runner.start();
       // Tickets are bound to a session; stub one live session so the endpoint's

--- a/tests/unit/gateway-dashboard-auth.test.ts
+++ b/tests/unit/gateway-dashboard-auth.test.ts
@@ -1,9 +1,11 @@
 /**
  * Regression tests for the bind=0.0.0.0 hardening: with API keys configured, the
  * dashboard-adjacent endpoints that used to be reachable with no credential
- * (/status, /processes, /dashboard) now require an API key OR a dashboard session
- * cookie, and /health leaks nothing beyond liveness. When no API keys are
- * configured, behavior stays open (keyless installs must not lock themselves out).
+ * (/status, /processes, /dashboard) now require an ADMIN API key OR a dashboard
+ * session cookie (itself only issued to an admin key), and /health leaks nothing
+ * beyond liveness. A valid-but-non-admin (scoped/write) key is rejected. When no
+ * API keys are configured, behavior stays open (keyless installs must not lock
+ * themselves out).
  *
  * These exercise the real Express app built by GatewayRouter (getApp()) with
  * supertest — no port binding, no WS.
@@ -13,6 +15,7 @@ import { GatewayRouter } from '../../src/api/gateway-router';
 import { AgentConfig, GatewayConfig, ApiKey } from '../../src/types';
 
 const KEY = 'sk-gateway-test-000000';
+const NON_ADMIN_KEY = 'sk-gateway-scoped-00000';
 
 function buildApp(apiKeys: ApiKey[] = [], bind?: string) {
   const gatewayConfig: GatewayConfig = {
@@ -30,7 +33,12 @@ function buildApp(apiKeys: ApiKey[] = [], bind?: string) {
   return router.getApp();
 }
 
-const WITH_KEYS = [{ key: KEY, description: 'test', agents: '*' as const }];
+// The dashboard/monitoring surface requires an ADMIN key. KEY is admin; the
+// scoped key below is a valid, configured key that must NOT reach the dashboard.
+const WITH_KEYS = [
+  { key: KEY, description: 'test admin', agents: '*' as const, admin: true },
+  { key: NON_ADMIN_KEY, description: 'test scoped', agents: ['some-agent'] },
+];
 
 /** Extract the `name=value` pair from a Set-Cookie header for reuse as a Cookie. */
 function cookieFrom(res: { headers: Record<string, string[] | string> }): string {
@@ -202,6 +210,46 @@ describe('gateway dashboard auth hardening (bind 0.0.0.0)', () => {
     it.each(['::', '192.168.1.10'])('keyless on non-loopback %s fails closed (503)', async (bind) => {
       const res = await supertest(buildApp([], bind)).get('/status');
       expect(res.status).toBe(503);
+    });
+  });
+
+  describe('④ dashboard/monitoring requires an ADMIN key (non-admin key rejected)', () => {
+    it('POST /dashboard/login with a valid NON-admin key → 401, no cookie', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).post('/dashboard/login').send({ key: NON_ADMIN_KEY });
+      expect(res.status).toBe(401);
+      expect(res.headers['set-cookie']).toBeUndefined();
+    });
+
+    it('/status with a valid NON-admin key (X-Api-Key) → 401', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/status').set('X-Api-Key', NON_ADMIN_KEY);
+      expect(res.status).toBe(401);
+    });
+
+    it('/status with a valid NON-admin key (Bearer) → 401', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/status').set('Authorization', `Bearer ${NON_ADMIN_KEY}`);
+      expect(res.status).toBe(401);
+    });
+
+    it('/processes with a valid NON-admin key → 401', async () => {
+      const res = await supertest(buildApp(WITH_KEYS)).get('/processes').set('X-Api-Key', NON_ADMIN_KEY);
+      expect(res.status).toBe(401);
+    });
+
+    it('an ADMIN key is accepted at /status and /dashboard/login', async () => {
+      const app = buildApp(WITH_KEYS);
+      const status = await supertest(app).get('/status').set('X-Api-Key', KEY);
+      expect(status.status).toBe(200);
+      const login = await supertest(app).post('/dashboard/login').send({ key: KEY });
+      expect(login.status).toBe(200);
+    });
+
+    it('a config with keys but no admin key rejects every key at login (fail-closed)', async () => {
+      const scopedOnly = [{ key: NON_ADMIN_KEY, description: 'scoped', agents: ['some-agent'] }];
+      const app = buildApp(scopedOnly);
+      const login = await supertest(app).post('/dashboard/login').send({ key: NON_ADMIN_KEY });
+      expect(login.status).toBe(401);
+      const status = await supertest(app).get('/status').set('X-Api-Key', NON_ADMIN_KEY);
+      expect(status.status).toBe(401);
     });
   });
 


### PR DESCRIPTION
Closes #232.

## Problem

The dashboard/monitoring auth added in #231 accepted **any configured API key**, regardless of privilege tier. The dashboard grants cross-agent, host-wide power — session list, host process tree, and **PTY keystroke injection into any agent's session** (RCE as that agent) — none of which re-check the caller's `agents` scope. A key scoped to a single agent (or a write-only key) could therefore obtain full host-wide control, bypassing the per-key scoping the `/api/*` routers enforce.

## Fix

Restrict all three dashboard auth entry points to keys with `admin: true` via a new `timingSafeAdminKeyMatch` helper (pre-filters to admin keys, reuses the existing timing-safe compare):

- `POST /dashboard/login` — issues the 8h session cookie (`gateway-router.ts:611`)
- `requireDashOrApiKey` — guards `/status`, `/processes`, `/screen`, `POST /api/v1/pty-stream-ticket` (`:341`)
- the WebSocket `pty-stream` header auth path (`:853`)

The session cookie and PTY tickets inherit admin-only automatically — they are only issued after an admin match. A valid but non-admin key is rejected (`401`), with a generic body that does not confirm the key exists.

### Edge cases
- **Keyless + loopback** stays open; **keyless + non-loopback** stays fail-closed (`503`) — unchanged from #231.
- **Keys configured but none is admin**: dashboard is inaccessible (login `401`, fail-closed). A startup warning is emitted, mirroring the existing keyless fail-closed warning.

## Tests

Added a `④ requires an ADMIN key` block plus a no-admin-key fail-closed case: a valid non-admin key is rejected at `/dashboard/login`, `/status` (X-Api-Key + Bearer), and `/processes`, while an admin key is accepted. **Verified the new assertions fail on the pre-fix code** (5/5 red when `src/api/gateway-router.ts` is reverted). Updated the pty-ticket integration setup to use an admin key.

- `npm run typecheck` clean
- Directly-affected suites green (`gateway-dashboard-auth`, `gateway-e2e`)
- Full suite: 2570+/2572 — the only failures are the known parallel temp-dir race (a different suite each run; all pass in isolation), unrelated to this change

## Docs
`API.md` and `README.md` updated to state the dashboard/monitoring surface requires an admin key.