### PR TITLE
fix(apps): don't orphan root-owned files when install/update rollback cleans up

### DIFF
--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -665,9 +665,16 @@ export class AppInstaller {
         if (stat.isSymbolicLink()) {
           fs.unlinkSync(appDir);
         } else {
-          fs.rmSync(appDir, { recursive: true, force: true });
+          this.rmrf(appDir);
         }
-      } catch { /* already gone */ }
+      } catch (cleanupErr) {
+        // Directory may already be gone — that's fine. Anything else (e.g. a
+        // root-owned file the sudo fallback still couldn't remove) leaves an
+        // orphan on disk, so surface it in the logs instead of swallowing.
+        if ((cleanupErr as NodeJS.ErrnoException).code !== 'ENOENT') {
+          this.log(job, `Warning: rollback could not fully remove "${appDir}": ${(cleanupErr as Error).message}`);
+        }
+      }
       throw err;
     }
   }
@@ -795,7 +802,7 @@ export class AppInstaller {
           rollbackFailed = true;
           this.log(job, `ROLLBACK FAILED — app "${appName}" may be in a broken state: ${(rollbackErr as Error).message}`);
         }
-        fs.rmSync(tmpDir, { recursive: true, force: true });
+        this.rmrf(tmpDir);
         if (rollbackFailed) {
           throw new Error(`Update failed and rollback also failed — app "${appName}" may be in a broken state. Check job logs for details.`);
         }
@@ -842,7 +849,7 @@ export class AppInstaller {
       try {
         this.run(['docker', 'compose', '-p', appName, 'down', '--rmi', 'all'], oldBackupDir, 120_000);
       } catch { /* non-fatal */ }
-      fs.rmSync(oldBackupDir, { recursive: true, force: true });
+      this.rmrf(oldBackupDir);
 
       // ── Build result ──────────────────────────────────────────────────────
       const proxyUrls: Record<string, string> = {};
@@ -862,7 +869,7 @@ export class AppInstaller {
 
     } catch (err) {
       if (fs.existsSync(tmpDir)) {
-        fs.rmSync(tmpDir, { recursive: true, force: true });
+        this.rmrf(tmpDir);
       }
       throw err;
     }
@@ -1023,8 +1030,11 @@ export class AppInstaller {
     try {
       fs.rmSync(dirPath, { recursive: true, force: true });
     } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code === 'EACCES') {
-        console.warn(`[installer] EACCES removing "${dirPath}" — falling back to sudo rm -rf`);
+      const code = (err as NodeJS.ErrnoException).code;
+      // Containers running as root leave root-owned files (e.g. postgres pgdata)
+      // that the gateway user cannot delete — fs.rmSync surfaces EACCES or EPERM.
+      if (code === 'EACCES' || code === 'EPERM') {
+        console.warn(`[installer] ${code} removing "${dirPath}" — falling back to sudo rm -rf`);
         this.run(['sudo', 'rm', '-rf', dirPath]);
       } else {
         throw err;

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -802,7 +802,7 @@ export class AppInstaller {
           rollbackFailed = true;
           this.log(job, `ROLLBACK FAILED — app "${appName}" may be in a broken state: ${(rollbackErr as Error).message}`);
         }
-        this.rmrf(tmpDir);
+        this.safeRmrf(tmpDir, job, 'update temp dir');
         if (rollbackFailed) {
           throw new Error(`Update failed and rollback also failed — app "${appName}" may be in a broken state. Check job logs for details.`);
         }
@@ -849,7 +849,7 @@ export class AppInstaller {
       try {
         this.run(['docker', 'compose', '-p', appName, 'down', '--rmi', 'all'], oldBackupDir, 120_000);
       } catch { /* non-fatal */ }
-      this.rmrf(oldBackupDir);
+      this.safeRmrf(oldBackupDir, job, 'old backup dir');
 
       // ── Build result ──────────────────────────────────────────────────────
       const proxyUrls: Record<string, string> = {};
@@ -869,7 +869,7 @@ export class AppInstaller {
 
     } catch (err) {
       if (fs.existsSync(tmpDir)) {
-        this.rmrf(tmpDir);
+        this.safeRmrf(tmpDir, job, 'update temp dir');
       }
       throw err;
     }
@@ -1038,6 +1038,22 @@ export class AppInstaller {
         this.run(['sudo', 'rm', '-rf', dirPath]);
       } else {
         throw err;
+      }
+    }
+  }
+
+  /**
+   * Best-effort directory removal for cleanup paths where a failure must not
+   * abort the operation (e.g. deleting a post-update backup, or a tmp clone
+   * during rollback). Logs a warning instead of throwing so a cleanup error
+   * never masks a successful result or the original failure.
+   */
+  private safeRmrf(dirPath: string, job: JobState, label: string): void {
+    try {
+      this.rmrf(dirPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        this.log(job, `Warning: failed to remove ${label} "${dirPath}": ${(err as Error).message}`);
       }
     }
   }

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -819,6 +819,77 @@ services:
       expect(job.status).toBe('failed');
       expect(job.error).toMatch(/local path|cannot be updated/i);
     });
