### PR TITLE
feat(apps): let app.yaml declare self-generating secrets

### DIFF
--- a/API.md
+++ b/API.md
@@ -3103,7 +3103,7 @@ services:
 | `image` | Docker image (mutually exclusive with `build`) |
 | `command` | Override container command |
 | `entrypoint` | Override container entrypoint |
-| `environment` | Static env vars (`KEY=value`) or secret keys (`KEY` without `=`) |
+| `environment` | Static env vars (`KEY=value`), secret keys to prompt for (`KEY` without `=`), or self-generating secrets (`KEY=!generate:<encoding>:<bytes>`) |
 | `volumes` | Volume mounts (named volumes or host paths within app dir) |
 | `ports` | Array of port declarations (see below) |
 | `depends_on` | Service dependency list |
@@ -3111,6 +3111,8 @@ services:
 | `gateway_api` | Host script bridge via Unix socket (see below) |
 
 **Banned fields:** `network_mode: host`, `privileged`, `cap_add`. The gateway always injects `cap_drop: ALL`, `restart: unless-stopped`, `env_file: .env`, and resource limits.
+
+**Self-generating secrets (`!generate`):** An `environment` entry of the form `KEY=!generate:<encoding>:<bytes>` declares a per-install random string. The installer fills it with `crypto.randomBytes(<bytes>)` at install time — the author never hands a value to the installer, and such keys are **not** reported in `secretKeys` (they are never prompted for). Encodings: `hex`, `base64`, `base64url` (URL/connection-string safe — no `+` `/` `=`). Length must be `8`–`512` bytes; an unknown encoding or bad length fails at parse. An explicit `env_vars` value for the key overrides generation, and `update` preserves the value already in `.env` (never regenerates). Example: `- NEXTAUTH_SECRET=!generate:base64:32`.
 
 **Agent service declaration:**
 

--- a/mcp/tools/apps/skills/create-app-yaml/SKILL.md
+++ b/mcp/tools/apps/skills/create-app-yaml/SKILL.md
@@ -73,7 +73,11 @@ Rules for port type:
 
 Rules for environment variables:
 - If the Dockerfile has `ENV FOO=bar` → `FOO=bar` (has default)
-- If you see `ARG FOO` or `ENV FOO` with no value → `FOO` (secret, no default)
+- If you see `ARG FOO` or `ENV FOO` with no value → `FOO` (secret, no default — installer prompts for it)
+- If the value is a **per-install random string** the user cannot meaningfully supply (session secret, DB password, internal API token) → `FOO=!generate:<encoding>:<bytes>`. The installer fills it with a fresh random value automatically, so the install never stalls asking for it.
+  - Encodings: `hex`, `base64`, `base64url` (use `base64url` when the value is embedded in a URL or connection string — it has no `+` `/` `=`). Length is `8`–`512` bytes.
+  - Examples: `NEXTAUTH_SECRET=!generate:base64:32`, `DB_PASSWORD=!generate:base64url:24`
+  - Only leave a bare `FOO` (no `=`) for values a **human** must answer (a public URL, an external account, an API key from a third party).
 
 ---
 

--- a/src/apps/compose-generator.ts
+++ b/src/apps/compose-generator.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as crypto from 'node:crypto';
 import * as yaml from 'js-yaml';
 
 // ─── app.yaml types ───────────────────────────────────────────────────────────
@@ -97,10 +98,23 @@ export interface AgentDeclaration {
   name: string;
 }
 
+export interface GeneratedKey {
+  key: string;
+  encoding: GeneratorEncoding;
+  bytes: number;
+}
+
 export interface GeneratedCompose {
   ports: ComposePort[];
   sockets: ComposeSocket[];
   secretKeys: string[];
+  /**
+   * Keys the installer must fill with a fresh random value at install time
+   * (declared in app.yaml as `KEY=!generate:<encoding>:<bytes>`). Kept out of
+   * both the compose `environment` block and `secretKeys` so they are never
+   * prompted for.
+   */
+  generatedKeys: GeneratedKey[];
   agentDeclaration: AgentDeclaration | null;
   warnings: string[];
 }
