### PR TITLE
fix(session): count child output as activity for the idle reaper (Closes #243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Config lives at `~/.claude-gateway/config.json` (or set `GATEWAY_CONFIG` env var
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `idleTimeoutMinutes` | `30` | Kill idle session subprocess after N minutes of inactivity |
+| `idleTimeoutMinutes` | `30` | Kill idle session subprocess after N minutes of inactivity. Inactivity means no incoming message **and** no subprocess output — a session actively producing output (e.g. a self-paced `/loop`) is not treated as idle |
 | `maxConcurrent` | `20` | Max simultaneous active sessions per agent; oldest idle is evicted when exceeded |
 
 ### `gateway.history` (optional)

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -659,6 +659,13 @@ export class SessionProcess extends EventEmitter {
     let lastMessageStartContext = 0;
 
     proc.stdout?.on('data', (data: Buffer) => {
+      // Child produced output => the session is doing real work right now. Count
+      // this as activity so the idle reaper measures "time since the session last
+      // did anything", not just "time since the parent last injected a message".
+      // Without this, a self-paced loop (a /loop in dynamic mode using
+      // ScheduleWakeup) that wakes itself and works entirely inside this child
+      // process stays invisible to the idle timer and gets reaped mid-flight.
+      this.lastActivityAt = Date.now();
       // Update heartbeat so the receiver's stalled detector knows Claude is active
       if (heartbeatPath) {
         try { fs.writeFileSync(heartbeatPath, String(Date.now())) } catch {}

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -665,7 +665,7 @@ export class SessionProcess extends EventEmitter {
       // Without this, a self-paced loop (a /loop in dynamic mode using
       // ScheduleWakeup) that wakes itself and works entirely inside this child
       // process stays invisible to the idle timer and gets reaped mid-flight.
-      this.lastActivityAt = Date.now();
+      this.touch();
       // Update heartbeat so the receiver's stalled detector knows Claude is active
       if (heartbeatPath) {
         try { fs.writeFileSync(heartbeatPath, String(Date.now())) } catch {}

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -2131,6 +2131,49 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
 
     await sp.stop();
   });
+
+  // --------------------------------------------------------------------------
+  // U-SP-IDLE-CHILD: child output counts as activity for the idle reaper.
+  // Regression for the idle cleaner reaping a session whose child is actively
+  // self-paced looping (a /loop in dynamic mode driven by ScheduleWakeup): the
+  // wake iterations run inside the child and produce output, but the parent
+  // never injects a message, so before the fix `lastActivityAt` was stale and
+  // `isIdle()` wrongly returned true -> the loop got killed mid-flight.
+  // --------------------------------------------------------------------------
+  it('U-SP-IDLE-CHILD: child stdout output resets the idle clock', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // Simulate a session that has had no parent-side injection for 2 minutes:
+    // the last human turn was long ago and it is now waiting between self-wakes.
+    (sp as unknown as { lastActivityAt: number }).lastActivityAt = Date.now() - 120_000;
+    expect(sp.isIdle(60_000)).toBe(true);
+
+    // The child wakes itself and produces output (a self-paced loop iteration).
+    const line = JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'working on the next batch' }] } });
+    lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
+
+    // The session did real work just now, so it must NOT be considered idle.
+    expect(sp.isIdle(60_000)).toBe(false);
+
+    await sp.stop();
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-IDLE-QUIET: a genuinely quiet session (no child output, no parent
+  // injection) still ages out — the fix must not defeat idle cleanup.
+  // --------------------------------------------------------------------------
+  it('U-SP-IDLE-QUIET: session with no child output stays idle and remains reapable', async () => {
+    const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    (sp as unknown as { lastActivityAt: number }).lastActivityAt = Date.now() - 120_000;
+
+    // No stdout output emitted — the child is sleeping. It must remain idle.
+    expect(sp.isIdle(60_000)).toBe(true);
+
+    await sp.stop();
+  });
 });
 
 // ── resolveMaxHistoryMessages ────────────────────────────────────────────────


### PR DESCRIPTION
## What

The idle cleaner reaps a session whose child process is actively running a **self-paced loop** (a `/loop` in dynamic mode driven by `ScheduleWakeup`, or any autonomous wake loop inside the Claude CLI child). The loop then dies silently.

Closes #243.

## Root cause

The idle cleaner (`runner.ts` `startIdleCleaner`, every 5 min) stops any session where `SessionProcess.isIdle(idleTimeoutMs)` is true — `Date.now() - lastActivityAt > idleMs`. But `lastActivityAt` was only refreshed on **parent-initiated** injection (channel turn / API message / heartbeat) via `touch()`. It was **never** refreshed when the **child** produced output on its own.

So a session that wakes itself, works, and emits output every N minutes still looked "idle since the last human message." Proven from session `68cef416` (agent `mona-lisa-jai-kere`), matching to the second:

- `05:43:51` last parent injection → `lastActivityAt` set here.
- `05:48` / `06:05` the loop self-woke and worked (finished a phase, scheduled the next wake ~`06:30`) — child output only, no parent injection → `lastActivityAt` unchanged.
- `06:13:51` crosses the 30-min idle threshold; `06:15:42` the sweep runs `Stopping idle session` → `proc.stop()` kills the child.
- The `~06:30` wake was in-process state and died with the child, so the loop never resumed. No channel message is sent on idle stop → silent.

## Fix

Refresh `lastActivityAt` in the `SessionProcess` stdout `data` handler (`src/session/process.ts`), so any child output resets the idle clock. The idle timer now measures "time since the session last did anything," not "time since the parent last spoke."

- A session actively producing output (a live self-wake iteration) is kept alive.
- A genuinely quiet session (child sleeping, no output, no injection) still ages out and is reaped — idle cleanup is preserved.

**Known limitation (out of scope):** a loop whose wake interval *exceeds* the idle timeout (e.g. `delaySeconds` 3600 with a 30-min timeout) can still be reaped during the wait, since the parent cannot see a wake the child scheduled internally. Reaper awareness of pending wakes is a separate, deeper change.

## Tests

- `U-SP-IDLE-CHILD` — after 2 min of no injection (`isIdle` true), a single child stdout emission flips `isIdle` back to false. **Proven to fail on the pre-fix code.**
- `U-SP-IDLE-QUIET` — a session with no child output stays idle and remains reapable (guards against defeating idle cleanup).
- `npm run typecheck` clean; full suite `2605 passed, 0 failed` (one integration suite is a known parallel-worker SIGTERM flake — passes in-band).

## Docs

- `README.md` — clarified `idleTimeoutMinutes`: inactivity means no incoming message **and** no subprocess output.
