### PR TITLE
Support Opus 5 as a first-class model (+ fix duplicate cron update from #240)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1388,12 +1388,15 @@ curl -H "X-Api-Key: my-secret-key-123" \
 ```json
 {
   "models": [
-    { "id": "claude-opus-4-8", "name": "Claude Opus 4.8", "alias": "opus",   "contextWindow": 1000000, "multiplier": 3 },
-    { "id": "claude-opus-4-7", "name": "Claude Opus 4.7", "alias": "opus47", "contextWindow": 1000000, "multiplier": 3 },
-    { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "alias": "sonnet", "contextWindow": 1000000, "multiplier": 1 }
+    { "id": "claude-opus-5",     "name": "Opus 5",     "alias": "opus",     "contextWindow": 200000,  "multiplier": 1 },
+    { "id": "claude-opus-5[1m]", "name": "Opus 5 (1M)", "alias": "opus[1m]", "contextWindow": 1000000, "multiplier": 1 },
+    { "id": "claude-opus-4-8",   "name": "Opus 4.8",   "alias": "opus48",   "contextWindow": 200000,  "multiplier": 1 },
+    { "id": "claude-sonnet-5",   "name": "Sonnet 5",   "alias": "sonnet",   "contextWindow": 200000,  "multiplier": 1 }
   ]
 }
 ```
+
+> The bare family alias always points at the newest model of that family (`opus` → Opus 5, `sonnet` → Sonnet 5); older members keep a versioned alias (`opus48`). This is a representative subset — the endpoint returns the full configured list.
 
 ---
 

--- a/config.template.json
+++ b/config.template.json
@@ -10,17 +10,19 @@
       "claude.dangerouslySkipPermissions"
     ]
   },