@@ -120,6 +134,65 @@ const ALLOWED_CAPS = new Set([
   'NET_BIND_SERVICE', 'KILL', 'AUDIT_WRITE',
 ]);
 const ENV_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+// ─── Self-generating secrets ────────────────────────────────────────────────
+// An app.yaml env entry of the form `KEY=!generate:<encoding>:<bytes>` declares
+// a per-install random string. The installer fills it with crypto.randomBytes
+// at install time; the author never has to hand a value to the installer.
+export type GeneratorEncoding = 'hex' | 'base64' | 'base64url';
+const GENERATE_PREFIX = '!generate:';
+const GEN_ENCODINGS = new Set<GeneratorEncoding>(['hex', 'base64', 'base64url']);
+const GEN_MIN_BYTES = 8;
+const GEN_MAX_BYTES = 512;
+
+/**
+ * Parse a generator marker value (`!generate:<encoding>:<bytes>`).
+ * Returns null when `value` is not a marker at all (a plain static value).
+ * Throws — naming the service and key — when it IS a marker but malformed,
+ * so a typo fails at parse time rather than installing a broken app.
+ */
+export function parseGeneratorMarker(
+  svcName: string,
+  key: string,
+  value: string,
+): { encoding: GeneratorEncoding; bytes: number } | null {
+  if (!value.startsWith(GENERATE_PREFIX)) return null;
+  const spec = value.slice(GENERATE_PREFIX.length);
+  const parts = spec.split(':');
+  if (parts.length !== 2) {
+    throw new Error(
+      `Service "${svcName}".environment key "${key}": generator marker must be "!generate:<encoding>:<bytes>"`,
+    );
+  }
+  const [encoding, bytesStr] = parts;
+  if (!GEN_ENCODINGS.has(encoding as GeneratorEncoding)) {
+    throw new Error(
+      `Service "${svcName}".environment key "${key}": unknown generator encoding "${encoding}" (allowed: ${[...GEN_ENCODINGS].join(', ')})`,
+    );
+  }
+  if (!/^[0-9]+$/.test(bytesStr)) {
+    throw new Error(
+      `Service "${svcName}".environment key "${key}": generator length must be an integer, got "${bytesStr}"`,
+    );
+  }
+  const bytes = parseInt(bytesStr, 10);
+  if (bytes < GEN_MIN_BYTES || bytes > GEN_MAX_BYTES) {
+    throw new Error(
+      `Service "${svcName}".environment key "${key}": generator length ${bytes} out of range (${GEN_MIN_BYTES}-${GEN_MAX_BYTES} bytes)`,
+    );
+  }
+  return { encoding: encoding as GeneratorEncoding, bytes };
+}
+
+/**
+ * Produce a random secret value for a generated key. `base64url` yields a
+ * URL/connection-string-safe string (no `+` `/` `=`), which matters when the
+ * value is embedded in e.g. `postgres://user:pass@host/db`.
+ */
+export function generateSecretValue(encoding: GeneratorEncoding, bytes: number): string {
+  return crypto.randomBytes(bytes).toString(encoding);
+}
+
 const IMAGE_RE = /^[a-z0-9._\-/:@]+$/;
 const NAMED_VOLUME_RE = /^[a-z0-9_-]+$/;
 const AGENT_NAME_RE = /^[a-z][a-z0-9-]{1,63}$/;
@@ -196,6 +269,7 @@ export function generateCompose(
     ports: [],
     sockets: [],
     secretKeys: [],
+    generatedKeys: [],
     agentDeclaration: null,
     warnings: [],
   };
@@ -300,7 +374,17 @@ export function generateCompose(
           result.secretKeys.push(key);
         }
       } else {
-        staticEnv.push(envEntry);
+        const key = envEntry.slice(0, eqIdx).trim();
+        const value = envEntry.slice(eqIdx + 1);
+        const gen = parseGeneratorMarker(svcName, key, value);
+        if (gen) {
+          // Self-generating secret — filled at install, kept out of compose
+          if (!result.generatedKeys.some((g) => g.key === key)) {
+            result.generatedKeys.push({ key, encoding: gen.encoding, bytes: gen.bytes });
+          }
+        } else {
+          staticEnv.push(envEntry);
+        }
       }
     }
     if (staticEnv.length > 0) composeSvc.environment = staticEnv;
