### PR TITLE
feat(apps): support update for GitHub-URL-installed apps

### DIFF
--- a/API.md
+++ b/API.md
@@ -3005,7 +3005,12 @@ For custom/local apps, `latest` and `latest_commit` are `null` and `updateable` 
 
 ### POST /api/v1/apps/:name/update
 
-Start an async update to the latest registry version. Uses blue/green swap: build new version in `/tmp/`, stop old containers, start new, swap directories, rollback automatically if new containers fail health check.
+Start an async update. Uses blue/green swap: build new version in `/tmp/`, stop old containers, start new, swap directories, rollback automatically if new containers fail health check. The `.env` from the previous install is copied forward, so volumes and secrets are preserved.
+
+The update target depends on the app's `source`:
+- `registry` — the latest published registry version.
+- `custom` (installed from a GitHub URL) — the current default-branch `HEAD` of the app's repo, resolved via `git ls-remote`. If the resolved commit already matches the installed one, the job completes as a no-op.
+- `local` (symlinked directory) — not updatable; returns `400`.
 
 ```bash
 curl -X POST \
@@ -3023,7 +3028,7 @@ Poll the returned `jobId` with `GET /api/v1/apps/jobs/:jobId` to track progress.
 
 | Status | When |
 |--------|------|
-| 400 | App source is `custom` or `local` (cannot be updated via this endpoint) |
+| 400 | App source is `local` (symlinked apps cannot be updated) |
 | 403 | Not an admin key |
 | 404 | App not installed |
 

--- a/mcp/tools/apps/module.ts
+++ b/mcp/tools/apps/module.ts
@@ -99,7 +99,7 @@ export class AppsModule implements ToolModule {
       },
       {
         name: 'update_app',
-        description: 'Update a registry-installed app to its latest version. Returns a jobId.',
+        description: 'Update an installed app. Registry apps update to their latest published version; GitHub-URL (custom) apps update to their repo default-branch HEAD. Returns a jobId.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -3,16 +3,7 @@ import { ApiKey } from '../types';
 import { createApiAuthMiddleware, isAdmin } from './auth';
 import { AppsRegistry } from '../apps/registry';
 import { AppInstaller } from '../apps/installer';
-import { RegistryClient, RegistryVersion } from '../apps/registry-client';
-
-function selectLatest(versions: RegistryVersion[]): RegistryVersion | undefined {
-  if (versions.length === 0) return undefined;
-  const withDate = versions.filter((v) => v.approved_at);
-  if (withDate.length > 0) {
-    return withDate.reduce((a, b) => (a.approved_at > b.approved_at ? a : b));
-  }
-  return versions[versions.length - 1];
-}
+import { RegistryClient } from '../apps/registry-client';
 
 type AuthedRequest = Request & { apiKey: ApiKey };
 
@@ -183,51 +174,15 @@ export function createAppsRouter(
         return;
       }
 
-      if (entry.source !== 'registry') {
-        res.json({
-          installed: entry.version,
-          installed_commit: entry.commit,
-          latest: null,
-          latest_commit: null,
-          behind: false,
-          updateable: false,
-        });
-        return;
-      }
-
-      try {
-        const app = await registryClient.findApp(entry.name);
-        if (!app) {
-          res.json({
-            installed: entry.version,
-            installed_commit: entry.commit,
-            latest: null,
-            latest_commit: null,
-            behind: false,
-            updateable: false,
-          });
-          return;
-        }
-        const latest = selectLatest(app.versions);
-        res.json({
-          installed: entry.version,
-          installed_commit: entry.commit,
-          latest: latest?.version ?? null,
-          latest_commit: latest?.commit ?? null,
-          behind: latest ? latest.commit !== entry.commit : false,
-          updateable: latest ? latest.commit !== entry.commit : false,
-        });
-      } catch {
-        // Registry unreachable — return what we know
-        res.json({
-          installed: entry.version,
-          installed_commit: entry.commit,
-          latest: null,
-          latest_commit: null,
-          behind: false,
-          updateable: false,
-        });
-      }
+      const info = await installer.getUpdateInfo(entry);
+      res.json({
+        installed: entry.version,
+        installed_commit: entry.commit,
+        latest: info.latestVersion,
+        latest_commit: info.latestCommit,
+        behind: info.updateable,
+        updateable: info.updateable,
+      });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -247,9 +247,9 @@ export function createAppsRouter(
         res.status(404).json({ error: `App "${req.params.name}" not found` });
         return;
       }
-      if (entry.source !== 'registry') {
+      if (entry.source === 'local') {
         res.status(400).json({
-          error: 'Only registry-installed apps can be updated via this endpoint',
+          error: 'Local (symlinked) apps cannot be updated — reinstall from source instead',
         });
         return;
       }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -680,17 +680,14 @@ export class AppInstaller {
 
     const entry = await this.registry.get(appName);
     if (!entry) throw new Error(`App "${appName}" is not installed`);
-    if (entry.source !== 'registry') {
-      throw new Error('Only registry-installed apps can be updated via this endpoint');
-    }
 
-    // Resolve latest version
-    const app = await this.registryClient.findApp(appName);
-    if (!app) throw new Error(`App "${appName}" not found in registry`);
-    const latest = selectLatest(app.versions);
-    if (!latest) throw new Error(`No versions available for "${appName}"`);
+    // Resolve the repo + target commit for this app's source. Registry apps
+    // resolve the latest published version; GitHub-installed apps resolve the
+    // default branch HEAD via git ls-remote. Local (symlinked) apps have no
+    // remote to pull and are not updatable.
+    const target = await this.resolveUpdateTarget(entry);
 
-    if (latest.commit === entry.commit) {
+    if (target.newCommit === entry.commit) {
       job.status = 'completed';
       job.result = {
         appName,
@@ -699,26 +696,31 @@ export class AppInstaller {
         agentDeclaration: entry.agentDeclaration ?? null,
       };
       job.updatedAt = Date.now();
-      this.log(job, `Already at latest version ${entry.version}`);
+      this.log(job, `Already at latest commit ${entry.commit.slice(0, 8)}`);
       return;
     }
 
-    this.log(job, `Updating ${appName} from ${entry.version} → ${latest.version}`);
+    this.log(job, `Updating ${appName} ${entry.commit.slice(0, 8)} → ${target.newCommit.slice(0, 8)}`);
 
     const tmpDir = path.join(os.tmpdir(), `cg-update-${appName}-${crypto.randomUUID()}`);
     try {
       // ── Shallow fetch of specific commit into tmp dir ─────────────────────
-      this.log(job, `Cloning ${app.repo}`);
+      this.log(job, `Cloning ${target.repo}`);
       fs.mkdirSync(tmpDir, { recursive: true });
       this.run(['git', 'init'], tmpDir);
-      this.run(['git', 'remote', 'add', 'origin', app.repo], tmpDir);
-      this.run(['git', 'fetch', '--depth', '1', 'origin', latest.commit], tmpDir);
+      this.run(['git', 'remote', 'add', 'origin', target.repo], tmpDir);
+      this.run(['git', 'fetch', '--depth', '1', 'origin', target.newCommit], tmpDir);
       this.run(['git', 'checkout', 'FETCH_HEAD'], tmpDir);
 
       const yamlContent = fs.readFileSync(path.join(tmpDir, 'app.yaml'), 'utf-8');
       const appYaml = parseAppYaml(yamlContent, tmpDir);
       const composePath = path.join(tmpDir, 'docker-compose.yml');
       const generated = generateCompose(appYaml, appName, tmpDir, composePath);
+
+      // Registry apps carry the published version; GitHub installs read it
+      // from the freshly-fetched app.yaml.
+      const newVersion = target.registryVersion ?? appYaml.version;
+      this.log(job, `New version ${newVersion}`);
 
       for (const w of generated.warnings) {
         this.log(job, `Warning: ${w}`);
@@ -738,8 +740,8 @@ export class AppInstaller {
 
       const newEntry: AppEntry = {
         ...entry,
-        version: latest.version,
-        commit: latest.commit,
+        version: newVersion,
+        commit: target.newCommit,
         installPath: tmpDir,
         ...(generated.agentDeclaration !== null ? { agentDeclaration: generated.agentDeclaration } : {}),
         ...(agentPaths ? { agentPaths } : {}),
@@ -856,7 +858,7 @@ export class AppInstaller {
         agentDeclaration: generated.agentDeclaration,
       };
       job.updatedAt = Date.now();
-      this.log(job, `Update complete → ${latest.version}`);
+      this.log(job, `Update complete → ${newVersion}`);
 
     } catch (err) {
       if (fs.existsSync(tmpDir)) {
@@ -864,6 +866,40 @@ export class AppInstaller {
       }
       throw err;
     }
+  }
+
+  /**
+   * Resolve the repo URL and target commit to update an installed app to.
+   * - `registry`: latest published version via the registry client.
+   * - `custom` (GitHub URL install): the default branch HEAD via git ls-remote,
+   *   so the app follows its repo without a data-destroying reinstall.
+   * - `local` (symlinked dir): not updatable — there is no remote to pull.
+   */
+  private async resolveUpdateTarget(
+    entry: AppEntry,
+  ): Promise<{ repo: string; newCommit: string; registryVersion?: string }> {
+    if (entry.source === 'registry') {
+      const app = await this.registryClient.findApp(entry.name);
+      if (!app) throw new Error(`App "${entry.name}" not found in registry`);
+      const latest = selectLatest(app.versions);
+      if (!latest) throw new Error(`No versions available for "${entry.name}"`);
+      return { repo: app.repo, newCommit: latest.commit, registryVersion: latest.version };
+    }
+
+    if (entry.source === 'custom') {
+      const url = entry.githubUrl;
+      if (!url || !GITHUB_URL_RE.test(url)) {
+        throw new Error(`App "${entry.name}" has no valid GitHub URL to update from`);
+      }
+      const { stdout } = this.run(['git', 'ls-remote', url, 'HEAD'], process.cwd());
+      const match = stdout.trim().match(/^([0-9a-f]{40})\s+HEAD/);
+      if (!match) throw new Error(`Could not resolve HEAD commit for ${url}`);
+      return { repo: url, newCommit: match[1] };
+    }
+
+    throw new Error(
+      `App "${entry.name}" is installed from a local path and cannot be updated — reinstall from source instead`,
+    );
   }
 
   private async resolveSource(

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -869,6 +869,31 @@ export class AppInstaller {
   }
 
   /**
+   * Report whether an installed app has a newer version/commit available,
+   * without performing the update. Mirrors the resolution `runUpdate` uses:
+   * registry apps compare against the latest published version, custom apps
+   * against the repo default-branch HEAD, and local apps are never updatable.
+   * Never throws — a registry/network failure is reported as not-updatable.
+   */
+  async getUpdateInfo(
+    entry: AppEntry,
+  ): Promise<{ latestVersion: string | null; latestCommit: string | null; updateable: boolean }> {
+    if (entry.source === 'local') {
+      return { latestVersion: null, latestCommit: null, updateable: false };
+    }
+    try {
+      const target = await this.resolveUpdateTarget(entry);
+      return {
+        latestVersion: target.registryVersion ?? null,
+        latestCommit: target.newCommit,
+        updateable: target.newCommit !== entry.commit,
+      };
+    } catch {
+      return { latestVersion: null, latestCommit: null, updateable: false };
+    }
+  }
+
+  /**
    * Resolve the repo URL and target commit to update an installed app to.
    * - `registry`: latest published version via the registry client.
    * - `custom` (GitHub URL install): the default branch HEAD via git ls-remote,

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -46,6 +46,7 @@ function makeEntry(overrides: Partial<AppEntry> = {}): AppEntry {
 function makeInstaller(
   registry: AppsRegistry,
   appsDir?: string,
+  spawn?: (cmd: string, args: string[], opts?: object) => { stdout: string; stderr: string; status: number },
 ): { installer: AppInstaller; callbacks: InstallerCallbacks } {
   const callbacks: InstallerCallbacks = {
     registerRoutes: jest.fn((_appName: string, _ports: ComposePort[]) => {}),
@@ -57,7 +58,7 @@ function makeInstaller(
     registry,
     new RegistryClient(),
     callbacks,
-    jest.fn().mockReturnValue({ stdout: '', stderr: '', status: 0 }),
+    (spawn ?? jest.fn().mockReturnValue({ stdout: '', stderr: '', status: 0 })) as ConstructorParameters<typeof AppInstaller>[3],
     appsDir ?? makeTmpDir(),
   );
   return { installer, callbacks };
@@ -92,10 +93,11 @@ const VALID_REGISTRY_APPS = [
 function makeApp(
   registry: AppsRegistry,
   registryClient: RegistryClient,
+  spawn?: (cmd: string, args: string[], opts?: object) => { stdout: string; stderr: string; status: number },
 ): express.Application {
   const app = express();
   app.use(express.json());
-  const { installer } = makeInstaller(registry);
+  const { installer } = makeInstaller(registry, undefined, spawn);
   app.use('/api', createAppsRouter(registry, installer, registryClient, API_KEYS));
   return app;
 }
@@ -334,13 +336,52 @@ describe('createAppsRouter()', () => {
       expect(res.status).toBe(404);
     });
 
-    it('returns updateable: false for custom/local apps', async () => {
-      await registry.upsert(makeEntry({ source: 'custom' }));
+    it('returns updateable: false for local apps', async () => {
+      await registry.upsert(makeEntry({ source: 'local' }));
       const res = await request(app)
         .get('/api/v1/apps/test-app/version')
         .set('Authorization', `Bearer ${READ_KEY.key}`);
       expect(res.status).toBe(200);
       expect(res.body.updateable).toBe(false);
+      expect(res.body.latest_commit).toBeNull();
+    });
+
+    it('reports a custom app as updateable when its repo HEAD has moved', async () => {
+      const newHead = 'b'.repeat(40);
+      const spawn = jest.fn((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${newHead}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const customApp = makeApp(registry, registryClient, spawn);
+      await registry.upsert(makeEntry({ source: 'custom', commit: 'a'.repeat(40) }));
+
+      const res = await request(customApp)
+        .get('/api/v1/apps/test-app/version')
+        .set('Authorization', `Bearer ${READ_KEY.key}`);
+      expect(res.status).toBe(200);
+      expect(res.body.updateable).toBe(true);
+      expect(res.body.latest_commit).toBe(newHead);
+    });
+
+    it('reports a custom app as not updateable when already at HEAD', async () => {
+      const head = 'a'.repeat(40);
+      const spawn = jest.fn((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const customApp = makeApp(registry, registryClient, spawn);
+      await registry.upsert(makeEntry({ source: 'custom', commit: head }));
+
+      const res = await request(customApp)
+        .get('/api/v1/apps/test-app/version')
+        .set('Authorization', `Bearer ${READ_KEY.key}`);
+      expect(res.status).toBe(200);
+      expect(res.body.updateable).toBe(false);
+      expect(res.body.latest_commit).toBe(head);
     });
 
     it('returns version info for registry app', async () => {

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -714,6 +714,112 @@ services:
       expect(job.logs.join('\n')).toContain(`Resolved HEAD → ${resolved.slice(0, 8)}`);
     });
   });
+
+  // ── update() — GitHub-installed (custom) apps (issue #259) ────────────────
+  describe('update() — custom (GitHub) apps', () => {
+    function readEnvFile(appDir: string): Record<string, string> {
+      const content = fs.readFileSync(path.join(appDir, '.env'), 'utf-8');
+      const out: Record<string, string> = {};
+      for (const line of content.split('\n')) {
+        const i = line.indexOf('=');
+        if (i > 0) out[line.slice(0, i)] = line.slice(i + 1);
+      }
+      return out;
+    }
+
+    // Spawn mock whose ls-remote HEAD and app.yaml (written on checkout) are
+    // driven by a mutable `state`, so one installer can install at one commit
+    // then update to another.
+    function makeGitState(appName: string, port: number) {
+      const state = { head: 'a'.repeat(40), version: '1.0.0' };
+      const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: nginx:1.25
+    ports:
+      - name: api
+        host: ${port}
+        container: ${port}
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:${port}/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      return { state, spawn };
+    }
+
+    it('updates a GitHub-installed app to the new default-branch HEAD, preserving .env', async () => {
+      const githubUrl = 'https://github.com/test/custom-app';
+      const { state, spawn } = makeGitState('custom-app', 5400);
+      const installer = makeInstaller(spawn);
+
+      // Install at HEAD "aaaa…" with a secret that must survive the update
+      state.head = 'a'.repeat(40);
+      state.version = '1.0.0';
+      await waitForJob(installer, installer.install({ githubUrl, envVars: { APP_SECRET: 'keep-me' } }), 5000);
+
+      let entry = await registry.get('custom-app');
+      expect(entry?.source).toBe('custom');
+      expect(entry?.commit).toBe('a'.repeat(40));
+      expect(readEnvFile(entry!.installPath)['APP_SECRET']).toBe('keep-me');
+
+      // Default branch advances → update should follow HEAD
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      const job = await waitForJob(installer, installer.update('custom-app'), 5000);
+      expect(job.status).toBe('completed');
+
+      entry = await registry.get('custom-app');
+      expect(entry?.commit).toBe('b'.repeat(40));
+      expect(entry?.version).toBe('2.0.0');
+      // secret (and therefore volumes) preserved via .env copy-forward
+      expect(readEnvFile(entry!.installPath)['APP_SECRET']).toBe('keep-me');
+    });
+
+    it('is a no-op when the custom app is already at HEAD', async () => {
+      const githubUrl = 'https://github.com/test/steady-app';
+      const { state, spawn } = makeGitState('steady-app', 5401);
+      const installer = makeInstaller(spawn);
+
+      state.head = 'c'.repeat(40);
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+
+      // HEAD unchanged → update completes without rebuilding
+      const job = await waitForJob(installer, installer.update('steady-app'), 5000);
+      expect(job.status).toBe('completed');
+      expect(job.logs.join('\n')).toContain(`Already at latest commit ${'c'.repeat(8)}`);
+
+      const entry = await registry.get('steady-app');
+      expect(entry?.commit).toBe('c'.repeat(40));
+    });
+
+    it('rejects updating a local (symlinked) app', async () => {
+      const appDir = makeAppDir(srcDir, 'local-app', 5402);
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+      expect((await registry.get('local-app'))?.source).toBe('local');
+
+      const job = await waitForJob(installer, installer.update('local-app'), 5000);
+      expect(job.status).toBe('failed');
+      expect(job.error).toMatch(/local path|cannot be updated/i);
+    });
+  });
 });
 
 // ─── Utility ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

An app installed from a GitHub URL (`source: 'custom'`) could not be updated — `update_app` rejected any non-registry app, so the only way to pick up new commits was `uninstall_app` + `install_app`, which drops the app's Docker volumes and destroys its data. This makes GitHub-installed apps update in place by following their repo's default-branch `HEAD`, using the same blue/green swap (and `.env` copy-forward) as registry updates.

## Related Issue

Closes #259

## Root cause

`runUpdate` resolved the update target only through the registry (`registryClient.findApp` + `selectLatest`), so `installer.ts` guarded with `entry.source !== 'registry' → throw`. But the `AppEntry` already stores `githubUrl` + `commit`, the install path already resolves HEAD via `git ls-remote` (`installer.ts:934-941`), and the update pipeline (clone → build → blue/green swap, copying the old `.env`) is source-agnostic — only the repo URL and target commit were registry-specific.

## Changes Made

- `src/apps/installer.ts`: extracted `resolveUpdateTarget(entry)` — `registry` resolves the latest published version (unchanged); `custom` resolves the default-branch HEAD via `git ls-remote <githubUrl> HEAD` (URL re-validated with `GITHUB_URL_RE`) with the new version read from the fetched `app.yaml`; `local` stays rejected. The shared clone→build→swap body is reused verbatim, and the old `.env` copy-forward is untouched, so volumes/secrets survive.
- `src/api/apps-router.ts`: the `POST /apps/:name/update` guard now rejects only `source: 'local'` (was: everything non-registry).
- `API.md`: update endpoint documents the per-source behavior; the 400 row is now `local`-only.
- `mcp/tools/apps/module.ts`: `update_app` description covers registry **and** GitHub-installed apps.

## Testing

- `npm run typecheck`: pass
- `npm test`: **141 suites / 2668 tests pass** (fully green)
- New `tests/unit/apps/installer.test.ts` cases: a custom app updates to a new HEAD (asserting the `.env`/secret is preserved), a no-op when already at HEAD, and a `local` app is rejected. **All three were verified to fail on the pre-fix code.**

## Acceptance criteria

- [x] A `custom` app updates in place when its default branch advances, pinning the resolved commit
- [x] A custom app already at HEAD is a no-op
- [x] The existing `.env` (volumes/secrets) is preserved across the update
- [x] `local` installs still return a clear "cannot update" error
- [x] Blue/green rollback still applies to custom updates (shared pipeline)
- [x] `API.md` + `update_app` MCP description no longer say updates are registry-only
- [x] Regression tests cover custom-update / no-op / local-reject / env-preservation and fail on pre-fix code