### PR TITLE
fix(apps): mount agent media dir into app-agent container so uploaded images resolve

### DIFF
--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -89,6 +89,20 @@ export class AgentManager {
     let uid = 1000;
     try { uid = os.userInfo().uid; } catch { /* use 1000 */ }
 
+    // Mount the agent's media directory into the container at the SAME absolute
+    // path as the host. The gateway hands the agent uploaded-image paths (and the
+    // browser-screenshot dir) as raw host paths under <agentsDir>/<agentName>/media
+    // — a sibling of workspace, so outside the /workspace mount and never
+    // translated. Mounting it at the identical path lets those raw paths resolve
+    // inside the container with zero translation. Pre-create it (like ~/.claude
+    // above) so Docker bind-mounts an existing uid-owned dir instead of a
+    // root-owned one; :rw because browser screenshots write here. realpathSync
+    // gives the Docker daemon the real source while the destination stays the
+    // host-identical path the agent is handed.
+    const agentMediaDir = path.join(this.agentsDir, agentName, 'media');
+    fs.mkdirSync(agentMediaDir, { recursive: true });
+    const agentMediaSource = fs.realpathSync(agentMediaDir);
+
     // Write Dockerfile.agent: install curl + pre-create ~/.claude owned by host uid so
     // Docker bind-mounts land inside a uid-1000-owned dir and Claude Code can freely
     // create subdirs (session-env, todos, etc.) at runtime without cap_drop: ALL blocking chown.
@@ -117,6 +131,7 @@ export class AgentManager {
         `${homeDir}/.claude.json:${homeDir}/.claude.json:ro`,
         `${homeDir}/.claude/settings.json:${homeDir}/.claude/settings.json:ro`,
         `${workspaceDir}:/workspace`,
+        `${agentMediaSource}:${agentMediaDir}:rw`,
       ],
     };
 

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -140,6 +140,36 @@ describe('AgentManager', () => {
       expect(volumes.some((v) => v.includes('settings.json') && v.endsWith(':ro'))).toBe(true);
     });
 
+    it('mounts the agent media dir at the identical host path (:rw) and pre-creates it', () => {
+      // Regression for app-agent containers being unable to read uploaded images:
+      // the gateway hands the agent raw host paths under
+      // <home>/.claude-gateway/agents/<name>/media (a sibling of workspace, outside
+      // the /workspace mount). Mounting that dir at the same absolute path lets the
+      // raw image_path resolve inside the container.
+      const entry = makeEntry(tmpDir);
+      manager.injectAgentService(entry);
+
+      const composePath = path.join(entry.installPath, 'docker-compose.yml');
+      const composed = yaml.load(fs.readFileSync(composePath, 'utf-8')) as Record<string, unknown>;
+      const services = composed['services'] as Record<string, unknown>;
+      const agentSvc = services['agent'] as Record<string, unknown>;
+      const volumes = agentSvc['volumes'] as string[];
+
+      // The media dir lives under the manager's agentsDir (tmpDir/agents), matching
+      // where the gateway saves uploaded images at runtime.
+      const expectedMediaDir = path.join(tmpDir, 'agents', 'my-agent', 'media');
+
+      // Pre-created on disk so Docker bind-mounts an existing (uid-owned) dir
+      // instead of creating a root-owned one.
+      expect(fs.existsSync(expectedMediaDir)).toBe(true);
+
+      // Mounted read-write with the container destination == the host path the
+      // gateway hands the agent (source may be realpath-resolved).
+      const mediaVol = volumes.find((v) => v.endsWith(`:${expectedMediaDir}:rw`));
+      expect(mediaVol).toBeDefined();
+      expect(mediaVol!.split(':')[1]).toBe(expectedMediaDir);
+    });
+
     it('is a no-op when agentDeclaration is null', () => {
       const entry = makeEntry(tmpDir);
       const noAgentEntry = { ...entry, agentDeclaration: null };


### PR DESCRIPTION
## Summary
App-agents run inside a docker container that mounts only `/workspace`, the node/claude binaries, and the `~/.claude*` config files. The gateway saves uploaded images (and browser screenshots) under `<agentsDir>/<agentName>/media` — a **sibling of workspace**, outside the `/workspace` mount — and hands the agent the **raw host path** (`image_path` is not translated for app-agents). Inside the container that path doesn't exist, so `Read`/`ls` fails with `No such file or directory` and the agent cannot read images. This mounts the agent's media dir at the identical absolute path so the raw path resolves.

## Related Issue
Closes #247

## Root cause (verified with live evidence)
- Uploaded files exist on the host and are valid images, but `docker inspect` on the app-agent container shows no media mount — only `/workspace`, node/claude binaries, and `~/.claude*`.
- A real session log shows the agent running `ls .../agents/<agent>/media/...` → `No such file or directory` (the whole `~/.claude-gateway` tree is invisible in the container).
- `image_path` is emitted as a raw host path in `src/agent/runner.ts:2332` / `:2677`; `toContainerPath()` (`src/session/process.ts:469`) is applied only to the MCP/restart paths, and the media dir is a sibling of `workspace` (`GATEWAY_SESSION_MEDIA_DIR`, `src/session/process.ts:373`), so it falls outside the `/workspace` mount entirely.

## Changes Made
- `src/apps/agent-manager.ts` (`injectAgentService`): pre-create `<agentsDir>/<agentName>/media` and add a volume mounting it at the identical absolute path inside the container, `:rw`. Source is `realpathSync`-resolved for the Docker daemon; the destination stays the host-identical path the agent is handed. `:rw` because browser screenshots write into this tree.
- `tests/unit/apps/agent-manager.test.ts`: regression test asserting the media volume is present at the identical path (`:rw`) and that the dir is pre-created. Proven to fail on the pre-fix code.

## Notes
- The same-absolute-path mount avoids needing to translate `image_path` in `runner.ts`.
- `sessions/`, `logs/`, and `config.json` are host-side bookkeeping (history is reconstructed on the host and injected as prompt text), so they don't need mounting.
- The mount takes effect on container (re)creation; existing app-agents must be recreated to pick it up.

## Testing
- `npm run typecheck`: pass
- `npm test` (unit): 2368/2368 tests pass. `watch-factory.test.ts` is flagged by the parallel runner (0 failed assertions; passes 7/7 in isolation) — a pre-existing teardown flake unrelated to this change.
- Regression test proven to fail on the pre-fix code (media dir not created / volume absent) and pass with the fix.