-  "configVersion": "1.0.14",
+  "configVersion": "1.0.15",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "bind": "127.0.0.1",
     "models": [
       { "id": "claude-fable-5[1m]",        "label": "Fable 5 (1M)",     "alias": "fable[1m]",   "contextWindow": 1000000 },
-      { "id": "claude-opus-4-8[1m]",       "label": "Opus 4.8 (1M)",    "alias": "opus[1m]",    "contextWindow": 1000000 },
+      { "id": "claude-opus-5[1m]",         "label": "Opus 5 (1M)",      "alias": "opus[1m]",    "contextWindow": 1000000 },
+      { "id": "claude-opus-4-8[1m]",       "label": "Opus 4.8 (1M)",    "alias": "opus48[1m]",  "contextWindow": 1000000 },
       { "id": "claude-sonnet-5[1m]",       "label": "Sonnet 5 (1M)",    "alias": "sonnet[1m]",  "contextWindow": 1000000 },
       { "id": "claude-fable-5",            "label": "Fable 5",          "alias": "fable",       "contextWindow": 200000 },
-      { "id": "claude-opus-4-8",           "label": "Opus 4.8",         "alias": "opus",        "contextWindow": 200000 },
+      { "id": "claude-opus-5",             "label": "Opus 5",           "alias": "opus",        "contextWindow": 200000 },
+      { "id": "claude-opus-4-8",           "label": "Opus 4.8",         "alias": "opus48",      "contextWindow": 200000 },
       { "id": "claude-opus-4-6",           "label": "Opus 4.6",         "alias": "opus46",      "contextWindow": 200000 },
       { "id": "claude-sonnet-5",           "label": "Sonnet 5",         "alias": "sonnet",      "contextWindow": 200000 },
       { "id": "claude-sonnet-4-6",         "label": "Sonnet 4.6",       "alias": "sonnet46",    "contextWindow": 200000 },

--- a/mcp/tools/cron/client.ts
+++ b/mcp/tools/cron/client.ts
@@ -68,13 +68,6 @@ export class CronClient {
     return this.request('PUT', `/${jobId}`, this.normalizeParams(params));
   }
 
-  async update(jobId: string, params: Record<string, unknown>): Promise<unknown> {
-    // Mirrors the backend PUT /v1/crons/:id route (CronManager.update). Unlike
-    // create, no agentId is sent — the route reads it from the stored job for
-    // its access check, and CronJobUpdate has no agentId field.
-    return this.request('PUT', `/${jobId}`, params);
-  }
-
   async delete(jobId: string): Promise<void> {
     await this.request('DELETE', `/${jobId}`);
   }

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -886,13 +886,18 @@ const BOT_COMMANDS = [
   { command: 'help', description: 'What this bot can do' },
 ]
 
-// Available AI models for /models command
+// Available AI models for /models command. Fallback only — the picker normally
+// uses the live list from the gateway (get_models); this is shown if that call
+// fails. Keep in sync with DEFAULT_MODELS (src/agent/runner.ts) and
+// config.template.json gateway.models.
 const AVAILABLE_MODELS = [
   { id: 'claude-fable-5[1m]',        label: 'Fable 5 (1M)',     alias: 'fable[1m]' },
-  { id: 'claude-opus-4-8[1m]',       label: 'Opus 4.8 (1M)',    alias: 'opus[1m]' },
+  { id: 'claude-opus-5[1m]',         label: 'Opus 5 (1M)',      alias: 'opus[1m]' },
+  { id: 'claude-opus-4-8[1m]',       label: 'Opus 4.8 (1M)',    alias: 'opus48[1m]' },
   { id: 'claude-sonnet-5[1m]',       label: 'Sonnet 5 (1M)',    alias: 'sonnet[1m]' },
   { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable' },
-  { id: 'claude-opus-4-8',           label: 'Opus 4.8',         alias: 'opus' },
+  { id: 'claude-opus-5',             label: 'Opus 5',           alias: 'opus' },
+  { id: 'claude-opus-4-8',           label: 'Opus 4.8',         alias: 'opus48' },
   { id: 'claude-opus-4-6',           label: 'Opus 4.6',         alias: 'opus46' },
   { id: 'claude-sonnet-5',           label: 'Sonnet 5',         alias: 'sonnet' },
   { id: 'claude-sonnet-4-6',         label: 'Sonnet 4.6',       alias: 'sonnet46' },

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -46,10 +46,12 @@ export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
 export const DEFAULT_MODELS: ModelConfig[] = [
   { id: 'claude-fable-5[1m]',        label: 'Fable 5 (1M)',     alias: 'fable[1m]',   contextWindow: 1000000 },
-  { id: 'claude-opus-4-8[1m]',       label: 'Opus 4.8 (1M)',    alias: 'opus[1m]',    contextWindow: 1000000 },
+  { id: 'claude-opus-5[1m]',         label: 'Opus 5 (1M)',      alias: 'opus[1m]',    contextWindow: 1000000 },
+  { id: 'claude-opus-4-8[1m]',       label: 'Opus 4.8 (1M)',    alias: 'opus48[1m]',  contextWindow: 1000000 },
   { id: 'claude-sonnet-5[1m]',       label: 'Sonnet 5 (1M)',    alias: 'sonnet[1m]',  contextWindow: 1000000 },
   { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable',       contextWindow: 200000 },
-  { id: 'claude-opus-4-8',           label: 'Opus 4.8',         alias: 'opus',        contextWindow: 200000 },
+  { id: 'claude-opus-5',             label: 'Opus 5',           alias: 'opus',        contextWindow: 200000 },
+  { id: 'claude-opus-4-8',           label: 'Opus 4.8',         alias: 'opus48',      contextWindow: 200000 },
   { id: 'claude-opus-4-6',           label: 'Opus 4.6',         alias: 'opus46',      contextWindow: 200000 },
   { id: 'claude-sonnet-5',           label: 'Sonnet 5',         alias: 'sonnet',      contextWindow: 200000 },
   { id: 'claude-sonnet-4-6',         label: 'Sonnet 4.6',       alias: 'sonnet46',    contextWindow: 200000 },

--- a/tests/unit/config-migration-real-upgrade.test.ts
+++ b/tests/unit/config-migration-real-upgrade.test.ts
@@ -200,3 +200,132 @@ describe('config migration — real v1.3.25 -> current upgrade (Issue #204)', ()
     expect(migrated.gateway.bind).toBe('0.0.0.0');
   });
 });
+
+/**
+ * Real-artifact upgrade tests for Opus 5 support.
+ *
+ * An existing install pins its own gateway.models list in config.json (it
+ * overrides DEFAULT_MODELS), so shipping Opus 5 only in the code registry would
+ * never reach upgrading users. migrateModels() merges the template's models by
+ * id on migration — but that only runs when the template configVersion is ahead
+ * of the user's. These tests drive the REAL template exactly like src/index.ts,
+ * so if someone adds Opus 5 to the registry but forgets to bump configVersion
+ * (or forgets the template entry), the upgrade goes red here — before release.
+ */
+describe('config migration — Opus 5 support reaches existing installs', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opus5-upgrade-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const tv = (): string =>
+    JSON.parse(fs.readFileSync(REAL_TEMPLATE, 'utf-8')).configVersion as string;
+
+  /** A realistic pre-Opus-5 install: bind already set (so bind isn't the trigger),
+   *  a models list where `opus` still points at 4.8, plus a custom BYOK model. */
+  function writePreOpus5Config(): string {
+    const p = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(
+      p,
+      JSON.stringify(
+        {
+          configVersion: '1.0.14',
+          gateway: {
+            bind: '0.0.0.0',
+            models: [
+              { id: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M)', alias: 'opus[1m]', contextWindow: 1000000 },
+              { id: 'claude-opus-4-8', label: 'Opus 4.8', alias: 'opus', contextWindow: 200000 },
+              { id: 'claude-sonnet-5', label: 'Sonnet 5', alias: 'sonnet', contextWindow: 200000 },
+              { id: 'openrouter/custom-model', label: 'My BYOK', alias: 'mine', contextWindow: 128000 },
+            ],
+          },
+          agents: [],
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+    return p;
+  }
+
+  function runRealUpgrade(configPath: string) {
+    const version = tv();
+    const detection = detectMigration(configPath, REAL_TEMPLATE, version);
+    if (!detection.needed) return { needed: false, addedFields: [] as string[] };
+    const { ignorePaths, removePaths } = loadCleanTemplate(REAL_TEMPLATE);
+    const result = applyMigration(
+      configPath,
+      detection.config,
+      detection.template,
+      version,
+      ignorePaths,
+      removePaths,
+    );
+    return { needed: true, addedFields: result.addedFields };
+  }
+
+  // Guard: the whole point is that the template is ahead of the fixture so a
+  // migration runs. If the template ever drops back to 1.0.14 this is moot.
+  it('the real template is ahead of the pre-Opus-5 fixture (migration will run)', () => {
+    expect(tv()).not.toBe('1.0.14');
+  });
+
+  it('adds both Opus 5 variants to an existing install on upgrade', () => {
+    const configPath = writePreOpus5Config();
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.needed).toBe(true);
+    expect(result.addedFields).toContain('gateway.models[claude-opus-5]');
+    expect(result.addedFields).toContain('gateway.models[claude-opus-5[1m]]');
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const ids = migrated.gateway.models.map((m: { id: string }) => m.id);
+    expect(ids).toContain('claude-opus-5');
+    expect(ids).toContain('claude-opus-5[1m]');
+  });
+
+  it('repoints the bare `opus` aliases to Opus 5 and demotes 4.8 to `opus48`', () => {
+    const configPath = writePreOpus5Config();
+    runRealUpgrade(configPath);
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const byAlias = (a: string) =>
+      migrated.gateway.models.find((m: { alias: string }) => m.alias === a)?.id;
+
+    expect(byAlias('opus')).toBe('claude-opus-5');
+    expect(byAlias('opus[1m]')).toBe('claude-opus-5[1m]');
+    expect(byAlias('opus48')).toBe('claude-opus-4-8');
+    expect(byAlias('opus48[1m]')).toBe('claude-opus-4-8[1m]');
+  });
+
+  it('gives Opus 5 the correct context windows (1M variant not defaulted to 200k)', () => {
+    const configPath = writePreOpus5Config();
+    runRealUpgrade(configPath);
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const ctx = (id: string) =>
+      migrated.gateway.models.find((m: { id: string }) => m.id === id)?.contextWindow;
+
+    expect(ctx('claude-opus-5[1m]')).toBe(1000000);
+    expect(ctx('claude-opus-5')).toBe(200000);
+  });
+
+  it('preserves a user BYOK model that is not in the template', () => {
+    const configPath = writePreOpus5Config();
+    runRealUpgrade(configPath);
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const custom = migrated.gateway.models.find(
+      (m: { id: string }) => m.id === 'openrouter/custom-model',
+    );
+    expect(custom).toBeDefined();
+    expect(custom.alias).toBe('mine');
+  });
+});

--- a/tests/unit/cron-client-update.test.ts
+++ b/tests/unit/cron-client-update.test.ts
@@ -1,0 +1,61 @@
+import { CronClient } from '../../mcp/tools/cron/client';
+
+/**
+ * Regression test for the MCP cron client's timeout normalization (#239/#240).
+ *
+ * The MCP tool schema advertises `timeout_ms` (snake_case), but the REST API
+ * expects `timeoutMs` (camelCase). CronClient.update() must run params through
+ * normalizeParams() so a timeout set via cron_update is actually honored.
+ *
+ * PR #240 accidentally left a DUPLICATE update() method whose (winning) copy
+ * sent params raw — silently dropping the timeout back to the default and, as a
+ * TS2393 duplicate implementation, breaking compilation of every suite that
+ * imports the MCP cron module. This test pins update() to the normalized body,
+ * so a raw-params regression (or a re-introduced duplicate) goes red here.
+ */
+describe('CronClient.update — timeout normalization (#240)', () => {
+  const realFetch = global.fetch;
+  let lastCall: { url: string; init: RequestInit } | null;
+
+  beforeEach(() => {
+    lastCall = null;
+    global.fetch = (async (url: string, init: RequestInit) => {
+      lastCall = { url, init };
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => ({ ok: true }),
+        text: async () => '',
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  function sentBody(): Record<string, unknown> {
+    if (!lastCall?.init?.body) throw new Error('fetch was not called with a body');
+    return JSON.parse(lastCall.init.body as string);
+  }
+
+  it('maps timeout_ms -> timeoutMs on update (does not send params raw)', async () => {
+    const client = new CronClient('http://gateway.local', 'agent-1', 'key');
+    await client.update('job-1', { timeout_ms: 5000, name: 'nightly' });
+
+    expect(lastCall?.init?.method).toBe('PUT');
+    expect(lastCall?.url).toBe('http://gateway.local/api/v1/crons/job-1');
+
+    const body = sentBody();
+    expect(body).toEqual({ timeoutMs: 5000, name: 'nightly' });
+    expect('timeout_ms' in body).toBe(false);
+  });
+
+  it('leaves an update without timeout_ms untouched', async () => {
+    const client = new CronClient('http://gateway.local', 'agent-1', 'key');
+    await client.update('job-1', { name: 'renamed' });
+
+    expect(sentBody()).toEqual({ name: 'renamed' });
+  });
+});

--- a/tests/unit/models-registry.test.ts
+++ b/tests/unit/models-registry.test.ts
@@ -80,3 +80,57 @@ describe('model registry — DEFAULT_MODELS and template stay in sync', () => {
     expect(new Set(aliases).size).toBe(aliases.length);
   });
 });
+
+/**
+ * The Telegram receiver (mcp/tools/telegram/receiver-server.ts) runs as a
+ * separate process and can't import DEFAULT_MODELS, so it keeps a hardcoded
+ * AVAILABLE_MODELS fallback for the /models picker (used when the live
+ * get_models call fails). That third copy silently drifted before — Opus 5 was
+ * added to the two src registries but not here. We can't import the module
+ * (top-level Bot construction needs a token), so we parse the array literal
+ * from source and assert its id/alias set matches the code registry.
+ */
+describe('model registry — Telegram fallback list stays in sync', () => {
+  const RECEIVER = path.join(
+    __dirname,
+    '..',
+    '..',
+    'mcp',
+    'tools',
+    'telegram',
+    'receiver-server.ts',
+  );
+
+  /** Extract { id, alias } pairs from the AVAILABLE_MODELS array literal. */
+  function telegramFallbackModels(): Array<{ id: string; alias: string }> {
+    const src = fs.readFileSync(RECEIVER, 'utf-8');
+    const start = src.indexOf('const AVAILABLE_MODELS = [');
+    expect(start).toBeGreaterThan(-1);
+    // Close on the array's own-line `]` — a bare indexOf(']') would stop at the
+    // `[1m]` suffix inside the first model id.
+    const end = src.indexOf('\n]', start);
+    expect(end).toBeGreaterThan(start);
+    const block = src.slice(start, end);
+    const out: Array<{ id: string; alias: string }> = [];
+    const re = /id:\s*'([^']+)'[^}]*alias:\s*'([^']+)'/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(block)) !== null) out.push({ id: m[1], alias: m[2] });
+    return out;
+  }
+
+  it('lists exactly the same model ids as DEFAULT_MODELS', () => {
+    const telegramIds = telegramFallbackModels().map((m) => m.id).sort();
+    const codeIds = DEFAULT_MODELS.map((m) => m.id).sort();
+    expect(telegramIds).toEqual(codeIds);
+  });
+
+  it('maps each alias identically to DEFAULT_MODELS (incl. opus -> Opus 5)', () => {
+    const codeMap = new Map(DEFAULT_MODELS.map((m) => [m.id, m.alias]));
+    for (const m of telegramFallbackModels()) {
+      expect(m.alias).toBe(codeMap.get(m.id));
+    }
+    // Explicit anchor for the repoint the user asked us to verify everywhere.
+    const opus = telegramFallbackModels().find((m) => m.alias === 'opus');
+    expect(opus?.id).toBe('claude-opus-5');
+  });
+});

--- a/tests/unit/models-registry.test.ts
+++ b/tests/unit/models-registry.test.ts
@@ -1,0 +1,82 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { DEFAULT_MODELS } from '../../src/agent/runner';
+import type { ModelConfig } from '../../src/types';
+
+/**
+ * Model registry invariants.
+ *
+ * The set of selectable models lives in TWO places that must stay in lockstep:
+ *   1. DEFAULT_MODELS (src/agent/runner.ts) — the fallback used when a config has
+ *      no gateway.models key.
+ *   2. config.template.json gateway.models — what fresh installs get, and the
+ *      source migrateModels() merges into existing installs.
+ *
+ * If they drift, some install paths see a model the others don't. These tests
+ * pin Opus 5 as a first-class model in both, and guard the "bare alias = newest"
+ * convention so `opus`/`sonnet`/`fable` always resolve to the latest of each
+ * family. They read the REAL template so a hand-edit that updates one file but
+ * not the other goes red here.
+ */
+
+const REAL_TEMPLATE = path.join(__dirname, '..', '..', 'config.template.json');
+
+function templateModels(): ModelConfig[] {
+  const t = JSON.parse(fs.readFileSync(REAL_TEMPLATE, 'utf-8'));
+  return t.gateway.models as ModelConfig[];
+}
+
+const byId = (models: ModelConfig[], id: string) => models.find((m) => m.id === id);
+const byAlias = (models: ModelConfig[], alias: string) => models.find((m) => m.alias === alias);
+
+describe('model registry — Opus 5 is a first-class model', () => {
+  it('DEFAULT_MODELS includes both Opus 5 variants with correct context windows', () => {
+    expect(byId(DEFAULT_MODELS, 'claude-opus-5')?.contextWindow).toBe(200000);
+    expect(byId(DEFAULT_MODELS, 'claude-opus-5[1m]')?.contextWindow).toBe(1000000);
+  });
+
+  it('the template includes both Opus 5 variants with correct context windows', () => {
+    const models = templateModels();
+    expect(byId(models, 'claude-opus-5')?.contextWindow).toBe(200000);
+    expect(byId(models, 'claude-opus-5[1m]')?.contextWindow).toBe(1000000);
+  });
+
+  it('the bare `opus` alias resolves to Opus 5 in both registries', () => {
+    expect(byAlias(DEFAULT_MODELS, 'opus')?.id).toBe('claude-opus-5');
+    expect(byAlias(DEFAULT_MODELS, 'opus[1m]')?.id).toBe('claude-opus-5[1m]');
+    expect(byAlias(templateModels(), 'opus')?.id).toBe('claude-opus-5');
+    expect(byAlias(templateModels(), 'opus[1m]')?.id).toBe('claude-opus-5[1m]');
+  });
+
+  it('Opus 4.8 is demoted to the `opus48` alias (kept, not dropped)', () => {
+    expect(byAlias(DEFAULT_MODELS, 'opus48')?.id).toBe('claude-opus-4-8');
+    expect(byAlias(DEFAULT_MODELS, 'opus48[1m]')?.id).toBe('claude-opus-4-8[1m]');
+    expect(byAlias(templateModels(), 'opus48')?.id).toBe('claude-opus-4-8');
+    expect(byAlias(templateModels(), 'opus48[1m]')?.id).toBe('claude-opus-4-8[1m]');
+  });
+});
+
+describe('model registry — DEFAULT_MODELS and template stay in sync', () => {
+  it('both registries contain exactly the same set of model ids', () => {
+    const codeIds = DEFAULT_MODELS.map((m) => m.id).sort();
+    const templateIds = templateModels().map((m) => m.id).sort();
+    expect(codeIds).toEqual(templateIds);
+  });
+
+  it('each model has an identical alias and contextWindow in both registries', () => {
+    const templateMap = new Map(templateModels().map((m) => [m.id, m]));
+    for (const m of DEFAULT_MODELS) {
+      const t = templateMap.get(m.id);
+      expect(t).toBeDefined();
+      expect({ alias: m.alias, contextWindow: m.contextWindow }).toEqual({
+        alias: t!.alias,
+        contextWindow: t!.contextWindow,
+      });
+    }
+  });
+
+  it('no two models share an alias (aliases are unambiguous)', () => {
+    const aliases = DEFAULT_MODELS.map((m) => m.alias);
+    expect(new Set(aliases).size).toBe(aliases.length);
+  });
+});


### PR DESCRIPTION
## What & why

Two changes, bundled per request:

### 1. Support Opus 5 as a first-class model (Closes #241)

Opus 5 already runs (`setModel()` accepts any model string), but it was a second-class citizen: missing from the picker, no short alias, context-window lookup falling back to 200k, and unreachable by existing installs that pin their own `gateway.models`.

- Add `claude-opus-5` (200k) and `claude-opus-5[1m]` (1M) to `DEFAULT_MODELS` (`src/agent/runner.ts`) and `config.template.json`.
- Repoint `opus` → `claude-opus-5`, `opus[1m]` → `claude-opus-5[1m]`; demote Opus 4.8 to `opus48` / `opus48[1m]` — the bare family alias now tracks the newest model, matching `sonnet` (Sonnet 5) and `fable` (Fable 5).
- Bump template `configVersion` `1.0.14` → `1.0.15` so `migrateModels()` delivers Opus 5 and the alias repoint to existing installs on upgrade, while preserving user BYOK models.

### 2. Fix duplicate `update()` left by #240

`mcp/tools/cron/client.ts` had two `update()` methods. The winning (second) copy sent params raw, bypassing `normalizeParams()` — so a `cron_update` `timeout_ms` was silently dropped instead of mapped to `timeoutMs`, defeating the fix #240 shipped. As a TS2393 duplicate implementation it also broke compilation of every suite importing the MCP cron module (main was red). Removed the duplicate; kept the `normalizeParams()` variant.

## Tests

- `tests/unit/models-registry.test.ts` — registry ↔ template sync (same id set, matching alias/contextWindow, unique aliases) + first-class Opus 5 + alias convention.
- `tests/unit/config-migration-real-upgrade.test.ts` — real-artifact migration: a pre-1.0.15 install gains both Opus 5 variants, aliases repoint, 1M context window is correct, and a user BYOK model is preserved.
- `tests/unit/cron-client-update.test.ts` — `update()` maps `timeout_ms` → `timeoutMs` and never sends it raw.
- All new tests were proven to fail on the pre-fix code (Opus 5 assertions red; the cron suite failed to compile with the duplicate present).
- `npm run typecheck` clean; full unit suite green (2317 passing; the lone flaky `workspace-loader` SIGTERM is a known parallel-run race — passes 20/20 in isolation).

## Docs

- `API.md` `/api/v1/models` example refreshed to Opus 5 with the `opus` → newest / `opus48` → older alias convention.