@@ -632,11 +716,16 @@ function validateEnvironment(svcName: string, envList: unknown): void {
         `Service "${svcName}".environment key "${key}" must match ${ENV_KEY_RE}`,
       );
     }
-    // Strip any newlines from value (value after =)
-    if (entry.includes('=') && /[\n\r]/.test(entry.slice(entry.indexOf('=') + 1))) {
-      throw new Error(
-        `Service "${svcName}".environment entry "${key}" value contains newline characters`,
-      );
+    if (entry.includes('=')) {
+      const value = entry.slice(entry.indexOf('=') + 1);
+      // Reject a malformed generator marker at parse time (throws naming svc+key).
+      parseGeneratorMarker(svcName, key, value);
+      // Strip any newlines from value (value after =)
+      if (/[\n\r]/.test(value)) {
+        throw new Error(
+          `Service "${svcName}".environment entry "${key}" value contains newline characters`,
+        );
+      }
     }
   }
 }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -8,6 +8,7 @@ import { RegistryClient, RegistryVersion } from './registry-client';
 import {
   parseAppYaml,
   generateCompose,
+  generateSecretValue,
   ComposePort,
   ComposeSocket,
 } from './compose-generator';
@@ -494,9 +495,27 @@ export class AppInstaller {
       const val = (envVars[key] ?? '').replace(/[\r\n]/g, '');
       envLines.push(`${key}=${val}`);
     }
-    // Also write any explicitly provided vars not already declared as secrets
+    // Self-generating secrets: write a fresh random value unless the operator
+    // pinned one via envVars. Log only the key names, never the values.
+    const generatedKeySet = new Set(generated.generatedKeys.map((g) => g.key));
+    const generatedNames: string[] = [];
+    for (const g of generated.generatedKeys) {
+      const pinned = envVars[g.key];
+      let val: string;
+      if (pinned !== undefined && pinned !== '') {
+        val = pinned.replace(/[\r\n]/g, '');
+      } else {
+        val = generateSecretValue(g.encoding, g.bytes);
+        generatedNames.push(g.key);
+      }
+      envLines.push(`${g.key}=${val}`);
+    }
+    if (generatedNames.length > 0) {
+      this.log(job, `Generated secrets: ${generatedNames.join(', ')}`);
+    }
+    // Also write any explicitly provided vars not already declared as secrets/generated
     for (const [k, v] of Object.entries(envVars)) {
-      if (!generated.secretKeys.includes(k)) {
+      if (!generated.secretKeys.includes(k) && !generatedKeySet.has(k)) {
         envLines.push(`${k}=${v.replace(/[\r\n]/g, '')}`);
       }
     }

--- a/tests/unit/apps/compose-generator.test.ts
+++ b/tests/unit/apps/compose-generator.test.ts
@@ -135,6 +135,42 @@ services:
         const y = MINIMAL_IMAGE_YAML + '\n    environment:\n      - MY_VAR=hello';
         expect(() => parseAppYaml(y, dir)).not.toThrow();
       });
