### PR TITLE
feat(cron): expose cron_update in the MCP cron tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ The MCP server (`mcp/server.ts`) uses a **modular multi-channel architecture**. 
 |--------|-----------|-------|---------|
 | `telegram` | `ChannelModule` | `telegram_reply`, `telegram_react`, `telegram_edit_message`, `telegram_download_attachment` | Send messages, reactions, edit messages in Telegram |
 | `discord` | `ChannelModule` | `discord_reply`, `discord_react`, `discord_edit_message` | Send messages, reactions, edit messages in Discord |
-| `cron` | `ToolModule` | `cron_list`, `cron_create`, `cron_delete`, `cron_run`, `cron_get_runs` | Manage scheduled jobs via gateway REST API |
+| `cron` | `ToolModule` | `cron_list`, `cron_create`, `cron_update`, `cron_delete`, `cron_run`, `cron_get_runs` | Manage scheduled jobs via gateway REST API |
 | `skills` | `ToolModule` | `skill_create`, `skill_delete`, `skill_install` | Create, delete, and install agent skills at runtime |
 
 Tools are **prefixed by channel name** to avoid collisions. Each module controls its own visibility and lifecycle.
@@ -661,7 +661,7 @@ claude-gateway/
         │       └── configure/SKILL.md     ← /telegram:configure skill
         │
         ├── cron/                       ← Cron tool module
-        │   ├── module.ts              ← ToolModule: cron_list, create, delete, run, get_runs
+        │   ├── module.ts              ← ToolModule: cron_list, create, update, delete, run, get_runs
         │   ├── client.ts             ← HTTP client for gateway cron REST API
         │   └── skills/
         │       └── cron/SKILL.md          ← /cron skill

--- a/mcp/tools/cron/client.ts
+++ b/mcp/tools/cron/client.ts
@@ -51,6 +51,13 @@ export class CronClient {
     return this.request('POST', '', { ...params, agentId: this.agentId });
   }
 
+  async update(jobId: string, params: Record<string, unknown>): Promise<unknown> {
+    // Mirrors the backend PUT /v1/crons/:id route (CronManager.update). Unlike
+    // create, no agentId is sent — the route reads it from the stored job for
+    // its access check, and CronJobUpdate has no agentId field.
+    return this.request('PUT', `/${jobId}`, params);
+  }
+
   async delete(jobId: string): Promise<void> {
     await this.request('DELETE', `/${jobId}`);
   }

