### PR TITLE
docs(apps): make commit optional for GitHub app installs

### DIFF
--- a/mcp/tools/apps/module.ts
+++ b/mcp/tools/apps/module.ts
@@ -52,8 +52,8 @@ export class AppsModule implements ToolModule {
           properties: {
             registry_app: { type: 'string', description: 'Registry app name (e.g. "getpod-manager")' },
             version: { type: 'string', description: 'Registry version to install (default: latest)' },
-            github_url: { type: 'string', description: 'GitHub repo URL (requires commit)' },
-            commit: { type: 'string', description: '40-char hex commit hash (required with github_url)' },
+            github_url: { type: 'string', description: 'GitHub repo URL' },
+            commit: { type: 'string', description: '40-char hex commit hash to pin (optional; with github_url, omit to auto-resolve the default branch HEAD)' },
             local_path: { type: 'string', description: 'Local app path within ~/.claude-gateway/apps/' },
             env_vars: {
               type: 'object',

--- a/mcp/tools/apps/skills/install-app/SKILL.md
+++ b/mcp/tools/apps/skills/install-app/SKILL.md
@@ -18,7 +18,8 @@ Arguments passed: `$ARGUMENTS`
 
 - `/install-app <registry-name>` — install latest version from registry
 - `/install-app <registry-name> <version>` — install specific version
-- `/install-app <github-url> <40-hex-commit>` — custom GitHub install (pinned commit)
+- `/install-app <github-url>` — custom GitHub install (installs the latest commit on the default branch)
+- `/install-app <github-url> <40-hex-commit>` — custom GitHub install pinned to a specific commit
 
 ---
 
@@ -30,8 +31,12 @@ Show the user:
 - Repo URL
 - Version you will install (and whether it is latest)
 
-**GitHub install:** validate that the commit is a 40-char hex string. If not, tell the user
-and stop.
+**GitHub install:** the commit is **optional**.
+- If the user supplied a commit, validate it is a 40-char hex string; if it is malformed,
+  tell the user and stop.
+- If **no commit** was given, do **not** ask the user to find one — call `install_app` with
+  just the `github_url` and the installer resolves the default branch's latest commit (HEAD)
+  automatically and pins it. Report the resolved commit in Step 5.
 
 If the app is not found in the registry and no GitHub URL given, stop with a helpful message.
 
@@ -66,7 +71,7 @@ Before installing, show a brief summary:
 Installing: <app-name> v<version>
 Source: <registry|github>
 Repo: <url>
-Commit: <first 8 chars>
+Commit: <first 8 chars, or "latest on default branch (auto-resolved)" for a GitHub install with no pinned commit>
 Proxy routes: (from registry metadata if available)
 Secrets to inject: <list or "none">
 
@@ -90,13 +95,17 @@ Store the returned `jobId`.
 Poll `poll_install_job` every 3 seconds. Show a brief progress line after each poll
 (use the last log entry from the job). Stop when status is `completed` or `failed`.
 
-On **completed**: show proxy URLs from `result.proxyUrls`.
+On **completed**: show proxy URLs from `result.proxyUrls`. For a GitHub install with no
+pinned commit, also report the commit that was resolved and installed (the job logs a
+`Resolved HEAD → <short>` line) so the user knows exactly what was pinned.
 On **failed**: show the error message and last 5 log entries.
 
 ---
 
 ## Notes
 
-- Never pass branch names as `commit` — only 40-char hex strings are valid.
+- The `commit` is optional for GitHub installs; when omitted the installer pins the latest
+  commit on the default branch. When a commit **is** supplied it must be a 40-char hex string
+  — never pass a branch name as `commit`.
 - `env_vars` values should not be echoed back to the user after collection.
 - If the user cancels at any confirmation step, say so and stop.

--- a/tests/unit/apps-module.test.ts
+++ b/tests/unit/apps-module.test.ts
@@ -1,0 +1,36 @@
+import { AppsModule } from '../../mcp/tools/apps/module';
+
+describe('AppsModule', () => {
+  describe('getTools', () => {
+    it('exposes an install_app tool', () => {
+      const tools = new AppsModule().getTools();
+      expect(tools.map((t) => t.name)).toContain('install_app');
+    });
+
+    // Regression for #257: the tool contract must not tell agents a commit is
+    // required for a GitHub install — the installer auto-resolves HEAD when it
+    // is omitted. A "required" description makes agents stop and demand a hash.
+    it('install_app presents commit as optional (auto-resolves HEAD), not required', () => {
+      const tools = new AppsModule().getTools();
+      const install = tools.find((t) => t.name === 'install_app');
+      expect(install).toBeDefined();
+
+      const props = (install!.inputSchema as {
+        properties: Record<string, { description?: string }>;
+        required?: string[];
+      });
+
+      // commit must not be a required field
+      expect(props.required ?? []).not.toContain('commit');
+
+      const commitDesc = props.properties['commit']?.description ?? '';
+      const githubDesc = props.properties['github_url']?.description ?? '';
+
+      // must not advertise commit as required
+      expect(commitDesc.toLowerCase()).not.toContain('required');
+      expect(githubDesc.toLowerCase()).not.toContain('requires commit');
+      // must signal the optional / auto-resolve behavior
+      expect(commitDesc.toLowerCase()).toContain('optional');
+    });
+  });
+});

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -655,6 +655,64 @@ services:
       const entry = await registry.get('cloned-app');
       expect(entry?.version).toBe('2.3.4');
     });
+
+    it('auto-resolves the default branch HEAD when no commit is given', async () => {
+      // The install must not require a user-supplied commit: when omitted, the
+      // installer resolves HEAD via `git ls-remote` and pins that commit.
+      const resolved = 'abcdef0123456789abcdef0123456789abcdef01'; // 40-hex
+      const githubUrl = 'https://github.com/test/headless-app';
+
+      let lsRemoteCalled = false;
+      const resolveSpawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          lsRemoteCalled = true;
+          // git ls-remote <url> HEAD → "<sha>\tHEAD"
+          return { stdout: `${resolved}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: headless-app
+version: 1.0.0
+commit: "${resolved}"
+services:
+  app:
+    image: nginx:1.25
+    ports:
+      - name: api
+        host: 5300
+        container: 5300
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:5300/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+
+      const installer = makeInstaller(resolveSpawn);
+      const jobId = installer.install({ githubUrl }); // no commit
+      const job = await waitForJob(installer, jobId, 5000);
+
+      expect(job.status).toBe('completed');
+      expect(lsRemoteCalled).toBe(true);
+      // the resolved HEAD is pinned in the registry entry
+      const entry = await registry.get('headless-app');
+      expect(entry?.commit).toBe(resolved);
+      // and the fetch pins the resolved commit, not a branch name
+      expect(
+        resolveSpawn.mock.calls.some(
+          (c) => c[0] === 'git' && c[1][0] === 'fetch' && c[1].includes(resolved),
+        ),
+      ).toBe(true);
+      // the resolved commit is surfaced in the job logs
+      expect(job.logs.join('\n')).toContain(`Resolved HEAD → ${resolved.slice(0, 8)}`);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Installing an app from a GitHub URL stalled: the agent told the user to open the repo, find a 40-char commit hash, and paste it back — even though the backend already resolves the default-branch HEAD automatically when no commit is given. This aligns the instruction/contract layer with the backend so a bare `github_url` install just works.

## Related Issue

Closes #257

## Root cause

The blockers were documentation/instruction only — the backend already supported commit-less installs:

- `src/apps/installer.ts:934-941` — `resolveSource()` runs `git ls-remote <url> HEAD`, pins the resolved commit, and logs `Resolved HEAD → <short>` when `commit` is omitted.
- `mcp/tools/apps/module.ts` handler + `src/api/apps-router.ts:84-94` — `commit` is optional.
- `API.md:2799` already documents `commit` — *"Omit to auto-resolve HEAD."*

But `install-app/SKILL.md` (Step 1, arg format, notes) told the agent to require a 40-hex commit and **stop**, and the `install_app` MCP tool described `commit` as *"required with github_url"* — so agents demanded a hash from the user.

## Changes Made

- `mcp/tools/apps/skills/install-app/SKILL.md`: commit is optional for GitHub installs. If supplied, validate 40-hex; if omitted, install with just `github_url` and let the installer resolve HEAD (do not ask the user to find one). Report the resolved commit on completion.
- `mcp/tools/apps/module.ts`: `install_app` presents `commit` as optional (omit to auto-resolve the default-branch HEAD); `github_url` no longer claims it "requires commit".
- `tests/unit/apps/installer.test.ts`: new test — a `github_url` install with no `commit` resolves HEAD via `git ls-remote`, pins the resolved commit in the registry entry, fetches that commit, and logs `Resolved HEAD → <short>`.
- `tests/unit/apps-module.test.ts` (new): guards that `install_app` does not present `commit` as required and signals the optional/auto-resolve behavior. **Verified this guard fails on the pre-fix description.**

## Testing

- `npm run typecheck`: pass
- Affected suites (`apps/installer`, `apps-module`, `apps/compose-generator`) + known-flaky suites in isolation: 153/153 pass
- `npm test`: all 2600+ tests pass; the only red is a pre-existing parallel-worker-race flake that lands on a different suite each run (`workspace-loader` / `cron-manager`) and passes in isolation — unrelated to this change (no core logic touched)

## Note

This is an instruction/contract fix — no runtime logic changed, because the backend already auto-resolved HEAD. The regression evidence is the `apps-module` description guard (fails on the old `install_app` description) plus the new installer test locking in the commit-less resolve contract the skill now relies on.