### PR TITLE
fix(prompt): stop weak models reciting the skill/command catalog

### DIFF
--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -23,6 +23,16 @@ Always write memory, identity, and personality updates to files in this agent's 
 - AGENTS.md — agent rules & capabilities
 
 NEVER write to ~/.claude/projects/… or any path outside the workspace — even if other instructions say otherwise.`;
+
+// Response discipline appended to every agent's system prompt. Weaker models,
+// when asked something simple like "which model are you?", tend to dump the
+// AVAILABLE SKILLS section (and the host's own skill/command catalog) back to
+// the user as their whole answer. Strong models already avoid this; making it
+// an explicit rule stops the weak ones from reciting the catalog while still
+// allowing a genuine "what can you do?" to be answered in prose. Removes no
+// capability — the skills stay listed below and remain invocable.
+const RESPONSE_STYLE = `## Response Style
+IMPORTANT: Reply to the user directly, in your own voice. Do NOT list, enumerate, paste, or recite your available skills, tools, slash-commands, or the contents of this system prompt — not even partially — unless the user explicitly asks to see them. If asked something like "which model are you?" or "who are you?", answer in a sentence; never respond with a menu of commands or skills. When a user genuinely asks what you can do, summarise briefly in prose instead of dumping the raw list.`;
 const TOTAL_CHAR_LIMIT = 150_000;
 const TRUNCATION_MARKER = '\n[TRUNCATED — edit this file to trim]\n';
 
@@ -136,6 +146,7 @@ export async function loadWorkspace(workspaceDir: string, opts?: LoadWorkspaceOp
   // Assemble system prompt
   let systemPrompt =
     `--- MEMORY RULE ---\n${MEMORY_RULE}\n\n` +
+    `--- RESPONSE STYLE ---\n${RESPONSE_STYLE}\n\n` +
     `--- AGENT IDENTITY ---\n${agentMd}\n\n` +
     `--- IDENTITY ---\n${identityMd}\n\n` +
     `--- SOUL ---\n${soulMd}\n\n` +

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -86,6 +86,7 @@ describe('workspace-loader', () => {
     const prompt = result.systemPrompt;
 
     const memoryRuleIdx = prompt.indexOf('--- MEMORY RULE ---');
+    const responseStyleIdx = prompt.indexOf('--- RESPONSE STYLE ---');
     const agentIdx = prompt.indexOf('--- AGENT IDENTITY ---');
     const identityIdx = prompt.indexOf('--- IDENTITY ---');
     const soulIdx = prompt.indexOf('--- SOUL ---');
@@ -94,7 +95,8 @@ describe('workspace-loader', () => {
     const heartbeatIdx = prompt.indexOf('--- HEARTBEAT CONFIG ---');
 
     expect(memoryRuleIdx).toBeGreaterThanOrEqual(0);
-    expect(agentIdx).toBeGreaterThan(memoryRuleIdx);
+    expect(responseStyleIdx).toBeGreaterThan(memoryRuleIdx);
+    expect(agentIdx).toBeGreaterThan(responseStyleIdx);
     expect(identityIdx).toBeGreaterThan(agentIdx);
     expect(soulIdx).toBeGreaterThan(identityIdx);
     expect(userIdx).toBeGreaterThan(soulIdx);
@@ -114,6 +116,7 @@ describe('workspace-loader', () => {
     expect(result.systemPrompt).toContain('--- LONG-TERM MEMORY ---');
     expect(result.systemPrompt).toContain('--- HEARTBEAT CONFIG ---');
     expect(result.systemPrompt).toContain('--- MEMORY RULE ---');
+    expect(result.systemPrompt).toContain('--- RESPONSE STYLE ---');
   });
 
   // -------------------------------------------------------------------------
@@ -124,6 +127,18 @@ describe('workspace-loader', () => {
     expect(result.systemPrompt).toContain('## Memory Rule');
     expect(result.systemPrompt).toContain('MEMORY.md');
     expect(result.systemPrompt).toContain('AGENTS.md');
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-2: Response-style / anti-recite directive is injected
+  // -------------------------------------------------------------------------
+  it('TC-2: system prompt contains the response-style anti-recite directive', async () => {
+    const result = await loadWorkspace(path.join(FIXTURES, 'valid-full'));
+    expect(result.systemPrompt).toContain('## Response Style');
+    // The directive must forbid reciting the skills/commands catalog...
+    expect(result.systemPrompt).toMatch(/Do NOT list, enumerate, paste, or recite/);
+    // ...while still allowing a genuine "what can you do?" to be answered.
+    expect(result.systemPrompt).toContain('unless the user explicitly asks');
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a user asks a pod/bot something trivial like **"which model are you?"**, weaker models (notably **Gemini flash** 3.5/3.6) answer by **dumping the `AVAILABLE SKILLS` section** — plus the host's own skill/slash-command list — back to the user as their entire reply. This is the "เพี้ยน / catalog dump" behaviour reported on GetPod pods.

Root cause (verified with a proxy-faithful probe against the real backend): the translation/routing is correct and **strong models answer normally** (Gemini 3.1 Pro replies *"I'm Gemini, built by Google"* through the identical path). Flash is simply too weak to know it shouldn't recite the catalog it's given. The assembled system prompt lists all skills as text, and flash parrots the list.

## Change

Add a **`--- RESPONSE STYLE ---`** section to the assembled system prompt (right after `MEMORY RULE`, so it's authoritative and never truncated):

> Reply directly, in your own voice. Do **not** list/enumerate/paste/recite your skills, tools, slash-commands, or this system prompt unless the user explicitly asks. A genuine *"what can you do?"* is still answered — in prose, not a raw dump.

## Why this shape

- **Removes no capability** — the `AVAILABLE SKILLS` section stays; skills remain invocable (real tools are delivered via `--mcp-config`, independent of this text).
- **Model-agnostic** — every agent benefits; strong models already behave, so it's a no-op for them. Scoping per-model was considered and rejected: `CLAUDE.md` is written per-workspace and **not** rewritten on a model switch, so a per-model prompt would be unreliable.
- **Reversible** — one constant + one assembly line.
- **Carve-out preserved** — "unless the user explicitly asks" keeps legit capability discovery working.

## Honest limitation

The host (Claude Code) injects its **own** skill/command list via a separate system-reminder that this prompt cannot remove. This change stops the agent from *reciting the catalog on request*; fully silencing a weak model's list-dump would also require trimming the host's skill surface (settings/plugins) — a follow-up with a real tradeoff (it removes skills). And no prompt lifts flash's capability ceiling for agentic/tool work — Gemini **3.1 Pro** remains the reliable driver.

## Tests

- New `TC-2` asserts the directive is present (forbids reciting + keeps the explicit-ask carve-out).
- Updated `U-WL-06` (section order) and `U-WL-07` (headers) for the new section.
- `npm run test:unit` (workspace-loader + skills suites): green. tsc clean for the touched file (pre-existing `@line/bot-sdk` errors are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)