### PR TITLE
feat(telegram): capture human-readable sender name for chat picker

### DIFF
--- a/mcp/tools/telegram/pure.ts
+++ b/mcp/tools/telegram/pure.ts
@@ -375,7 +375,7 @@ export type TelegramSender = {
  * Telegram guarantees `first_name` for real users but makes `username` optional, so the
  * old `username ?? id` fallback surfaced a bare numeric id for anyone without a @handle —
  * which is what users saw in the cron Target picker. Prefer the real name:
- *   "First Last"  →  "First"  →  "@username"  →  "<id>"
+ *   "First Last"  →  "First"  →  "username"  →  "<id>"
  * The id fallback only triggers for the degenerate case (no name and no username at all),
  * preserving the legacy value rather than emitting an empty string.
  */

--- a/mcp/tools/telegram/pure.ts
+++ b/mcp/tools/telegram/pure.ts
@@ -360,3 +360,28 @@ export function isMentionedPure(input: GateInput, extraPatterns?: string[]): boo
   }
   return false
 }
+
+/** A Telegram sender, narrowed to the identity fields we read (grammy's `User`). */
+export type TelegramSender = {
+  id: number | string
+  first_name?: string
+  last_name?: string
+  username?: string
+}
+
+/**
+ * Human-readable display name for a Telegram sender, for the chat picker / history.
+ *
+ * Telegram guarantees `first_name` for real users but makes `username` optional, so the
+ * old `username ?? id` fallback surfaced a bare numeric id for anyone without a @handle —
+ * which is what users saw in the cron Target picker. Prefer the real name:
+ *   "First Last"  →  "First"  →  "@username"  →  "<id>"
+ * The id fallback only triggers for the degenerate case (no name and no username at all),
+ * preserving the legacy value rather than emitting an empty string.
+ */
+export function telegramDisplayName(from: TelegramSender): string {
+  const fullName = [from.first_name, from.last_name].filter(Boolean).join(' ').trim()
+  if (fullName) return fullName
+  if (from.username) return from.username
+  return String(from.id)
+}

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -38,7 +38,7 @@ import { formatTurnIncident, type TurnIncident } from '../../../dist/agent/turn-
 import { createIncidentStore } from '../../../dist/agent/incident-store.js'
 import type { RecoveryOutcome } from '../../../dist/agent/incident.js'
 import { initDedupDir, isDuplicate as _isDuplicate, pruneDedup as _pruneDedup } from './dedup'
