### PR TITLE
feat(cli): keyboard shortcut bar in viewer input mode

### DIFF
--- a/src/ui/cli-viewer-ui.ts
+++ b/src/ui/cli-viewer-ui.ts
@@ -180,12 +180,27 @@ export function generateCliViewerPage(opts: CliViewerPageOpts): string {
     button.on { background:#1f6feb; border-color:#1f6feb; color:#fff; }
     #term { flex:1; min-height:0; padding:6px; }
     .hint { color:#7a88a8; padding:16px; font-size:13px; }
+    /* Shortcut keys — inline in the header, only shown in input mode. Compact but
+       still touch-friendly for mobile webviews. */
+    #keybar { display:none; align-items:center; gap:4px; }
+    #keybar button {
+      min-width:30px; min-height:30px; font-size:13px; line-height:1;
+      padding:4px 8px; touch-action:manipulation; -webkit-user-select:none; user-select:none;
+    }
+    #keybar button:active { background:#1f6feb; border-color:#1f6feb; color:#fff; }
+    #keybar .esc { font-weight:600; }
   `;
   const body = `
   <header>
-    <span class="agent">${htmlEscape(opts.agentId)}</span>
     <select id="sess" title="Session" style="display:none"></select>
     <button id="toggle" title="Toggle input">🔒 Read-only</button>
+    <div id="keybar">
+      <button type="button" class="esc" data-seq="esc" title="Escape">Esc</button>
+      <button type="button" data-seq="left" title="Arrow Left" aria-label="Arrow Left">◀</button>
+      <button type="button" data-seq="up" title="Arrow Up" aria-label="Arrow Up">▲</button>
+      <button type="button" data-seq="down" title="Arrow Down" aria-label="Arrow Down">▼</button>
+      <button type="button" data-seq="right" title="Arrow Right" aria-label="Arrow Right">▶</button>
+    </div>
     <span class="status" id="status">connecting…</span>
   </header>
   <div id="term"></div>
@@ -198,7 +213,9 @@ export function generateCliViewerPage(opts: CliViewerPageOpts): string {
     var statusEl = document.getElementById('status');
     var sel = document.getElementById('sess');
     var toggleBtn = document.getElementById('toggle');
+    var keybar = document.getElementById('keybar');
     function setStatus(t){ statusEl.textContent = t; }
+    var ESC = String.fromCharCode(27);
 
     var term = new Terminal({
       cols: 200, rows: 50, scrollback: 0, disableStdin: true, convertEol: false,
@@ -209,11 +226,38 @@ export function generateCliViewerPage(opts: CliViewerPageOpts): string {
 
     var ws = null, inputMode = false, onDataDisposable = null, currentSession = null, reconnectT = null;
 
+    function wsSend(s){ if (s && ws && ws.readyState===1) ws.send(s); }
+
+    // Map a shortcut button to the bytes a real key would send. Arrow keys depend
+    // on the terminal's DECCKM (application cursor keys) state — xterm.js exposes
+    // it via term.modes; fall back to the normal-mode CSI form when unavailable.
+    function keySeq(name){
+      var app = term.modes && term.modes.applicationCursorKeysMode;
+      var p = app ? 'O' : '[';
+      switch (name) {
+        case 'esc':   return ESC;
+        case 'up':    return ESC + p + 'A';
+        case 'down':  return ESC + p + 'B';
+        case 'right': return ESC + p + 'C';
+        case 'left':  return ESC + p + 'D';
+      }
+      return '';
+    }
+
+    Array.prototype.forEach.call(keybar.querySelectorAll('button'), function(btn){
+      // preventDefault on press keeps the terminal's hidden textarea focused so the
+      // mobile soft keyboard does not dismiss when a shortcut is tapped.
+      btn.addEventListener('mousedown', function(e){ e.preventDefault(); });
+      btn.addEventListener('touchstart', function(e){ e.preventDefault(); wsSend(keySeq(btn.getAttribute('data-seq'))); }, { passive:false });
+      btn.addEventListener('click', function(e){ e.preventDefault(); wsSend(keySeq(btn.getAttribute('data-seq'))); });
+    });
+
     function setInputMode(on){
       inputMode = on;
       term.options.disableStdin = !on;
       toggleBtn.className = on ? 'on' : '';
       toggleBtn.textContent = on ? '⌨️ Input ON' : '🔒 Read-only';
+      keybar.style.display = on ? 'flex' : 'none';
       if (onDataDisposable) { onDataDisposable.dispose(); onDataDisposable = null; }
       if (on) { onDataDisposable = term.onData(function(d){ if (ws && ws.readyState===1) ws.send(d); }); }
     }
@@ -240,7 +284,7 @@ export function generateCliViewerPage(opts: CliViewerPageOpts): string {
         ws = new WebSocket(wsUrl(d.ticket));
         ws.binaryType = 'arraybuffer';
         var dec = new TextDecoder();
-        ws.onopen = function(){ setStatus('live'); };
+        ws.onopen = function(){ setStatus(''); };
         ws.onmessage = function(ev){
           var data = typeof ev.data === 'string' ? ev.data : dec.decode(ev.data, { stream:true });
           term.write(data);

--- a/src/ui/cli-viewer-ui.ts
+++ b/src/ui/cli-viewer-ui.ts
@@ -171,7 +171,6 @@ export function generateCliViewerPage(opts: CliViewerPageOpts): string {
       display:flex; align-items:center; gap:10px; padding:8px 12px;
       background:#0b0e14; border-bottom:1px solid #232a3b; font-size:13px; flex:0 0 auto;
     }
-    header .agent { font-weight:600; }
     header .status { color:#7a88a8; margin-left:auto; }
     select, button {
       background:#131722; color:#c8d3f5; border:1px solid #2b3450; border-radius:8px;

--- a/tests/unit/cli-viewer-routes.test.ts
+++ b/tests/unit/cli-viewer-routes.test.ts
@@ -96,6 +96,16 @@ describe('/cli webview terminal viewer routes', () => {
     expect(view.status).toBe(200);
     expect(view.text).toContain(AGENT);
 
+    // Input-mode shortcut bar: Esc + four arrows, wired by data-seq and gated by
+    // the input toggle (display:none until input mode is on).
+    expect(view.text).toContain('id="keybar"');
+    for (const seq of ['esc', 'left', 'up', 'down', 'right']) {
+      expect(view.text).toContain(`data-seq="${seq}"`);
+    }
+    expect(view.text).toContain("keybar.style.display = on ? 'flex' : 'none'");
+    // Arrow keys must honor DECCKM (application vs normal cursor keys).
+    expect(view.text).toContain('applicationCursorKeysMode');
+
     // Sessions list is filtered to the agent's live pty-shell sessions.
     const sessions = await supertest(app).get(`/cli/${pairingId}/sessions`).set('Cookie', session);
     expect(sessions.body.agentId).toBe(AGENT);


### PR DESCRIPTION
## Summary
Adds a compact keyboard-shortcut bar (`Esc` / `←` `↑` `↓` `→`) to the `/cli` webview terminal viewer, shown only while **Input mode** is on.

## Changes
- New inline `#keybar` in the header, next to the **Input** toggle — appears/disappears with input mode.
- Buttons send the proper escape sequences straight to the PTY over the WebSocket:
  - `Esc` → `\x1b`
  - Arrows are **DECCKM-aware** — emit `\x1bO{A..D}` in application cursor mode and `\x1b[{A..D}` in normal mode, so they work correctly in TUIs (e.g. Claude, vim) and shells alike.
- Small, touch-friendly buttons (30×30) so the mobile keyboard doesn't collapse on tap.
- Freed header space on narrow screens by removing the agent-id label and the redundant "live" status text.

## Testing
- `tsc --noEmit` clean
- `tests/unit/cli-viewer-routes.test.ts` — 8/8 pass (includes keybar markup assertion)

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)