### PR TITLE
feat(session): agy runtime for gemini/* models (Antigravity CLI native)

### DIFF
--- a/src/session/agy-shell.ts
+++ b/src/session/agy-shell.ts
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+/**
+ * agy-shell — drives the Antigravity CLI (`agy`, native Gemini) while speaking
+ * the gateway's headless stream-json protocol on stdio, so the gateway can run
+ * `gemini/*` models with ZERO changes to the stdout parser or the runner reply
+ * bridge (they keep consuming Claude-shaped stream-json lines).
+ *
+ * Drop-in usage (process.ts spawns this for gemini/* models):
+ *   node dist/session/agy-shell.js
+ * driven by env:
+ *   AGY_BIN                 path to the agy binary (default: "agy" on PATH)
+ *   AGY_MODEL               the gateway model id, e.g. "gemini/gemini-3.6-flash-low"
+ *   AGY_PERSONA             custom-agent name to select (default "getpod")
+ *   AGY_SYSTEM_PROMPT_FILE  file whose contents become the persona system prompt
+ *   AGY_MCP_CONFIG_FILE     a {mcpServers:{…}} manifest to install for agy
+ *
+ * Protocol contract (what the gateway expects on our stdout, per turn):
+ *   - optional partial  {type:'assistant', stop_reason:null, message:{content:[{type:'text',text:<cumulative>}]}}
+ *   - exactly one final {type:'assistant', stop_reason:'end_turn', message:{content:[{type:'text',text:<full>}]}}
+ *   - exactly one       {type:'result', is_error, result:<text>, usage:{output_tokens}}
+ * The turn text arrives on stdin as {type:'user', message:{content:[{type:'text',text}]}}.
+ *
+ * agy is one-shot per turn (`agy -p <text>` exits), while the gateway assumes a
+ * long-lived child fed turns over stdin — so this wrapper stays resident, reads
+ * each stdin turn, spawns agy for it, and threads agy's conversation_id across
+ * turns via --conversation for multi-turn continuity.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as readline from 'readline';
+import { spawn } from 'child_process';
+
+// ---- pure translation core (unit-tested) -----------------------------------
+
+export interface AgyTurnState {
+  conversationId: string | null;
+  partialText: string;
+}
+
+export interface TranslateResult {
+  lines: string[]; // Claude-shaped stream-json lines to emit on stdout
+  done: boolean; // true once the agy `result` event was seen (turn complete)
+  conversationId: string | null; // updated conversation id to persist for the next turn
+}
+
+/** Build the Claude-shaped `assistant` line carrying `text`. */
+export function claudeAssistantLine(text: string, final: boolean): string {
+  return JSON.stringify({
+    type: 'assistant',
+    stop_reason: final ? 'end_turn' : null,
+    message: { content: [{ type: 'text', text }] },
+  });
+}
+
+/** Build the Claude-shaped `message_start` stream_event carrying input usage. */
+export function claudeMessageStartLine(inputTokens: number, cacheReadTokens: number): string {
+  return JSON.stringify({
+    type: 'stream_event',
+    event: {
+      type: 'message_start',
+      message: {
+        usage: {
+          input_tokens: Math.max(0, inputTokens - cacheReadTokens),
+          cache_read_input_tokens: cacheReadTokens,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    },
+  });
+}
+
+/** Build the Claude-shaped terminal `result` line. */
+export function claudeResultLine(text: string, isError: boolean, outputTokens: number): string {
+  return JSON.stringify({
+    type: 'result',
+    is_error: isError,
+    result: text,
+    usage: { output_tokens: outputTokens },
+  });
+}
+
+/**
+ * translateAgyEvent maps ONE parsed agy stream-json event into zero or more
+ * Claude-shaped stdout lines, mutating `state` (cumulative partial text +
+ * conversation id). Pure w.r.t. IO so it can be table-tested.
+ *
+ * agy events:
+ *  - {event:'init', conversation_id, init:{model,tools,...}}
+ *  - {event:'step_update', step_update:{step_type, state, text_delta?, usage?}}
+ *      step_type 'agent_response' carries text_delta (progressive assistant text)
+ *  - {event:'result', result:{status:'SUCCESS'|…, response, usage}}
+ */
+export function translateAgyEvent(evt: any, state: AgyTurnState): TranslateResult {
+  const out: string[] = [];
+  if (!evt || typeof evt !== 'object') {
+    return { lines: out, done: false, conversationId: state.conversationId };
+  }
+
+  switch (evt.event) {
+    case 'init': {
+      if (typeof evt.conversation_id === 'string') {
+        state.conversationId = evt.conversation_id;
+      }
+      return { lines: out, done: false, conversationId: state.conversationId };
+    }
+    case 'step_update': {
+      const su = evt.step_update || {};
+      if (typeof su.conversation_id === 'string') state.conversationId = su.conversation_id;
+      // Progressive assistant text: agy emits a text_delta chunk. The gateway's
+      // parser expects partials to carry the CUMULATIVE text, so accumulate.
+      if (su.step_type === 'agent_response' && typeof su.text_delta === 'string' && su.text_delta.length > 0) {
+        state.partialText += su.text_delta;
+        out.push(claudeAssistantLine(state.partialText, false));
+      }
+      return { lines: out, done: false, conversationId: state.conversationId };
+    }
+    case 'result': {
+      const r = evt.result || {};
+      if (typeof r.conversation_id === 'string') state.conversationId = r.conversation_id;
+      const text: string = typeof r.response === 'string' ? r.response : state.partialText;
+      const isError = r.status !== undefined && r.status !== 'SUCCESS';
+      const usage = r.usage || {};
+      const inputTokens = Number(usage.input_tokens) || 0;
+      const cacheRead = Number(usage.cache_read_tokens) || 0;
+      const outputTokens = (Number(usage.output_tokens) || 0) + (Number(usage.thinking_tokens) || 0);
+      if (inputTokens > 0) out.push(claudeMessageStartLine(inputTokens, cacheRead));
+      out.push(claudeAssistantLine(text, true));
+      out.push(claudeResultLine(text, isError, outputTokens));
+      return { lines: out, done: true, conversationId: state.conversationId };
+    }
+    default:
+      return { lines: out, done: false, conversationId: state.conversationId };
+  }
+}
+
+/** Extract the plain text from a gateway {type:'user'} turn line. */
+export function textFromUserTurn(line: string): string | null {
+  let obj: any;
+  try {
+    obj = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!obj || obj.type !== 'user' || !obj.message || !Array.isArray(obj.message.content)) return null;
+  return obj.message.content
+    .filter((b: any) => b && b.type === 'text' && typeof b.text === 'string')
+    .map((b: any) => b.text)
+    .join('');
+}
+
+/** agy model id = the gateway id with the "gemini/" prefix stripped. */
+export function agyModelId(gatewayModel: string): string {
+  return gatewayModel.startsWith('gemini/') ? gatewayModel.slice('gemini/'.length) : gatewayModel;
+}
+
+// ---- runtime wiring (not unit-tested; thin IO shell) -----------------------
+
+const GEMINI_CONFIG_DIR = path.join(os.homedir(), '.gemini', 'config');
+
+/** Install the persona agent.md + mcp_config.json agy reads on startup. */
+function installAgyConfig(persona: string): void {
+  try {
+    const promptFile = process.env.AGY_SYSTEM_PROMPT_FILE;
+    if (promptFile && fs.existsSync(promptFile)) {
+      const systemPrompt = fs.readFileSync(promptFile, 'utf8');
+      const agentDir = path.join(GEMINI_CONFIG_DIR, 'agents', persona);
+      fs.mkdirSync(agentDir, { recursive: true });
+      const frontmatter = `---\nname: ${persona}\ndescription: GetPod pod assistant\n---\n\n`;
+      fs.writeFileSync(path.join(agentDir, 'agent.md'), frontmatter + systemPrompt, { mode: 0o600 });
+    }
+    const mcpFile = process.env.AGY_MCP_CONFIG_FILE;
+    if (mcpFile && fs.existsSync(mcpFile)) {
+      fs.mkdirSync(GEMINI_CONFIG_DIR, { recursive: true });
+      fs.copyFileSync(mcpFile, path.join(GEMINI_CONFIG_DIR, 'mcp_config.json'));
+    }
+  } catch (err) {
+    process.stderr.write(`agy-shell: config install failed: ${String(err)}\n`);
+  }
+}
+
+/** Run one agy turn, translating its stream-json onto our stdout. */
+function runTurn(text: string, state: AgyTurnState): Promise<void> {
+  return new Promise((resolve) => {
+    const bin = process.env.AGY_BIN || 'agy';
+    const model = agyModelId(process.env.AGY_MODEL || '');
+    const persona = process.env.AGY_PERSONA || 'getpod';
+    const args = [
+      '-p', text,
+      '--output-format', 'stream-json',
+      '--dangerously-skip-permissions',
+      '--agent', persona,
+    ];
+    if (model) args.push('--model', model);
+    if (state.conversationId) args.push('--conversation', state.conversationId);
+
+    state.partialText = '';
+    const child = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const rl = readline.createInterface({ input: child.stdout });
+    let sawResult = false;
+
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      let evt: any;
+      try {
+        evt = JSON.parse(trimmed);
+      } catch {
+        return;
+      }
+      const res = translateAgyEvent(evt, state);
+      for (const out of res.lines) process.stdout.write(out + '\n');
+      if (res.done) sawResult = true;
+    });
+
+    child.stderr.on('data', (d) => process.stderr.write(d));
+    child.on('error', (err) => {
+      process.stdout.write(claudeResultLine(`agy spawn error: ${String(err)}`, true, 0) + '\n');
+      resolve();
+    });
+    child.on('close', () => {
+      // If agy exited without a result event, synthesize a terminal error so the
+      // gateway never hangs waiting for end-of-turn.
+      if (!sawResult) {
+        const text = state.partialText || 'agy produced no result';
+        process.stdout.write(claudeResultLine(text, true, 0) + '\n');
+      }
+      resolve();
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const persona = process.env.AGY_PERSONA || 'getpod';
+  installAgyConfig(persona);
+  const state: AgyTurnState = { conversationId: null, partialText: '' };
+
+  const rl = readline.createInterface({ input: process.stdin });
+  const queue: string[] = [];
+  let running = false;
+
+  const pump = async () => {
+    if (running) return;
+    running = true;
+    while (queue.length > 0) {
+      const text = queue.shift()!;
+      await runTurn(text, state);
+    }
+    running = false;
+  };
+
+  rl.on('line', (line) => {
+    const text = textFromUserTurn(line.trim());
+    if (text !== null) {
+      queue.push(text);
+      void pump();
+    }
+  });
+  rl.on('close', () => process.exit(0));
+}
+
+// Only run the IO loop when invoked directly (not when imported by tests).
+if (require.main === module) {
+  void main();
+}

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -474,6 +474,13 @@ export class SessionProcess extends EventEmitter {
     const freshModel = this.readFreshModel();
     const args = this.buildArgs(effectiveMcpPath, freshModel);
 
+    // gemini/* models are driven by the Antigravity CLI (agy) via the agy-shell
+    // wrapper instead of the claude binary. The wrapper speaks the identical
+    // stream-json stdio protocol, so everything downstream (stdin priming,
+    // stdout parser, runner reply bridge) is unchanged — only the spawned
+    // command and a few AGY_* env vars differ.
+    const isGemini = freshModel.startsWith('gemini/');
+
     // Resolve the claude binary. An explicit CLAUDE_BIN (which may carry args) is
     // trusted verbatim; otherwise probe PATH and the native-installer / legacy
     // install locations so a gateway launched with a minimal PATH still finds it.
@@ -517,7 +524,7 @@ export class SessionProcess extends EventEmitter {
     // Safe mode (forceHeadless) overrides the configured PTY backend so a
     // repeatedly-failing wrapper degrades to headless instead of re-wedging.
     const usePtyShell =
-      this.gatewayConfig.gateway.headless === false && !isAppAgent && !this.forceHeadless;
+      this.gatewayConfig.gateway.headless === false && !isAppAgent && !this.forceHeadless && !isGemini;
     this.backend = usePtyShell ? 'pty-shell' : 'headless';
     let ptyRealBin: string | null = null;
     // Pre-calculate heartbeat path so we can pass it to the PTY shell before spawn.
@@ -542,6 +549,15 @@ export class SessionProcess extends EventEmitter {
       this.logger.warn('gateway.headless=false is not supported for app-agents — using headless backend', {
         sessionId: this.sessionId,
       });
+    }
+
+    // gemini/* → run the agy-shell wrapper (node) instead of claude. It reads the
+    // model / persona system prompt / MCP manifest from the AGY_* env set on the
+    // spawn below, drives `agy -p` per turn, and emits Claude-shaped stream-json.
+    if (isGemini && !isAppAgent) {
+      const agyShellPath = path.resolve(__dirname, 'agy-shell.js');
+      claudeBin = process.execPath;
+      allArgs = [agyShellPath];
     }
 
     this.logger.info('Spawning session subprocess', {
@@ -601,6 +617,15 @@ export class SessionProcess extends EventEmitter {
         ...(ptyRealBin ? { CLAUDE_REAL_BIN: ptyRealBin } : {}),
         ...(ptyHeartbeatPath ? { PTY_SHELL_HEARTBEAT_PATH: ptyHeartbeatPath } : {}),
         ...(ptyStreamSocketPath ? { PTY_SHELL_STREAM_SOCKET: ptyStreamSocketPath } : {}),
+        ...(isGemini
+          ? {
+              AGY_MODEL: freshModel,
+              AGY_BIN: process.env.AGY_BIN || 'agy',
+              AGY_PERSONA: process.env.AGY_PERSONA || 'getpod',
+              AGY_SYSTEM_PROMPT_FILE: path.join(this.agentConfig.workspace, 'CLAUDE.md'),
+              ...(effectiveMcpPath ? { AGY_MCP_CONFIG_FILE: effectiveMcpPath } : {}),
+            }
+          : {}),
       },
       cwd: this.agentConfig.workspace,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/unit/agy-shell.test.ts
+++ b/tests/unit/agy-shell.test.ts
@@ -1,0 +1,128 @@
+import {
+  translateAgyEvent,
+  textFromUserTurn,
+  agyModelId,
+  claudeAssistantLine,
+  claudeResultLine,
+  AgyTurnState,
+} from '../../src/session/agy-shell';
+
+function freshState(): AgyTurnState {
+  return { conversationId: null, partialText: '' };
+}
+
+describe('agy-shell translation core', () => {
+  test('init captures conversation_id, emits nothing', () => {
+    const s = freshState();
+    const r = translateAgyEvent(
+      { event: 'init', conversation_id: 'conv-1', init: { model: 'gemini-3.6-flash-low' } },
+      s,
+    );
+    expect(r.lines).toEqual([]);
+    expect(r.done).toBe(false);
+    expect(s.conversationId).toBe('conv-1');
+  });
+
+  test('agent_response text_delta emits cumulative partial assistant lines', () => {
+    const s = freshState();
+    const r1 = translateAgyEvent(
+      { event: 'step_update', step_update: { step_type: 'agent_response', text_delta: 'Hel' } },
+      s,
+    );
+    const r2 = translateAgyEvent(
+      { event: 'step_update', step_update: { step_type: 'agent_response', text_delta: 'lo' } },
+      s,
+    );
+    expect(JSON.parse(r1.lines[0])).toMatchObject({
+      type: 'assistant',
+      stop_reason: null,
+      message: { content: [{ type: 'text', text: 'Hel' }] },
+    });
+    // Partials are CUMULATIVE (the gateway parser diffs against the last partial).
+    expect(JSON.parse(r2.lines[0]).message.content[0].text).toBe('Hello');
+    expect(r2.done).toBe(false);
+  });
+
+  test('result SUCCESS emits message_start + final assistant + result', () => {
+    const s = freshState();
+    s.partialText = 'Hello';
+    const r = translateAgyEvent(
+      {
+        event: 'result',
+        result: {
+          status: 'SUCCESS',
+          response: 'Hello, dear user!',
+          usage: { input_tokens: 18946, output_tokens: 8, thinking_tokens: 2, cache_read_tokens: 1200 },
+        },
+      },
+      s,
+    );
+    expect(r.done).toBe(true);
+    const parsed = r.lines.map((l) => JSON.parse(l));
+    // message_start: net input = 18946 - 1200, cache carried separately.
+    expect(parsed[0]).toMatchObject({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { usage: { input_tokens: 17746, cache_read_input_tokens: 1200 } } },
+    });
+    // final assistant
+    expect(parsed[1]).toMatchObject({
+      type: 'assistant',
+      stop_reason: 'end_turn',
+      message: { content: [{ type: 'text', text: 'Hello, dear user!' }] },
+    });
+    // terminal result — output includes thinking tokens (8 + 2)
+    expect(parsed[2]).toMatchObject({ type: 'result', is_error: false, result: 'Hello, dear user!', usage: { output_tokens: 10 } });
+  });
+
+  test('result with non-SUCCESS status is flagged is_error', () => {
+    const s = freshState();
+    const r = translateAgyEvent(
+      { event: 'result', result: { status: 'ERROR', response: 'boom', usage: {} } },
+      s,
+    );
+    const result = r.lines.map((l) => JSON.parse(l)).find((p) => p.type === 'result');
+    expect(result.is_error).toBe(true);
+    expect(result.result).toBe('boom');
+  });
+
+  test('result falls back to accumulated partial text when response missing', () => {
+    const s = freshState();
+    s.partialText = 'partial only';
+    const r = translateAgyEvent({ event: 'result', result: { status: 'SUCCESS', usage: {} } }, s);
+    const result = r.lines.map((l) => JSON.parse(l)).find((p) => p.type === 'result');
+    expect(result.result).toBe('partial only');
+  });
+
+  test('unknown / malformed events are ignored', () => {
+    const s = freshState();
+    expect(translateAgyEvent({ event: 'mystery' }, s).lines).toEqual([]);
+    expect(translateAgyEvent(null, s).lines).toEqual([]);
+    expect(translateAgyEvent({ event: 'step_update', step_update: { step_type: 'checkpoint' } }, s).lines).toEqual([]);
+  });
+});
+
+describe('agy-shell helpers', () => {
+  test('textFromUserTurn extracts concatenated text', () => {
+    const line = JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }] },
+    });
+    expect(textFromUserTurn(line)).toBe('ab');
+  });
+
+  test('textFromUserTurn returns null for non-user / malformed', () => {
+    expect(textFromUserTurn('not json')).toBeNull();
+    expect(textFromUserTurn(JSON.stringify({ type: 'assistant' }))).toBeNull();
+  });
+
+  test('agyModelId strips the gemini/ prefix', () => {
+    expect(agyModelId('gemini/gemini-3.6-flash-low')).toBe('gemini-3.6-flash-low');
+    expect(agyModelId('gemini-3.1-pro-high')).toBe('gemini-3.1-pro-high');
+  });
+
+  test('line builders produce the expected shapes', () => {
+    expect(JSON.parse(claudeAssistantLine('hi', true)).stop_reason).toBe('end_turn');
+    expect(JSON.parse(claudeAssistantLine('hi', false)).stop_reason).toBeNull();
+    expect(JSON.parse(claudeResultLine('hi', false, 5))).toMatchObject({ type: 'result', is_error: false, usage: { output_tokens: 5 } });
+  });
+});


### PR DESCRIPTION
## What
A second **runtime**: `gemini/*` models are driven by the **Antigravity CLI (`agy`, native Gemini)** instead of the `claude` binary. This fixes the failures that come from running Gemini under the Claude Code harness — the weak flash models reciting the skill/MCP catalog when asked their identity, and tool-call 400s/prompt-echo (diagnosed on a live pod).

## Design (no parser/runner changes)
A resident **`agy-shell`** wrapper (`src/session/agy-shell.ts`) speaks the gateway's exact stream-json stdio protocol, so `process.ts`'s stdout parser and `runner.ts`'s reply-bridge consume it unchanged:
- reads `{type:'user'}` turns from stdin;
- per turn spawns `agy -p <text> --output-format stream-json --dangerously-skip-permissions --agent getpod [--conversation <id>]`;
- translates agy events → Claude-shaped lines: `step_update.agent_response.text_delta` → cumulative partial `type:'assistant'`; `result` → final `type:'assistant'` + terminal `type:'result'` (+ a `message_start` stream_event for input-token accounting);
- threads `conversation_id` across turns for multi-turn continuity (agy is one-shot per `-p`, the gateway assumes a long-lived child — the wrapper bridges that);
- on startup installs the persona `~/.gemini/config/agents/getpod/agent.md` (from the assembled CLAUDE.md) + `~/.gemini/config/mcp_config.json` for agy.

`process.ts` branches on `freshModel.startsWith('gemini/')` right after `readFreshModel()`: spawns `node agy-shell.js` instead of claude, forces headless (no PTY wrapper), and passes `AGY_*` env (model, bin, persona, system-prompt file, MCP manifest). Existing claude sessions are entirely unaffected (the branch is gated on the `gemini/` prefix).

## Why a wrapper (vs refactoring the parsers)
The two existing stream-json parsers (`process.ts` stdout + `runner.ts` bridge) hardcode the Claude event vocabulary. Emitting Claude-shaped events from a wrapper is far lower-risk than rewriting both to a new normalized vocab, and it reuses the reply-bridge as-is: a correct `type:'result'` line is auto-forwarded to the channel with zero runner changes.

## Tests
`tests/unit/agy-shell.test.ts` — the translation core (init→conv-id; text_delta→cumulative partial; result→message_start+assistant+result; error status→is_error; response-missing fallback; malformed ignored) + helpers (`textFromUserTurn`, `agyModelId`, line builders). 10/10 pass. `tsc --noEmit` clean for the changed files; full unit run 1801/1801 tests pass (the 26 red suites are the pre-existing `@line/bot-sdk` missing-dep compile errors on main, unrelated).

## Scope
Phase 2 of the Gemini-native runtime. Companion Phase 1 (getpod proxy `v1internal` passthrough) is Crown-Labs/getpod #1944. Phase 3 (pod image: bake `agy`, provision token + `CLOUD_CODE_URL` + configs) and Phase 4 (integration + rollout) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)