### PR TITLE
[Enhancement] Add pre-install inspect so GitHub-URL installs surface required secrets

### DIFF
--- a/API.md
+++ b/API.md
@@ -150,6 +150,7 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 | `GET` | `/api/v1/apps/registry/:name` | Key | Get versions of a registry app |
 | `GET` | `/api/v1/apps` | Key | List installed apps |
 | `POST` | `/api/v1/apps/install` | Admin | Start async install → `jobId` |
+| `POST` | `/api/v1/apps/inspect` | Admin | Read-only preview of a source → required/generated secrets (no install) |
 | `GET` | `/api/v1/apps/jobs/:jobId` | Key | Poll install/update job status + logs |
 | `GET` | `/api/v1/apps/:name` | Key | Get installed app info |
 | `DELETE` | `/api/v1/apps/:name` | Admin | Uninstall app |
@@ -2696,6 +2697,7 @@ Manage Docker-compose apps installed on the gateway. Apps can be sourced from th
 | `GET` | `/api/v1/apps/registry/:name` | Key | Get versions of a specific registry app |
 | `GET` | `/api/v1/apps` | Key | List all installed apps |
 | `POST` | `/api/v1/apps/install` | Admin | Start async install → returns `jobId` |
+| `POST` | `/api/v1/apps/inspect` | Admin | Read-only preview of a source → required/generated secrets (no install) |
 | `GET` | `/api/v1/apps/jobs/:jobId` | Key | Poll install/update job status + logs |
 | `GET` | `/api/v1/apps/:name` | Key | Get installed app info |
 | `DELETE` | `/api/v1/apps/:name` | Admin | Uninstall app (docker down + cleanup) |
@@ -2862,6 +2864,57 @@ curl -X POST \
 | 403 | Not an admin key |
 
 > Poll `GET /api/v1/apps/jobs/:jobId` to track progress. Install pipeline: clone/symlink → validate `app.yaml` → generate compose → build images → start containers → register proxy routes. On failure, container logs are appended to `logs` before rollback.