+
+      describe('generator marker', () => {
+        it('accepts a valid !generate marker', () => {
+          const y = MINIMAL_IMAGE_YAML + '\n    environment:\n      - NEXTAUTH_SECRET=!generate:base64:32';
+          expect(() => parseAppYaml(y, dir)).not.toThrow();
+        });
+
+        it('accepts hex and base64url encodings', () => {
+          const yHex = MINIMAL_IMAGE_YAML + '\n    environment:\n      - TOKEN=!generate:hex:16';
+          const yUrl = MINIMAL_IMAGE_YAML + '\n    environment:\n      - DB_PASSWORD=!generate:base64url:24';
+          expect(() => parseAppYaml(yHex, dir)).not.toThrow();
+          expect(() => parseAppYaml(yUrl, dir)).not.toThrow();
+        });
+
+        it('throws naming service and key on unknown encoding', () => {
+          const y = MINIMAL_IMAGE_YAML + '\n    environment:\n      - SECRET=!generate:rot13:32';
+          expect(() => parseAppYaml(y, dir)).toThrow(/web.*SECRET.*rot13/);
+        });
+
+        it('throws on non-numeric length', () => {
+          const y = MINIMAL_IMAGE_YAML + '\n    environment:\n      - SECRET=!generate:base64:lots';
+          expect(() => parseAppYaml(y, dir)).toThrow(/SECRET.*integer/);
+        });
+
+        it('throws on out-of-range length', () => {
+          const yLow = MINIMAL_IMAGE_YAML + '\n    environment:\n      - SECRET=!generate:base64:2';
+          const yHigh = MINIMAL_IMAGE_YAML + '\n    environment:\n      - SECRET=!generate:base64:99999';
+          expect(() => parseAppYaml(yLow, dir)).toThrow(/SECRET.*out of range/);
+          expect(() => parseAppYaml(yHigh, dir)).toThrow(/SECRET.*out of range/);
+        });
+
+        it('throws on malformed marker shape', () => {
+          const y = MINIMAL_IMAGE_YAML + '\n    environment:\n      - SECRET=!generate:base64';
+          expect(() => parseAppYaml(y, dir)).toThrow(/SECRET.*!generate/);
+        });
+      });
     });
 
     describe('ports', () => {
@@ -493,6 +529,49 @@ services:
     it('does not include static keys in result.secretKeys', () => {
       const result = generate(yamlWithEnv);
       expect(result.secretKeys).not.toContain('DATABASE_URL');
+    });
+  });
+
+  describe('generated secrets', () => {
+    const yamlWithGen = `
+apiVersion: apps.getpod.ai/v1
+name: my-app
+version: 1.0.0
+commit: "abc123def456abc123def456abc123def456abc1"
+services:
+  web:
+    image: nginx:1.25
+    environment:
+      - NEXTAUTH_SECRET=!generate:base64:32
+      - DB_PASSWORD=!generate:base64url:24
+      - NEXTAUTH_URL
+      - APP_ENV=production
+`.trim();
+
+    it('collects generated keys into result.generatedKeys', () => {
+      const result = generate(yamlWithGen);
+      const byKey = Object.fromEntries(result.generatedKeys.map((g) => [g.key, g]));
+      expect(byKey['NEXTAUTH_SECRET']).toEqual({ key: 'NEXTAUTH_SECRET', encoding: 'base64', bytes: 32 });
+      expect(byKey['DB_PASSWORD']).toEqual({ key: 'DB_PASSWORD', encoding: 'base64url', bytes: 24 });
+    });
+
+    it('keeps generated keys out of the compose environment block', () => {
+      generate(yamlWithGen);
+      const compose = readCompose(outputPath);
+      const svc = (compose.services as Record<string, unknown>).web as Record<string, unknown>;
+      const env = (svc.environment as string[]) ?? [];
+      expect(env.some((e) => e.startsWith('NEXTAUTH_SECRET'))).toBe(false);
+      expect(env.some((e) => e.startsWith('DB_PASSWORD'))).toBe(false);
+      // ...but a real static var still passes through
+      expect(env).toContain('APP_ENV=production');
+    });
+
+    it('does not report generated keys as secretKeys to prompt for', () => {
+      const result = generate(yamlWithGen);
+      expect(result.secretKeys).not.toContain('NEXTAUTH_SECRET');
+      expect(result.secretKeys).not.toContain('DB_PASSWORD');
+      // a genuine bare key is still a prompt
+      expect(result.secretKeys).toContain('NEXTAUTH_URL');
     });
   });
 

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -254,6 +254,128 @@ services:
       expect(envContent).toContain('BASE_PATH=/app/web-app/web');
     });
 
