### PR TITLE
Add /cli: agent-scoped webview terminal viewer across Telegram, Discord, and LINE

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,6 +34,31 @@ until `gateway.api.keys` is set, so the surface is never exposed unauthenticated
 network. If keys are configured but **none is admin**, the dashboard is inaccessible
 (login returns `401`) and a startup warning is emitted. `/health` stays public in all cases.
 
+### Terminal viewer (`/cli`)
+
+The `/cli` chat command opens a live, **agent-scoped** webview terminal for an agent
+running with `gateway.headless: false`. Unlike `/dashboard` (admin, host-wide), a `/cli`
+session can only ever reach the single agent that the pairing was created for — it never
+issues or accepts the admin `dash_session` cookie. Requires `gateway.publicUrl` to be set
+(the absolute, externally-reachable origin used to build the link); when unset, `/cli`
+replies that the viewer is not configured.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/cli/:pairingId` | Pairing (binds the browser) | Device page — "waiting for approval" (Discord/LINE) or Telegram Mini App initData submit |
+| `GET` | `/cli/:pairingId/status` | `cli_pair` cookie | Poll; issues the agent-scoped `cli_session` cookie once approved |
+| `POST` | `/cli/:pairingId/tg-init` | Telegram initData | Verify the signed initData (HMAC with the agent's bot token) and unlock |
+| `GET` | `/cli/:pairingId/view` | `cli_session` cookie | The xterm.js viewer, scoped to the pairing's agent (read-only by default) |
+| `GET` | `/cli/:pairingId/sessions` | `cli_session` cookie | The agent's live `pty-shell` sessions to attach to |
+| `POST` | `/cli/:pairingId/pty-ticket` | `cli_session` cookie | One-time PTY ticket, validated to belong to the pairing's agent |
+
+**Authorization model.** The link is not a credential. Unlocking requires proof bound to
+an allowlist-gated chat action: **Telegram** submits a signed Mini App `initData` (verified
+against the agent's bot token; the `initData` user must match the pairing's user), while
+**Discord** and **LINE** require the operator to tap **Approve** in the chat. The first
+browser to open a link owns it (a link opened in a second browser is rejected), and the
+`cli_pair` / `cli_session` cookies are `HttpOnly` and scoped to the pairing's path only.
+
 ### Agent API
 
 | Method | Path | Auth | Description |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A self-hosted multi-agent gateway for Claude Code. Connect Claude agents to Tele
 - **App Store** — install, update, and host Docker-compose apps on the gateway; apps get a reverse proxy at `/app/:name/:portName/*`, optional Unix socket bridge for host scripts, and optional AI agent injection
 - **Self-update API** — check for newer versions of `claude-gateway` and `claude-code` and trigger an update via a single API call; no SSH or shell access needed
 - **Session persistence** — conversation history saved and restored across restarts
-- **PTY shell (wrap-shell mode)** — optional interactive pseudo-terminal backend (`gateway.headless: false`) for tools that require a real TTY; includes a live browser viewer (xterm.js) and a `/api/v1/sessions/:sessionId/screen` endpoint that returns the visible screen as plain text — agents can poll it to detect hang states, menus, or unexpected output without parsing ANSI escape codes; app-agents always stay headless
+- **PTY shell (wrap-shell mode)** — optional interactive pseudo-terminal backend (`gateway.headless: false`) for tools that require a real TTY; includes a live browser viewer (xterm.js) and a `/api/v1/sessions/:sessionId/screen` endpoint that returns the visible screen as plain text — agents can poll it to detect hang states, menus, or unexpected output without parsing ANSI escape codes; a `/cli` chat command (Telegram/Discord/LINE) opens the same viewer for a single agent, agent-scoped and without an admin key; app-agents always stay headless
 
 ---
 
@@ -346,6 +346,18 @@ Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (l
 
 > **⚠️ Upgrade note:** the default bind changed from `0.0.0.0` to `127.0.0.1` (configVersion 1.0.13). To avoid silently cutting off external access, the config migrator is **behavior-preserving**: whenever it upgrades a config that never set `gateway.bind`, it pins `bind` to `0.0.0.0` and logs a one-time warning, so a deployment that was reachable from another host stays reachable. This applies to *any* upgraded config with no `bind` key — including one already stamped `1.0.13` that never received a bind (an earlier version gated this on `< 1.0.13` and left such configs stuck on the `127.0.0.1` default). New installs (no prior config, so no migration runs) keep the secure `127.0.0.1` default. If you *want* localhost-only after upgrading, set `gateway.bind` to `127.0.0.1` explicitly (or the `GATEWAY_BIND` env var).
 
+### `gateway.publicUrl`
+
+Absolute, externally-reachable origin of the gateway (for example `https://gateway.example.com`, or `https://host.example.com/gateway` behind an ingress path prefix). The process cannot infer its own public URL — it binds localhost by default and sits behind a reverse proxy — so it must be set explicitly for features that hand out a phone-openable link. Currently that is the `/cli` terminal viewer; when `publicUrl` is unset, `/cli` replies that the viewer is not configured. Leave it blank to keep `/cli` disabled. A trailing slash is optional. Use an `https://` origin — Telegram Mini Apps require HTTPS.
+
+```json
+{
+  "gateway": {
+    "publicUrl": "https://gateway.example.com"
+  }
+}
+```
+
 ### Terminal Viewer — interactive terminal mode
 
 The dashboard's **Terminal Viewer** opens read-only (a live mirror of the PTY). A toggle in the top-right of the viewer switches it into an **interactive terminal**: keystrokes typed into the panel — printable characters, Enter, arrows, Ctrl-combos, Esc — are streamed into the live PTY, and the panel title changes to reflect the active mode. This is a per-browser client-side choice (Issue #201); there is no server config flag to enable it.
@@ -356,6 +368,17 @@ Because interactive mode turns a read-only view into a remote-write surface, acc
 - **`gateway.bind`** — the gateway binds to `127.0.0.1` (localhost) by default, so the dashboard is not reachable from the network out of the box. On a non-loopback bind (`0.0.0.0`), configure an admin key in `gateway.api.keys` so the dashboard and monitoring endpoints require an admin credential, and prefer a TLS-terminating reverse proxy so credentials are not sent in the clear.
 
 Inbound frames are always bounded (text-only, size-capped) and are dropped for headless sessions (no PTY).
+
+#### `/cli` — open the terminal viewer from chat
+
+The `/cli` command (Telegram, Discord, LINE) opens the same live terminal viewer for **one agent**, without an admin key. It requires `gateway.publicUrl` and an agent running with `gateway.headless: false`. Unlike the admin dashboard, a `/cli` session is **agent-scoped**: its cookie and PTY ticket can only reach the originating agent's own sessions — never another agent, the process tree, or a cross-agent stream.
+
+The viewer link is never a credential; unlocking it requires a proof tied to an allowlist-gated chat action:
+
+- **Telegram** opens a Mini App and the gateway verifies Telegram's signed `initData` (HMAC with the agent's own bot token) — nothing secret rides in the URL, and the `initData` user must match the user who ran `/cli`.
+- **Discord** and **LINE** send an open-viewer link plus an **Approve** button; the browser stays locked until you approve in the chat, so a leaked or forwarded link cannot be unlocked by anyone who cannot approve there.
+
+The first browser to open a link owns it (opening the link in a second browser is rejected), the viewer defaults to read-only (toggle for input), and viewer sessions expire (30 min) — send `/cli` again to reconnect.
 
 ### `gateway.api.keys`
 

--- a/config.template.json
+++ b/config.template.json
@@ -15,6 +15,7 @@
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "bind": "127.0.0.1",
+    "publicUrl": "",
     "models": [
       { "id": "claude-fable-5[1m]",        "label": "Fable 5 (1M)",     "alias": "fable[1m]",   "contextWindow": 1000000 },
       { "id": "claude-opus-5[1m]",         "label": "Opus 5 (1M)",      "alias": "opus[1m]",    "contextWindow": 1000000 },

--- a/mcp/tools/discord/module.ts
+++ b/mcp/tools/discord/module.ts
@@ -33,6 +33,18 @@ import type { DiscordMessageContext } from './types';
 
 const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 
+/** AgentRunner callback base (origin of CLAUDE_CHANNEL_CALLBACK, "" when unset).
+ *  Used to mint/approve `/cli` pairings via the runner, the same bridge the
+ *  Telegram receiver uses for /models. */
+function cliCallbackBase(): string {
+  try {
+    const u = new URL(process.env.CLAUDE_CHANNEL_CALLBACK ?? '');
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return '';
+  }
+}
+
 export class DiscordModule implements ChannelModule {
   id = 'discord' as ChannelId;
   toolVisibility: ToolVisibility = 'current-channel';
@@ -281,6 +293,45 @@ export class DiscordModule implements ChannelModule {
       }
 
       // action === 'deliver'
+      // `/cli` opens the live terminal viewer: mint a pairing (link + Approve
+      // button) instead of forwarding the text to the agent. Only reached after
+      // gate() authorized this user, so it inherits the channel's access control.
+      const cliText = (msg.content ?? '').replace(/<@!?\d+>/g, '').trim().toLowerCase();
+      if (cliText === '/cli') {
+        const base = cliCallbackBase();
+        try {
+          const res = await fetch(base + '/command', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ command: 'cli_pair', payload: { channel: 'discord', user_id: context.userId } }),
+          });
+          const data = (await res.json()) as { success?: boolean; url?: string; code?: string; pairingId?: string; error?: string };
+          if (!data.success || !data.url || !data.pairingId) {
+            await msg.channel.send(
+              data.error === 'not_configured'
+                ? 'Terminal viewer is not configured. Set gateway.publicUrl in config.json first.'
+                : 'Could not open the terminal viewer right now.',
+            ).catch(() => {});
+            return;
+          }
+          const components = [{
+            type: 1,
+            components: [
+              { type: 2, style: 5, label: '\u{1F5A5} Open terminal', url: data.url },
+              { type: 2, style: 2, label: `Approve ${data.code}`, custom_id: `cli:approve:${data.pairingId}` },
+              { type: 2, style: 4, label: 'Deny', custom_id: `cli:deny:${data.pairingId}` },
+            ],
+          }];
+          await msg.channel.send({
+            content: 'Live terminal viewer — open the link, confirm the code matches, then tap **Approve** to unlock (read-only by default).',
+            components,
+          }).catch(() => {});
+        } catch {
+          await msg.channel.send('Could not open the terminal viewer right now.').catch(() => {});
+        }
+        return;
+      }
+
       // Start typing indicator before handing off to runner
       const channelId = context.channelId;
       const typingFileDir = path.join(this.stateDir, 'typing');