-import { hasMarkdown, toTelegramHtml, migrateAccess } from './pure'
+import { hasMarkdown, toTelegramHtml, migrateAccess, telegramDisplayName } from './pure'
 
 // Standalone fallback: default state dir to ~/.claude/channels/telegram
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
@@ -1044,6 +1044,9 @@ async function handleInbound(
       ...(msgId != null ? { message_id: String(msgId) } : {}),
       user: from.username ?? String(from.id),
       user_id: String(from.id),
+      // Human-readable name for the chat picker / history (first_name is always
+      // present; `user` above stays the @handle-or-id for the channel tag).
+      sender_name: telegramDisplayName(from),
       ts: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),
       ...(imagePath ? { image_path: imagePath } : {}),
       ...(attachment ? {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -879,7 +879,7 @@ export class AgentRunner extends EventEmitter {
             source: channelSource as HistorySource,
             role: 'user',
             content: userContent,
-            senderName: meta['user'] ?? undefined,
+            senderName: meta['sender_name'] ?? meta['user'] ?? undefined,
             senderId: meta['user_id'] ?? meta['chat_id'] ?? undefined,
             platformMessageId: meta['message_id'] ?? undefined,
             mediaFiles: mediaFiles.length > 0 ? mediaFiles : undefined,

--- a/tests/unit/telegram-plugin/display-name.test.ts
+++ b/tests/unit/telegram-plugin/display-name.test.ts
@@ -19,6 +19,12 @@ describe('telegramDisplayName', () => {
     expect(telegramDisplayName(from)).toBe('Elizabeth')
   })
 
+  it('uses last name alone when first name is absent', () => {
+    // Unrealistic for Telegram (first_name is guaranteed), but completes the name-branch matrix.
+    const from: TelegramSender = { id: 42, last_name: 'Churchill', username: 'liz' }
+    expect(telegramDisplayName(from)).toBe('Churchill')
+  })
+
   it('prefers the real name over the @username handle', () => {
     // The regression: a user WITH a name should never surface as their handle.
     const from: TelegramSender = { id: 42, first_name: 'Elizabeth', username: 'liz' }

--- a/tests/unit/telegram-plugin/display-name.test.ts
+++ b/tests/unit/telegram-plugin/display-name.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for telegramDisplayName() from mcp/tools/telegram/pure.ts
+ *
+ * Guards the cron Target picker fix: the display name recorded to history (and
+ * surfaced by listChats().displayName) must be a human-readable name, not the
+ * bare numeric chat id that the old `username ?? id` fallback produced for users
+ * without a @handle.
+ */
+import { telegramDisplayName, TelegramSender } from '../../../mcp/tools/telegram/pure'
+
+describe('telegramDisplayName', () => {
+  it('uses first + last name when both are present', () => {
+    const from: TelegramSender = { id: 42, first_name: 'Elizabeth', last_name: 'Churchill', username: 'liz' }
+    expect(telegramDisplayName(from)).toBe('Elizabeth Churchill')
+  })
+
+  it('uses first name alone when last name is absent', () => {
+    const from: TelegramSender = { id: 42, first_name: 'Elizabeth', username: 'liz' }
+    expect(telegramDisplayName(from)).toBe('Elizabeth')
+  })
+
+  it('prefers the real name over the @username handle', () => {
+    // The regression: a user WITH a name should never surface as their handle.
+    const from: TelegramSender = { id: 42, first_name: 'Elizabeth', username: 'liz' }
+    expect(telegramDisplayName(from)).not.toBe('liz')
+    expect(telegramDisplayName(from)).toBe('Elizabeth')
+  })
+
+  it('falls back to the username when no name is set', () => {
+    const from: TelegramSender = { id: 42, username: 'liz' }
+    expect(telegramDisplayName(from)).toBe('liz')
+  })
+
+  it('falls back to the id only when neither name nor username exists', () => {
+    // This is the exact case the fix targets: previously the picker showed this number.
+    const from: TelegramSender = { id: 7144530640 }
+    expect(telegramDisplayName(from)).toBe('7144530640')
+  })
+
+  it('stringifies a numeric id in the last-resort fallback', () => {
+    const from: TelegramSender = { id: 12345 }
+    expect(telegramDisplayName(from)).toBe('12345')
+    expect(typeof telegramDisplayName(from)).toBe('string')
+  })
+
+  it('ignores an empty-string first name and falls through to username', () => {
+    const from: TelegramSender = { id: 42, first_name: '', username: 'liz' }
+    expect(telegramDisplayName(from)).toBe('liz')
+  })
+
+  it('trims surrounding whitespace from the composed name', () => {
+    const from: TelegramSender = { id: 42, first_name: ' Elizabeth ', last_name: '' }
+    expect(telegramDisplayName(from)).toBe('Elizabeth')
+  })
+})


### PR DESCRIPTION
## Summary

Telegram makes `username` optional, so the previous `username ?? id` fallback surfaced a bare **numeric chat id** for any sender without a `@handle`. That numeric id is what users saw in the cron **Target picker** (via `listChats().displayName`, which reads `MAX(sender_name)`), instead of a human-readable name.

This PR captures a human-readable sender name at the source, on inbound message meta, so every downstream consumer (chat picker included) gets a real name.

## Changes

- Add a pure `telegramDisplayName()` helper with the fallback chain **"First Last" → "First" → "username" → "\<id\>"** (`mcp/tools/telegram/pure.ts`).
- Populate a new `sender_name` field on inbound message meta from that helper (`mcp/tools/telegram/receiver-server.ts`).
- Agent runner prefers `sender_name` over the raw `user` handle (`src/agent/runner.ts`).
- The channel tag `user` value is **unchanged**, so nothing downstream breaks.

## Testing

- 9 unit tests over the full fallback chain (`tests/unit/telegram-plugin/display-name.test.ts`).

## Notes

- 4 files changed, +91 / -2.
- Related: #187 (editable agent name — a distinct feature; that is the bot's own name, this is the human sender's name).

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