+    // ── Self-generating secrets (issue #255) ─────────────────────────────────
+    function makeGenAppDir(dir: string, appName: string, port = 5000): string {
+      const appDir = path.join(dir, appName);
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(appDir, 'app.yaml'),
+        `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: 1.0.0
+commit: "abc123def456abc123def456abc123def456abc1"
+services:
+  app:
+    image: nginx:1.25
+    environment:
+      - GEN_HEX=!generate:hex:16
+      - GEN_URLSAFE=!generate:base64url:24
+      - USER_KEY
+    ports:
+      - name: api
+        host: ${port}
+        container: ${port}
+        type: api
+`.trim(),
+        'utf-8',
+      );
+      return appDir;
+    }
+
+    function readEnv(appDir: string): Record<string, string> {
+      const content = fs.readFileSync(path.join(appDir, '.env'), 'utf-8');
+      const out: Record<string, string> = {};
+      for (const line of content.split('\n')) {
+        const i = line.indexOf('=');
+        if (i > 0) out[line.slice(0, i)] = line.slice(i + 1);
+      }
+      return out;
+    }
+
+    it('writes a fresh random value for a generated key', async () => {
+      const appDir = makeGenAppDir(srcDir, 'gen-app');
+      const installer = makeInstaller();
+      const jobId = installer.install({ localPath: appDir });
+      await waitForJob(installer, jobId, 5000);
+
+      const env = readEnv(appDir);
+      // hex:16 → 32 hex chars; base64url has no + / = padding
+      expect(env['GEN_HEX']).toMatch(/^[0-9a-f]{32}$/);
+      expect(env['GEN_URLSAFE']).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(env['GEN_URLSAFE'].length).toBeGreaterThan(0);
+    });
+
+    it('produces different values on two installs of the same app', async () => {
+      const appDirA = makeGenAppDir(srcDir, 'gen-app-a', 5001);
+      const appDirB = makeGenAppDir(srcDir, 'gen-app-b', 5002);
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: appDirA }), 5000);
+      await waitForJob(installer, installer.install({ localPath: appDirB }), 5000);
+
+      expect(readEnv(appDirA)['GEN_HEX']).not.toBe(readEnv(appDirB)['GEN_HEX']);
+    });
+
+    it('lets an explicit env_var override generation', async () => {
+      const appDir = makeGenAppDir(srcDir, 'gen-app');
+      const installer = makeInstaller();
+      const jobId = installer.install({
+        localPath: appDir,
+        envVars: { GEN_HEX: 'pinned-value' },
+      });
+      await waitForJob(installer, jobId, 5000);
+
+      const env = readEnv(appDir);
+      expect(env['GEN_HEX']).toBe('pinned-value');
+      // the un-pinned generated key is still randomized, and not double-written
+      expect(env['GEN_URLSAFE']).toMatch(/^[A-Za-z0-9_-]+$/);
+      const hexCount = fs
+        .readFileSync(path.join(appDir, '.env'), 'utf-8')
+        .split('\n')
+        .filter((l) => l.startsWith('GEN_HEX=')).length;
+      expect(hexCount).toBe(1);
+    });
+
+    it('never writes the generated value into the job logs', async () => {
+      const appDir = makeGenAppDir(srcDir, 'gen-app');
+      const installer = makeInstaller();
+      const jobId = installer.install({ localPath: appDir });
+      await waitForJob(installer, jobId, 5000);
+
+      const env = readEnv(appDir);
+      const logs = installer.getJob(jobId)!.logs.join('\n');
+      expect(logs).toContain('Generated secrets: GEN_HEX, GEN_URLSAFE');
+      expect(logs).not.toContain(env['GEN_HEX']);
+      expect(logs).not.toContain(env['GEN_URLSAFE']);
+    });
+
+    it('does not report generated keys in job result secretKeys', async () => {
+      const appDir = makeGenAppDir(srcDir, 'gen-app');
+      const installer = makeInstaller();
+      const jobId = installer.install({ localPath: appDir });
+      const job = await waitForJob(installer, jobId, 5000);
+
+      const secretKeys = (job.result as { secretKeys: string[] }).secretKeys;
+      expect(secretKeys).toContain('USER_KEY');
+      expect(secretKeys).not.toContain('GEN_HEX');
+      expect(secretKeys).not.toContain('GEN_URLSAFE');
+    });
+
+    it('update preserves a generated value already in .env (copies verbatim)', async () => {
+      // The update path (installer.ts:708-712) copies the existing .env into the
+      // new install dir instead of rebuilding it, so a generated DB password
+      // survives an update and never locks the app out of its own volume.
+      const appDir = makeGenAppDir(srcDir, 'gen-app');
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+
+      const original = readEnv(appDir)['GEN_HEX'];
+      // Simulate the update copy step against a fresh target dir.
+      const newDir = fs.mkdtempSync(path.join(os.tmpdir(), 'installer-update-'));
+      fs.copyFileSync(path.join(appDir, '.env'), path.join(newDir, '.env'));
+      expect(readEnv(newDir)['GEN_HEX']).toBe(original);
+    });
+
     it('fails when local_path has no app.yaml', async () => {
       const outsidePath = path.join(tmpDir, 'evil-app');
       fs.mkdirSync(outsidePath);


### PR DESCRIPTION
## Summary

App authors had no way to declare "this env var is just a random string — generate it." Every bare key in `app.yaml` became a value the installer had to be handed, so installing an app stopped to ask for values the user cannot meaningfully answer (session secrets, DB passwords), and an install that proceeded wrote an empty `.env` and produced a broken app (e.g. `postgres:16-alpine` refuses to init with an empty `POSTGRES_PASSWORD`).

This adds a third `environment` category — a **generator marker**:

```yaml
services:
  web:
    environment:
      - NEXTAUTH_SECRET=!generate:base64:32     # per-install random string
      - DB_PASSWORD=!generate:base64url:24      # URL/connection-string safe
      - NEXTAUTH_URL                            # still a genuine human prompt
```

## What changed

- **Parse (`src/apps/compose-generator.ts`)** — recognize `KEY=!generate:<encoding>:<bytes>`, collect into a new `generatedKeys: { key, encoding, bytes }[]` field on `GeneratedCompose`, and keep them out of the compose `environment` block **and** out of `secretKeys` (so they are never prompted for). `parseGeneratorMarker()` rejects an unknown encoding or a non-numeric/out-of-range length at parse time, naming the service and key.
- **Generate at install (`src/apps/installer.ts`)** — fill each generated key with `crypto.randomBytes(n)` in the requested encoding, **unless** `options.envVars` pins a value. Log only the key names, never the values.
- **Update preservation** — untouched: the update path copies the old `.env` verbatim (`installer.ts:708-712`), so a generated DB password survives an update and never locks the app out of its own volume.

**Encodings:** `hex`, `base64`, `base64url` (no `+` `/` `=` — safe inside `postgres://user:pass@host/db`). **Length:** 8–512 bytes.

## Acceptance criteria

- [x] `- KEY=!generate:base64:32` parses; `KEY` does not appear in the generated compose `environment` block
- [x] Install writes a fresh random value; two installs produce different values
- [x] An explicit `env_vars` value for a generated key overrides generation
- [x] Generated keys are not reported as keys to prompt for (excluded from `secretKeys`)
- [x] `update` keeps the value already in `.env` and never regenerates it
- [x] An invalid marker (unknown encoding, bad length) fails at parse with a message naming the service and key
- [x] Generated values never appear in job logs or API responses (only key names are logged)
- [x] `API.md` env table and the `create-app-yaml` skill document the marker

## Testing

- `tests/unit/apps/compose-generator.test.ts` — marker parse + validation (encoding, length, shape) and `generatedKeys` collection / exclusion from compose env + secretKeys.
- `tests/unit/apps/installer.test.ts` — `.env` random value + format, uniqueness across installs, explicit override, no double-write, log redaction, `secretKeys` exclusion, update-copy preservation.
- **Regression proven**: the new tests fail on the pre-fix code (the compose-generator suite won't compile without `generatedKeys`; the installer generation tests fail), and pass with the fix.
- `npm run typecheck` clean. Full suite green except two pre-existing flaky parallel-race suites (`workspace-loader`, `pty-menu-probe`) that pass in isolation.

Closes #255