+
+---
+
+### POST /api/v1/apps/inspect
+
+Read-only preview of an install source. Fetches and parses the app's `app.yaml`
+(shallow clone for registry/GitHub sources; direct read for a local path)
+**without installing anything and leaving no files behind**, and returns the
+metadata needed for an accurate pre-install summary — most importantly which
+secrets the operator must supply versus which the gateway auto-generates.
+
+This is essential for a **GitHub-URL** install: such apps have no registry entry,
+so `GET /api/v1/apps/registry/:name` cannot reveal their required secrets — only
+this endpoint can.
+
+**Request body:** same source fields as install (`registry_app` [+ `version`],
+`github_url` [+ `commit`], or `local_path`). `env_vars` is ignored — nothing is
+injected. One of the three sources is required.
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: admin-key" \
+  -H "Content-Type: application/json" \
+  -d '{"github_url": "https://github.com/myorg/my-app"}' \
+  http://localhost:10850/api/v1/apps/inspect | jq
+```
+
+**Response `200`:**
+```json
+{
+  "name": "my-app",
+  "version": "1.0.0",
+  "source": "custom",
+  "commit": "abc123def456abc123def456abc123def456abc1",
+  "secretKeys": ["DB_PASSWORD"],
+  "generatedKeys": [{ "key": "SESSION_SECRET", "encoding": "hex", "bytes": 32 }],
+  "ports": [{ "name": "web", "service": "app", "hostPort": 12000, "containerPort": 3000, "type": "web" }],
+  "agentDeclaration": null,
+  "warnings": []
+}
+```
+
+- `secretKeys` — env vars the operator **must** supply (declared as bare keys in `app.yaml`).
+- `generatedKeys` — secrets the gateway fills with a fresh random value at install (declared as `KEY=!generate:<encoding>:<bytes>`); never prompted for.
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Missing source fields, invalid `github_url`/`commit` format, repo unreachable, or `app.yaml` missing/invalid |
+| 403 | Not an admin key |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ Pass API key via `X-Api-Key: <key>` or `Authorization: Bearer <key>` header.
 | `POST` | `/api/v1/agents/wizard/:wizardId/complete` | Skip channel and finalise wizard (admin) |
 | `GET` | `/api/v1/apps/registry` | Browse community app registry (admin key) |
 | `POST` | `/api/v1/apps/install` | Install app from registry, GitHub, or local path → `jobId` (admin) |
+| `POST` | `/api/v1/apps/inspect` | Preview a source's required/generated secrets before install, no install (admin) |
 | `GET` | `/api/v1/apps/jobs/:jobId` | Poll install/update job status and logs |
 | `GET` | `/api/v1/apps` | List installed apps |
 | `GET` | `/api/v1/apps/:name` | Get app info |

--- a/mcp/tools/apps/client.ts
+++ b/mcp/tools/apps/client.ts
@@ -60,6 +60,10 @@ export class AppsClient {
     return this.request('POST', '/install', params);
   }
 
+  async inspect(params: Record<string, unknown>): Promise<unknown> {
+    return this.request('POST', '/inspect', params);
+  }
+
   async pollJob(jobId: string): Promise<unknown> {
     return this.request('GET', `/jobs/${encodeURIComponent(jobId)}`);
   }

--- a/mcp/tools/apps/module.ts
+++ b/mcp/tools/apps/module.ts
@@ -77,6 +77,21 @@ export class AppsModule implements ToolModule {
         },
       },
       {
+        name: 'inspect_app',
+        description: 'Preview an install source WITHOUT installing: fetch and parse the app.yaml and return the required secrets (secretKeys, must be provided) and auto-generated secrets (generatedKeys, filled by the gateway), plus name, version, ports, and warnings. Call this BEFORE install_app for a GitHub URL — such apps have no registry entry, so browse_registry cannot reveal their required secrets. Pass github_url (+ optional commit), registry_app (+ optional version), or local_path.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            registry_app: { type: 'string', description: 'Registry app name' },
+            version: { type: 'string', description: 'Registry version (default: latest)' },
+            github_url: { type: 'string', description: 'GitHub repo URL' },
+            commit: { type: 'string', description: '40-char hex commit hash to pin (optional; with github_url, omit to auto-resolve the default branch HEAD)' },
+            local_path: { type: 'string', description: 'Local app path within ~/.claude-gateway/apps/' },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'list_apps',
         description: 'List all installed apps with their status and proxy URLs.',
         inputSchema: {
@@ -164,6 +179,17 @@ export class AppsModule implements ToolModule {
       case 'poll_install_job': {
         const jobId = args['job_id'] as string;
         const data = await client.pollJob(jobId);
+        return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+      }
+
+      case 'inspect_app': {
+        const params: Record<string, unknown> = {};
+        if (args['registry_app']) params['registry_app'] = args['registry_app'];
+        if (args['version']) params['version'] = args['version'];
+        if (args['github_url']) params['github_url'] = args['github_url'];
+        if (args['commit']) params['commit'] = args['commit'];
+        if (args['local_path']) params['local_path'] = args['local_path'];
+        const data = await client.inspect(params);
         return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
       }
 

--- a/mcp/tools/apps/skills/install-app/SKILL.md
+++ b/mcp/tools/apps/skills/install-app/SKILL.md
@@ -4,6 +4,7 @@ description: Install an app from the registry or a GitHub URL. Interactive — s
 user-invocable: true
 allowed-tools:
   - mcp__gateway__install_app
+  - mcp__gateway__inspect_app
   - mcp__gateway__poll_install_job
   - mcp__gateway__browse_registry
 ---
@@ -44,8 +45,20 @@ If the app is not found in the registry and no GitHub URL given, stop with a hel
 
 ## Step 2 — Check for required env vars
 
-Call `browse_registry` to get the app definition. If the app has `secretKeys` listed, those
-env vars must be supplied. Prompt the user for each missing secret before proceeding:
+Call `inspect_app` with the same source you will install (`github_url` [+ `commit`],
+`registry_app` [+ `version`], or `local_path`). It fetches and parses the app's
+`app.yaml` **without installing** and returns the real secret requirements:
+
+- `secretKeys` — env vars the operator **must** supply (no default). Prompt for
+  each one before proceeding.
+- `generatedKeys` — secrets the gateway **auto-generates** at install time
+  (declared as `KEY=!generate:...`). Do **not** prompt for these; just note they
+  will be generated.
+
+This is essential for a **GitHub-URL** install: such apps have no registry entry,
+so `browse_registry` cannot reveal their secrets — only `inspect_app` can.
+
+If `inspect_app` reports `secretKeys`, prompt the user for each:
 
 ```
 This app requires the following environment variables:
