### PR TITLE
[Fix] Allow channel-less agent cron jobs on create (#253)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1974,8 +1974,8 @@ Jobs are persisted to `~/.claude-gateway/crons.json` and survive gateway restart
 | `type` | No | `"command"` (default) or `"agent"` |
 | `command` | If `type=command` | Shell command to run |
 | `prompt` | If `type=agent` | Prompt sent to the agent as a new turn |
-| `telegram` | If `type=agent` | Telegram chat_id to deliver the agent response |
-| `discord` | If `type=agent` | Discord channel_id to deliver the agent response |
+| `telegram` | No | Telegram chat_id to deliver the agent response (optional for `type=agent`) |
+| `discord` | No | Discord channel_id to deliver the agent response (optional for `type=agent`) |
 | `timeoutMs` | No | Execution timeout in ms (default 120000) — applies to both `command` and `agent` |
 | `deleteAfterRun` | No | `true` to auto-delete after first run (one-shot jobs) |
 | `enabled` | No | `true` (default) / `false` to create disabled |
@@ -1985,11 +1985,11 @@ Jobs are persisted to `~/.claude-gateway/crons.json` and survive gateway restart
 | | `command` | `agent` |
 |---|---|---|
 | Runs | Shell command | Agent turn (new Claude session) |
-| Key field | `command` | `prompt` + `telegram` and/or `discord` |
+| Key field | `command` | `prompt` (channels optional) |
 | Output | stdout/stderr | Agent response text |
-| Delivery | Logged only | Sent to Telegram and/or Discord |
+| Delivery | Logged only | Sent to Telegram and/or Discord if set, otherwise logged only |
 
-> **Note:** For `type=agent`, at least one of `telegram` or `discord` is required. Both can be set to deliver to multiple channels simultaneously.
+> **Note:** For `type=agent`, only `prompt` is required. `telegram` and `discord` are optional — set either (or both) to deliver the agent response to those channels; with neither, the job still runs on schedule and its response is logged only (no delivery).
 
 ---
 

--- a/src/api/cron-router.ts
+++ b/src/api/cron-router.ts
@@ -104,10 +104,9 @@ export function createCronRouter(manager: CronManager, apiKeys?: ApiKey[], known
       res.status(400).json({ error: 'prompt is required for type=agent' });
       return;
     }
-    if (type === 'agent' && !body.telegram && !body.discord) {
-      res.status(400).json({ error: 'telegram or discord is required for type=agent' });
-      return;
-    }
+    // Note: telegram/discord are optional for type=agent. A channel-less job still
+    // runs and persists its result to Run History (executeJob → appendRunLog is
+    // unconditional; delivery is skipped when no channel is set). See #253.
 
     try {
       const job = await manager.create(body as CronJobCreate);

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -329,9 +329,8 @@ export class CronManager extends EventEmitter {
       if (!input.command) throw new Error('command is required for type=command');
     } else if (kind === 'agent') {
       if (!input.prompt) throw new Error('prompt is required for type=agent');
-      if (!input.telegram && !input.discord) {
-        throw new Error('telegram or discord is required for type=agent');
-      }
+      // telegram/discord are optional: a channel-less agent job runs and its
+      // output is saved to Run History; delivery is simply skipped (see #253).
     }
   }
 

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -400,6 +400,75 @@ describe('T11-T13: Telegram delivery', () => {
     manager.stop();
   });
 
+  it('T11c: update() on an existing channel-less agent job → prompt change succeeds, not rejected (#253)', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'no-channel-update',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hello',
+      // no telegram, no discord
+    });
+
+    // Changing `prompt` triggers manager.update()'s validatePayload(merged) branch.
+    // Before #253, merged still had no telegram/discord and this threw
+    // "telegram or discord is required for type=agent" even though the update
+    // never touched the channel fields.
+    const updated = await manager.update(job.id, { prompt: 'updated prompt' });
+
+    expect(updated.prompt).toBe('updated prompt');
+    expect(updated.telegram).toBeUndefined();
+    expect(updated.discord).toBeUndefined();
+
+    manager.stop();
+  });
+
+  it('T11d: update() changing type command→agent on a channel-less job succeeds (#253)', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'type-flip-no-channel',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'command',
+      command: 'echo hi',
+      // no telegram, no discord
+    });
+
+    const updated = await manager.update(job.id, { type: 'agent', prompt: 'now an agent' });
+
+    expect(updated.type).toBe('agent');
+    expect(updated.prompt).toBe('now an agent');
+
+    manager.stop();
+  });
+
+  it('T11e: update() changing type command→agent WITHOUT a prompt is still rejected (#253 did not loosen this)', async () => {
+    const { manager, agentId } = makeManager();
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'type-flip-no-prompt',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'command',
+      command: 'echo hi',
+    });
+
+    await expect(manager.update(job.id, { type: 'agent' })).rejects.toThrow(
+      'prompt is required for type=agent',
+    );
+
+    manager.stop();
+  });
+
   it('T12: type=agent error → Telegram not called', async () => {
     const runner = {
       sendApiMessage: jest.fn().mockRejectedValue(new Error('agent failed')),

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -369,6 +369,37 @@ describe('T11-T13: Telegram delivery', () => {
     manager.stop();
   });
 
+  it('T11b: type=agent with no channel → runs and captures output, no delivery (#253)', async () => {
+    const runner = makeRunner('channel-less result');
+    const { manager, agentId } = makeManager({ runner, botToken: 'TOKEN123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'no-channel-job',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hello',
+      // no telegram, no discord — result lives in Run History only
+    });
+
+    const log = await manager.run(job.id);
+
+    // Engine still runs the agent and persists the outcome (→ Run History)…
+    expect(runner.sendApiMessage).toHaveBeenCalled();
+    expect(log.status).toBe('ok');
+    expect(log.output).toContain('channel-less result');
+
+    // …but no channel delivery is attempted.
+    const telegramCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('/sendMessage'),
+    );
+    expect(telegramCall).toBeUndefined();
+
+    manager.stop();
+  });
+
   it('T12: type=agent error → Telegram not called', async () => {
     const runner = {
       sendApiMessage: jest.fn().mockRejectedValue(new Error('agent failed')),

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -371,7 +371,9 @@ describe('T11-T13: Telegram delivery', () => {
 
   it('T11b: type=agent with no channel → runs and captures output, no delivery (#253)', async () => {
     const runner = makeRunner('channel-less result');
-    const { manager, agentId } = makeManager({ runner, botToken: 'TOKEN123' });
+    // Configure BOTH bot tokens so the "no delivery" assertions below prove it's the
+    // job's missing channel *destination* — not missing bot config — that skips delivery.
+    const { manager, agentId } = makeManager({ runner, botToken: 'TOKEN123', discordBotToken: 'DISC123' });
     await manager.start();
 
     const job = await manager.create({
@@ -391,11 +393,16 @@ describe('T11-T13: Telegram delivery', () => {
     expect(log.status).toBe('ok');
     expect(log.output).toContain('channel-less result');
 
-    // …but no channel delivery is attempted.
+    // …but no channel delivery is attempted — neither Telegram nor Discord.
     const telegramCall = fetchMock.mock.calls.find((c) =>
       typeof c[0] === 'string' && (c[0] as string).includes('/sendMessage'),
     );
     expect(telegramCall).toBeUndefined();
+
+    const discordCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    expect(discordCall).toBeUndefined();
 
     manager.stop();
   });

--- a/tests/unit/cron-router.test.ts
+++ b/tests/unit/cron-router.test.ts
@@ -119,7 +119,7 @@ describe('T21-T23: Router validation for new fields', () => {
     expect(res.body.error).toContain('prompt');
   });
 
-  it('T23b: POST with type=agent + missing telegram and discord → 400', async () => {
+  it('T23b: POST with type=agent + no telegram and no discord → 201 (channel-less, #253)', async () => {
     const { app } = makeApp();
 
     const res = await request(app)
@@ -131,11 +131,13 @@ describe('T21-T23: Router validation for new fields', () => {
         schedule: '* * * * *',
         type: 'agent',
         prompt: 'hello',
-        // no telegram, no discord
+        // no telegram, no discord — result is read from Run History
       });
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe('telegram or discord is required for type=agent');
+    expect(res.status).toBe(201);
+    expect(res.body.job).toBeDefined();
+    expect(res.body.job.telegram).toBeUndefined();
+    expect(res.body.job.discord).toBeUndefined();
   });
 
   it('T23c: POST with type=agent + telegram only → 201', async () => {


### PR DESCRIPTION
## Summary
Cron **create** rejected agent jobs that had no Telegram/Discord destination, even though the run engine fully supports channel-less agent jobs (results are always persisted to Run History; delivery is the only thing that's skipped). This contradicted the getpod form copy that tells users they can leave the channel blank and read the result in Run History. This PR removes the over-strict require-channel guard on create so a channel-less agent job can be created and runs to Run History as designed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor / Tech debt
- [ ] Documentation

## Related Issues
Closes #253

## Root Cause
The engine already supports channel-less agent jobs:
- `executeJob` → `appendRunLog` persists the run result to Run History **unconditionally**.
- Delivery is guarded by `if (job.telegram)` / `if (job.discord)` — no channel simply means delivery is skipped, the job still runs.

The bug was purely in **create-time validation**, which hard-blocked the job before it could ever run:
- `src/api/cron-router.ts` — returned `400 "telegram or discord is required"` on create.
- `src/cron/manager.ts` — the same check in `validatePayload` (runs on both create and update).

## Changes Made
- `src/api/cron-router.ts`: removed the API-layer require-channel `400` on create.
- `src/cron/manager.ts`: removed the same require-channel check in `validatePayload` (so create **and** update are consistent). The `prompt`-required rule for `type=agent` is unchanged, and channel-delivery logic when a channel *is* present is untouched.
- `tests/unit/cron-router.test.ts`: inverted T23b — channel-less agent create must now return `201` (previously locked the buggy `400`).
- `tests/unit/cron-manager.test.ts`: added a manager-level test (T11b) proving a channel-less agent job runs, persists its output to the run log, and skips delivery; plus tests covering the previously-uncovered update path (`PUT /v1/crons/:id`).

## How to Test
1. Check out this branch.
2. Create an agent cron job on an agent with **no** Telegram/Discord connected (empty channel destination).
3. Expected: creation succeeds (`201`), the job runs on schedule, and its output appears in **Run History** with no delivery attempted.
4. Regression: creating/updating an agent job *with* a channel still delivers as before; `type=agent` still requires a `prompt`.

## Out of Scope
- No change to delivery behavior when a channel is present.
- No change to the `prompt`-required rule for `type=agent`.

## Checklist
- [x] Reviewed my own code
- [x] Tests pass (typecheck ✓ · cron-router + cron-manager 62/62 · full unit suite green)
- [x] No console errors

Discovered via getpod #1690 (cron UX) manual UI testing on `chubby-tunnel.getpod.ai/crons`.