+
+    const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+    // A cleanup failure on the post-update backup dir must not fail an
+    // already-successful update (issue #261 self-review). As root the dir is
+    // always removable, so the scenario can't occur.
+    (isRoot ? it.skip : it)(
+      'completes the update even when the old backup dir cannot be removed',
+      async () => {
+        const githubUrl = 'https://github.com/test/backup-app';
+        const appName = 'backup-app';
+        const state = { head: 'a'.repeat(40), version: '1.0.0' };
+        const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+          if (cmd === 'git' && args[0] === 'ls-remote') {
+            return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+          }
+          if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+            fs.writeFileSync(
+              path.join(opts.cwd, 'app.yaml'),
+              `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: nginx:1.25
+    ports:
+      - name: api
+        host: 5600
+        container: 5600
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:5600/health
+      interval: 30s
+`.trim(),
+              'utf-8',
+            );
+          }
+          // The sudo fallback also fails, so removal genuinely cannot complete.
+          if (cmd === 'sudo') return { stdout: '', stderr: 'mock: sudo denied', status: 1 };
+          return { stdout: '', stderr: '', status: 0 };
+        });
+        const installer = makeInstaller(spawn);
+
+        await waitForJob(installer, installer.install({ githubUrl }), 5000);
+        const appDir = path.join(appsDir, appName);
+        // Make the installed dir un-removable — after the swap it becomes the
+        // old backup dir the post-update cleanup tries (and fails) to delete.
+        const locked = path.join(appDir, 'pgdata');
+        fs.mkdirSync(locked);
+        fs.writeFileSync(path.join(locked, 'PG_VERSION'), '16');
+        fs.chmodSync(locked, 0o000);
+
+        try {
+          state.head = 'b'.repeat(40);
+          state.version = '2.0.0';
+          const job = await waitForJob(installer, installer.update(appName), 5000);
+
+          // Update itself succeeded — the backup-cleanup failure must not flip it to failed.
+          expect(job.status).toBe('completed');
+          expect((await registry.get(appName))?.commit).toBe('b'.repeat(40));
+          expect(job.logs.join('\n')).toMatch(/failed to remove old backup dir/i);
+        } finally {
+          for (const d of fs.readdirSync(appsDir)) {
+            if (d.startsWith(appName)) {
+              try { fs.chmodSync(path.join(appsDir, d, 'pgdata'), 0o755); } catch { /* n/a */ }
+            }
+          }
+        }
+      },
+    );
   });
 
   // ── Rollback cleanup of root-owned / undeletable app dirs (issue #261) ─────

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -820,6 +820,83 @@ services:
       expect(job.error).toMatch(/local path|cannot be updated/i);
     });
   });