--- a/mcp/tools/cron/module.ts
+++ b/mcp/tools/cron/module.ts
@@ -90,6 +90,39 @@ export class CronModule implements ToolModule {
         },
       },
       {
+        name: 'cron_update',
+        description: 'Update an existing cron job. Provide job_id plus only the fields to change.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            job_id: { type: 'string', description: 'ID of the job to update' },
+            name: { type: 'string', description: 'Job name' },
+            schedule: { type: 'string', description: '5-field cron expression' },
+            type: { type: 'string', enum: ['command', 'agent'], description: 'Job type' },
+            command: { type: 'string', description: 'Shell command (type=command)' },
+            prompt: { type: 'string', description: 'Agent prompt (type=agent)' },
+            telegram: { type: 'string', description: 'Telegram chat_id for response' },
+            discord: { type: 'string', description: 'Discord channel_id for agent response delivery' },
+            timeout_ms: { type: 'number', description: 'Timeout in milliseconds' },
+            scheduleKind: {
+              type: 'string',
+              enum: ['cron', 'at'],
+              description: 'Schedule type: "cron" for recurring, "at" for one-shot at a specific ISO datetime',
+            },
+            scheduleAt: {
+              type: 'string',
+              description: 'ISO 8601 datetime for one-shot execution (required when scheduleKind=at)',
+            },
+            deleteAfterRun: {
+              type: 'boolean',
+              description: 'Delete the job after it runs once',
+            },
+          },
+          required: ['job_id'],
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'cron_run',
         description: 'Run a cron job immediately',
         inputSchema: {
@@ -138,6 +171,14 @@ export class CronModule implements ToolModule {
         case 'cron_delete': {
           await client.delete(args.job_id as string);
           return { content: [{ type: 'text', text: `deleted job ${args.job_id}` }] };
+        }
+        case 'cron_update': {
+          const { job_id, ...rest } = args as { job_id?: string } & Record<string, unknown>;
+          if (!job_id) {
+            return { content: [{ type: 'text', text: 'cron_update failed: job_id is required' }], isError: true };
+          }
+          const job = await client.update(job_id, rest);
+          return { content: [{ type: 'text', text: JSON.stringify(job, null, 2) }] };
         }
         case 'cron_run': {
           const run = await client.run(args.job_id as string);

--- a/mcp/tools/cron/skills/cron/SKILL.md
+++ b/mcp/tools/cron/skills/cron/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: cron
-description: Manage scheduled cron jobs for this agent — list, create, delete, run, and view run history. Use when the user asks to schedule tasks, set up recurring jobs, or check cron status.
+description: Manage scheduled cron jobs for this agent — list, create, update, delete, run, and view run history. Use when the user asks to schedule tasks, set up recurring jobs, or check cron status.
 user-invocable: true
 allowed-tools:
   - cron_list
   - cron_create
+  - cron_update
   - cron_delete
   - cron_run
   - cron_get_runs
@@ -36,6 +37,13 @@ Use `cron_create` with the required parameters:
 ### "delete <job_id>" — Delete a cron job
 
 Use `cron_delete` with `job_id`.
+
+### "update <job_id>" — Update an existing cron job
+
+Use `cron_update` with `job_id` plus only the fields to change (e.g. `schedule`,
+`name`, `prompt`, `telegram`, `discord`, `scheduleKind`, `scheduleAt`). Fields left
+out are kept as-is. This edits the job in place, preserving its id and run history
+(unlike delete-and-recreate).
 
 ### "run <job_id>" — Run a job immediately
 

--- a/tests/unit/cron-module.test.ts
+++ b/tests/unit/cron-module.test.ts
@@ -36,15 +36,16 @@ describe('CronModule', () => {
   });
 
   describe('getTools', () => {
-    it('should return 5 cron-prefixed tools', () => {
+    it('should return 6 cron-prefixed tools', () => {
       const mod = new CronModule();
       const tools = mod.getTools();
 
-      expect(tools).toHaveLength(5);
+      expect(tools).toHaveLength(6);
 
       const names = tools.map(t => t.name);
       expect(names).toContain('cron_list');
       expect(names).toContain('cron_create');
+      expect(names).toContain('cron_update');
       expect(names).toContain('cron_delete');
       expect(names).toContain('cron_run');
       expect(names).toContain('cron_get_runs');
@@ -75,6 +76,21 @@ describe('CronModule', () => {
 
       expect(list).toBeDefined();
       expect(list.description).toContain('List');
+    });
+
+    // cron_update tool schema: job_id required, editable fields present
+    it('cron_update tool should require job_id and expose editable fields', () => {
+      const mod = new CronModule();
+      const tools = mod.getTools();
+      const update = tools.find(t => t.name === 'cron_update')!;
+
+      expect(update).toBeDefined();
+      const schema = update.inputSchema as any;
+      expect(schema.required).toEqual(['job_id']);
+      expect(schema.properties).toHaveProperty('schedule');
+      expect(schema.properties).toHaveProperty('prompt');
+      expect(schema.properties).toHaveProperty('telegram');
+      expect(schema.properties).toHaveProperty('discord');
     });
   });
 
@@ -190,6 +206,65 @@ describe('CronModule', () => {
 
       const body = capturedBody(fetchMock);
       expect(body.deleteAfterRun).toBe(false);
+    });
+  });
+
+  // ─── cron_update (#237) ────────────────────────────────────────────────────
+
+  describe('cron_update handler', () => {
+    let originalFetch: typeof global.fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+      process.env.GATEWAY_API_URL = 'http://localhost:3000';
+      process.env.GATEWAY_AGENT_ID = 'test-agent';
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    function mockFetch(responseBody: unknown) {
+      return jest.fn().mockImplementation(async () => {
+        return new Response(JSON.stringify(responseBody), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+    }
+
+    it('maps to PUT /api/v1/crons/:id with only the changed fields (no agentId)', async () => {
+      const fetchMock = mockFetch({ id: 'j1', name: 'renamed' });
+      global.fetch = fetchMock;
+
+      const mod = new CronModule();
+      const result = await mod.handleTool('cron_update', {
+        job_id: 'j1',
+        name: 'renamed',
+        schedule: '30 9 * * *',
+      });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('PUT');
+      expect(url).toBe('http://localhost:3000/api/v1/crons/j1');
+
+      const body = JSON.parse(init.body as string);
+      expect(body).toEqual({ name: 'renamed', schedule: '30 9 * * *' });
+      expect(body).not.toHaveProperty('job_id'); // job_id goes in the path, not the body
+      expect(body).not.toHaveProperty('agentId'); // update reads agentId from the stored job
+
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('rejects a call with no job_id without hitting the API', async () => {
+      const fetchMock = mockFetch({});
+      global.fetch = fetchMock;
+
+      const mod = new CronModule();
+      const result = await mod.handleTool('cron_update', { name: 'x' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('job_id is required');
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/cron-module.test.ts
+++ b/tests/unit/cron-module.test.ts
@@ -266,5 +266,20 @@ describe('CronModule', () => {
       expect(result.content[0].text).toContain('job_id is required');
       expect(fetchMock).not.toHaveBeenCalled();
     });
+
+    it('sends an empty body when only job_id is given (no-op update)', async () => {
+      const fetchMock = mockFetch({ id: 'j1' });
+      global.fetch = fetchMock;
+
+      const mod = new CronModule();
+      const result = await mod.handleTool('cron_update', { job_id: 'j1' });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('PUT');
+      expect(url).toBe('http://localhost:3000/api/v1/crons/j1');
+      // Only job_id was supplied → it goes in the path, leaving an empty body.
+      expect(JSON.parse(init.body as string)).toEqual({});
+      expect(result.isError).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
## Summary
Expose a `cron_update` tool in the MCP cron toolset so an agent can edit an existing cron job in place. The backend update path already exists end-to-end (`CronManager.update` + `PUT /v1/crons/:id`); this PR only adds the missing MCP wrapper — previously an agent could create/list/delete/run jobs but never modify one (only delete-and-recreate, which loses the job id and run history).

Closes #237.

## Changes
- **`mcp/tools/cron/client.ts`** — add `CronClient.update(jobId, params)` issuing `PUT /api/v1/crons/:id`. Unlike `create`, no `agentId` is sent in the body — the route reads it from the stored job for its access check, and `CronJobUpdate` has no `agentId` field.
- **`mcp/tools/cron/module.ts`** — add the `cron_update` tool (required `job_id` + editable fields mirroring `cron_create`) and its handler; a missing `job_id` errors without hitting the API.
- **`mcp/tools/cron/skills/cron/SKILL.md`** — document `cron_update`.
- **`tests/unit/cron-module.test.ts`** — tool count 5→6, a schema assertion, and handler tests for the PUT URL/body mapping and the missing-`job_id` guard.

## Testing
- `cron-module.test.ts`: 15/15 pass
- Full cron group (module + manager + router + scheduler): 85/85 pass

## Notes
- **Schema coupling with #234:** #234 (LINE cron delivery) adds a `line` param to `cron_create`. Whichever of {#234, this PR} merges second must rebase `module.ts`, and once both land `cron_update` should also accept `line` so an existing job's LINE target can be edited.
- **Pre-existing `timeout_ms` mismatch:** this tool mirrors `cron_create`'s field names exactly, including `timeout_ms`, even though `CronManager` reads `timeoutMs` (camelCase). This snake/camel mismatch predates this PR and affects `cron_create` equally; behavior is preserved here rather than silently changed. Tracked and fixed for both tools in #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)