### PR TITLE
fix(apps): reclaim orphaned agent registration instead of blocking reinstall

### DIFF
--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -203,7 +203,13 @@ export class AgentManager {
    */
   async deleteAgentByName(agentName: string): Promise<void> {
     const workspaceLink = path.join(this.agentsDir, agentName, 'workspace');
-    try { fs.rmSync(workspaceLink, { force: true }); } catch { /* already gone */ }
+    // Only remove the symlink an app-agent owns — never a user agent's real
+    // workspace directory that may sit at the same path under a shared name.
+    try {
+      if (fs.lstatSync(workspaceLink).isSymbolicLink()) {
+        fs.rmSync(workspaceLink, { force: true });
+      }
+    } catch { /* already gone */ }
     await this.removeConfigEntry(agentName);
   }
 
@@ -306,7 +312,11 @@ export class AgentManager {
   private async removeConfigEntry(agentId: string): Promise<void> {
     return this.withConfigLock(() => {
       const config = this.readConfig();
-      config.agents = config.agents.filter((a) => a['id'] !== agentId);
+      // Only ever remove the app-agent entry — never a user-created agent that
+      // happens to share the same id. All callers operate on app agents.
+      config.agents = config.agents.filter(
+        (a) => !(a['id'] === agentId && a['type'] === 'app-agent'),
+      );
       this.writeConfig(config);
     });
   }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -467,11 +467,25 @@ export class AppInstaller {
 
     // Conflict check — agent name (if app declares an agent), inside install lock
     if (generated.agentDeclaration && this.agentManager) {
-      const conflict = await this.agentManager.findAgentByName(generated.agentDeclaration.name);
+      const agentName = generated.agentDeclaration.name;
+      const conflict = await this.agentManager.findAgentByName(agentName);
       if (conflict) {
-        throw new Error(
-          `Agent name "${generated.agentDeclaration.name}" is already registered — agent name conflict`,
+        // The agent is registered in config.json — but is it owned by an app that
+        // is actually installed? If a different installed app declares it, that's a
+        // real conflict. If no installed app owns it, it's an orphan left behind by
+        // a prior install that was killed before rollback could deregister it —
+        // reclaim it (preserves the agent's sessions) so the app can install.
+        const apps = await this.registry.list();
+        const owner = apps.find(
+          (a) => a.name !== appName && a.agentDeclaration?.name === agentName,
         );
+        if (owner) {
+          throw new Error(
+            `Agent name "${agentName}" is already registered by app "${owner.name}"`,
+          );
+        }
+        this.log(job, `Reclaiming orphaned agent registration "${agentName}"`);
+        await this.agentManager.deleteAgentByName(agentName);
       }
     }
 

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -312,6 +312,40 @@ describe('AgentManager', () => {
       await manager.deleteAgent(entry);
       // no throw = pass
     });
+
+    // Safety: deleting an app-agent must never remove a user-created agent that
+    // happens to share the same id (issue #263 — orphan reclaim must not touch
+    // user agents).
+    it('removes only the app-agent entry, preserving a same-named user agent', async () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          gateway: { logDir: 'logs', timezone: 'UTC' },
+          agents: [
+            { id: 'shared', type: 'user' }, // user-created agent (not an app-agent)
+            { id: 'shared', type: 'app-agent', containerName: 'app-shared' },
+          ],
+        }),
+        'utf-8',
+      );
+      // The user agent has a REAL workspace dir at the shared path.
+      const userWs = path.join(tmpDir, 'agents', 'shared', 'workspace');
+      fs.mkdirSync(userWs, { recursive: true });
+      fs.writeFileSync(path.join(userWs, 'SOUL.md'), 'user data', 'utf-8');
+
+      await manager.deleteAgentByName('shared');
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        agents: Array<Record<string, unknown>>;
+      };
+      // app-agent entry removed…
+      expect(config.agents.filter((a) => a['id'] === 'shared' && a['type'] === 'app-agent')).toHaveLength(0);
+      // …but the user agent entry is preserved
+      expect(config.agents.filter((a) => a['id'] === 'shared' && a['type'] === 'user')).toHaveLength(1);
+      // and its real workspace dir is untouched
+      expect(fs.existsSync(path.join(userWs, 'SOUL.md'))).toBe(true);
+    });
   });
 
   // ─── findAgentByName() ────────────────────────────────────────────────────

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -820,6 +820,126 @@ services:
       expect(job.error).toMatch(/local path|cannot be updated/i);
     });
   });