+
+  // ── Rollback cleanup of root-owned / undeletable app dirs (issue #261) ─────
+  describe('install rollback — undeletable (root-owned) app directory', () => {
+    // Emulate the prod failure: a GitHub install clones successfully, a
+    // container leaves behind a directory the gateway user cannot traverse
+    // (stand-in for root-owned postgres/pgdata), then `docker compose up`
+    // fails. The rollback's fs.rmSync then throws EACCES and must escalate to
+    // `sudo rm -rf` instead of silently orphaning the directory.
+    function makeFailingGitSpawn(appName: string, port: number, head: string) {
+      return jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: 1.0.0
+commit: "${head}"
+services:
+  app:
+    image: postgres:16-alpine
+    ports:
+      - name: api
+        host: ${port}
+        container: ${port}
+        type: api
+    healthcheck:
+      test: pg_isready
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+          // Stand-in for a root-owned bind mount: a dir this user can't recurse.
+          const locked = path.join(opts.cwd, 'pgdata');
+          fs.mkdirSync(locked);
+          fs.writeFileSync(path.join(locked, 'PG_VERSION'), '16');
+          fs.chmodSync(locked, 0o000);
+        }
+        if (args.some((a) => a === 'up')) {
+          return { stdout: '', stderr: 'mock: compose up failed', status: 1 };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+    // As root the scenario can't occur (root deletes anything), so skip.
+    (isRoot ? it.skip : it)(
+      'escalates to sudo rm -rf when rollback hits an EACCES app dir instead of swallowing it',
+      async () => {
+        const githubUrl = 'https://github.com/test/rollback-app';
+        const appDir = path.join(appsDir, 'rollback-app');
+        const locked = path.join(appDir, 'pgdata');
+        const spawn = makeFailingGitSpawn('rollback-app', 5500, 'e'.repeat(40));
+        const installer = makeInstaller(spawn);
+
+        try {
+          const job = await waitForJob(installer, installer.install({ githubUrl }), 5000);
+          expect(job.status).toBe('failed'); // install failed at compose up
+
+          // The rollback must escalate to `sudo rm -rf <appDir>` rather than
+          // silently swallowing EACCES and orphaning the directory.
+          const sawSudoRm = spawn.mock.calls.some(
+            (c) => c[0] === 'sudo' && Array.isArray(c[1]) && c[1].join(' ') === `rm -rf ${appDir}`,
+          );
+          expect(sawSudoRm).toBe(true);
+        } finally {
+          // Restore perms so the leftover tmp dir can be cleaned up.
+          try { fs.chmodSync(locked, 0o755); } catch { /* already gone */ }
+          try { fs.rmSync(appDir, { recursive: true, force: true }); } catch { /* ignore */ }
+        }
+      },
+    );
+  });
 });
 
 // ─── Utility ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

A failed app install that had already started containers left a partial app directory on disk with no error reported. The rollback removed the dir with raw `fs.rmSync` (no privilege escalation) inside a `catch { /* already gone */ }` that swallowed the failure, so root-owned files a container created (e.g. `postgres/pgdata`) couldn't be deleted and the rest of the directory was orphaned silently.

## Related Issue

Closes #261

## Root cause (proven with live prod evidence)

On prod (gateway v1.5.3), a postgres-backed app install failed. Result:
- `apps.json` had no entry for the app (rollback removed it at `installer.ts:654`).
- The app dir still existed with `postgres/pgdata` owned by `root:root` (mode `700`) plus the files `fs.rmSync` reached before throwing, while `.env`/`app.yaml`/`Dockerfile`/`package.json`/`docker-compose.yml` were gone.
- No error surfaced — the `catch {}` at `installer.ts:663-670` discarded the `EACCES`.

`uninstall` and orphan-cleanup already used `this.rmrf()` (which escalates to `sudo rm -rf`), but the install rollback and the update cleanup paths used raw `fs.rmSync`, and `rmrf` only escalated on `EACCES` (not `EPERM`).

## Changes Made

- `src/apps/installer.ts`:
  - Use `this.rmrf()` for the install rollback (`appDir`) and the update paths (`tmpDir` on failed compose-up, `oldBackupDir`, `tmpDir` on outer catch) — every removal that can hit container-created root-owned files.
  - Broaden `rmrf`'s `sudo rm -rf` fallback to fire on `EACCES` **or** `EPERM`.
  - In the install rollback, log a warning when cleanup still fails instead of swallowing it — without rethrowing, so the original install error still surfaces.

## Testing

- `npm run typecheck`: pass
- `npm test`: 2555/2555 tests pass (the only red is a pre-existing parallel-worker-race flake — a suite-level crash with zero failing tests that lands on a different suite each run and passes in isolation)
- New regression test (`tests/unit/apps/installer.test.ts`): a failed GitHub install whose app dir contains an unreadable (EACCES) directory now escalates to `sudo rm -rf` instead of orphaning the dir. **Verified it fails on the pre-fix code** (old rollback swallows the error and never escalates). Skipped when the test runs as root, where the scenario can't occur.

## Notes

- The `EPERM` half of the broadened fallback shares the exact same escalation branch as `EACCES`; the regression test exercises `EACCES` (the only permission error reproducible without root in a unit test).
- Out of scope: preventing the install failure itself, rootless containers, and cleaning up orphan dirs already left on disk by the pre-fix code.