@@ -347,11 +398,58 @@ export class DiscordModule implements ChannelModule {
       message?: { id: string };
       client: { user?: { id: string } };
       reply(opts: { content: string; ephemeral: boolean }): Promise<unknown>;
-      update(opts: { components: unknown[] }): Promise<unknown>;
+      update(opts: { components: unknown[]; content?: string }): Promise<unknown>;
     }
     this.client.on('interactionCreate', async (interaction: ButtonInteraction) => {
       try {
         if (!interaction.isButton?.()) return;
+
+        // `/cli` approve/deny — unlock (or reject) a pending terminal-viewer
+        // pairing. Re-runs the access gate on the tapping user, then relays the
+        // decision to the runner. The pairing itself checks the user id matches.
+        const cliM = /^cli:(approve|deny):([0-9a-f]{36})$/.exec(interaction.customId ?? '');
+        if (cliM) {
+          const isDM = !interaction.guildId;
+          const isThread = interaction.channel?.isThread?.() ?? false;
+          const context: DiscordMessageContext = {
+            guildId: interaction.guildId ?? null,
+            channelId: interaction.channelId,
+            threadId: isThread ? interaction.channelId : null,
+            userId: interaction.user.id,
+            username: interaction.user.username,
+            messageId: interaction.message?.id ?? '',
+            isDM,
+            isThread,
+            mentionsBot: true,
+          };
+          const access = loadAccessFn();
+          const result = gate(access, context, saveAccessFn, () => randomBytes(3).toString('hex'));
+          if (result.action !== 'deliver') {
+            await interaction.reply({ content: 'Not authorized.', ephemeral: true }).catch(() => {});
+            return;
+          }
+          const deny = cliM[1] === 'deny';
+          const base = cliCallbackBase();
+          let ok = false;
+          try {
+            const res = await fetch(base + '/command', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                command: 'cli_approve',
+                payload: { channel: 'discord', pairing_id: cliM[2], user_id: interaction.user.id, deny },
+              }),
+            });
+            ok = !!((await res.json()) as { success?: boolean }).success;
+          } catch {}
+          const content = deny
+            ? '\u{1F6AB} Denied.'
+            : ok
+              ? '✅ Approved — return to the browser.'
+              : '⚠️ Could not approve (the link may have expired). Send /cli again.';
+          await interaction.update({ components: [], content }).catch(() => {});
+          return;
+        }
 
         // Cancel button: send ESC sentinel to dismiss the pending menu cleanly.
         if ((interaction.customId ?? '') === 'menu:cancel') {

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -881,6 +881,7 @@ const BOT_COMMANDS = [
   { command: 'restart', description: 'Graceful restart session' },
   { command: 'model', description: 'Show current AI model' },
   { command: 'models', description: 'Switch AI model' },
+  { command: 'cli', description: 'Open the live terminal viewer' },
   { command: 'start', description: 'Welcome and setup guide' },
   { command: 'status', description: 'Check your pairing status' },
   { command: 'help', description: 'What this bot can do' },
@@ -1146,7 +1147,8 @@ bot.command('help', async ctx => {
     `/restart — graceful restart session\n\n` +
     `*Agent*\n` +
     `/model — show current AI model\n` +
-    `/models — switch AI model\n\n` +
+    `/models — switch AI model\n` +
+    `/cli — open the live terminal viewer\n\n` +
     `*Account*\n` +
     `/start — pairing instructions\n` +
     `/status — check your pairing state`,
@@ -1235,6 +1237,44 @@ bot.command('models', async ctx => {
     })
   } catch (err) {
     await ctx.reply('Failed to get model info.')
+  }
+})
+
+// /cli — open the live terminal viewer as a Telegram Mini App. The Mini App
+// page reads Telegram's signed initData and the gateway verifies it (HMAC with
+// this bot's token), so nothing secret rides in the URL. Private chat + allowlist
+// only, matching every other command.
+bot.command('cli', async ctx => {
+  if (ctx.chat?.type !== 'private') return
+  const access = loadAccess()
+  if (!access.allowFrom.includes(String(ctx.from!.id))) return
+  if (!CALLBACK_URL_BASE) return
+
+  try {
+    const res = await fetch(CALLBACK_URL_BASE + '/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        command: 'cli_pair',
+        payload: { channel: 'telegram', user_id: String(ctx.from!.id) },
+      }),
+    })
+    const data = (await res.json()) as { success?: boolean; url?: string; error?: string }
+    if (!data.success || !data.url) {
+      if (data.error === 'not_configured') {
+        await ctx.reply('Terminal viewer is not configured. Set gateway.publicUrl in config.json first.')
+      } else {
+        await ctx.reply('Could not open the terminal viewer right now.')
+      }
+      return
+    }
+    // web_app button launches the Mini App; Telegram requires an HTTPS URL.
+    const keyboard = new InlineKeyboard().webApp('\u{1F5A5} Open terminal', data.url)
+    await ctx.reply('Live terminal viewer (read-only by default — toggle input inside):', {
+      reply_markup: keyboard,
+    })
+  } catch {
+    await ctx.reply('Could not open the terminal viewer right now.')
   }
 })
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -20,6 +20,8 @@ import { runRecovery, toRecoveryOutcome, type RecoveryEffects, type RecoveryRequ
 import { initialBudget, type BudgetState } from './recovery-policy';
 import { scrubText } from './incident';
 import { ptyStreamRegistry } from '../shell/pty-stream-registry';
+import { cliPairingStore, isCliChannel, type CliChannel } from '../cli-viewer/pairing-store';
+import { buildCliUrl } from '../cli-viewer/url';
 import { TUI_REQUEST_TOO_LARGE } from '../shell/screen';
 import { HistoryDB } from '../history/db';
 import { MediaStore } from '../history/media-store';
@@ -624,6 +626,34 @@ export class AgentRunner extends EventEmitter {
   };
 
   /**
+   * Create a `/cli` webview pairing for an already-authenticated chat user.
+   * Shared by the receiver callback (Telegram/Discord subprocesses) and the
+   * in-process LINE webhook so both mint links the same way. Returns null when
+   * `gateway.publicUrl` is not configured (no link can be built).
+   */
+  createCliPairing(
+    channel: CliChannel,
+    userId: string,
+  ): { pairingId: string; code: string; url: string } | null {
+    if (!isCliChannel(channel) || !userId) return null;
+    if (!buildCliUrl(this.gatewayConfig.gateway.publicUrl, 'probe')) return null;
+    const { pairingId, code } = cliPairingStore.create(this.agentConfig.id, channel, userId);
+    return { pairingId, code, url: buildCliUrl(this.gatewayConfig.gateway.publicUrl, pairingId)! };
+  }
+
+  /** Approve (or deny) a `/cli` pairing on behalf of the authenticated chat user. */
+  approveCliPairing(
+    channel: CliChannel,
+    pairingId: string,
+    userId: string,
+    deny = false,
+  ): 'ok' | 'mismatch' | 'gone' {
+    return deny
+      ? cliPairingStore.deny(pairingId, channel, userId)
+      : cliPairingStore.approve(pairingId, channel, userId);
+  }
+
+  /**
    * Handle POST /command requests from the receiver process.
    * Supports: get_model, set_model, restart.
    */
@@ -651,6 +681,45 @@ export class AgentRunner extends EventEmitter {
     if (command === 'get_models') {
       const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
       respond({ models: availableModels.map(m => ({ id: m.id, label: m.label })) });
+      return;
+    }
+
+    // `/cli` webview terminal viewer — create a pairing on behalf of an
+    // already-authenticated chat user. The channel receiver has verified the
+    // user against its allowlist before calling this; we bind the pairing to that
+    // (channel, user) so only that same user can approve it or (Telegram) match
+    // its initData. The browser-facing routes live on the gateway; here we only
+    // mint the pairing and hand back the phone-openable link.
+    if (command === 'cli_pair') {
+      const payload = body.payload ?? {};
+      const channel = payload['channel'];
+      const userId = typeof payload['user_id'] === 'string' ? payload['user_id'] : '';
+      if (!isCliChannel(channel) || !userId) {
+        respond({ success: false, error: 'invalid_request' }, 400);
+        return;
+      }
+      const pairing = this.createCliPairing(channel, userId);
+      if (!pairing) {
+        respond({ success: false, error: 'not_configured' });
+        return;
+      }
+      respond({ success: true, ...pairing });
+      return;
+    }
+
+    // `/cli` approve/deny — the authenticated chat user acted on the pairing.
+    if (command === 'cli_approve') {
+      const payload = body.payload ?? {};
+      const channel = payload['channel'];
+      const pairingId = typeof payload['pairing_id'] === 'string' ? payload['pairing_id'] : '';
+      const userId = typeof payload['user_id'] === 'string' ? payload['user_id'] : '';
+      const deny = payload['deny'] === true;
+      if (!isCliChannel(channel) || !pairingId || !userId) {
+        respond({ success: false, error: 'invalid_request' }, 400);
+        return;
+      }
+      const result = this.approveCliPairing(channel, pairingId, userId, deny);
+      respond({ success: result === 'ok', result });
       return;
     }
 

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -15,6 +15,14 @@ import { getWatcherHealth } from '../watch/factory';
 import { CronScheduler } from '../cron/scheduler';
 import { CronManager } from '../cron/manager';
 import { generateDashboardHtml, generateLoginHtml } from '../ui/web-ui';
+import {
+  generateCliDevicePage,
+  generateCliViewerPage,
+  generateCliMessagePage,
+} from '../ui/cli-viewer-ui';
+import { cliPairingStore, type CliPairing } from '../cli-viewer/pairing-store';
+import { verifyTelegramInitData } from '../cli-viewer/telegram-initdata';
+import { normalizePublicUrl } from '../cli-viewer/url';
 import { createApiRouter } from './router';
 import { createCronRouter } from './cron-router';
 import { createWorkspaceRouter } from './workspace-router';
@@ -33,6 +41,12 @@ const APP_NAME_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
 const DASH_SESSION_COOKIE = 'dash_session';
 /** Dashboard session lifetime — long enough to avoid re-login mid-work. */
 const DASH_SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+
+/** `/cli` device-flow cookies (scoped to a single pairing's path, never `/`). */
+const CLI_PAIR_COOKIE = 'cli_pair';       // binds the browser that opened the link
+const CLI_SESSION_COOKIE = 'cli_session'; // agent-scoped viewer access session
+const CLI_PAIR_TTL_MS = 5 * 60 * 1000;
+const CLI_SESSION_TTL_MS = 30 * 60 * 1000;
 
 /**
  * Parse a Cookie request header into a name→value map. Manual parser so we take
@@ -402,6 +416,177 @@ export class GatewayRouter {
     return `${DASH_SESSION_COOKIE}=${token}; HttpOnly; SameSite=Lax; Path=/; Max-Age=${maxAge}${secure}`;
   }
 
+  // ─── /cli webview terminal viewer ──────────────────────────────────────────
+
+  /** Path portion of the configured public URL (e.g. "/gateway" behind an
+   *  ingress prefix, or "" at the origin root). Injected into the viewer so its
+   *  API/WS URLs resolve regardless of where the gateway is mounted. */
+  private cliBasePath(): string {
+    const base = normalizePublicUrl(this.gatewayConfig?.gateway?.publicUrl);
+    if (!base) return '';
+    try {
+      return new URL(base).pathname.replace(/\/+$/, '');
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   * Build a `/cli` cookie scoped to a SINGLE pairing's path — never `/`. This
+   * keeps the browser-binding and access tokens off every other route (including
+   * the admin dashboard) and prevents two concurrent `/cli` links from clobbering
+   * each other's cookies.
+   */
+  private buildCliCookie(req: Request, name: string, pairingId: string, value: string, ttlMs: number): string {
+    const secure = req.secure || req.headers['x-forwarded-proto'] === 'https' ? '; Secure' : '';
+    const maxAge = Math.max(0, Math.floor(ttlMs / 1000));
+    const scope = `${this.cliBasePath()}/cli/${encodeURIComponent(pairingId)}`;
+    return `${name}=${value}; HttpOnly; SameSite=Lax; Path=${scope}; Max-Age=${maxAge}${secure}`;
+  }
+
+  /**
+   * Resolve the `cli_session` cookie to its agent-scoped pairing, verifying it
+   * belongs to THIS pairing id. Returns null (caller 401s) when the access
+   * session is missing, expired, or points at a different pairing — so a viewer
+   * cookie can only ever reach the one agent it was issued for.
+   */
+  private resolveCliAccess(req: Request, pairingId: string): CliPairing | null {
+    const token = parseCookies(req.headers['cookie'])[CLI_SESSION_COOKIE] ?? '';
+    const p = cliPairingStore.resolveAccess(token);
+    if (!p || p.pairingId !== pairingId) return null;
+    return p;
+  }
+
+  /** Register the `/cli/*` routes (device flow + agent-scoped viewer). */
+  private setupCliRoutes(): void {
+    // Device page — the browser lands here from the chat link. Binds the first
+    // browser (first-writer-wins) and shows the waiting/verify UI.
+    this.app.get('/cli/:pairingId', (req: Request, res: Response) => {
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      const pairingId = req.params['pairingId'] ?? '';
+      const p = cliPairingStore.get(pairingId);
+      if (!p) {
+        res.status(404).send(generateCliMessagePage('Link not found', 'This viewer link is invalid or has expired. Send /cli again.', 'err'));
+        return;
+      }
+      // If this browser already holds a live access session, go straight in.
+      if (this.resolveCliAccess(req, pairingId)) {
+        res.redirect(302, `${this.cliBasePath()}/cli/${encodeURIComponent(pairingId)}/view`);
+        return;
+      }
+      let browserToken = parseCookies(req.headers['cookie'])[CLI_PAIR_COOKIE] ?? '';
+      const fresh = !browserToken;
+      if (fresh) browserToken = crypto.randomBytes(24).toString('hex');
+      const bind = cliPairingStore.bindBrowser(pairingId, browserToken);
+      if (bind === 'gone') {
+        res.status(410).send(generateCliMessagePage('Link expired', 'This viewer link has expired. Send /cli again.', 'err'));
+        return;
+      }
+      if (bind === 'already') {
+        res.status(409).send(generateCliMessagePage('Opened elsewhere', 'This link was already opened in another browser. Send /cli again to get a fresh one.', 'err'));
+        return;
+      }
+      if (fresh) {
+        res.setHeader('Set-Cookie', this.buildCliCookie(req, CLI_PAIR_COOKIE, pairingId, browserToken, CLI_PAIR_TTL_MS));
+      }
+      res.send(generateCliDevicePage({
+        pairingId,
+        agentId: p.agentId,
+        code: p.code,
+        channel: p.channel,
+        basePath: this.cliBasePath(),
+      }));
+    });
+
+    // Poll endpoint (Discord/LINE). Issues the access session once approved.
+    this.app.get('/cli/:pairingId/status', (req: Request, res: Response) => {
+      const pairingId = req.params['pairingId'] ?? '';
+      const p = cliPairingStore.get(pairingId);
+      if (!p) { res.json({ status: 'gone' }); return; }
+      const browserToken = parseCookies(req.headers['cookie'])[CLI_PAIR_COOKIE] ?? '';
+      if (!browserToken || p.browserToken !== browserToken) { res.json({ status: 'foreign' }); return; }
+      if (p.status === 'denied') { res.json({ status: 'denied' }); return; }
+      if (p.status === 'approved' || p.status === 'consumed') {
+        const consumed = cliPairingStore.consume(pairingId, browserToken);
+        if (consumed) {
+          res.setHeader('Set-Cookie', this.buildCliCookie(req, CLI_SESSION_COOKIE, pairingId, consumed.accessToken, CLI_SESSION_TTL_MS));
+          res.json({ status: 'ready' });
+          return;
+        }
+        res.json({ status: 'gone' });
+        return;
+      }
+      res.json({ status: 'pending' });
+    });
+
+    // Telegram initData fast-path — verify the signed payload and unlock.
+    this.app.post('/cli/:pairingId/tg-init', (req: Request, res: Response) => {
+      const pairingId = req.params['pairingId'] ?? '';
+      const p = cliPairingStore.get(pairingId);
+      if (!p || p.channel !== 'telegram') { res.status(404).json({ error: 'not found' }); return; }
+      const botToken = this.configs.get(p.agentId)?.telegram?.botToken ?? '';
+      if (!botToken) { res.status(400).json({ error: 'telegram not configured for this agent' }); return; }
+      const initData = ((req.body as { initData?: unknown })?.initData ?? '').toString();
+      const verified = verifyTelegramInitData(initData, botToken);
+      if (!verified) { res.status(401).json({ error: 'invalid initData' }); return; }
+      if (verified.userId !== p.userId) { res.status(403).json({ error: 'user mismatch' }); return; }
+      cliPairingStore.approve(pairingId, 'telegram', p.userId);
+      // initData already proves identity, so bind THIS browser and issue —
+      // without depending on the cli_pair cookie from the page load, which a
+      // Telegram Mini App webview may not replay.
+      let browserToken = parseCookies(req.headers['cookie'])[CLI_PAIR_COOKIE] ?? '';
+      const fresh = !browserToken;
+      if (fresh) browserToken = crypto.randomBytes(24).toString('hex');
+      const consumed = cliPairingStore.issueAccessForVerifiedUser(pairingId, browserToken);
+      if (!consumed) { res.status(409).json({ error: 'pairing no longer available' }); return; }
+      const cookies = [this.buildCliCookie(req, CLI_SESSION_COOKIE, pairingId, consumed.accessToken, CLI_SESSION_TTL_MS)];
+      if (fresh) cookies.push(this.buildCliCookie(req, CLI_PAIR_COOKIE, pairingId, browserToken, CLI_PAIR_TTL_MS));
+      res.setHeader('Set-Cookie', cookies);
+      res.json({ status: 'ready' });
+    });
+
+    // Agent-scoped viewer page.
+    this.app.get('/cli/:pairingId/view', (req: Request, res: Response) => {
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      const pairingId = req.params['pairingId'] ?? '';
+      const p = this.resolveCliAccess(req, pairingId);
+      if (!p) {
+        res.status(401).send(generateCliMessagePage('Session expired', 'Your viewer session has ended. Send /cli again to reconnect.', 'err'));
+        return;
+      }
+      res.send(generateCliViewerPage({ pairingId, agentId: p.agentId, basePath: this.cliBasePath() }));
+    });
+
+    // Agent-scoped list of live pty-shell sessions to attach to.
+    this.app.get('/cli/:pairingId/sessions', (req: Request, res: Response) => {
+      const pairingId = req.params['pairingId'] ?? '';
+      const p = this.resolveCliAccess(req, pairingId);
+      if (!p) { res.status(401).json({ error: 'Unauthorized' }); return; }
+      const runner = this.agents.get(p.agentId);
+      const sessions = (runner?.getSessionsSummary() ?? [])
+        .filter((s) => s.mode === 'pty-shell' && s.isRunning && ptyStreamRegistry.hasSockets(s.sessionId))
+        .map((s) => ({ sessionId: s.sessionId, source: s.source, model: s.model, uptimeSec: s.uptimeSec }));
+      res.json({ agentId: p.agentId, sessions });
+    });
+
+    // Agent-scoped PTY ticket — mints into the same one-time ticket map the
+    // dashboard uses, but gated by the cli_session cookie and pinned to this
+    // pairing's agent. Reuses the existing pty-stream WebSocket auth path.
+    this.app.post('/cli/:pairingId/pty-ticket', (req: Request, res: Response) => {
+      const pairingId = req.params['pairingId'] ?? '';
+      const p = this.resolveCliAccess(req, pairingId);
+      if (!p) { res.status(401).json({ error: 'Unauthorized' }); return; }
+      const sessionId = ((req.body as { sessionId?: unknown })?.sessionId ?? '').toString();
+      const runner = this.agents.get(p.agentId);
+      const belongs = (runner?.getSessionsSummary() ?? []).some((s) => s.sessionId === sessionId);
+      if (!sessionId || !belongs) { res.status(404).json({ error: 'Session not found' }); return; }
+      const ticket = crypto.randomBytes(16).toString('hex');
+      const expiresAt = Date.now() + 30_000;
+      this.ptyStreamTickets.set(ticket, { agentId: p.agentId, sessionId, expiresAt });
+      res.json({ ticket, expiresAt: new Date(expiresAt).toISOString() });
+    });
+  }
+
   private setupRoutes(): void {
     if (process.env.DEV_MODE) {
       process.stderr.write('[gateway] DEV_MODE=1 active — module cache busted on every /dashboard request. Never enable in production.\n');
@@ -416,6 +601,11 @@ export class GatewayRouter {
     );
 
     this.app.use(express.json());
+
+    // `/cli` webview terminal viewer routes (device flow + agent-scoped viewer).
+    // Registered here (after the body parser, before the /api auth router) so it
+    // owns its own cookie/approval auth without the API-key gate intercepting.
+    this.setupCliRoutes();
 
     // Ephemeral WS ticket — exchange a short-lived token for PTY stream access.
     // MUST be registered before the apiRouter middleware so it handles its own auth
@@ -833,6 +1023,7 @@ export class GatewayRouter {
         for (const [ip, rec] of this.loginAttempts) {
           if (rec.resetAt < now) this.loginAttempts.delete(ip);
         }
+        cliPairingStore.prune();
       }, 60_000);
       this.ticketPruner.unref();
 

--- a/src/api/line-webhook-router.ts
+++ b/src/api/line-webhook-router.ts
@@ -147,6 +147,19 @@ export function normalizeLineEvent(
 
 export type NormalizedLinePostback = { chatId: string; replyToken: string; data: string };
 
+/** Parse a `/cli` approve/deny postback payload, or null when it's not ours. */
+export function parseCliPostback(data: string): { pairingId: string; deny: boolean } | null {
+  try {
+    const p = JSON.parse(data) as { action?: string; pairing_id?: string };
+    if (p.action === 'cli_approve' || p.action === 'cli_deny') {
+      return { pairingId: typeof p.pairing_id === 'string' ? p.pairing_id : '', deny: p.action === 'cli_deny' };
+    }
+  } catch {
+    // not JSON / not ours
+  }
+  return null;
+}
+
 /**
  * Normalize a LINE postback event (the slow-LLM "Get answer" button tap) into
  * {chatId, replyToken, data}. Returns null for non-postback / non-user / tokenless
@@ -269,6 +282,25 @@ export function createLineWebhookHandler(
       // is safe — only users who received the button can tap it.
       const pb = normalizeLinePostback(event);
       if (pb) {
+        // `/cli` approve/deny — unlock (or reject) a terminal-viewer pairing.
+        // The pairing binds the requesting user; approveCliPairing checks the
+        // tapping user (pb.chatId, a LINE-verified id) matches, so bypassing the
+        // access gate here is safe — same as the slow-LLM postback below.
+        const cli = parseCliPostback(pb.data);
+        if (cli) {
+          const result = runner.approveCliPairing('line', cli.pairingId, pb.chatId, cli.deny);
+          if (client && pb.replyToken) {
+            const text = cli.deny
+              ? 'Denied.'
+              : result === 'ok'
+                ? 'Approved — return to the browser.'
+                : 'Could not approve (the link may have expired). Send /cli again.';
+            await client
+              .replyMessage({ replyToken: pb.replyToken, messages: [{ type: 'text', text }] })
+              .catch(() => {});
+          }
+          continue;
+        }
         try {
           await runner.handleLinePostback(pb.chatId, pb.replyToken, pb.data);
         } catch (err) {
@@ -357,6 +389,37 @@ export function createLineWebhookHandler(
       const norm = normalizeLineEvent(event, resolved);
       if (!norm) continue;
       const userId = norm.meta.chat_id;
+
+      // `/cli` opens the live terminal viewer (DM only). Mint a pairing and reply
+      // with an open-link + Approve/Deny buttons instead of forwarding to the
+      // agent. Reached only after the access gate above authorized this source.
+      if ((norm.content ?? '').trim().toLowerCase() === '/cli') {
+        if (norm.meta['line_chat_type'] === 'user' && client) {
+          const replyToken = norm.meta['reply_token'] ?? '';
+          const pairing = runner.createCliPairing('line', userId);
+          if (replyToken) {
+            const messages: messagingApi.Message[] = pairing
+              ? [{
+                  type: 'template',
+                  altText: 'Live terminal viewer',
+                  template: {
+                    type: 'buttons',
+                    text: `Live terminal viewer\nCode ${pairing.code} — open, confirm the code, then Approve.`,
+                    actions: [
+                      { type: 'uri', label: 'Open terminal', uri: pairing.url },
+                      { type: 'postback', label: `Approve ${pairing.code}`, data: JSON.stringify({ action: 'cli_approve', pairing_id: pairing.pairingId }), displayText: 'Approve terminal viewer' },
+                      { type: 'postback', label: 'Deny', data: JSON.stringify({ action: 'cli_deny', pairing_id: pairing.pairingId }) },
+                    ],
+                  },
+                }]
+              : [{ type: 'text', text: 'Terminal viewer is not configured. Set gateway.publicUrl in config.json first.' }];
+            await client.replyMessage({ replyToken, messages }).catch((err) => {
+              logger.debug('LINE /cli reply failed', { error: (err as Error).message });
+            });
+          }
+        }
+        continue;
+      }
 
       // Group/room activation gate: unless requireMention is explicitly false,
       // only respond when the bot is @mentioned (native isSelf or its name).

--- a/src/cli-viewer/pairing-store.ts
+++ b/src/cli-viewer/pairing-store.ts
@@ -1,0 +1,238 @@
+import crypto from 'crypto';
+
+/**
+ * Chat channel a `/cli` pairing originated from. The channel already
+ * authenticated the requesting user (allowlist / pairing gate) before a pairing
+ * is ever created, so the channel + user id recorded here is a trusted binding.
+ */
+export type CliChannel = 'telegram' | 'discord' | 'line';
+
+/** Runtime guard for the trusted channel set (payloads cross a process boundary). */
+export function isCliChannel(value: unknown): value is CliChannel {
+  return value === 'telegram' || value === 'discord' || value === 'line';
+}
+
+/**
+ * Pairing lifecycle:
+ *   pending   — created by `/cli`, waiting for proof (chat-approve or initData).
+ *   approved  — the authenticated chat user approved (or initData verified).
+ *   consumed  — a browser exchanged the approval for an access session cookie.
+ *   denied    — the user explicitly rejected.
+ */
+export type CliPairingStatus = 'pending' | 'approved' | 'consumed' | 'denied';
+
+export interface CliPairing {
+  /** Random, URL-safe id in the `/cli/<id>` link. NOT a secret on its own —
+   *  approval on an authenticated channel is still required to unlock. */
+  pairingId: string;
+  agentId: string;
+  channel: CliChannel;
+  /** Channel user id the pairing was minted for. Approval must come from this
+   *  same user, and (Telegram) initData's user id must match it. */
+  userId: string;
+  /** Short human-readable code shown both in chat and in the browser so the
+   *  operator can visually confirm the browser they opened is the right one. */
+  code: string;
+  status: CliPairingStatus;
+  /** Bound to the first browser that opens the link (first-writer-wins). The
+   *  access session is only ever issued to the browser holding this token, so a
+   *  later opener (e.g. a leaked link) cannot ride someone else's approval. */
+  browserToken?: string;
+  /** Issued once, at consume time; carried by the `cli_session` cookie and
+   *  resolved back to this (agent-scoped) pairing on every viewer request. */
+  accessToken?: string;
+  createdAt: number;
+  /** Approval window — a pending pairing past this is dead. */
+  expiresAt: number;
+  /** Access session lifetime — set at consume; the viewer is locked out after. */
+  accessExpiresAt?: number;
+}
+
+/** Approval window: how long the operator has to approve after `/cli`. */
+const PAIRING_TTL_MS = 3 * 60 * 1000;
+/** Viewer session lifetime once unlocked. Short — re-run `/cli` to renew. */
+const ACCESS_TTL_MS = 30 * 60 * 1000;
+
+export interface CreatedPairing {
+  pairingId: string;
+  code: string;
+}
+
+/**
+ * In-memory store of `/cli` webview pairings (device-authorization flow).
+ *
+ * A single process-wide instance is shared by the runner's callback handler
+ * (which creates and approves pairings on behalf of the authenticated chat) and
+ * the gateway HTTP routes (which serve the browser side). Mirrors the singleton
+ * shape of `pty-stream-registry` so both sides reference one source of truth
+ * without threading a dependency through constructors.
+ *
+ * Security model: the pairing id in the URL is not a credential. Unlocking a
+ * viewer requires EITHER a chat approval from the pairing's own user (Discord /
+ * LINE) OR a verified Telegram initData whose user id matches — both gated by
+ * the channel's existing allowlist. The resulting access session is scoped to a
+ * single agent; it never carries admin/dashboard authority.
+ */
+export class CliPairingStore {
+  private readonly pairings = new Map<string, CliPairing>();
+
+  /** Create a pending pairing for an authenticated chat user. */
+  create(agentId: string, channel: CliChannel, userId: string): CreatedPairing {
+    const pairingId = crypto.randomBytes(18).toString('hex');
+    // 4-digit visual-confirm code (0000–9999). Not a secret — it only helps the
+    // operator confirm the browser matches; security rests on channel approval.
+    const code = String(crypto.randomInt(0, 10000)).padStart(4, '0');
+    const now = Date.now();
+    this.pairings.set(pairingId, {
+      pairingId,
+      agentId,
+      channel,
+      userId,
+      code,
+      status: 'pending',
+      createdAt: now,
+      expiresAt: now + PAIRING_TTL_MS,
+    });
+    return { pairingId, code };
+  }
+
+  /** Raw lookup (no expiry filtering) — callers decide how to treat state. */
+  get(pairingId: string): CliPairing | undefined {
+    return this.pairings.get(pairingId);
+  }
+
+  /** True when a pairing is still within its pre-consume approval window. */
+  private isLive(p: CliPairing | undefined): p is CliPairing {
+    return !!p && p.status !== 'consumed' && p.status !== 'denied' && p.expiresAt > Date.now();
+  }
+
+  /**
+   * Bind (or re-check) the browser that opened the link. First-writer-wins: the
+   * first browser to GET the link owns the pairing. A different browser (no or
+   * mismatched token) gets `'already'` — a leaked/forwarded link opened
+   * elsewhere is visibly rejected rather than silently sharing the session.
+   */
+  bindBrowser(pairingId: string, browserToken: string): 'bound' | 'already' | 'gone' {
+    const p = this.pairings.get(pairingId);
+    // A consumed pairing is still reachable by its own bound browser (the viewer
+    // keeps loading), so allow the matching token through even post-consume.
+    if (!p || p.status === 'denied' || (p.status !== 'consumed' && p.expiresAt <= Date.now())) {
+      return 'gone';
+    }
+    if (!p.browserToken) {
+      p.browserToken = browserToken;
+      return 'bound';
+    }
+    return p.browserToken === browserToken ? 'bound' : 'already';
+  }
+
+  /**
+   * Approve via an authenticated chat action (Discord / LINE) or a verified
+   * Telegram initData. The approving user and channel must match the pairing.
+   */
+  approve(pairingId: string, channel: CliChannel, userId: string): 'ok' | 'mismatch' | 'gone' {
+    const p = this.pairings.get(pairingId);
+    if (!this.isLive(p)) return 'gone';
+    if (p.channel !== channel || p.userId !== userId) return 'mismatch';
+    if (p.status === 'pending') p.status = 'approved';
+    return 'ok';
+  }
+
+  /** Explicit rejection from the authenticated chat user. */
+  deny(pairingId: string, channel: CliChannel, userId: string): 'ok' | 'mismatch' | 'gone' {
+    const p = this.pairings.get(pairingId);
+    if (!this.isLive(p)) return 'gone';
+    if (p.channel !== channel || p.userId !== userId) return 'mismatch';
+    p.status = 'denied';
+    return 'ok';
+  }
+
+  /**
+   * Exchange an approval for an access session. Returns the access token exactly
+   * once per pairing. `requireBrowserToken` enforces that only the bound browser
+   * (Discord / LINE device flow) may consume; the Telegram initData path proves
+   * identity cryptographically in the same request and passes it through here
+   * with the freshly-bound token.
+   */
+  consume(pairingId: string, browserToken: string): { accessToken: string } | null {
+    const p = this.pairings.get(pairingId);
+    if (!p) return null;
+    // Idempotent for the owning browser: a repeat call returns the same token so
+    // a re-poll after unlock still works.
+    if (p.status === 'consumed') {
+      if (p.accessToken && p.browserToken === browserToken && (p.accessExpiresAt ?? 0) > Date.now()) {
+        return { accessToken: p.accessToken };
+      }
+      return null;
+    }
+    if (p.status !== 'approved' || p.expiresAt <= Date.now()) return null;
+    if (!p.browserToken || p.browserToken !== browserToken) return null;
+    const accessToken = crypto.randomBytes(32).toString('hex');
+    p.accessToken = accessToken;
+    p.status = 'consumed';
+    p.accessExpiresAt = Date.now() + ACCESS_TTL_MS;
+    return { accessToken };
+  }
+
+  /**
+   * Issue an access session for the Telegram initData fast-path. Identity is
+   * already proven cryptographically (the caller verified the signed initData and
+   * that its user matches the pairing), so — unlike the Discord/LINE device flow —
+   * this does NOT depend on the first-writer browser binding: a Telegram Mini App
+   * webview may not replay the `cli_pair` cookie set on the initial page load, so
+   * we (re)bind this browser and issue. Idempotent for the same browser.
+   */
+  issueAccessForVerifiedUser(pairingId: string, browserToken: string): { accessToken: string } | null {
+    const p = this.pairings.get(pairingId);
+    if (!p || p.status === 'denied') return null;
+    if (p.status === 'consumed') {
+      if (p.accessToken && p.browserToken === browserToken && (p.accessExpiresAt ?? 0) > Date.now()) {
+        return { accessToken: p.accessToken };
+      }
+      return null;
+    }
+    if (p.expiresAt <= Date.now()) return null;
+    p.browserToken = browserToken;
+    const accessToken = crypto.randomBytes(32).toString('hex');
+    p.accessToken = accessToken;
+    p.status = 'consumed';
+    p.accessExpiresAt = Date.now() + ACCESS_TTL_MS;
+    return { accessToken };
+  }
+
+  /**
+   * Resolve an access-session token to its (agent-scoped) pairing. Used by every
+   * viewer request to authorize and to learn which single agent it may touch.
+   */
+  resolveAccess(accessToken: string): CliPairing | null {
+    if (!accessToken) return null;
+    for (const p of this.pairings.values()) {
+      if (
+        p.status === 'consumed' &&
+        p.accessToken === accessToken &&
+        (p.accessExpiresAt ?? 0) > Date.now()
+      ) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  /** Drop dead pairings: expired-and-unconsumed, or access sessions past TTL. */
+  prune(): void {
+    const now = Date.now();
+    for (const [id, p] of this.pairings) {
+      const deadPending = p.status !== 'consumed' && p.expiresAt <= now;
+      const deadAccess = p.status === 'consumed' && (p.accessExpiresAt ?? 0) <= now;
+      if (deadPending || deadAccess) this.pairings.delete(id);
+    }
+  }
+
+  /** Test/introspection helper. */
+  size(): number {
+    return this.pairings.size;
+  }
+}
+
+/** Process-wide singleton shared by the runner callback and the gateway routes. */
+export const cliPairingStore = new CliPairingStore();

--- a/src/cli-viewer/telegram-initdata.ts
+++ b/src/cli-viewer/telegram-initdata.ts
@@ -1,0 +1,75 @@
+import crypto from 'crypto';
+
+export interface VerifiedInitData {
+  /** Telegram user id (stringified) proven by the signature. */
+  userId: string;
+}
+
+/** Max age of a Telegram initData payload we still trust (replay bound). */
+const INITDATA_MAX_AGE_SEC = 60 * 60;
+
+/**
+ * Verify a Telegram Mini App `initData` string against a bot token.
+ *
+ * Telegram signs the launch parameters so a Mini App can prove which user opened
+ * it without any secret in the URL. The check (per Telegram's spec):
+ *   secret_key      = HMAC_SHA256(key = "WebAppData", data = <bot token>)
+ *   data_check_str  = every "key=value" except `hash`, sorted, joined by "\n"
+ *   expected_hash   = HMAC_SHA256(key = secret_key, data = data_check_str)
+ * and `expected_hash` must equal the payload's `hash` (timing-safe).
+ *
+ * Returns the verified user id, or null if the payload is missing fields,
+ * tampered, stale, or the signature does not match. The caller is still
+ * responsible for authorizing that user for the target agent — a valid
+ * signature only proves *who* opened the Mini App, not *what* they may see.
+ */
+export function verifyTelegramInitData(
+  initData: string,
+  botToken: string,
+): VerifiedInitData | null {
+  if (!initData || !botToken) return null;
+
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(initData);
+  } catch {
+    return null;
+  }
+
+  const hash = params.get('hash');
+  if (!hash || !/^[0-9a-f]+$/i.test(hash)) return null;
+  params.delete('hash');
+
+  const dataCheckString = [...params.entries()]
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join('\n');
+
+  const secretKey = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
+  const expected = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest();
+
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(hash, 'hex');
+  } catch {
+    return null;
+  }
+  if (provided.length !== expected.length || !crypto.timingSafeEqual(provided, expected)) {
+    return null;
+  }
+
+  // Reject stale payloads (replay bound). auth_date is unix seconds.
+  const authDate = Number(params.get('auth_date') ?? '');
+  if (!Number.isFinite(authDate) || authDate <= 0) return null;
+  if (Date.now() / 1000 - authDate > INITDATA_MAX_AGE_SEC) return null;
+
+  const userRaw = params.get('user');
+  if (!userRaw) return null;
+  try {
+    const user = JSON.parse(userRaw) as { id?: number | string };
+    if (user.id === undefined || user.id === null || user.id === '') return null;
+    return { userId: String(user.id) };
+  } catch {
+    return null;
+  }
+}

--- a/src/cli-viewer/url.ts
+++ b/src/cli-viewer/url.ts
@@ -1,0 +1,22 @@
+/**
+ * Build the absolute, phone-openable URL for a `/cli` webview from the operator-
+ * configured `gateway.publicUrl`. Kept tiny and dependency-free so both the
+ * runner callback (which mints pairings) and the gateway routes can share one
+ * definition of "how a /cli link is formed".
+ */
+
+/** Trim and validate the configured public origin. Returns null when unusable
+ *  (unset, blank, or not http(s)) so callers can report "not configured" rather
+ *  than emit a broken link. Trailing slashes are stripped. */
+export function normalizePublicUrl(publicUrl: string | undefined): string | null {
+  const u = (publicUrl ?? '').trim().replace(/\/+$/, '');
+  if (!u) return null;
+  if (!/^https?:\/\//i.test(u)) return null;
+  return u;
+}
+
+/** Full viewer link for a pairing, or null when no public URL is configured. */
+export function buildCliUrl(publicUrl: string | undefined, pairingId: string): string | null {
+  const base = normalizePublicUrl(publicUrl);
+  return base ? `${base}/cli/${pairingId}` : null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,16 @@ export interface GatewayConfig {
      * var, when set, takes precedence over this field.
      */
     bind?: string;
+    /**
+     * Absolute, externally-reachable origin of this gateway (e.g.
+     * "https://gateway.example.com"), used to build phone-openable links such as
+     * the `/cli` webview terminal viewer. The process cannot infer its own public
+     * URL (it binds localhost by default and sits behind a reverse proxy), so the
+     * operator sets it explicitly. Unset = features that need a public link (e.g.
+     * `/cli`) are disabled and report that they are not configured. No trailing
+     * slash required; a trailing slash is trimmed when building links.
+     */
+    publicUrl?: string;
     models?: ModelConfig[];
     api?: {
       keys: ApiKey[];

--- a/src/ui/cli-viewer-ui.ts
+++ b/src/ui/cli-viewer-ui.ts
@@ -1,0 +1,289 @@
+/**
+ * Slim, agent-scoped webview for the `/cli` command. This is deliberately NOT
+ * the admin dashboard (`web-ui.ts`): the dashboard exposes every agent, the
+ * process tree, and cross-agent PTY injection behind an admin key. The `/cli`
+ * viewer shows exactly ONE agent's interactive (pty-shell) session, unlocked by
+ * a chat approval or a verified Telegram initData — never an admin credential.
+ *
+ * Three pages:
+ *   - device page: "waiting for approval" (Discord/LINE) or auto-initData
+ *     submit (Telegram), polling until the browser is granted an access session.
+ *   - viewer page: xterm.js attached to the agent's live PTY over the existing
+ *     ticket→WebSocket path.
+ *   - message page: terminal states (expired, opened elsewhere, denied).
+ *
+ * All API/WebSocket URLs are built relative to `basePath` (the path portion of
+ * gateway.publicUrl, e.g. "/gateway" behind an ingress prefix) so the viewer
+ * works whether the gateway is mounted at the origin root or under a prefix.
+ */
+
+const XTERM_CSS = 'https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/css/xterm.min.css';
+const XTERM_JS = 'https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/lib/xterm.min.js';
+const TG_WEBAPP_JS = 'https://telegram.org/js/telegram-web-app.js';
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const BASE_STYLE = `
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: #0b0e14; color: #c8d3f5;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    height: 100vh; display: flex; flex-direction: column;
+  }
+  .center { flex: 1; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .card {
+    max-width: 460px; width: 100%; text-align: center;
+    background: #131722; border: 1px solid #232a3b; border-radius: 14px; padding: 28px 24px;
+  }
+  h1 { font-size: 17px; margin: 0 0 6px; font-weight: 600; }
+  .muted { color: #7a88a8; font-size: 13px; line-height: 1.5; }
+  .agent { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #82aaff; }
+  .code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 40px; letter-spacing: 10px; font-weight: 700; color: #c3e88d;
+    margin: 18px 0 8px; padding-left: 10px;
+  }
+  .spinner {
+    width: 26px; height: 26px; margin: 18px auto 0;
+    border: 3px solid #232a3b; border-top-color: #82aaff; border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .err { color: #ff757f; }
+  .ok { color: #c3e88d; }
+`;
+
+/** Shared page shell. `body` is raw HTML; `head` optional extra tags. */
+function page(title: string, style: string, body: string, head = ''): string {
+  return `<!doctype html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>${htmlEscape(title)}</title>
+  ${head}
+  <style>${style}</style>
+  </head><body>${body}</body></html>`;
+}
+
+/** A plain centered message page for terminal/error states. */
+export function generateCliMessagePage(title: string, message: string, tone: 'err' | 'ok' | 'muted' = 'muted'): string {
+  return page(title, BASE_STYLE, `
+    <div class="center"><div class="card">
+      <h1>${htmlEscape(title)}</h1>
+      <p class="${tone === 'muted' ? 'muted' : tone}">${htmlEscape(message)}</p>
+    </div></div>`);
+}
+
+export interface CliDevicePageOpts {
+  pairingId: string;
+  agentId: string;
+  code: string;
+  channel: 'telegram' | 'discord' | 'line';
+  basePath: string;
+}
+
+/** "Waiting for approval" device page (or Telegram initData auto-submit). */
+export function generateCliDevicePage(opts: CliDevicePageOpts): string {
+  const cfg = JSON.stringify({
+    pairingId: opts.pairingId,
+    basePath: opts.basePath,
+    channel: opts.channel,
+  });
+  const isTelegram = opts.channel === 'telegram';
+  const head = isTelegram ? `<script src="${TG_WEBAPP_JS}"></script>` : '';
+  const body = `
+  <div class="center"><div class="card">
+    <h1>Terminal viewer</h1>
+    <p class="muted">Agent <span class="agent">${htmlEscape(opts.agentId)}</span></p>
+    ${isTelegram
+      ? `<p class="muted" id="msg">Verifying with Telegram…</p><div class="spinner" id="spin"></div>`
+      : `<div class="code">${htmlEscape(opts.code)}</div>
+         <p class="muted">Confirm this code matches your chat, then tap <b>Approve</b> there.</p>
+         <p class="muted" id="msg">Waiting for approval…</p><div class="spinner" id="spin"></div>`}
+  </div></div>
+  <script>
+  (function(){
+    var CFG = ${cfg};
+    var msg = document.getElementById('msg');
+    var spin = document.getElementById('spin');
+    function base(p){ return CFG.basePath + '/cli/' + CFG.pairingId + p; }
+    function fail(t){ if(msg){msg.textContent=t; msg.className='err';} if(spin) spin.style.display='none'; }
+    function done(){ if(msg){msg.textContent='Approved — opening…'; msg.className='ok';} location.replace(base('/view')); }
+
+    if (CFG.channel === 'telegram') {
+      var tg = window.Telegram && window.Telegram.WebApp;
+      var initData = tg && tg.initData;
+      if (tg && tg.ready) { try { tg.ready(); tg.expand && tg.expand(); } catch(e){} }
+      if (!initData) { fail('Please open this from the Telegram button.'); return; }
+      fetch(base('/tg-init'), {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        credentials:'same-origin', body: JSON.stringify({ initData: initData })
+      }).then(function(r){ return r.ok ? r.json() : r.json().then(function(e){ throw new Error(e.error||('HTTP '+r.status)); }); })
+        .then(function(d){ if(d.status==='ready') done(); else fail('Could not verify.'); })
+        .catch(function(e){ fail(e.message || 'Verification failed.'); });
+      return;
+    }
+
+    // Discord / LINE: poll until the chat approval lands.
+    var tries = 0;
+    function poll(){
+      if (tries++ > 160) { fail('Timed out. Send /cli again.'); return; }
+      fetch(base('/status'), { credentials:'same-origin' })
+        .then(function(r){ return r.json(); })
+        .then(function(d){
+          if (d.status==='ready') return done();
+          if (d.status==='denied') return fail('Request denied.');
+          if (d.status==='gone') return fail('Link expired. Send /cli again.');
+          if (d.status==='foreign') return fail('This link was opened in another browser.');
+          setTimeout(poll, 1500);
+        })
+        .catch(function(){ setTimeout(poll, 2000); });
+    }
+    poll();
+  })();
+  </script>`;
+  return page('Terminal viewer', BASE_STYLE, body, head);
+}
+
+export interface CliViewerPageOpts {
+  pairingId: string;
+  agentId: string;
+  basePath: string;
+}
+
+/** The xterm.js viewer, scoped to a single agent's PTY sessions. */
+export function generateCliViewerPage(opts: CliViewerPageOpts): string {
+  const cfg = JSON.stringify({
+    pairingId: opts.pairingId,
+    agentId: opts.agentId,
+    basePath: opts.basePath,
+  });
+  const style = `${BASE_STYLE}
+    body { background:#000; }
+    header {
+      display:flex; align-items:center; gap:10px; padding:8px 12px;
+      background:#0b0e14; border-bottom:1px solid #232a3b; font-size:13px; flex:0 0 auto;
+    }
+    header .agent { font-weight:600; }
+    header .status { color:#7a88a8; margin-left:auto; }
+    select, button {
+      background:#131722; color:#c8d3f5; border:1px solid #2b3450; border-radius:8px;
+      padding:6px 10px; font-size:13px; cursor:pointer;
+    }
+    button.on { background:#1f6feb; border-color:#1f6feb; color:#fff; }
+    #term { flex:1; min-height:0; padding:6px; }
+    .hint { color:#7a88a8; padding:16px; font-size:13px; }
+  `;
+  const body = `
+  <header>
+    <span class="agent">${htmlEscape(opts.agentId)}</span>
+    <select id="sess" title="Session" style="display:none"></select>
+    <button id="toggle" title="Toggle input">🔒 Read-only</button>
+    <span class="status" id="status">connecting…</span>
+  </header>
+  <div id="term"></div>
+  <link rel="stylesheet" href="${XTERM_CSS}">
+  <script src="${XTERM_JS}"></script>
+  <script>
+  (function(){
+    var CFG = ${cfg};
+    function api(p){ return CFG.basePath + '/cli/' + CFG.pairingId + p; }
+    var statusEl = document.getElementById('status');
+    var sel = document.getElementById('sess');
+    var toggleBtn = document.getElementById('toggle');
+    function setStatus(t){ statusEl.textContent = t; }
+
+    var term = new Terminal({
+      cols: 200, rows: 50, scrollback: 0, disableStdin: true, convertEol: false,
+      fontSize: 12, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+      theme: { background: '#000000' }
+    });
+    term.open(document.getElementById('term'));
+
+    var ws = null, inputMode = false, onDataDisposable = null, currentSession = null, reconnectT = null;
+
+    function setInputMode(on){
+      inputMode = on;
+      term.options.disableStdin = !on;
+      toggleBtn.className = on ? 'on' : '';
+      toggleBtn.textContent = on ? '⌨️ Input ON' : '🔒 Read-only';
+      if (onDataDisposable) { onDataDisposable.dispose(); onDataDisposable = null; }
+      if (on) { onDataDisposable = term.onData(function(d){ if (ws && ws.readyState===1) ws.send(d); }); }
+    }
+    toggleBtn.addEventListener('click', function(){ setInputMode(!inputMode); });
+
+    function wsUrl(ticket){
+      var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      return proto + '//' + location.host + CFG.basePath +
+        '/api/v1/agents/' + encodeURIComponent(CFG.agentId) + '/pty-stream?ticket=' + encodeURIComponent(ticket);
+    }
+
+    function connect(sessionId){
+      currentSession = sessionId;
+      if (ws) { try { ws.close(); } catch(e){} ws = null; }
+      setStatus('authorizing…');
+      fetch(api('/pty-ticket'), {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        credentials:'same-origin', body: JSON.stringify({ sessionId: sessionId })
+      }).then(function(r){
+        if (r.status===401){ setStatus('session expired — send /cli again'); throw new Error('unauth'); }
+        return r.json();
+      }).then(function(d){
+        if (!d.ticket) throw new Error('no ticket');
+        ws = new WebSocket(wsUrl(d.ticket));
+        ws.binaryType = 'arraybuffer';
+        var dec = new TextDecoder();
+        ws.onopen = function(){ setStatus('live'); };
+        ws.onmessage = function(ev){
+          var data = typeof ev.data === 'string' ? ev.data : dec.decode(ev.data, { stream:true });
+          term.write(data);
+        };
+        ws.onclose = function(ev){
+          setStatus('disconnected');
+          if (ev.code === 4404) { setStatus('session ended'); return; }
+          if (sessionId === currentSession) { clearTimeout(reconnectT); reconnectT = setTimeout(function(){ connect(sessionId); }, 2000); }
+        };
+        ws.onerror = function(){ try { ws.close(); } catch(e){} };
+      }).catch(function(){ /* status already set */ });
+    }
+
+    function loadSessions(){
+      setStatus('finding session…');
+      fetch(api('/sessions'), { credentials:'same-origin' })
+        .then(function(r){ if(r.status===401){ setStatus('session expired'); throw new Error('unauth'); } return r.json(); })
+        .then(function(d){
+          var list = (d && d.sessions) || [];
+          if (!list.length) {
+            setStatus('');
+            document.getElementById('term').innerHTML = '<div class="hint">No interactive session to view. The agent must be running with headless=false to expose a live terminal.</div>';
+            return;
+          }
+          if (list.length > 1) {
+            sel.style.display = '';
+            sel.innerHTML = '';
+            list.forEach(function(s){
+              var o = document.createElement('option');
+              o.value = s.sessionId;
+              o.textContent = (s.source||'session') + ' · ' + s.sessionId.slice(0,8);
+              sel.appendChild(o);
+            });
+            sel.addEventListener('change', function(){ connect(sel.value); });
+          }
+          setInputMode(false);
+          connect(list[0].sessionId);
+        })
+        .catch(function(){ /* status set */ });
+    }
+
+    loadSessions();
+  })();
+  </script>`;
+  return page('Terminal viewer', style, body);
+}

--- a/tests/integration/telegram-plugin-process.test.ts
+++ b/tests/integration/telegram-plugin-process.test.ts
@@ -206,6 +206,32 @@ function makeMcpReader(proc: ChildProcess) {
   }
 }
 
+// ── mock AgentRunner callback server (for /cli) ──────────────────────────────
+
+/** Minimal stand-in for the runner's /command endpoint. Captures cli_pair
+ *  requests and returns a viewer link, so the receiver's /cli command can render
+ *  its web_app button. */
+function startMockCallbackServer(port: number) {
+  const commands: Array<Record<string, unknown>> = []
+  const server = http.createServer((req, res) => {
+    let raw = ''
+    req.on('data', c => { raw += c })
+    req.on('end', () => {
+      let body: Record<string, unknown> = {}
+      try { body = raw ? JSON.parse(raw) : {} } catch {}
+      commands.push(body)
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      if (body['command'] === 'cli_pair') {
+        res.end(JSON.stringify({ success: true, pairingId: 'a'.repeat(36), code: '1234', url: 'https://host.example/cli/' + 'a'.repeat(36) }))
+      } else {
+        res.end(JSON.stringify({ success: true }))
+      }
+    })
+  })
+  server.listen(port, '127.0.0.1')
+  return { commands, close: () => new Promise<void>(r => server.close(() => r())) }
+}
+
 // ── test suite ──────────────────────────────────────────────────────────────
 
 describe('Telegram plugin E2E (process + mock Telegram API)', () => {
@@ -214,6 +240,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
   let proc: ChildProcess
   let mcp: ReturnType<typeof makeMcpReader>
   let idSeq = 10
+  let mockCb: ReturnType<typeof startMockCallbackServer>
 
   function nextId() { return ++idSeq }
 
@@ -241,12 +268,16 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     const port = await getFreePort()
     mock = startMockTelegramServer(port)
 
+    const cbPort = await getFreePort()
+    mockCb = startMockCallbackServer(cbPort)
+
     proc = spawn('bun', [RECEIVER_PATH], {
       env: {
         ...process.env,
         TELEGRAM_BOT_TOKEN: BOT_TOKEN,
         TELEGRAM_STATE_DIR: tmpDir,
         TELEGRAM_API_ROOT: `http://127.0.0.1:${port}`,
+        CLAUDE_CHANNEL_CALLBACK: `http://127.0.0.1:${cbPort}/channel`,
       },
       stdio: ['pipe', 'pipe', 'pipe'],
     })
@@ -286,6 +317,7 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
   afterAll(async () => {
     try { proc?.kill('SIGTERM') } catch {}
     await mock.close()
+    await mockCb?.close()
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
@@ -423,4 +455,39 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     )
     expect(notifForStranger).toBeUndefined()
   }, 15000)
+
+  // ── test 6: /cli opens a Mini App (web_app) button ────────────────────────
+
+  test('/cli command → cli_pair callback → sendMessage with a web_app button', async () => {
+    const t0 = Date.now()
+    const now = Math.floor(t0 / 1000)
+
+    mock.queueUpdate({
+      message: {
+        message_id: 77,
+        from: { id: Number(USER_ID), username: 'tester', is_bot: false, first_name: 'Tester' },
+        chat: { id: Number(USER_ID), type: 'private' },
+        date: now,
+        text: '/cli',
+        entities: [{ type: 'bot_command', offset: 0, length: 4 }],
+      },
+    })
+
+    // The receiver must reply with an inline keyboard carrying a Mini App button.
+    const send = await mock.waitForCall('sendMessage', t0, 20000)
+    expect(String(send.body['chat_id'])).toBe(USER_ID)
+
+    let markup = send.body['reply_markup'] as unknown
+    if (typeof markup === 'string') markup = JSON.parse(markup)
+    const rows = (markup as { inline_keyboard?: Array<Array<Record<string, unknown>>> }).inline_keyboard ?? []
+    const webAppBtn = rows.flat().find(b => b['web_app'] !== undefined)
+    expect(webAppBtn).toBeTruthy()
+    expect((webAppBtn!['web_app'] as { url: string }).url).toMatch(/^https:\/\/host\.example\/cli\/[0-9a-f]{36}$/)
+
+    // And it went through the runner callback as a cli_pair for this user.
+    const pair = mockCb.commands.find(c => c['command'] === 'cli_pair')
+    expect(pair).toBeTruthy()
+    expect((pair!['payload'] as { channel: string; user_id: string }).channel).toBe('telegram')
+    expect((pair!['payload'] as { channel: string; user_id: string }).user_id).toBe(USER_ID)
+  }, 30000)
 })

--- a/tests/unit/cli-discord-e2e.test.ts
+++ b/tests/unit/cli-discord-e2e.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DiscordModule } from '../../mcp/tools/discord/module';
+import { cliPairingStore } from '../../src/cli-viewer/pairing-store';
+
+/**
+ * Discord `/cli` end-to-end (mocked): drive the REAL message + interaction
+ * handlers through an injected fake discord.js client. A `/cli` DM must render an
+ * open-viewer Link button + an Approve button, and tapping Approve must flip the
+ * pairing to approved. The runner callback is emulated by a fetch stub that talks
+ * to the real CliPairingStore, so the assertion is on real store state.
+ */
+
+const AGENT = 'agent-disc';
+const USER = 'user-123';
+
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+// Emulate the runner's /command callback against the real store.
+function installCallbackStub(): jest.Mock {
+  const fetchMock = jest.fn(async (_url: string, init: { body: string }) => {
+    const body = JSON.parse(init.body) as { command: string; payload: Record<string, unknown> };
+    if (body.command === 'cli_pair') {
+      const { pairingId, code } = cliPairingStore.create(AGENT, 'discord', String(body.payload['user_id']));
+      return jsonResponse({ success: true, pairingId, code, url: `https://host.example/cli/${pairingId}` });
+    }
+    if (body.command === 'cli_approve') {
+      const pid = String(body.payload['pairing_id']);
+      const uid = String(body.payload['user_id']);
+      const result = body.payload['deny'] === true
+        ? cliPairingStore.deny(pid, 'discord', uid)
+        : cliPairingStore.approve(pid, 'discord', uid);
+      return jsonResponse({ success: result === 'ok', result });
+    }
+    return jsonResponse({ success: false });
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function makeFakeClient(): EventEmitter & { user: unknown; channels: unknown } {
+  const c = new EventEmitter() as EventEmitter & { user: unknown; channels: unknown };
+  c.user = { id: 'bot-1' };
+  c.channels = { fetch: async () => ({}), cache: { has: () => true } };
+  return c;
+}
+
+async function tick(times = 6): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise((r) => setImmediate(r));
+}
+
+describe('Discord /cli end-to-end (mocked client)', () => {
+  let tmp: string;
+  let mod: DiscordModule;
+  let client: ReturnType<typeof makeFakeClient>;
+  let abort: AbortController;
+  let fetchMock: jest.Mock;
+  const origFetch = global.fetch;
+  const origEnv = { ...process.env };
+
+  beforeEach(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-disc-'));
+    fs.writeFileSync(path.join(tmp, 'access.json'), JSON.stringify({ dmPolicy: 'open' }));
+    process.env.DISCORD_STATE_DIR = tmp;
+    process.env.CLAUDE_CHANNEL_CALLBACK = 'http://127.0.0.1:9/channel';
+    fetchMock = installCallbackStub();
+
+    mod = new DiscordModule();
+    client = makeFakeClient();
+    (mod as unknown as { client: unknown }).client = client;
+    abort = new AbortController();
+    // start() blocks until the signal aborts — fire and forget.
+    void mod.start(async () => {}, abort.signal);
+    await tick(2);
+  });
+
+  afterEach(() => {
+    abort.abort();
+    global.fetch = origFetch;
+    process.env = { ...origEnv };
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function dmMessage(content: string, id: string) {
+    return {
+      author: { id: USER, username: 'tester', bot: false },
+      system: false,
+      guild: null,
+      channelId: 'dm-chan',
+      id,
+      content,
+      channel: { send: jest.fn(async () => ({})) },
+    };
+  }
+
+  it('/cli renders an open-viewer Link + Approve button, and Approve unlocks the pairing', async () => {
+    const msg = dmMessage('/cli', 'm-1');
+    client.emit('messageCreate', msg);
+    await tick();
+
+    // A cli_pair callback was made and a reply with components was sent.
+    expect(fetchMock).toHaveBeenCalled();
+    expect(msg.channel.send as jest.Mock).toHaveBeenCalledTimes(1);
+    const sent = (msg.channel.send as jest.Mock).mock.calls[0][0] as { components: Array<{ components: Array<Record<string, unknown>> }> };
+    const buttons = sent.components[0].components;
+    const link = buttons.find((b) => b['style'] === 5);
+    const approve = buttons.find((b) => typeof b['custom_id'] === 'string' && (b['custom_id'] as string).startsWith('cli:approve:'));
+    expect(link).toBeTruthy();
+    expect(String(link!['url'])).toMatch(/^https:\/\/host\.example\/cli\/[0-9a-f]{36}$/);
+    expect(approve).toBeTruthy();
+
+    const pairingId = (approve!['custom_id'] as string).slice('cli:approve:'.length);
+    expect(cliPairingStore.get(pairingId)?.status).toBe('pending');
+
+    // Tap Approve → interaction handler relays cli_approve → store flips.
+    const interaction = {
+      isButton: () => true,
+      customId: `cli:approve:${pairingId}`,
+      guildId: null,
+      channelId: 'dm-chan',
+      user: { id: USER, username: 'tester' },
+      message: { id: 'm-1' },
+      client: { user: { id: 'bot-1' } },
+      reply: jest.fn(async () => ({})),
+      update: jest.fn(async () => ({})),
+    };
+    client.emit('interactionCreate', interaction);
+    await tick();
+
+    expect(cliPairingStore.get(pairingId)?.status).toBe('approved');
+    expect(interaction.update).toHaveBeenCalled();
+  });
+
+  it('Deny marks the pairing denied instead of approved', async () => {
+    const msg = dmMessage('/cli', 'm-2');
+    client.emit('messageCreate', msg);
+    await tick();
+    const sent = (msg.channel.send as jest.Mock).mock.calls[0][0] as { components: Array<{ components: Array<Record<string, unknown>> }> };
+    const approve = sent.components[0].components.find((b) => String(b['custom_id'] ?? '').startsWith('cli:approve:'))!;
+    const pairingId = (approve['custom_id'] as string).slice('cli:approve:'.length);
+
+    const interaction = {
+      isButton: () => true,
+      customId: `cli:deny:${pairingId}`,
+      guildId: null,
+      channelId: 'dm-chan',
+      user: { id: USER, username: 'tester' },
+      message: { id: 'm-2' },
+      client: { user: { id: 'bot-1' } },
+      reply: jest.fn(async () => ({})),
+      update: jest.fn(async () => ({})),
+    };
+    client.emit('interactionCreate', interaction);
+    await tick();
+
+    expect(cliPairingStore.get(pairingId)?.status).toBe('denied');
+  });
+});

--- a/tests/unit/cli-line-e2e.test.ts
+++ b/tests/unit/cli-line-e2e.test.ts
@@ -1,0 +1,145 @@
+import { createHmac } from 'crypto';
+import { createLineWebhookHandler } from '../../src/api/line-webhook-router';
+import { cliPairingStore } from '../../src/cli-viewer/pairing-store';
+import type { AgentRunner } from '../../src/agent/runner';
+
+/**
+ * LINE `/cli` end-to-end (mocked): drive the REAL webhook handler (`handlePost`)
+ * with signed events. A `/cli` DM must reply with a buttons template carrying an
+ * open-viewer URI action + Approve/Deny postback actions; a `cli_approve`
+ * postback must flip the real pairing to approved. `validateSignature` stays
+ * real (a valid HMAC is computed here); only the outbound client is captured.
+ */
+
+const mockReplyCalls: Array<{ replyToken?: string; messages?: unknown[] }> = [];
+jest.mock('@line/bot-sdk', () => {
+  const actual = jest.requireActual('@line/bot-sdk');
+  class MockMessagingApiClient {
+    constructor(_opts: unknown) {}
+    async replyMessage(arg: { replyToken?: string; messages?: unknown[] }) { mockReplyCalls.push(arg); return {}; }
+    async pushMessage() { return {}; }
+    async showLoadingAnimation() { return {}; }
+    async getProfile() { return { displayName: 'x' }; }
+  }
+  class MockBlobClient { constructor(_opts: unknown) {} }
+  return {
+    ...actual,
+    messagingApi: {
+      ...actual.messagingApi,
+      MessagingApiClient: MockMessagingApiClient,
+      MessagingApiBlobClient: MockBlobClient,
+    },
+  };
+});
+
+const AGENT = 'line-agent';
+const SECRET = 'test-channel-secret';
+const USER = 'U-line-1';
+
+function fakeRunner(): AgentRunner {
+  return {
+    getAgentConfig: () => ({
+      id: AGENT,
+      line: { channelSecret: SECRET, channelAccessToken: 'tok', dmPolicy: 'open' },
+    }),
+    getCallbackPort: () => 0,
+    createCliPairing: (channel: 'telegram' | 'discord' | 'line', userId: string) => {
+      const { pairingId, code } = cliPairingStore.create(AGENT, channel, userId);
+      return { pairingId, code, url: `https://host.example/cli/${pairingId}` };
+    },
+    approveCliPairing: (channel: 'telegram' | 'discord' | 'line', pairingId: string, userId: string, deny = false) =>
+      deny ? cliPairingStore.deny(pairingId, channel, userId) : cliPairingStore.approve(pairingId, channel, userId),
+  } as unknown as AgentRunner;
+}
+
+function makeRes() {
+  const res = { status: jest.fn(), json: jest.fn() };
+  res.status.mockReturnValue(res as never);
+  res.json.mockReturnValue(res as never);
+  return res;
+}
+
+function post(handler: ReturnType<typeof createLineWebhookHandler>, events: unknown[]) {
+  const buf = Buffer.from(JSON.stringify({ events }));
+  const sig = createHmac('sha256', SECRET).update(buf).digest('base64');
+  const req = {
+    params: { agentId: AGENT },
+    header: (h: string) => (h.toLowerCase() === 'x-line-signature' ? sig : undefined),
+    body: buf,
+  };
+  return handler.handlePost(req as never, makeRes() as never);
+}
+
+describe('LINE /cli end-to-end (mocked client)', () => {
+  let handler: ReturnType<typeof createLineWebhookHandler>;
+
+  beforeEach(() => {
+    mockReplyCalls.length = 0;
+    const agents = new Map<string, AgentRunner>([[AGENT, fakeRunner()]]);
+    handler = createLineWebhookHandler(agents, '/tmp');
+  });
+
+  it('/cli replies with a buttons template (open URI + approve/deny postback)', async () => {
+    await post(handler, [{
+      type: 'message',
+      mode: 'active',
+      timestamp: 1,
+      source: { type: 'user', userId: USER },
+      replyToken: 'rt-1',
+      message: { id: '1', type: 'text', text: '/cli' },
+    }]);
+
+    expect(mockReplyCalls).toHaveLength(1);
+    const tmpl = (mockReplyCalls[0].messages as Array<{ type: string; template: { actions: Array<Record<string, string>> } }>)[0];
+    expect(tmpl.type).toBe('template');
+    const actions = tmpl.template.actions;
+    const uri = actions.find((a) => a['type'] === 'uri');
+    const approve = actions.find((a) => a['type'] === 'postback' && a['data'].includes('cli_approve'));
+    const deny = actions.find((a) => a['type'] === 'postback' && a['data'].includes('cli_deny'));
+    expect(String(uri!['uri'])).toMatch(/^https:\/\/host\.example\/cli\/[0-9a-f]{36}$/);
+    expect(approve).toBeTruthy();
+    expect(deny).toBeTruthy();
+
+    // The pairing exists and is pending until approved.
+    const pairingId = String(uri!['uri']).split('/cli/')[1];
+    expect(cliPairingStore.get(pairingId)?.status).toBe('pending');
+  });
+
+  it('a cli_approve postback flips the real pairing to approved', async () => {
+    // Mint a pairing for this user first (as /cli would).
+    const { pairingId } = cliPairingStore.create(AGENT, 'line', USER);
+
+    await post(handler, [{
+      type: 'postback',
+      mode: 'active',
+      timestamp: 2,
+      source: { type: 'user', userId: USER },
+      replyToken: 'rt-2',
+      postback: { data: JSON.stringify({ action: 'cli_approve', pairing_id: pairingId }) },
+    }]);
+
+    expect(cliPairingStore.get(pairingId)?.status).toBe('approved');
+    expect(mockReplyCalls).toHaveLength(1);
+  });
+
+  it('a cli_deny postback marks the pairing denied', async () => {
+    const { pairingId } = cliPairingStore.create(AGENT, 'line', USER);
+    await post(handler, [{
+      type: 'postback',
+      mode: 'active',
+      timestamp: 3,
+      source: { type: 'user', userId: USER },
+      replyToken: 'rt-3',
+      postback: { data: JSON.stringify({ action: 'cli_deny', pairing_id: pairingId }) },
+    }]);
+    expect(cliPairingStore.get(pairingId)?.status).toBe('denied');
+  });
+
+  it('rejects a request with a bad signature (401)', async () => {
+    const buf = Buffer.from(JSON.stringify({ events: [] }));
+    const req = { params: { agentId: AGENT }, header: () => 'wrong-sig', body: buf };
+    const res = makeRes();
+    await handler.handlePost(req as never, res as never);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});

--- a/tests/unit/cli-pairing-store.test.ts
+++ b/tests/unit/cli-pairing-store.test.ts
@@ -1,0 +1,112 @@
+import { CliPairingStore } from '../../src/cli-viewer/pairing-store';
+
+/**
+ * `/cli` pairing store — the device-authorization state machine behind the
+ * webview terminal viewer. These pin the security-relevant transitions:
+ *  - a link is not a credential (approval is required before consume),
+ *  - first-writer-wins browser binding (a leaked/forwarded link opened in a
+ *    second browser is rejected, and cannot ride the real user's approval),
+ *  - approval must come from the pairing's own channel + user,
+ *  - the access token is agent-scoped and single-issue.
+ */
+describe('CliPairingStore', () => {
+  const BROWSER = 'browser-token-aaa';
+  const OTHER_BROWSER = 'browser-token-bbb';
+
+  function pending() {
+    const store = new CliPairingStore();
+    const { pairingId, code } = store.create('agent-1', 'discord', 'user-9');
+    return { store, pairingId, code };
+  }
+
+  it('creates a pending pairing with a 4-digit code', () => {
+    const { store, pairingId, code } = pending();
+    expect(pairingId).toMatch(/^[0-9a-f]{36}$/);
+    expect(code).toMatch(/^\d{4}$/);
+    expect(store.get(pairingId)?.status).toBe('pending');
+  });
+
+  it('does NOT consume before approval — a link alone unlocks nothing', () => {
+    const { store, pairingId } = pending();
+    expect(store.bindBrowser(pairingId, BROWSER)).toBe('bound');
+    expect(store.consume(pairingId, BROWSER)).toBeNull();
+  });
+
+  it('full happy path: bind → approve → consume → resolveAccess (agent-scoped)', () => {
+    const { store, pairingId } = pending();
+    expect(store.bindBrowser(pairingId, BROWSER)).toBe('bound');
+    expect(store.approve(pairingId, 'discord', 'user-9')).toBe('ok');
+    const res = store.consume(pairingId, BROWSER);
+    expect(res).not.toBeNull();
+    const p = store.resolveAccess(res!.accessToken);
+    expect(p?.agentId).toBe('agent-1');
+    expect(p?.status).toBe('consumed');
+  });
+
+  it('first-writer-wins: a second browser is rejected and cannot consume', () => {
+    const { store, pairingId } = pending();
+    expect(store.bindBrowser(pairingId, BROWSER)).toBe('bound');
+    expect(store.bindBrowser(pairingId, OTHER_BROWSER)).toBe('already');
+    expect(store.approve(pairingId, 'discord', 'user-9')).toBe('ok');
+    // Even after a real approval, the wrong browser gets nothing.
+    expect(store.consume(pairingId, OTHER_BROWSER)).toBeNull();
+    // The bound browser still succeeds.
+    expect(store.consume(pairingId, BROWSER)).not.toBeNull();
+  });
+
+  it('approval must match the pairing channel and user', () => {
+    const { store, pairingId } = pending();
+    store.bindBrowser(pairingId, BROWSER);
+    expect(store.approve(pairingId, 'telegram', 'user-9')).toBe('mismatch');
+    expect(store.approve(pairingId, 'discord', 'someone-else')).toBe('mismatch');
+    expect(store.get(pairingId)?.status).toBe('pending');
+    expect(store.approve(pairingId, 'discord', 'user-9')).toBe('ok');
+  });
+
+  it('deny blocks the flow permanently', () => {
+    const { store, pairingId } = pending();
+    store.bindBrowser(pairingId, BROWSER);
+    expect(store.deny(pairingId, 'discord', 'user-9')).toBe('ok');
+    expect(store.approve(pairingId, 'discord', 'user-9')).toBe('gone');
+    expect(store.consume(pairingId, BROWSER)).toBeNull();
+  });
+
+  it('consume is idempotent for the owning browser, single-issue otherwise', () => {
+    const { store, pairingId } = pending();
+    store.bindBrowser(pairingId, BROWSER);
+    store.approve(pairingId, 'discord', 'user-9');
+    const first = store.consume(pairingId, BROWSER)!;
+    const again = store.consume(pairingId, BROWSER)!;
+    expect(again.accessToken).toBe(first.accessToken);
+    // A different browser cannot consume a consumed pairing.
+    expect(store.consume(pairingId, OTHER_BROWSER)).toBeNull();
+  });
+
+  it('resolveAccess rejects unknown / empty tokens', () => {
+    const { store } = pending();
+    expect(store.resolveAccess('')).toBeNull();
+    expect(store.resolveAccess('deadbeef')).toBeNull();
+  });
+
+  it('an expired pending pairing is gone; prune drops it', () => {
+    const store = new CliPairingStore();
+    const { pairingId } = store.create('agent-1', 'line', 'u1');
+    const p = store.get(pairingId)!;
+    p.expiresAt = Date.now() - 1; // force-expire
+    expect(store.bindBrowser(pairingId, BROWSER)).toBe('gone');
+    expect(store.approve(pairingId, 'line', 'u1')).toBe('gone');
+    store.prune();
+    expect(store.get(pairingId)).toBeUndefined();
+  });
+
+  it('prune removes access sessions past their TTL', () => {
+    const { store, pairingId } = pending();
+    store.bindBrowser(pairingId, BROWSER);
+    store.approve(pairingId, 'discord', 'user-9');
+    const res = store.consume(pairingId, BROWSER)!;
+    store.get(pairingId)!.accessExpiresAt = Date.now() - 1; // force-expire access
+    expect(store.resolveAccess(res.accessToken)).toBeNull();
+    store.prune();
+    expect(store.get(pairingId)).toBeUndefined();
+  });
+});

--- a/tests/unit/cli-telegram-initdata.test.ts
+++ b/tests/unit/cli-telegram-initdata.test.ts
@@ -1,0 +1,68 @@
+import crypto from 'crypto';
+import { verifyTelegramInitData } from '../../src/cli-viewer/telegram-initdata';
+
+/**
+ * Telegram Mini App initData verification. The gateway trusts initData to prove
+ * *who* opened the `/cli` Mini App without any secret in the URL, so the HMAC
+ * check must be exact: a tampered field, a foreign signature, a stale payload,
+ * or a missing user must all fail closed.
+ */
+const BOT_TOKEN = '123456:test-bot-token-abcdef';
+
+/** Build a validly-signed initData string exactly the way Telegram does. */
+function signInitData(
+  fields: Record<string, string>,
+  botToken = BOT_TOKEN,
+): string {
+  const params = new URLSearchParams(fields);
+  const dataCheckString = [...params.entries()]
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join('\n');
+  const secretKey = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
+  const hash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}
+
+function freshFields(userId = 777): Record<string, string> {
+  return {
+    auth_date: String(Math.floor(Date.now() / 1000)),
+    query_id: 'AAA',
+    user: JSON.stringify({ id: userId, first_name: 'Test' }),
+  };
+}
+
+describe('verifyTelegramInitData', () => {
+  it('accepts a valid payload and returns the user id', () => {
+    const initData = signInitData(freshFields(777));
+    expect(verifyTelegramInitData(initData, BOT_TOKEN)).toEqual({ userId: '777' });
+  });
+
+  it('rejects a tampered field (signature no longer matches)', () => {
+    const params = new URLSearchParams(signInitData(freshFields(777)));
+    params.set('user', JSON.stringify({ id: 999, first_name: 'Mallory' }));
+    expect(verifyTelegramInitData(params.toString(), BOT_TOKEN)).toBeNull();
+  });
+
+  it('rejects a payload signed with a different bot token', () => {
+    const initData = signInitData(freshFields(777), 'other:token');
+    expect(verifyTelegramInitData(initData, BOT_TOKEN)).toBeNull();
+  });
+
+  it('rejects a stale payload (auth_date too old)', () => {
+    const stale = freshFields(777);
+    stale.auth_date = String(Math.floor(Date.now() / 1000) - 7200); // 2h old
+    const initData = signInitData(stale);
+    expect(verifyTelegramInitData(initData, BOT_TOKEN)).toBeNull();
+  });
+
+  it('rejects a missing hash / missing user / empty inputs', () => {
+    expect(verifyTelegramInitData('', BOT_TOKEN)).toBeNull();
+    expect(verifyTelegramInitData('auth_date=123', BOT_TOKEN)).toBeNull();
+    const noUser = signInitData({ auth_date: String(Math.floor(Date.now() / 1000)) });
+    expect(verifyTelegramInitData(noUser, BOT_TOKEN)).toBeNull();
+    const valid = signInitData(freshFields(1));
+    expect(verifyTelegramInitData(valid, '')).toBeNull();
+  });
+});

--- a/tests/unit/cli-viewer-routes.test.ts
+++ b/tests/unit/cli-viewer-routes.test.ts
@@ -1,0 +1,185 @@
+import supertest from 'supertest';
+import crypto from 'crypto';
+import { GatewayRouter } from '../../src/api/gateway-router';
+import { cliPairingStore } from '../../src/cli-viewer/pairing-store';
+import { ptyStreamRegistry } from '../../src/shell/pty-stream-registry';
+import type { AgentConfig, GatewayConfig } from '../../src/types';
+
+/**
+ * `/cli` webview terminal viewer — HTTP surface on the real Express app.
+ *
+ * Proves the device-authorization flow and, critically, that the viewer is
+ * AGENT-SCOPED: its access cookie and PTY ticket can only reach the one agent
+ * the pairing was created for — never another agent, never the admin dashboard.
+ * A leaked link stays locked; only a chat approval (or verified Telegram
+ * initData) unlocks it.
+ */
+
+const BOT_TOKEN = '111222:test-bot-token';
+const AGENT = 'agent-x';
+const OTHER_AGENT = 'agent-y';
+
+function fakeRunner(sessions: Array<Record<string, unknown>>) {
+  return { getSessionsSummary: () => sessions } as never;
+}
+
+function buildApp() {
+  const gatewayConfig: GatewayConfig = {
+    gateway: { logDir: '/tmp', timezone: 'UTC', publicUrl: 'https://host.example/gw' },
+    agents: [],
+  };
+  const agents = new Map<string, never>();
+  agents.set(AGENT, fakeRunner([
+    { sessionId: 'sess-1', chatId: 'c1', source: 'telegram', mode: 'pty-shell', model: 'm', isRunning: true, spawnedAt: 0, uptimeSec: 5, tokens: 0 },
+    { sessionId: 'sess-head', chatId: 'c2', source: 'api', mode: 'headless', model: 'm', isRunning: true, spawnedAt: 0, uptimeSec: 5, tokens: 0 },
+  ]));
+  agents.set(OTHER_AGENT, fakeRunner([
+    { sessionId: 'other-sess', chatId: 'c9', source: 'telegram', mode: 'pty-shell', model: 'm', isRunning: true, spawnedAt: 0, uptimeSec: 5, tokens: 0 },
+  ]));
+  const configs = new Map<string, AgentConfig>();
+  configs.set(AGENT, { id: AGENT, telegram: { botToken: BOT_TOKEN } } as unknown as AgentConfig);
+  const router = new GatewayRouter(agents as never, configs, undefined, gatewayConfig);
+  return router.getApp();
+}
+
+function pairCookie(res: { headers: Record<string, unknown> }, name: string): string {
+  const set = (res.headers['set-cookie'] as string[] | undefined) ?? [];
+  const hit = set.find((c) => c.startsWith(`${name}=`));
+  return hit ? hit.split(';')[0] : '';
+}
+
+function signInitData(userId: number, botToken = BOT_TOKEN, ageSec = 0): string {
+  const params = new URLSearchParams({
+    auth_date: String(Math.floor(Date.now() / 1000) - ageSec),
+    user: JSON.stringify({ id: userId, first_name: 'T' }),
+  });
+  const dcs = [...params.entries()].map(([k, v]) => `${k}=${v}`).sort().join('\n');
+  const secret = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
+  params.set('hash', crypto.createHmac('sha256', secret).update(dcs).digest('hex'));
+  return params.toString();
+}
+
+describe('/cli webview terminal viewer routes', () => {
+  let app: ReturnType<typeof buildApp>;
+  let hasSocketsSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    app = buildApp();
+    hasSocketsSpy = jest.spyOn(ptyStreamRegistry, 'hasSockets').mockReturnValue(true);
+  });
+  afterEach(() => hasSocketsSpy.mockRestore());
+
+  it('device flow: open → approve in chat → unlock → agent-scoped viewer', async () => {
+    const { pairingId } = cliPairingStore.create(AGENT, 'discord', 'user-1');
+
+    // Browser opens the link → device page, binds this browser.
+    const open = await supertest(app).get(`/cli/${pairingId}`);
+    expect(open.status).toBe(200);
+    const pair = pairCookie(open, 'cli_pair');
+    expect(pair).toBeTruthy();
+
+    // Still pending before approval.
+    const pending = await supertest(app).get(`/cli/${pairingId}/status`).set('Cookie', pair);
+    expect(pending.body).toEqual({ status: 'pending' });
+
+    // The authenticated chat user approves.
+    expect(cliPairingStore.approve(pairingId, 'discord', 'user-1')).toBe('ok');
+
+    // Now the poll issues the agent-scoped access cookie.
+    const ready = await supertest(app).get(`/cli/${pairingId}/status`).set('Cookie', pair);
+    expect(ready.body).toEqual({ status: 'ready' });
+    const session = pairCookie(ready, 'cli_session');
+    expect(session).toBeTruthy();
+
+    // Viewer renders, scoped to this agent.
+    const view = await supertest(app).get(`/cli/${pairingId}/view`).set('Cookie', session);
+    expect(view.status).toBe(200);
+    expect(view.text).toContain(AGENT);
+
+    // Sessions list is filtered to the agent's live pty-shell sessions.
+    const sessions = await supertest(app).get(`/cli/${pairingId}/sessions`).set('Cookie', session);
+    expect(sessions.body.agentId).toBe(AGENT);
+    expect(sessions.body.sessions.map((s: { sessionId: string }) => s.sessionId)).toEqual(['sess-1']);
+
+    // A ticket can be minted for the agent's own session…
+    const ticket = await supertest(app).post(`/cli/${pairingId}/pty-ticket`).set('Cookie', session).send({ sessionId: 'sess-1' });
+    expect(ticket.status).toBe(200);
+    expect(ticket.body.ticket).toMatch(/^[0-9a-f]{32}$/);
+
+    // …but NOT for another agent's session (agent-scoping).
+    const cross = await supertest(app).post(`/cli/${pairingId}/pty-ticket`).set('Cookie', session).send({ sessionId: 'other-sess' });
+    expect(cross.status).toBe(404);
+  });
+
+  it('a leaked link opened in a second browser is rejected (first-writer-wins)', async () => {
+    const { pairingId } = cliPairingStore.create(AGENT, 'discord', 'user-1');
+    await supertest(app).get(`/cli/${pairingId}`).expect(200); // first browser binds
+    const second = await supertest(app).get(`/cli/${pairingId}`); // no cookie = different browser
+    expect(second.status).toBe(409);
+  });
+
+  it('status is foreign for a browser that did not bind the pairing', async () => {
+    const { pairingId } = cliPairingStore.create(AGENT, 'discord', 'user-1');
+    await supertest(app).get(`/cli/${pairingId}`).expect(200);
+    const res = await supertest(app).get(`/cli/${pairingId}/status`).set('Cookie', 'cli_pair=someone-elses-token');
+    expect(res.body).toEqual({ status: 'foreign' });
+  });
+
+  it('viewer and ticket require a valid access session (no cookie → 401)', async () => {
+    const { pairingId } = cliPairingStore.create(AGENT, 'discord', 'user-1');
+    await supertest(app).get(`/cli/${pairingId}/view`).expect(401);
+    await supertest(app).get(`/cli/${pairingId}/sessions`).expect(401);
+    await supertest(app).post(`/cli/${pairingId}/pty-ticket`).send({ sessionId: 'sess-1' }).expect(401);
+  });
+
+  it('an access session for one pairing cannot be replayed against another', async () => {
+    const a = cliPairingStore.create(AGENT, 'discord', 'user-1');
+    const b = cliPairingStore.create(OTHER_AGENT, 'discord', 'user-2');
+    const open = await supertest(app).get(`/cli/${a.pairingId}`);
+    const pair = pairCookie(open, 'cli_pair');
+    cliPairingStore.approve(a.pairingId, 'discord', 'user-1');
+    const ready = await supertest(app).get(`/cli/${a.pairingId}/status`).set('Cookie', pair);
+    const session = pairCookie(ready, 'cli_session');
+    // The session cookie from pairing A must not authorize pairing B's viewer.
+    await supertest(app).get(`/cli/${b.pairingId}/view`).set('Cookie', session).expect(401);
+  });
+
+  it('Telegram initData fast-path: valid unlocks, foreign user 403, tampered 401', async () => {
+    // Valid initData for the pairing's own user unlocks.
+    const good = cliPairingStore.create(AGENT, 'telegram', '777');
+    const open = await supertest(app).get(`/cli/${good.pairingId}`);
+    const pair = pairCookie(open, 'cli_pair');
+    const ok = await supertest(app).post(`/cli/${good.pairingId}/tg-init`).set('Cookie', pair).send({ initData: signInitData(777) });
+    expect(ok.status).toBe(200);
+    expect(ok.body).toEqual({ status: 'ready' });
+    expect(pairCookie(ok, 'cli_session')).toBeTruthy();
+
+    // initData for a DIFFERENT user id is rejected (403) even if validly signed.
+    const foreign = cliPairingStore.create(AGENT, 'telegram', '777');
+    const fOpen = await supertest(app).get(`/cli/${foreign.pairingId}`);
+    const f = await supertest(app).post(`/cli/${foreign.pairingId}/tg-init`).set('Cookie', pairCookie(fOpen, 'cli_pair')).send({ initData: signInitData(999) });
+    expect(f.status).toBe(403);
+
+    // A tampered payload fails the HMAC (401).
+    const bad = cliPairingStore.create(AGENT, 'telegram', '777');
+    const bOpen = await supertest(app).get(`/cli/${bad.pairingId}`);
+    const tampered = signInitData(777).replace(/first_name%22%3A%22T/, 'first_name%22%3A%22X');
+    const b = await supertest(app).post(`/cli/${bad.pairingId}/tg-init`).set('Cookie', pairCookie(bOpen, 'cli_pair')).send({ initData: tampered });
+    expect(b.status).toBe(401);
+  });
+
+  it('Telegram initData works even without a prior page-load cookie (Mini App webview)', async () => {
+    // A Telegram Mini App may not replay the cli_pair cookie from the device
+    // page load; initData alone must still unlock (identity is proven by HMAC).
+    const { pairingId } = cliPairingStore.create(AGENT, 'telegram', '777');
+    const res = await supertest(app).post(`/cli/${pairingId}/tg-init`).send({ initData: signInitData(777) });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ready' });
+    expect(pairCookie(res, 'cli_session')).toBeTruthy();
+  });
+
+  it('an unknown pairing id 404s the device page', async () => {
+    const res = await supertest(app).get('/cli/deadbeef');
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/command-endpoint.test.ts
+++ b/tests/unit/command-endpoint.test.ts
@@ -350,6 +350,90 @@ describe('AgentRunner /command endpoint', () => {
     expect(data.success).toBe(true);
     expect(data.restarted).toBe(false);
   });
+
+  // --------------------------------------------------------------------------
+  // U-CMD-CLI-01: cli_pair reports not_configured when gateway.publicUrl is unset
+  // --------------------------------------------------------------------------
+  it('U-CMD-CLI-01: cli_pair → not_configured without gateway.publicUrl', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    const { data } = await sendCommand(port, {
+      command: 'cli_pair',
+      payload: { channel: 'telegram', user_id: '42' },
+    });
+    expect(data.success).toBe(false);
+    expect(data.error).toBe('not_configured');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-CMD-CLI-02: cli_pair mints a pairing + link when publicUrl is configured
+  // --------------------------------------------------------------------------
+  it('U-CMD-CLI-02: cli_pair returns pairingId/code/url when configured', async () => {
+    gatewayConfig.gateway.publicUrl = 'https://host.example/gw';
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    const { data } = await sendCommand(port, {
+      command: 'cli_pair',
+      payload: { channel: 'discord', user_id: 'u-7' },
+    });
+    expect(data.success).toBe(true);
+    expect(String(data.pairingId)).toMatch(/^[0-9a-f]{36}$/);
+    expect(String(data.code)).toMatch(/^\d{4}$/);
+    expect(String(data.url)).toBe(`https://host.example/gw/cli/${data.pairingId}`);
+  });
+
+  // --------------------------------------------------------------------------
+  // U-CMD-CLI-03: cli_approve validates channel + user against the pairing
+  // --------------------------------------------------------------------------
+  it('U-CMD-CLI-03: cli_approve only succeeds for the pairing owner', async () => {
+    gatewayConfig.gateway.publicUrl = 'https://host.example';
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    const { data: pair } = await sendCommand(port, {
+      command: 'cli_pair',
+      payload: { channel: 'discord', user_id: 'owner' },
+    });
+    const pairingId = String(pair.pairingId);
+
+    // Wrong user → mismatch, not approved.
+    const { data: wrong } = await sendCommand(port, {
+      command: 'cli_approve',
+      payload: { channel: 'discord', pairing_id: pairingId, user_id: 'intruder' },
+    });
+    expect(wrong.success).toBe(false);
+    expect(wrong.result).toBe('mismatch');
+
+    // Correct owner → approved.
+    const { data: ok } = await sendCommand(port, {
+      command: 'cli_approve',
+      payload: { channel: 'discord', pairing_id: pairingId, user_id: 'owner' },
+    });
+    expect(ok.success).toBe(true);
+    expect(ok.result).toBe('ok');
+  });
+
+  // --------------------------------------------------------------------------
+  // U-CMD-CLI-04: cli_pair rejects an unknown channel
+  // --------------------------------------------------------------------------
+  it('U-CMD-CLI-04: cli_pair rejects an invalid channel (400)', async () => {
+    gatewayConfig.gateway.publicUrl = 'https://host.example';
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    const { status, data } = await sendCommand(port, {
+      command: 'cli_pair',
+      payload: { channel: 'sms', user_id: 'u-1' },
+    });
+    expect(status).toBe(400);
+    expect(data.success).toBe(false);
+  });
 });
 
 // ── SessionProcess restart watcher tests (U-CMD-08, U-CMD-09) ────────────────


### PR DESCRIPTION
Closes #245

## What

Adds a `/cli` chat command (Telegram, Discord, LINE) that opens a live, **agent-scoped** webview terminal for an agent running with `gateway.headless: false` — so an operator can watch (and optionally drive) what the agent is doing, from their phone, **without an admin key** and **without exposing the host-wide dashboard**.

## Why

The only existing live terminal viewer is the admin `/dashboard`, which is intentionally gated behind an **admin** key because it grants cross-agent, host-wide power (every agent's sessions, the process tree, PTY keystroke injection anywhere). That is the wrong door for "let me peek at *this one* agent from chat." `/cli` gives a single-agent view unlocked by an allowlist-gated chat action.

## Design (two problems, as discussed in the issue)

1. **The gateway doesn't know its public URL** → new opt-in config `gateway.publicUrl`. Unset ⇒ `/cli` replies "not configured" (never crashes).
2. **Authenticate the browser without an admin key and without a bearer secret in the URL** → the link is never a credential:
   - **Telegram** opens a Mini App; the gateway verifies the signed `initData` (HMAC-SHA256 with the agent's own bot token) and that the `initData` user matches the user who ran `/cli`.
   - **Discord / LINE** send an open-viewer link + an **Approve** button; the browser stays locked until the operator approves in the chat. A leaked/forwarded link stalls at "waiting for approval."

## How it fits the existing code

- Reuses the existing PTY `ticket → WebSocket` path — `/cli` just mints an **agent-scoped** ticket (gated by a `cli_session` cookie, pinned to the pairing's agent) into the same ticket map the dashboard uses.
- Reaches the runner through the same per-agent callback bridge that `/models` already uses, so no channel subprocess needs the gateway's public port (the runner builds the link from `publicUrl`).
- Reuses the viewer's read-only-default + input-toggle UX (a dedicated slim page, **not** the admin dashboard).

## Security properties (tested)

- **Agent-scoped**: a `/cli` session cookie and PTY ticket can only reach the originating agent — a ticket for another agent's session is refused (404).
- **No admin surface**: `/cli` never issues or accepts the admin `dash_session` cookie; the dashboard admin-gate is unchanged.
- **The URL is not a credential**: unlocking requires verified initData (Telegram) or an in-chat approval (Discord/LINE).
- **First-writer-wins** browser binding; a link opened in a second browser is rejected. Cookies are `HttpOnly` and scoped to a single pairing's path.
- **Cross-pairing replay** rejected: an access session for pairing A cannot authorize pairing B.
- Pairings/sessions carry short TTLs and are pruned.

## Tests

- `cli-pairing-store` (11) — device-flow state machine, first-writer-wins, approval user/channel match, TTL/prune.
- `cli-telegram-initdata` (5) — valid / tampered / foreign-token / stale / missing.
- `cli-viewer-routes` (8) — full device flow, agent-scoping, cross-pairing replay, foreign browser, initData fast-path incl. a Mini App with no page-load cookie.
- `command-endpoint` (+4) — runner `cli_pair` / `cli_approve` (not_configured, minted link, owner-only approve, invalid channel).
- Security-critical guards proven to fail on pre-fix code (agent-scoping + initData HMAC removed → tests go red), then restored.
- `npm run typecheck` clean; full `npm test` green (2625 passed; the one worker OOM is an unrelated parallel-memory flake — `character-system` passes standalone).

## Docs

- `README.md`: `gateway.publicUrl` section + a `/cli` subsection under Terminal Viewer.
- `API.md`: `/cli/*` route table + authorization model.

## Operator setup

Set `gateway.publicUrl` to the externally-reachable HTTPS origin (e.g. `https://gateway.example.com`, or `https://host/gateway` behind an ingress prefix). Run the agent with `gateway.headless: false`. Then `/cli` in chat.