@@ -59,21 +72,27 @@ Please provide values, e.g.:
 
 Wait for the user's reply. Parse key=value pairs.
 
-If no secrets are needed, proceed immediately.
+If `secretKeys` is empty (only `generatedKeys`, or no secrets at all), proceed
+immediately — do not invent secrets or ask for ones the app did not declare.
+
+> If `inspect_app` fails (e.g. the repo is unreachable), tell the user the error
+> and stop — do not fall back to assuming "no secrets".
 
 ---
 
 ## Step 3 — Show permissions summary
 
-Before installing, show a brief summary:
+Before installing, show a brief summary (use the `name`, `version`, `ports`,
+`secretKeys`, and `generatedKeys` returned by `inspect_app`):
 
 ```
 Installing: <app-name> v<version>
 Source: <registry|github>
 Repo: <url>
 Commit: <first 8 chars, or "latest on default branch (auto-resolved)" for a GitHub install with no pinned commit>
-Proxy routes: (from registry metadata if available)
-Secrets to inject: <list or "none">
+Proxy routes: <from inspect_app ports, or "none">
+Secrets to provide: <secretKeys the user supplied, or "none">
+Secrets auto-generated: <generatedKeys, or "none">
 
 Proceed? (yes/no)
 ```

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -95,6 +95,44 @@ export function createAppsRouter(
     }
   });
 