+
+  // ── Agent-name conflict / orphan reclaim (issue #263) ──────────────────────
+  describe('install — agent-name conflict vs orphan reclaim', () => {
+    function makeAgentMgr(existingAgentName: string) {
+      return {
+        findAgentByName: jest.fn(async (n: string) => (n === existingAgentName ? n : null)),
+        deleteAgentByName: jest.fn(async () => {}),
+        deleteAgent: jest.fn(async () => {}),
+        detectAgentPaths: jest.fn(() => ({
+          claudeBin: '/usr/bin/claude',
+          nodeBin: '/usr/bin/node',
+          npmRoot: '/usr/lib/node_modules',
+        })),
+        injectAgentService: jest.fn(() => {}),
+        upsertAgent: jest.fn(async () => {}),
+        backupMemory: jest.fn(() => null),
+        restoreMemory: jest.fn(() => {}),
+      };
+    }
+
+    function makeInstallerWithAgent(
+      spawn: typeof successSpawn,
+      agentMgr: ReturnType<typeof makeAgentMgr>,
+    ) {
+      return new AppInstaller(
+        registry,
+        new RegistryClient(),
+        callbacks,
+        spawn,
+        appsDir,
+        agentMgr as unknown as ConstructorParameters<typeof AppInstaller>[5],
+        successAsyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
+      );
+    }
+
+    // GitHub install of an app that declares an agent service.
+    function agentGitSpawn(appName: string, agentName: string, port: number, head: string) {
+      return jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: 1.0.0
+commit: "${head}"
+services:
+  app:
+    image: nginx:1.25
+    ports:
+      - name: api
+        host: ${port}
+        container: ${port}
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:${port}/health
+      interval: 30s
+  agent:
+    path: ./agent
+    name: ${agentName}
+`.trim(),
+            'utf-8',
+          );
+          fs.mkdirSync(path.join(opts.cwd, 'agent'), { recursive: true });
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    it('reclaims an orphaned agent (registered but owned by no installed app) and proceeds', async () => {
+      const agentMgr = makeAgentMgr('orphan-bot'); // config says it exists…
+      // …but no installed app declares it → orphan
+      const spawn = agentGitSpawn('agent-app', 'orphan-bot', 5700, 'a'.repeat(40));
+      const installer = makeInstallerWithAgent(spawn as unknown as typeof successSpawn, agentMgr);
+
+      const job = await waitForJob(
+        installer,
+        installer.install({ githubUrl: 'https://github.com/test/agent-app' }),
+        5000,
+      );
+
+      expect(agentMgr.deleteAgentByName).toHaveBeenCalledWith('orphan-bot');
+      expect(job.status).toBe('completed');
+    });
+
+    it('throws a clear conflict when the agent is owned by a different installed app', async () => {
+      // A different app already owns "shared-bot".
+      await registry.upsert({
+        name: 'other-app',
+        version: '1.0.0',
+        commit: 'b'.repeat(40),
+        githubUrl: 'https://github.com/test/other-app',
+        installPath: path.join(appsDir, 'other-app'),
+        ports: [],
+        sockets: {},
+        installedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        status: 'running',
+        source: 'custom',
+        agentDeclaration: { path: './agent', name: 'shared-bot' },
+      });
+
+      const agentMgr = makeAgentMgr('shared-bot');
+      const spawn = agentGitSpawn('agent-app', 'shared-bot', 5701, 'c'.repeat(40));
+      const installer = makeInstallerWithAgent(spawn as unknown as typeof successSpawn, agentMgr);
+
+      const job = await waitForJob(
+        installer,
+        installer.install({ githubUrl: 'https://github.com/test/agent-app' }),
+        5000,
+      );
+
+      expect(job.status).toBe('failed');
+      expect(job.error).toMatch(/already registered by app "other-app"/);
+      expect(agentMgr.deleteAgentByName).not.toHaveBeenCalled();
+    });
+  });
 });
 
 // ─── Utility ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

An app that declares an `agent:` service could become permanently un-installable: a prior install killed before rollback (idle reaper, restart, OOM) left the agent's `config.json` entry behind, and the installer's agent-name conflict check then rejected every future install. This makes the check reclaim an **orphaned** agent (registered but owned by no installed app) instead of failing — while never touching a user-created agent.

## Related Issue

Closes #263

## Root cause (proven with a live install on prod, v1.5.3)

Installing an app that declares `agent: { name: <bot> }` failed immediately at `src/apps/installer.ts:468`:

```
Validating app.yaml -> Generating docker-compose.yml
FAILED: Agent name "<bot>" is already registered — agent name conflict
```

…even after the app directory, containers, and registry entry were removed. The conflict check called `findAgentByName`, which only checks whether an `app-agent` with that id exists in `config.json` — it never checked whether an installed app actually owns it. The install rollback *does* deregister the agent it created, but a process killed mid-install never runs rollback, leaving the entry orphaned.

## Changes Made

- `src/apps/installer.ts` (conflict check): when the agent name is already registered, look up whether a **different installed app** (`registry.list()`) declares it. If so → clear conflict error naming the owner. If no installed app owns it → it's an orphan: log and reclaim via `deleteAgentByName`, then proceed. `deleteAgentByName` preserves `sessions/`, so history survives.
- `src/apps/agent-manager.ts` — **user-agent safety** (must never delete a user's own agent that shares the name):
  - `removeConfigEntry` now removes only the entry with `id === X && type === 'app-agent'`, not any agent sharing the id.
  - `deleteAgentByName` only unlinks an actual symlink (an app-agent's workspace), never a user agent's real workspace directory at a shared path.
  - (`findAgentByName` already matched only `type === 'app-agent'`, so a user agent is never seen as a conflict in the first place.)

## Testing

- `npm run typecheck`: pass
- `npm test`: 2600+ tests pass (only red is the pre-existing parallel-worker-race flake — a suite-level crash with zero failing tests that lands on a different suite each run and passes in isolation)
- New tests, all **verified to fail on the pre-fix code**:
  - `installer.test.ts`: install reclaims an orphaned agent and proceeds; install still errors (naming the owner) when a different installed app owns the name.
  - `agent-manager.test.ts`: `deleteAgentByName` removes only the app-agent entry and preserves a same-named user agent + its real workspace dir.

## Note

Related orphan-cleanup work: the install/update rollback `rmrf` fix (#261) handles orphaned *directories*; this handles the orphaned *agent registration*. Both stem from a failed/killed install leaving state behind.