### PR TITLE
fix(cron): honor timeout_ms in MCP cron_create/cron_update

### DIFF
--- a/mcp/tools/cron/client.ts
+++ b/mcp/tools/cron/client.ts
@@ -51,6 +51,13 @@ export class CronClient {
     return this.request('POST', '', { ...params, agentId: this.agentId });
   }
 
+  async update(jobId: string, params: Record<string, unknown>): Promise<unknown> {
+    // Mirrors the backend PUT /v1/crons/:id route (CronManager.update). Unlike
+    // create, no agentId is sent — the route reads it from the stored job for
+    // its access check, and CronJobUpdate has no agentId field.
+    return this.request('PUT', `/${jobId}`, params);
+  }
+
   async delete(jobId: string): Promise<void> {
     await this.request('DELETE', `/${jobId}`);
   }

--- a/mcp/tools/cron/client.ts
+++ b/mcp/tools/cron/client.ts
@@ -20,6 +20,16 @@ export class CronClient {
     return `${base}?${qs}`;
   }
 
+  // The MCP cron tool schemas advertise `timeout_ms` (snake_case), but the REST
+  // API and the CronJob model use `timeoutMs` (camelCase). Map it here so a
+  // timeout set via cron_create / cron_update is actually honored instead of
+  // silently falling back to the default. See #239.
+  private normalizeParams(params: Record<string, unknown>): Record<string, unknown> {
+    if (!('timeout_ms' in params)) return params;
+    const { timeout_ms, ...rest } = params as { timeout_ms?: unknown } & Record<string, unknown>;
+    return timeout_ms !== undefined ? { ...rest, timeoutMs: timeout_ms } : rest;
+  }
+
   private async request(method: string, path: string, body?: unknown, query?: Record<string, string>): Promise<unknown> {
     const headers: Record<string, string> = {};
     if (body) headers['Content-Type'] = 'application/json';
@@ -48,14 +58,14 @@ export class CronClient {
   }
 
   async create(params: Record<string, unknown>): Promise<unknown> {
-    return this.request('POST', '', { ...params, agentId: this.agentId });
+    return this.request('POST', '', { ...this.normalizeParams(params), agentId: this.agentId });
   }
 
   async update(jobId: string, params: Record<string, unknown>): Promise<unknown> {
     // Mirrors the backend PUT /v1/crons/:id route (CronManager.update). Unlike
     // create, no agentId is sent — the route reads it from the stored job for
     // its access check, and CronJobUpdate has no agentId field.
-    return this.request('PUT', `/${jobId}`, params);
+    return this.request('PUT', `/${jobId}`, this.normalizeParams(params));
   }
 
   async delete(jobId: string): Promise<void> {

--- a/mcp/tools/cron/module.ts
+++ b/mcp/tools/cron/module.ts
@@ -90,6 +90,39 @@ export class CronModule implements ToolModule {
         },
       },
       {
+        name: 'cron_update',
+        description: 'Update an existing cron job. Provide job_id plus only the fields to change.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            job_id: { type: 'string', description: 'ID of the job to update' },
+            name: { type: 'string', description: 'Job name' },
+            schedule: { type: 'string', description: '5-field cron expression' },
+            type: { type: 'string', enum: ['command', 'agent'], description: 'Job type' },
+            command: { type: 'string', description: 'Shell command (type=command)' },
+            prompt: { type: 'string', description: 'Agent prompt (type=agent)' },
+            telegram: { type: 'string', description: 'Telegram chat_id for response' },
+            discord: { type: 'string', description: 'Discord channel_id for agent response delivery' },
+            timeout_ms: { type: 'number', description: 'Timeout in milliseconds' },
+            scheduleKind: {
+              type: 'string',
+              enum: ['cron', 'at'],
+              description: 'Schedule type: "cron" for recurring, "at" for one-shot at a specific ISO datetime',
+            },
+            scheduleAt: {
+              type: 'string',
+              description: 'ISO 8601 datetime for one-shot execution (required when scheduleKind=at)',
+            },
+            deleteAfterRun: {
+              type: 'boolean',
+              description: 'Delete the job after it runs once',
+            },
+          },
+          required: ['job_id'],
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'cron_run',
         description: 'Run a cron job immediately',
         inputSchema: {
@@ -138,6 +171,14 @@ export class CronModule implements ToolModule {
         case 'cron_delete': {
           await client.delete(args.job_id as string);
           return { content: [{ type: 'text', text: `deleted job ${args.job_id}` }] };
+        }
+        case 'cron_update': {
+          const { job_id, ...rest } = args as { job_id?: string } & Record<string, unknown>;
+          if (!job_id) {
+            return { content: [{ type: 'text', text: 'cron_update failed: job_id is required' }], isError: true };
+          }
+          const job = await client.update(job_id, rest);
+          return { content: [{ type: 'text', text: JSON.stringify(job, null, 2) }] };
         }
         case 'cron_run': {
           const run = await client.run(args.job_id as string);

--- a/mcp/tools/cron/skills/cron/SKILL.md
+++ b/mcp/tools/cron/skills/cron/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: cron
-description: Manage scheduled cron jobs for this agent — list, create, delete, run, and view run history. Use when the user asks to schedule tasks, set up recurring jobs, or check cron status.
+description: Manage scheduled cron jobs for this agent — list, create, update, delete, run, and view run history. Use when the user asks to schedule tasks, set up recurring jobs, or check cron status.
 user-invocable: true
 allowed-tools:
   - cron_list
   - cron_create
+  - cron_update
   - cron_delete
   - cron_run
   - cron_get_runs
@@ -36,6 +37,13 @@ Use `cron_create` with the required parameters:
 ### "delete <job_id>" — Delete a cron job
 
 Use `cron_delete` with `job_id`.
+
+### "update <job_id>" — Update an existing cron job
+
+Use `cron_update` with `job_id` plus only the fields to change (e.g. `schedule`,
+`name`, `prompt`, `telegram`, `discord`, `scheduleKind`, `scheduleAt`). Fields left
+out are kept as-is. This edits the job in place, preserving its id and run history
+(unlike delete-and-recreate).
 
 ### "run <job_id>" — Run a job immediately
 

--- a/tests/unit/cron-module.test.ts
+++ b/tests/unit/cron-module.test.ts
@@ -36,15 +36,16 @@ describe('CronModule', () => {
   });
 
   describe('getTools', () => {
-    it('should return 5 cron-prefixed tools', () => {
+    it('should return 6 cron-prefixed tools', () => {
       const mod = new CronModule();
       const tools = mod.getTools();
 
-      expect(tools).toHaveLength(5);
+      expect(tools).toHaveLength(6);
 
       const names = tools.map(t => t.name);
       expect(names).toContain('cron_list');
       expect(names).toContain('cron_create');
+      expect(names).toContain('cron_update');
       expect(names).toContain('cron_delete');
       expect(names).toContain('cron_run');
       expect(names).toContain('cron_get_runs');
@@ -75,6 +76,21 @@ describe('CronModule', () => {
 
       expect(list).toBeDefined();
       expect(list.description).toContain('List');
+    });
+
+    // cron_update tool schema: job_id required, editable fields present
+    it('cron_update tool should require job_id and expose editable fields', () => {
+      const mod = new CronModule();
+      const tools = mod.getTools();
+      const update = tools.find(t => t.name === 'cron_update')!;
+
+      expect(update).toBeDefined();
+      const schema = update.inputSchema as any;
+      expect(schema.required).toEqual(['job_id']);
+      expect(schema.properties).toHaveProperty('schedule');
+      expect(schema.properties).toHaveProperty('prompt');
+      expect(schema.properties).toHaveProperty('telegram');
+      expect(schema.properties).toHaveProperty('discord');
     });
   });
 
@@ -190,6 +206,65 @@ describe('CronModule', () => {
 
       const body = capturedBody(fetchMock);
       expect(body.deleteAfterRun).toBe(false);
+    });
+  });
+
+  // ─── cron_update (#237) ────────────────────────────────────────────────────
+
+  describe('cron_update handler', () => {
+    let originalFetch: typeof global.fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+      process.env.GATEWAY_API_URL = 'http://localhost:3000';
+      process.env.GATEWAY_AGENT_ID = 'test-agent';
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    function mockFetch(responseBody: unknown) {
+      return jest.fn().mockImplementation(async () => {
+        return new Response(JSON.stringify(responseBody), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+    }
+
+    it('maps to PUT /api/v1/crons/:id with only the changed fields (no agentId)', async () => {
+      const fetchMock = mockFetch({ id: 'j1', name: 'renamed' });
+      global.fetch = fetchMock;
+
+      const mod = new CronModule();
+      const result = await mod.handleTool('cron_update', {
+        job_id: 'j1',
+        name: 'renamed',
+        schedule: '30 9 * * *',
+      });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('PUT');
+      expect(url).toBe('http://localhost:3000/api/v1/crons/j1');
+
+      const body = JSON.parse(init.body as string);
+      expect(body).toEqual({ name: 'renamed', schedule: '30 9 * * *' });
+      expect(body).not.toHaveProperty('job_id'); // job_id goes in the path, not the body
+      expect(body).not.toHaveProperty('agentId'); // update reads agentId from the stored job
+
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('rejects a call with no job_id without hitting the API', async () => {
+      const fetchMock = mockFetch({});
+      global.fetch = fetchMock;
+
+      const mod = new CronModule();
+      const result = await mod.handleTool('cron_update', { name: 'x' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('job_id is required');
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/cron-module.test.ts
+++ b/tests/unit/cron-module.test.ts
@@ -266,5 +266,20 @@ describe('CronModule', () => {
       expect(result.content[0].text).toContain('job_id is required');
       expect(fetchMock).not.toHaveBeenCalled();
     });
+
+    it('sends an empty body when only job_id is given (no-op update)', async () => {
+      const fetchMock = mockFetch({ id: 'j1' });
+      global.fetch = fetchMock;
+
+      const mod = new CronModule();
+      const result = await mod.handleTool('cron_update', { job_id: 'j1' });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('PUT');
+      expect(url).toBe('http://localhost:3000/api/v1/crons/j1');
+      // Only job_id was supplied → it goes in the path, leaving an empty body.
+      expect(JSON.parse(init.body as string)).toEqual({});
+      expect(result.isError).toBeFalsy();
+    });
   });
 });

--- a/tests/unit/cron-module.test.ts
+++ b/tests/unit/cron-module.test.ts
@@ -207,6 +207,26 @@ describe('CronModule', () => {
       const body = capturedBody(fetchMock);
       expect(body.deleteAfterRun).toBe(false);
     });
+
+    // #239: the tool advertises timeout_ms (snake) but the backend reads timeoutMs (camel)
+    it('#239: cron_create maps timeout_ms → timeoutMs in the request body', async () => {
+      const fetchMock = mockFetch({ id: 'j4', name: 'test' });
+      global.fetch = fetchMock;
+
+      const mod = new CronModule();
+      await mod.handleTool('cron_create', {
+        name: 'timed-job',
+        type: 'agent',
+        schedule: '* * * * *',
+        prompt: 'do something',
+        telegram: 'PLACEHOLDER_CHAT_ID',
+        timeout_ms: 5000,
+      });
+
+      const body = capturedBody(fetchMock);
+      expect(body.timeoutMs).toBe(5000);
+      expect(body).not.toHaveProperty('timeout_ms');
+    });
   });
 
   // ─── cron_update (#237) ────────────────────────────────────────────────────
@@ -280,6 +300,20 @@ describe('CronModule', () => {
       // Only job_id was supplied → it goes in the path, leaving an empty body.
       expect(JSON.parse(init.body as string)).toEqual({});
       expect(result.isError).toBeFalsy();
+    });
+
+    // #239: same snake→camel mapping on the update path
+    it('#239: maps timeout_ms → timeoutMs in the request body', async () => {
+      const fetchMock = mockFetch({ id: 'j1' });
+      global.fetch = fetchMock;
+
+      const mod = new CronModule();
+      await mod.handleTool('cron_update', { job_id: 'j1', timeout_ms: 5000 });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body).toEqual({ timeoutMs: 5000 });
+      expect(body).not.toHaveProperty('timeout_ms');
     });
   });
 });


### PR DESCRIPTION
## Summary
The MCP cron tool schemas advertise a `timeout_ms` parameter, but the REST API and the `CronJob` model read `timeoutMs` (camelCase), so a timeout set via `cron_create` or `cron_update` was silently dropped — the job always fell back to the default (120000ms). This maps `timeout_ms` → `timeoutMs` at the `CronClient` boundary, keeping the advertised tool param name unchanged.

Closes #239.

## ⚠️ Depends on #238 — merge order
This branch is **stacked on #238** (`feat/237-cron-update-mcp-tool`) because the fix covers `cron_update`, which only exists in #238. Until #238 merges, this PR's diff will also show #238's two commits (`6210c21`, `74f96de`). **Merge #238 first, then this PR** (or rebase this onto `main` after #238 lands). The only commit unique to this PR is `02184d1`.

## Changes
- **`mcp/tools/cron/client.ts`** — add `normalizeParams()` that renames `timeout_ms` → `timeoutMs`, applied in both `create` and `update`. The public tool parameter name stays `timeout_ms` (no breaking change); the mapping is internal.
- **`tests/unit/cron-module.test.ts`** — assert the request body carries `timeoutMs` (and no leftover `timeout_ms`) for both `cron_create` and `cron_update`.

## Testing
- `cron-module.test.ts`: 18/18 pass
- Full cron group (module + manager + router + scheduler): 88/88 pass

## Out of Scope
- No change to `CronManager` / the REST route / the `CronJob*` types — the backend contract (`timeoutMs`) is already correct.
- Renaming the advertised tool parameter to `timeoutMs` (would break any caller already using `timeout_ms`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