+  /**
+   * POST /api/v1/apps/inspect — read-only preview of an install source.
+   * Fetches and parses the app.yaml (without installing) so callers can see the
+   * required secrets (`secretKeys`) and auto-generated secrets (`generatedKeys`)
+   * before install — essential for GitHub-URL apps that have no registry entry.
+   * Admin-gated to match the install authorization floor.
+   */
+  router.post('/v1/apps/inspect', async (req: Request, res: Response) => {
+    const authed = req as AuthedRequest;
+    if (!isAdmin(authed.apiKey)) {
+      res.status(403).json({ error: 'Admin access required to inspect apps' });
+      return;
+    }
+
+    const body = req.body as Record<string, unknown>;
+    const options = {
+      registryApp: typeof body.registry_app === 'string' ? body.registry_app : undefined,
+      version: typeof body.version === 'string' ? body.version : undefined,
+      githubUrl: typeof body.github_url === 'string' ? body.github_url : undefined,
+      commit: typeof body.commit === 'string' ? body.commit : undefined,
+      localPath: typeof body.local_path === 'string' ? body.local_path : undefined,
+    };
+
+    if (!options.registryApp && !options.githubUrl && !options.localPath) {
+      res.status(400).json({
+        error: 'Provide one of: registry_app, github_url, or local_path',
+      });
+      return;
+    }
+
+    try {
+      const info = await installer.inspectSource(options);
+      res.json(info);
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
   /** GET /api/v1/apps/jobs/:jobId — poll install job status */
   router.get('/v1/apps/jobs/:jobId', (req: Request, res: Response) => {
     const job = installer.getJob(req.params.jobId);

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -11,6 +11,8 @@ import {
   generateSecretValue,
   ComposePort,
   ComposeSocket,
+  GeneratedKey,
+  AgentDeclaration,
 } from './compose-generator';
 import { AgentManager } from './agent-manager';
 
@@ -36,6 +38,25 @@ export interface InstallResult {
   proxyUrls: Record<string, string>; // portName → /app/<name>/<port>/
   secretKeys: string[];
   agentDeclaration?: { path: string; name: string } | null;
+}
+
+/**
+ * Read-only preview of an install source, computed by fetching and parsing the
+ * app.yaml BEFORE any install. Surfaces the secrets an operator must supply
+ * ({@link InspectResult.secretKeys}) and the ones the gateway auto-generates
+ * ({@link InspectResult.generatedKeys}) so the pre-install summary is accurate
+ * even for a GitHub-URL app that has no registry entry.
+ */
+export interface InspectResult {
+  name: string;
+  version: string;
+  source: AppEntry['source'];
+  commit: string;
+  secretKeys: string[];
+  generatedKeys: GeneratedKey[];
+  ports: ComposePort[];
+  agentDeclaration: AgentDeclaration | null;
+  warnings: string[];
 }
 
 export interface JobState {
@@ -152,6 +173,84 @@ export class AppInstaller {
 
   getJob(jobId: string): JobState | undefined {
     return this.jobs.get(jobId);
+  }
+
+  /**
+   * Read-only inspection of an install source — no install side effects, no
+   * files left behind. Resolves the repo + commit, fetches the app.yaml
+   * (shallow clone into a tmp dir for registry/GitHub sources; direct read for
+   * a local path), parses it, and returns the metadata needed for an accurate
+   * pre-install summary: the required secrets (`secretKeys`, must be prompted)
+   * and the self-generated secrets (`generatedKeys`, auto-filled at install).
+   *
+   * This is what lets a GitHub-URL install surface its required secrets before
+   * installing — such apps have no registry entry, so `browse_registry` cannot
+   * reveal them.
+   */
+  async inspectSource(options: InstallOptions): Promise<InspectResult> {
+    // Mode B — local path: read app.yaml directly, no clone.
+    if (options.localPath) {
+      const resolved = path.resolve(options.localPath);
+      if (!fs.existsSync(path.join(resolved, 'app.yaml'))) {
+        throw new Error(`app.yaml not found in "${resolved}"`);
+      }
+      return this.inspectDir(resolved, 'local', 'local');
+    }
+
+    // Mode A — registry or GitHub: resolve, then shallow-clone into a tmp dir.
+    // Passing a null job keeps resolveSource silent (there is no install job).
+    const resolved = await this.resolveSource(null, options, options.version ?? '0.0.0');
+    const tmpDir = path.join(os.tmpdir(), `cg-inspect-${crypto.randomUUID()}`);
+    try {
+      fs.mkdirSync(tmpDir, { recursive: true });
+      this.run(['git', 'init'], tmpDir);
+      this.run(['git', 'remote', 'add', 'origin', resolved.githubUrl], tmpDir);
+      this.run(['git', 'fetch', '--depth', '1', 'origin', resolved.commit], tmpDir);
+      this.run(['git', 'checkout', 'FETCH_HEAD'], tmpDir);
+      return this.inspectDir(tmpDir, resolved.source, resolved.commit, resolved.version);
+    } finally {
+      try {
+        this.rmrf(tmpDir);
+      } catch {
+        /* best-effort cleanup of a read-only tmp clone */
+      }
+    }
+  }
+
+  /**
+   * Parse the app.yaml in `appDir` and derive the pre-install metadata without
+   * mutating `appDir`. generateCompose writes the compose file to its output
+   * path, so we point it at a throwaway tmp file (removed here) to keep the
+   * inspection read-only even for a local source.
+   */
+  private inspectDir(
+    appDir: string,
+    source: AppEntry['source'],
+    commit: string,
+    fallbackVersion?: string,
+  ): InspectResult {
+    const appYaml = parseAppYaml(fs.readFileSync(path.join(appDir, 'app.yaml'), 'utf-8'), appDir);
+    const tmpCompose = path.join(os.tmpdir(), `cg-inspect-compose-${crypto.randomUUID()}.yml`);
+    try {
+      const generated = generateCompose(appYaml, appYaml.name, appDir, tmpCompose);
+      return {
+        name: appYaml.name,
+        version: appYaml.version || fallbackVersion || '0.0.0',
+        source,
+        commit,
+        secretKeys: generated.secretKeys,
+        generatedKeys: generated.generatedKeys,
+        ports: generated.ports,
+        agentDeclaration: generated.agentDeclaration,
+        warnings: generated.warnings,
+      };
+    } finally {
+      try {
+        fs.rmSync(tmpCompose, { force: true });
+      } catch {
+        /* best-effort cleanup of the throwaway compose file */
+      }
+    }
   }
 
   /** Start an async update job. Returns jobId immediately. */
@@ -949,7 +1048,7 @@ export class AppInstaller {
   }
 
   private async resolveSource(
-    job: JobState,
+    job: JobState | null,
     options: InstallOptions,
     defaultVersion: string,
   ): Promise<{
@@ -985,7 +1084,7 @@ export class AppInstaller {
         if (!app) throw new Error(`App "${options.registryApp}" not found in registry`);
         const latest = selectLatest(app.versions);
         if (!latest) throw new Error(`No versions available for "${options.registryApp}"`);
-        this.log(job, `Using latest version ${latest.version}`);
+        if (job) this.log(job, `Using latest version ${latest.version}`);
         return {
           appName: options.registryApp,
           commit: latest.commit,
@@ -1015,12 +1114,12 @@ export class AppInstaller {
         commit = options.commit;
       } else {
         // Auto-resolve HEAD commit via git ls-remote
-        this.log(job, `Resolving HEAD commit for ${options.githubUrl}`);
+        if (job) this.log(job, `Resolving HEAD commit for ${options.githubUrl}`);
         const { stdout } = this.run(['git', 'ls-remote', options.githubUrl, 'HEAD'], process.cwd());
         const match = stdout.trim().match(/^([0-9a-f]{40})\s+HEAD/);
         if (!match) throw new Error(`Could not resolve HEAD commit for ${options.githubUrl}`);
         commit = match[1];
-        this.log(job, `Resolved HEAD → ${commit.slice(0, 8)}`);
+        if (job) this.log(job, `Resolved HEAD → ${commit.slice(0, 8)}`);
       }
       const appName = options.githubUrl.split('/').pop()?.replace(/\.git$/, '') ?? 'app';
       return {

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -225,6 +225,81 @@ describe('createAppsRouter()', () => {
     });
   });
 
+  // ── POST /api/v1/apps/inspect ──────────────────────────────────────────
+
+  describe('POST /api/v1/apps/inspect', () => {
+    /** Spawn that resolves HEAD and writes an app.yaml (bare-key secret +
+     *  self-generating secret) on checkout, so inspect returns real keys. */
+    function inspectSpawn(head: string) {
+      return (cmd: string, args: string[], opts?: object) => {
+        const cwd = (opts as { cwd?: string } | undefined)?.cwd;
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && cwd) {
+          fs.writeFileSync(
+            path.join(cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: secretful-app
+version: 3.1.0
+commit: "${head}"
+services:
+  app:
+    image: nginx:1.25
+    environment:
+      - DB_PASSWORD
+      - SESSION_SECRET=!generate:hex:32
+    ports:
+      - name: api
+        host: 5400
+        container: 5400
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:5400/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      };
+    }
+
+    it('returns 403 for non-admin key', async () => {
+      const res = await request(app)
+        .post('/api/v1/apps/inspect')
+        .set('Authorization', `Bearer ${READ_KEY.key}`)
+        .send({ github_url: 'https://github.com/test/secretful-app' });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 400 when no source provided', async () => {
+      const res = await request(app)
+        .post('/api/v1/apps/inspect')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({});
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 200 with required + generated secrets for a GitHub URL', async () => {
+      const head = 'abcdef0123456789abcdef0123456789abcdef01';
+      const inspectApp = makeApp(registry, registryClient, inspectSpawn(head));
+      const res = await request(inspectApp)
+        .post('/api/v1/apps/inspect')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ github_url: 'https://github.com/test/secretful-app' });
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe('secretful-app');
+      expect(res.body.secretKeys).toEqual(['DB_PASSWORD']);
+      expect(res.body.generatedKeys).toEqual([
+        { key: 'SESSION_SECRET', encoding: 'hex', bytes: 32 },
+      ]);
+      // No install happened.
+      expect(await registry.get('secretful-app')).toBeUndefined();
+    });
+  });
+
   // ── GET /api/v1/apps/jobs/:jobId ───────────────────────────────────────
 
   describe('GET /api/v1/apps/jobs/:jobId', () => {

--- a/tests/unit/apps-module.test.ts
+++ b/tests/unit/apps-module.test.ts
@@ -32,5 +32,26 @@ describe('AppsModule', () => {
       // must signal the optional / auto-resolve behavior
       expect(commitDesc.toLowerCase()).toContain('optional');
     });
+
+    // Regression for #265: a pre-install inspect tool must exist so GitHub-URL
+    // installs can surface required secrets before installing (browse_registry
+    // only knows registry apps). Without it the agent reports "Secrets: none".
+    it('exposes an inspect_app tool that accepts a github_url source', () => {
+      const tools = new AppsModule().getTools();
+      const inspect = tools.find((t) => t.name === 'inspect_app');
+      expect(inspect).toBeDefined();
+
+      const props = (inspect!.inputSchema as {
+        properties: Record<string, { description?: string }>;
+      }).properties;
+      // accepts the same source fields as install (at least github_url)
+      expect(props['github_url']).toBeDefined();
+      expect(props['registry_app']).toBeDefined();
+      expect(props['local_path']).toBeDefined();
+
+      // description must point agents at it before install for secret discovery
+      const desc = (inspect!.description ?? '').toLowerCase();
+      expect(desc).toContain('secret');
+    });
   });
 });

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -715,6 +715,94 @@ services:
     });
   });
 
+  // ── inspectSource() — read-only pre-install preview (issue #265) ──────────
+  describe('inspectSource() — GitHub URL', () => {
+    /** Spawn mock: resolves HEAD via ls-remote and writes an app.yaml whose
+     *  service declares a bare-key secret + a self-generating secret. */
+    function inspectSpawn(head: string) {
+      return jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: secretful-app
+version: 3.1.0
+commit: "${head}"
+services:
+  app:
+    image: nginx:1.25
+    environment:
+      - DB_PASSWORD
+      - SESSION_SECRET=!generate:hex:32
+      - NODE_ENV=production
+    ports:
+      - name: api
+        host: 5400
+        container: 5400
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:5400/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    function tmpInspectDirs(): string[] {
+      return fs.readdirSync(os.tmpdir()).filter((n) => n.startsWith('cg-inspect-'));
+    }
+
+    it('returns required + generated secrets parsed from app.yaml, without installing', async () => {
+      const head = 'abcdef0123456789abcdef0123456789abcdef01';
+      const before = tmpInspectDirs();
+      const installer = makeInstaller(inspectSpawn(head));
+
+      const info = await installer.inspectSource({
+        githubUrl: 'https://github.com/test/secretful-app',
+      });
+
+      // Real required secret (bare key) is surfaced — the whole point of the fix.
+      expect(info.secretKeys).toEqual(['DB_PASSWORD']);
+      // Self-generating secret is reported separately (never prompted for).
+      expect(info.generatedKeys).toEqual([
+        { key: 'SESSION_SECRET', encoding: 'hex', bytes: 32 },
+      ]);
+      // Canonical metadata comes from the fetched app.yaml, not the URL.
+      expect(info.name).toBe('secretful-app');
+      expect(info.version).toBe('3.1.0');
+      expect(info.source).toBe('custom');
+      expect(info.commit).toBe(head); // auto-resolved HEAD
+
+      // No install side effects: nothing registered, no app dir created.
+      expect(await registry.get('secretful-app')).toBeUndefined();
+      expect(fs.existsSync(path.join(appsDir, 'secretful-app'))).toBe(false);
+      expect(callbacks.registeredRoutes).toHaveLength(0);
+
+      // No tmp clone dir left behind.
+      expect(tmpInspectDirs()).toEqual(before);
+    });
+
+    it('propagates a resolution failure instead of silently reporting no secrets', async () => {
+      const failing = jest.fn((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: '', stderr: 'not found', status: 1 };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeInstaller(failing as typeof successSpawn);
+      await expect(
+        installer.inspectSource({ githubUrl: 'https://github.com/test/missing' }),
+      ).rejects.toThrow();
+    });
+  });
+
   // ── update() — GitHub-installed (custom) apps (issue #259) ────────────────
   describe('update() — custom (GitHub) apps', () => {
     function readEnvFile(appDir: string): Record<string, string> {


### PR DESCRIPTION
## Summary
GitHub-URL app installs could not surface an app's required secrets before installing — the pre-install summary printed `Secrets: none` and the install then failed on empty required env (e.g. empty `POSTGRES_PASSWORD`). This adds a read-only pre-install inspect path that fetches and parses the repo `app.yaml` so callers see the true required and auto-generated secrets before installing.

## Related Issue
Closes #265

## Root Cause
- The install-app skill discovers secrets only via `browse_registry`, which reads the registry index (`mcp/tools/apps/module.ts`). A GitHub-URL app has no registry entry → empty `secretKeys` → summary prints `none`.
- The real secret metadata is computed by `generateCompose` (`src/apps/compose-generator.ts:366-389`), which only runs inside `installer.install()` **after** the repo is cloned (`src/apps/installer.ts:449`) — never before the summary.
- No inspect/preview path existed anywhere in the apps subsystem.

## Changes Made
- `src/apps/installer.ts`: new read-only `inspectSource()` (+ `inspectDir()` helper) that resolves the source, shallow-clones into a tmp dir (or reads a local path directly), runs `parseAppYaml` + `generateCompose`, and returns `{ name, version, source, commit, secretKeys, generatedKeys, ports, agentDeclaration, warnings }` — no install side effects, tmp clone + throwaway compose file removed. `resolveSource` now accepts a `null` job so the silent read-only path can reuse it.
- `src/api/apps-router.ts`: `POST /api/v1/apps/inspect`, admin-gated (same floor as install).
- `mcp/tools/apps/module.ts` + `client.ts`: `inspect_app` MCP tool + client method.
- `mcp/tools/apps/skills/install-app/SKILL.md`: Step 2 now calls `inspect_app` to list the true required (`secretKeys`) and auto-generated (`generatedKeys`) secrets before the summary.
- `API.md`: documents `POST /api/v1/apps/inspect` + endpoint-table rows.

## Testing
- `npm run typecheck`: pass
- `npm test`: 2664/2664 tests pass (1 unrelated flaky worker-race in `apps/socket-server.test.ts`, SIGTERM with 0 test failures — passes in isolation).
- Regression tests (installer, router, MCP module) proven to fail on the pre-fix code: the inspect capability did not exist there.
