### PR TITLE
feat(apps): add reconfigure endpoint + host-port override

### DIFF
--- a/API.md
+++ b/API.md
@@ -159,6 +159,7 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 | `POST` | `/api/v1/apps/:name/restart` | Admin | Restart app |
 | `GET` | `/api/v1/apps/:name/version` | Key | Check installed vs latest version |
 | `POST` | `/api/v1/apps/:name/update` | Admin | Start async update with rollback → `jobId` |
+| `POST` | `/api/v1/apps/:name/reconfigure` | Admin | Start async env/host-port reconfigure (keeps volumes) → `jobId` |
 | `GET` | `/app/:name/:portName/*` | None | Reverse proxy to installed app |
 
 ### Cron API
@@ -2706,6 +2707,7 @@ Manage Docker-compose apps installed on the gateway. Apps can be sourced from th
 | `POST` | `/api/v1/apps/:name/restart` | Admin | Restart app |
 | `GET` | `/api/v1/apps/:name/version` | Key | Check current + latest version |
 | `POST` | `/api/v1/apps/:name/update` | Admin | Start async update with rollback → returns `jobId` |
+| `POST` | `/api/v1/apps/:name/reconfigure` | Admin | Start async env/host-port reconfigure (keeps volumes) → returns `jobId` |
 
 ---
 
@@ -2801,6 +2803,7 @@ Start an asynchronous install job. Returns immediately with a `jobId` to poll.
 | `commit` | If `github_url` | 40-char hex commit SHA (branch names not accepted). Omit to auto-resolve HEAD. |
 | `local_path` | One of | Absolute path to local project dir (dev mode — symlinked, source never deleted) |
 | `env_vars` | No | Pre-supplied env vars as a JSON **object** (not array). Keys must match vars declared in `app.yaml`. |
+| `ports` | No | Host-port overrides as a JSON **object** mapping port name → host port (e.g. `{ "web": 4000 }`). Default host port comes from `app.yaml`. Overrides must be integers ≥ 1024 and not banned (`22`, `80`, `443`, `10850`). |
 
 **Mode A — registry install:**
 ```bash
@@ -3084,6 +3087,45 @@ Poll the returned `jobId` with `GET /api/v1/apps/jobs/:jobId` to track progress.
 | 400 | App source is `local` (symlinked apps cannot be updated) |
 | 403 | Not an admin key |
 | 404 | App not installed |
+
+---
+
+### POST /api/v1/apps/:name/reconfigure
+
+Start an async reconfigure of an already-installed app — change its env vars and/or host ports, then force-recreate the container **in place**. Named volumes (and their data) are preserved: this is a `docker compose up --force-recreate`, never a `down -v`. The container always restarts so it picks up the new values.
+
+**Request body** (at least one of `env_vars` / `ports` is required):
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `env_vars` | One of | Env vars to **merge** into the app's existing `.env` as a JSON **object** (values must be strings). Keys not supplied are preserved; existing self-generated secrets are kept, not rotated. |
+| `ports` | One of | Host-port overrides as a JSON **object** mapping port name → host port (e.g. `{ "web": 4000 }`). Overrides must be integers ≥ 1024 and not banned (`22`, `80`, `443`, `10850`), and must not collide with another installed app. |
+
+```bash
+curl -X POST \
+  -H "X-Api-Key: admin-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "env_vars": { "DATABASE_URL": "postgres://..." },
+    "ports": { "web": 4000 }
+  }' \
+  http://localhost:10850/api/v1/apps/agent-note/reconfigure | jq
+```
+
+```json
+{ "jobId": "772fa622-a41d-63f6-c938-668877662222" }
+```
+
+Poll the returned `jobId` with `GET /api/v1/apps/jobs/:jobId` to track progress. When a host port changes, the proxy route is re-registered and the returned job's `proxyUrls` reflect the new port.
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Neither `env_vars` nor `ports` supplied; a `ports` value is non-integer / banned / `< 1024` / collides with another app; an `env_vars` value is not a string; app source is `local` |
+| 403 | Not an admin key |
+| 404 | App not installed |
+| 409 | App is already being installed / updated / reconfigured |
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2803,7 +2803,7 @@ Start an asynchronous install job. Returns immediately with a `jobId` to poll.
 | `commit` | If `github_url` | 40-char hex commit SHA (branch names not accepted). Omit to auto-resolve HEAD. |
 | `local_path` | One of | Absolute path to local project dir (dev mode — symlinked, source never deleted) |
 | `env_vars` | No | Pre-supplied env vars as a JSON **object** (not array). Keys must match vars declared in `app.yaml`. |
-| `ports` | No | Host-port overrides as a JSON **object** mapping port name → host port (e.g. `{ "web": 4000 }`). Default host port comes from `app.yaml`. Overrides must be integers ≥ 1024 and not banned (`22`, `80`, `443`, `10850`). |
+| `ports` | No | Host-port overrides as a JSON **object** mapping port name → host port (e.g. `{ "web": 4000 }`). Default host port comes from `app.yaml`. Overrides must be integers ≥ 1024 and not banned (`22`, `80`, `443`, `10850`). The integer/banned/`< 1024` checks are synchronous (`400`); a port **name** that the app does not declare is caught only once the source is fetched, so it surfaces as a **failed install job**, not a sync `400` (the app's `app.yaml` is not available until the job runs). Reconfigure, by contrast, validates names synchronously because the app is already installed. |
 
 **Mode A — registry install:**
 ```bash
@@ -3098,8 +3098,8 @@ Start an async reconfigure of an already-installed app — change its env vars a
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `env_vars` | One of | Env vars to **merge** into the app's existing `.env` as a JSON **object** (values must be strings). Keys not supplied are preserved; existing self-generated secrets are kept, not rotated. |
-| `ports` | One of | Host-port overrides as a JSON **object** mapping port name → host port (e.g. `{ "web": 4000 }`). Overrides must be integers ≥ 1024 and not banned (`22`, `80`, `443`, `10850`), and must not collide with another installed app. |
+| `env_vars` | One of | Env vars to **merge** into the app's existing `.env` as a JSON **object** (values must be strings). Keys not supplied are preserved; existing self-generated secrets are kept, not rotated. Passing an **empty string** (`""`) for a self-generating (`!generate`) key rotates it — the installer discards the old value and generates a fresh secret. |
+| `ports` | One of | Host-port overrides as a JSON **object** mapping port name → host port (e.g. `{ "web": 4000 }`). Overrides must be integers ≥ 1024 and not banned (`22`, `80`, `443`, `10850`), and must not collide with another installed app. A port name not declared by the app is rejected with `400` (see errors). |
 
 ```bash
 curl -X POST \
@@ -3117,6 +3117,8 @@ curl -X POST \
 ```
 
 Poll the returned `jobId` with `GET /api/v1/apps/jobs/:jobId` to track progress. When a host port changes, the proxy route is re-registered and the returned job's `proxyUrls` reflect the new port.
+
+**Rollback on failure:** if a host-port reconfigure fails to recreate the container (e.g. the new port is unbindable or the healthcheck never passes), the app is rolled back to its previous ports — the old compose/`.env` are restored, the old container is brought back up, and the old proxy routes are re-registered — so the app stays reachable. The job is still reported as `failed`.
 
 **Error responses:**
 

--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Pass API key via `X-Api-Key: <key>` or `Authorization: Bearer <key>` header.
 | `DELETE` | `/api/v1/apps/:name` | Uninstall app (admin) |
 | `POST` | `/api/v1/apps/:name/start\|stop\|restart` | Start/stop/restart app containers (admin) |
 | `POST` | `/api/v1/apps/:name/update` | Blue-green update with auto-rollback → `jobId` (admin) |
+| `POST` | `/api/v1/apps/:name/reconfigure` | Change env vars / host ports on an installed app, with rollback → `jobId` (admin) |
 | `GET` | `/app/:name/:portName/*` | Reverse proxy to installed app (no auth) |
 
 **Wizard API** — create agents programmatically with the same flow as the interactive `make create-agent` terminal wizard. The wizard generates workspace files via Claude, writes them on confirm, and optionally pairs a Telegram/Discord bot. State is in-memory with a 30-minute TTL; nothing is written until `/confirm`. See [API.md](./API.md) for the full wizard flow.

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -346,6 +346,19 @@ export function createAppsRouter(
         });
         return;
       }
+      // Reject overrides for ports the app does not declare — the registry entry
+      // already carries the valid port names, so this is a clean 400 up front
+      // rather than a failed job.
+      if (hasPorts && portOverrides) {
+        const knownPorts = new Set(entry.ports.map((p) => p.name));
+        const unknown = Object.keys(portOverrides).filter((name) => !knownPorts.has(name));
+        if (unknown.length > 0) {
+          res.status(400).json({
+            error: `Unknown port name(s): ${unknown.join(', ')}`,
+          });
+          return;
+        }
+      }
       // Cross-app host-port collision — deterministic, so reject up front (400).
       if (hasPorts && portOverrides) {
         const collision = await installer.findHostPortCollision(

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -4,8 +4,50 @@ import { createApiAuthMiddleware, isAdmin } from './auth';
 import { AppsRegistry } from '../apps/registry';
 import { AppInstaller } from '../apps/installer';
 import { RegistryClient } from '../apps/registry-client';
+import { assertValidHostPort } from '../apps/compose-generator';
 
 type AuthedRequest = Request & { apiKey: ApiKey };
+
+/**
+ * Parse a request-body `ports` field into a validated host-port override map.
+ * Returns undefined when absent. Throws (→ 400) on a non-object, a non-integer
+ * value, or a banned / sub-1024 port — the same floor generateCompose enforces,
+ * surfaced synchronously so callers get a clear error instead of a failed job.
+ */
+function parsePortsField(raw: unknown): Record<string, number> | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('"ports" must be an object mapping port name to host port');
+  }
+  const out: Record<string, number> = {};
+  for (const [name, val] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof val !== 'number' || !Number.isInteger(val)) {
+      throw new Error(`Port override "${name}" must be an integer`);
+    }
+    assertValidHostPort(name, val); // throws on banned / < 1024
+    out[name] = val;
+  }
+  return out;
+}
+
+/**
+ * Parse a request-body `env_vars` field into a validated string map. Returns
+ * undefined when absent. Throws (→ 400) on a non-object or a non-string value.
+ */
+function parseEnvVarsField(raw: unknown): Record<string, string> | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('"env_vars" must be an object');
+  }
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v !== 'string') {
+      throw new Error(`env var "${k}" must be a string`);
+    }
+    out[k] = v;
+  }
+  return out;
+}
 
 // ─── Router ───────────────────────────────────────────────────────────────────
 
@@ -69,6 +111,13 @@ export function createAppsRouter(
     }
 
     const body = req.body as Record<string, unknown>;
+    let portOverrides: Record<string, number> | undefined;
+    try {
+      portOverrides = parsePortsField(body.ports);
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+      return;
+    }
     const options = {
       registryApp: typeof body.registry_app === 'string' ? body.registry_app : undefined,
       version: typeof body.version === 'string' ? body.version : undefined,
@@ -78,6 +127,7 @@ export function createAppsRouter(
       envVars: typeof body.env_vars === 'object' && body.env_vars !== null && !Array.isArray(body.env_vars)
         ? (body.env_vars as Record<string, string>)
         : undefined,
+      portOverrides,
     };
 
     if (!options.registryApp && !options.githubUrl && !options.localPath) {
@@ -250,6 +300,72 @@ export function createAppsRouter(
       res.status(202).json({ jobId });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/v1/apps/:name/reconfigure — async reconfigure → { jobId }.
+   * Merges `env_vars` into the app's existing .env (keys not sent are kept) and
+   * optionally overrides host `ports`, then force-recreates the container while
+   * preserving its named volumes/data. Admin-gated to match install/update.
+   */
+  router.post('/v1/apps/:name/reconfigure', async (req: Request, res: Response) => {
+    const authed = req as AuthedRequest;
+    if (!isAdmin(authed.apiKey)) {
+      res.status(403).json({ error: 'Admin access required to reconfigure apps' });
+      return;
+    }
+
+    const body = req.body as Record<string, unknown>;
+    let envVars: Record<string, string> | undefined;
+    let portOverrides: Record<string, number> | undefined;
+    try {
+      envVars = parseEnvVarsField(body.env_vars);
+      portOverrides = parsePortsField(body.ports);
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+      return;
+    }
+
+    const hasEnv = envVars !== undefined && Object.keys(envVars).length > 0;
+    const hasPorts = portOverrides !== undefined && Object.keys(portOverrides).length > 0;
+    if (!hasEnv && !hasPorts) {
+      res.status(400).json({ error: 'Provide env_vars and/or ports to reconfigure' });
+      return;
+    }
+
+    try {
+      const entry = await registry.get(req.params.name);
+      if (!entry) {
+        res.status(404).json({ error: `App "${req.params.name}" not found` });
+        return;
+      }
+      if (entry.source === 'local') {
+        res.status(400).json({
+          error: 'Local (symlinked) apps cannot be reconfigured — reinstall from source instead',
+        });
+        return;
+      }
+      // Cross-app host-port collision — deterministic, so reject up front (400).
+      if (hasPorts && portOverrides) {
+        const collision = await installer.findHostPortCollision(
+          req.params.name,
+          Object.entries(portOverrides).map(([name, hostPort]) => ({ name, hostPort })),
+        );
+        if (collision) {
+          res.status(400).json({ error: collision });
+          return;
+        }
+      }
+      const jobId = installer.reconfigure(req.params.name, { envVars, portOverrides });
+      res.status(202).json({ jobId });
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes('already being')) {
+        res.status(409).json({ error: msg });
+        return;
+      }
+      res.status(500).json({ error: msg });
     }
   });
 

--- a/src/apps/compose-generator.ts
+++ b/src/apps/compose-generator.ts
@@ -121,7 +121,25 @@ export interface GeneratedCompose {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const BANNED_PORTS = new Set([22, 80, 443, 10850]);
+export const BANNED_PORTS = new Set([22, 80, 443, 10850]);
+
+/**
+ * Validate a host port supplied as an override (install `ports` field or the
+ * reconfigure endpoint). External input — enforce the same floor and banned
+ * set the app.yaml validator ({@link validatePorts}) applies to declared host
+ * ports, so an override can never map an app onto ssh/http/https/the gateway.
+ * Throws with a caller-friendly message on failure.
+ */
+export function assertValidHostPort(portName: string, value: number): void {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new Error(`Port override for "${portName}" must be an integer`);
+  }
+  if (value < 1024 || BANNED_PORTS.has(value)) {
+    throw new Error(
+      `Port override for "${portName}" (${value}) is banned or below 1024`,
+    );
+  }
+}
 const ALLOWED_SERVICE_FIELDS = new Set([
   'build', 'image', 'command', 'entrypoint', 'working_dir', 'user',
   'environment', 'volumes', 'ports', 'depends_on', 'healthcheck', 'gateway_api',
@@ -260,10 +278,15 @@ export function generateCompose(
   appName: string,
   appDir: string,
   outputPath: string,
+  portOverrides?: Record<string, number>,
 ): GeneratedCompose {
   if (!APP_NAME_RE.test(appName)) {
     throw new Error(`Invalid app name: "${appName}"`);
   }
+
+  // Track which override keys actually match a declared port name so an
+  // override for a non-existent port is reported rather than silently ignored.
+  const unusedOverrides = new Set(Object.keys(portOverrides ?? {}));
 
   const result: GeneratedCompose = {
     ports: [],
@@ -408,7 +431,15 @@ export function generateCompose(
 
     for (const portDef of svc.ports ?? []) {
       const containerPort = portDef.container;
-      const hostPort = portDef.host;
+      let hostPort = portDef.host;
+      // Host-port override (install `ports` field / reconfigure). Validated
+      // against the same floor + banned set as declared ports.
+      if (portOverrides && Object.prototype.hasOwnProperty.call(portOverrides, portDef.name)) {
+        const override = portOverrides[portDef.name];
+        assertValidHostPort(portDef.name, override);
+        hostPort = override;
+        unusedOverrides.delete(portDef.name);
+      }
       composeSvc.ports = (composeSvc.ports as string[] | undefined) ?? [];
       (composeSvc.ports as string[]).push(`${hostPort}:${containerPort}`);
 
@@ -502,6 +533,27 @@ export function generateCompose(
     };
 
     composeServices[svcName] = composeSvc;
+  }
+
+  // Port-override post-checks (only when overrides were supplied, so existing
+  // installs without overrides keep their exact behavior).
+  if (portOverrides) {
+    if (unusedOverrides.size > 0) {
+      throw new Error(
+        `Port override for unknown port name(s): ${[...unusedOverrides].join(', ')}`,
+      );
+    }
+    // Reject overrides that make two ports share one host port within the app.
+    const seenHost = new Map<number, string>();
+    for (const p of result.ports) {
+      const prev = seenHost.get(p.hostPort);
+      if (prev !== undefined && prev !== p.name) {
+        throw new Error(
+          `Host port ${p.hostPort} is used by more than one port ("${prev}" and "${p.name}")`,
+        );
+      }
+      seenHost.set(p.hostPort, p.name);
+    }
   }
 
   // Top-level volumes for named volumes

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -12,6 +12,7 @@ import {
   ComposePort,
   ComposeSocket,
   GeneratedKey,
+  GeneratedCompose,
   AgentDeclaration,
 } from './compose-generator';
 import { AgentManager } from './agent-manager';
@@ -31,6 +32,16 @@ export interface InstallOptions {
   localPath?: string;
   /** Pre-supplied env vars (secrets that would otherwise be prompted) */
   envVars?: Record<string, string>;
+  /** Host-port overrides per port name (default host comes from app.yaml) */
+  portOverrides?: Record<string, number>;
+}
+
+/** Options for {@link AppInstaller.reconfigure}. */
+export interface ReconfigureOptions {
+  /** Env vars to merge into the existing .env (unsent keys are preserved) */
+  envVars?: Record<string, string>;
+  /** Host-port overrides per port name (unset = app.yaml default) */
+  portOverrides?: Record<string, number>;
 }
 
 export interface InstallResult {
@@ -273,6 +284,40 @@ export class AppInstaller {
     this.jobs.set(jobId, job);
 
     void this.runUpdate(job, appName).catch((err: unknown) => {
+      this.failJob(job, err instanceof Error ? err.message : String(err));
+    }).finally(() => {
+      this.installingNames.delete(appName);
+    });
+
+    return jobId;
+  }
+
+  /**
+   * Start an async reconfigure job — merge env vars and/or override host ports
+   * on an already-installed app, then force-recreate the container. Named
+   * volumes (and their data) survive because this is an `up --force-recreate`,
+   * never a `down -v`. Returns jobId immediately. Throws synchronously (409)
+   * if the app is mid install/update/reconfigure.
+   */
+  reconfigure(appName: string, options: ReconfigureOptions): string {
+    this.pruneOldJobs();
+
+    if (this.installingNames.has(appName)) {
+      throw new Error(`App "${appName}" is already being installed or updated`);
+    }
+    this.installingNames.add(appName);
+
+    const jobId = crypto.randomUUID();
+    const job: JobState = {
+      id: jobId,
+      status: 'pending',
+      logs: [],
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    this.jobs.set(jobId, job);
+
+    void this.runReconfigure(job, appName, options).catch((err: unknown) => {
       this.failJob(job, err instanceof Error ? err.message : String(err));
     }).finally(() => {
       this.installingNames.delete(appName);
@@ -545,23 +590,15 @@ export class AppInstaller {
     // ── Generate docker-compose.yml ───────────────────────────────────────
     this.log(job, 'Generating docker-compose.yml');
     const composePath = path.join(appDir, 'docker-compose.yml');
-    const generated = generateCompose(appYaml, appName, appDir, composePath);
+    const generated = generateCompose(appYaml, appName, appDir, composePath, options.portOverrides);
 
     // Conflict check — host port uniqueness across all installed apps
-    const installedApps = await this.registry.list();
-    const usedHostPorts = new Map<number, string>();
-    for (const app of installedApps) {
-      for (const port of app.ports) {
-        usedHostPorts.set(port.hostPort, app.name);
-      }
-    }
-    for (const port of generated.ports) {
-      const owner = usedHostPorts.get(port.hostPort);
-      if (owner) {
-        throw new Error(
-          `Host port ${port.hostPort} (port "${port.name}") is already used by app "${owner}"`,
-        );
-      }
+    const collision = await this.findHostPortCollision(
+      appName,
+      generated.ports.map((p) => ({ name: p.name, hostPort: p.hostPort })),
+    );
+    if (collision) {
+      throw new Error(collision);
     }
 
     // Conflict check — agent name (if app declares an agent), inside install lock
@@ -594,50 +631,9 @@ export class AppInstaller {
 
     // ── Write .env ────────────────────────────────────────────────────────
     this.log(job, 'Writing .env');
-    const envVars = options.envVars ?? {};
-    const envLines: string[] = [];
-
-    // Inject BASE_PATH for web-type ports
-    for (const port of generated.ports) {
-      if (port.type === 'web') {
-        envVars[`BASE_PATH`] = `/app/${appName}/${port.name}`;
-      }
-    }
-
-    for (const key of generated.secretKeys) {
-      const val = (envVars[key] ?? '').replace(/[\r\n]/g, '');
-      envLines.push(`${key}=${val}`);
-    }
-    // Self-generating secrets: write a fresh random value unless the operator
-    // pinned one via envVars. Log only the key names, never the values.
-    const generatedKeySet = new Set(generated.generatedKeys.map((g) => g.key));
-    const generatedNames: string[] = [];
-    for (const g of generated.generatedKeys) {
-      const pinned = envVars[g.key];
-      let val: string;
-      if (pinned !== undefined && pinned !== '') {
-        val = pinned.replace(/[\r\n]/g, '');
-      } else {
-        val = generateSecretValue(g.encoding, g.bytes);
-        generatedNames.push(g.key);
-      }
-      envLines.push(`${g.key}=${val}`);
-    }
+    const generatedNames = this.writeEnvFile(appDir, appName, generated, options.envVars ?? {});
     if (generatedNames.length > 0) {
       this.log(job, `Generated secrets: ${generatedNames.join(', ')}`);
-    }
-    // Also write any explicitly provided vars not already declared as secrets/generated
-    for (const [k, v] of Object.entries(envVars)) {
-      if (!generated.secretKeys.includes(k) && !generatedKeySet.has(k)) {
-        envLines.push(`${k}=${v.replace(/[\r\n]/g, '')}`);
-      }
-    }
-
-    const envPath = path.join(appDir, '.env');
-    try {
-      fs.writeFileSync(envPath, envLines.join('\n') + '\n', { mode: 0o600 });
-    } catch (err) {
-      throw new Error(`Failed to write .env: ${(err as Error).message}`);
     }
 
     // ── Create socket files ───────────────────────────────────────────────
@@ -1014,6 +1010,226 @@ export class AppInstaller {
   }
 
   /**
+   * Reconfigure an installed app: merge env vars and/or override host ports,
+   * then force-recreate the container in place. No clone, no dir swap — the app
+   * stays at its current commit/appDir; only its .env and (optionally) its
+   * compose port mappings change. Named volumes and their data survive because
+   * this is an `up --force-recreate`, never a `down -v`.
+   */
+  private async runReconfigure(
+    job: JobState,
+    appName: string,
+    options: ReconfigureOptions,
+  ): Promise<void> {
+    job.status = 'running';
+    job.updatedAt = Date.now();
+
+    const entry = await this.registry.get(appName);
+    if (!entry) throw new Error(`App "${appName}" is not installed`);
+    if (entry.source === 'local') {
+      throw new Error(
+        `App "${appName}" is installed from a local path and cannot be reconfigured — reinstall from source instead`,
+      );
+    }
+
+    const appDir = entry.installPath;
+    const composePath = path.join(appDir, 'docker-compose.yml');
+    const portOverrides = options.portOverrides;
+    const hasPortChange =
+      portOverrides !== undefined && Object.keys(portOverrides).length > 0;
+
+    // Parse the app's on-disk app.yaml (present from the original install/update).
+    const yamlPath = path.join(appDir, 'app.yaml');
+    if (!fs.existsSync(yamlPath)) {
+      throw new Error(`app.yaml not found for "${appName}" — cannot reconfigure`);
+    }
+    const appYaml = parseAppYaml(fs.readFileSync(yamlPath, 'utf-8'), appDir);
+
+    this.log(job, 'Preparing reconfigure');
+
+    // Compute (and validate) the port metadata. Only overwrite the live compose
+    // file when a host port actually changed — regenerating drops the injected
+    // agent service, so we re-inject it, and an env-only reconfigure must not
+    // touch the compose at all. generateCompose validates the overrides.
+    let generated: GeneratedCompose;
+    if (hasPortChange) {
+      generated = generateCompose(appYaml, appName, appDir, composePath, portOverrides);
+      if (generated.agentDeclaration && this.agentManager) {
+        const agentPaths = entry.agentPaths ?? this.agentManager.detectAgentPaths();
+        this.agentManager.injectAgentService({ ...entry, agentPaths });
+      }
+    } else {
+      const tmpCompose = path.join(os.tmpdir(), `cg-reconf-${appName}-${crypto.randomUUID()}.yml`);
+      try {
+        generated = generateCompose(appYaml, appName, appDir, tmpCompose, portOverrides);
+      } finally {
+        fs.rmSync(tmpCompose, { force: true });
+      }
+    }
+
+    // Host-port collision across other installed apps (only if ports changed).
+    if (hasPortChange) {
+      const collision = await this.findHostPortCollision(
+        appName,
+        generated.ports.map((p) => ({ name: p.name, hostPort: p.hostPort })),
+      );
+      if (collision) throw new Error(collision);
+    }
+
+    // Merge the new env vars onto the existing .env: keys not supplied are
+    // preserved, and existing generated-secret values are carried over rather
+    // than rotated (writeEnvFile treats an already-present value as pinned).
+    this.log(job, 'Writing .env');
+    const mergedEnv = { ...this.readEnvFile(appDir), ...(options.envVars ?? {}) };
+    this.writeEnvFile(appDir, appName, generated, mergedEnv);
+
+    // Deregister old proxy routes before the port mapping changes (the proxy is
+    // bound to the old hostPort).
+    if (hasPortChange) {
+      this.callbacks.deregisterRoutes(appName);
+    }
+
+    // Force-recreate so the container picks up the new .env / port mapping —
+    // compose does not detect an env_file content change on its own. This is an
+    // `up`, not a `down -v`, so named volumes (and their data) survive.
+    this.log(job, 'Recreating container');
+    this.composeUp(appName, appDir, job, { forceRecreate: true });
+
+    await this.registry.updateStatus(appName, 'running');
+
+    // Persist the new port mappings + re-register proxy routes.
+    if (hasPortChange) {
+      const portEntries: PortEntry[] = generated.ports.map((p) => ({
+        name: p.name,
+        service: p.service,
+        hostPort: p.hostPort,
+        containerPort: p.containerPort,
+        type: p.type,
+        rateLimit: p.rateLimit,
+      }));
+      await this.registry.upsert({
+        ...entry,
+        ports: portEntries,
+        updatedAt: new Date().toISOString(),
+      });
+      this.callbacks.registerRoutes(appName, generated.ports);
+    }
+
+    const proxyUrls: Record<string, string> = {};
+    for (const p of generated.ports) {
+      proxyUrls[p.name] = `/app/${appName}/${p.name}/`;
+    }
+
+    job.status = 'completed';
+    job.result = {
+      appName,
+      proxyUrls,
+      secretKeys: generated.secretKeys,
+      agentDeclaration: entry.agentDeclaration ?? null,
+    };
+    job.updatedAt = Date.now();
+    this.log(job, `Reconfigure complete: ${JSON.stringify(proxyUrls)}`);
+  }
+
+  /**
+   * Return an error message if any of the given host ports is already bound by a
+   * *different* installed app, else null. Shared by install and reconfigure so
+   * the cross-app collision rule stays in one place.
+   */
+  async findHostPortCollision(
+    selfName: string,
+    ports: Array<{ name: string; hostPort: number }>,
+  ): Promise<string | null> {
+    const installedApps = await this.registry.list();
+    const usedHostPorts = new Map<number, string>();
+    for (const app of installedApps) {
+      if (app.name === selfName) continue;
+      for (const port of app.ports) {
+        usedHostPorts.set(port.hostPort, app.name);
+      }
+    }
+    for (const p of ports) {
+      const owner = usedHostPorts.get(p.hostPort);
+      if (owner) {
+        return `Host port ${p.hostPort} (port "${p.name}") is already used by app "${owner}"`;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Write the app's .env file (mode 0600). Emits, in order: BASE_PATH for web
+   * ports, declared secretKeys, self-generating generatedKeys (a fresh random
+   * value unless already present in `envVars` — operator-pinned on install, or
+   * the existing value on reconfigure), then any extra vars. Returns the names
+   * of freshly generated secrets (for logging — never the values). Shared by
+   * runInstall and runReconfigure so the .env format cannot drift.
+   */
+  private writeEnvFile(
+    appDir: string,
+    appName: string,
+    generated: Pick<GeneratedCompose, 'ports' | 'secretKeys' | 'generatedKeys'>,
+    envVars: Record<string, string>,
+  ): string[] {
+    const merged: Record<string, string> = { ...envVars };
+    // Inject BASE_PATH for web-type ports
+    for (const port of generated.ports) {
+      if (port.type === 'web') {
+        merged['BASE_PATH'] = `/app/${appName}/${port.name}`;
+      }
+    }
+
+    const envLines: string[] = [];
+    for (const key of generated.secretKeys) {
+      const val = (merged[key] ?? '').replace(/[\r\n]/g, '');
+      envLines.push(`${key}=${val}`);
+    }
+    const generatedKeySet = new Set(generated.generatedKeys.map((g) => g.key));
+    const generatedNames: string[] = [];
+    for (const g of generated.generatedKeys) {
+      const pinned = merged[g.key];
+      let val: string;
+      if (pinned !== undefined && pinned !== '') {
+        val = pinned.replace(/[\r\n]/g, '');
+      } else {
+        val = generateSecretValue(g.encoding, g.bytes);
+        generatedNames.push(g.key);
+      }
+      envLines.push(`${g.key}=${val}`);
+    }
+    // Any explicitly provided vars not already declared as secrets/generated.
+    for (const [k, v] of Object.entries(merged)) {
+      if (!generated.secretKeys.includes(k) && !generatedKeySet.has(k)) {
+        envLines.push(`${k}=${v.replace(/[\r\n]/g, '')}`);
+      }
+    }
+
+    const envPath = path.join(appDir, '.env');
+    try {
+      fs.writeFileSync(envPath, envLines.join('\n') + '\n', { mode: 0o600 });
+    } catch (err) {
+      throw new Error(`Failed to write .env: ${(err as Error).message}`);
+    }
+    return generatedNames;
+  }
+
+  /** Parse an app's existing .env into a key→value map (empty if absent). */
+  private readEnvFile(appDir: string): Record<string, string> {
+    const envPath = path.join(appDir, '.env');
+    const out: Record<string, string> = {};
+    if (!fs.existsSync(envPath)) return out;
+    const content = fs.readFileSync(envPath, 'utf-8');
+    for (const rawLine of content.split('\n')) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      out[line.slice(0, eq)] = line.slice(eq + 1);
+    }
+    return out;
+  }
+
+  /**
    * Resolve the repo URL and target commit to update an installed app to.
    * - `registry`: latest published version via the registry client.
    * - `custom` (GitHub URL install): the default branch HEAD via git ls-remote,
@@ -1176,10 +1392,14 @@ export class AppInstaller {
    * Captures container logs into the job on failure before rethrowing.
    * job is optional — when omitted (e.g. startStopRestart) logs go to stderr.
    */
-  private composeUp(appName: string, dir: string, job?: JobState): void {
+  private composeUp(appName: string, dir: string, job?: JobState, opts?: { forceRecreate?: boolean }): void {
     this.stopConflictingContainers(appName);
+    const args = ['docker', 'compose', '-p', appName, 'up', '-d', '--wait'];
+    if (opts?.forceRecreate) {
+      args.push('--force-recreate');
+    }
     try {
-      this.run(['docker', 'compose', '-p', appName, 'up', '-d', '--wait'], dir, 600_000);
+      this.run(args, dir, 600_000);
     } catch (upErr) {
       if (job) {
         try {

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -1048,36 +1048,38 @@ export class AppInstaller {
     this.log(job, 'Preparing reconfigure');
 
     // Snapshot the current on-disk state BEFORE any mutation so a failed
-    // recreate can be rolled back. A port change rewrites the live compose file
-    // and swaps proxy routes; if the new container never comes up the app would
-    // otherwise be left unreachable (routes gone, compose/registry mismatched).
+    // recreate can be rolled back. Both an env-only and a port change rewrite
+    // .env and force-recreate the container; a port change additionally rewrites
+    // the live compose file and swaps proxy routes. If the new container never
+    // comes up the app would otherwise be left down (or, for a port change,
+    // unreachable with routes gone and compose/registry mismatched).
     const envPath = path.join(appDir, '.env');
     const oldComposeContent =
       hasPortChange && fs.existsSync(composePath) ? fs.readFileSync(composePath, 'utf-8') : null;
     const oldEnvContent = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : null;
     const oldPorts = entry.ports;
 
-    // Compute (and validate) the port metadata. Only overwrite the live compose
-    // file when a host port actually changed — regenerating drops the injected
-    // agent service, so we re-inject it, and an env-only reconfigure must not
-    // touch the compose at all. generateCompose validates the overrides.
+    // Compute (and validate) the port metadata. Always generate to a TEMP file
+    // first: the live compose must not change until the overrides are validated
+    // (generateCompose checks them) and we are inside the guarded section below.
+    // Writing the live file here would leave the new ports on disk against the
+    // still-running old container if a later step (collision, agent inject)
+    // throws (finding F2). An env-only reconfigure never touches the compose.
     let generated: GeneratedCompose;
-    if (hasPortChange) {
-      generated = generateCompose(appYaml, appName, appDir, composePath, portOverrides);
-      if (generated.agentDeclaration && this.agentManager) {
-        const agentPaths = entry.agentPaths ?? this.agentManager.detectAgentPaths();
-        this.agentManager.injectAgentService({ ...entry, agentPaths });
-      }
-    } else {
+    let newComposeContent: string;
+    {
       const tmpCompose = path.join(os.tmpdir(), `cg-reconf-${appName}-${crypto.randomUUID()}.yml`);
       try {
         generated = generateCompose(appYaml, appName, appDir, tmpCompose, portOverrides);
+        newComposeContent = fs.readFileSync(tmpCompose, 'utf-8');
       } finally {
         fs.rmSync(tmpCompose, { force: true });
       }
     }
 
     // Host-port collision across other installed apps (only if ports changed).
+    // Runs before the live compose is touched, so a collision leaves nothing to
+    // undo on disk.
     if (hasPortChange) {
       const collision = await this.findHostPortCollision(
         appName,
@@ -1086,11 +1088,24 @@ export class AppInstaller {
       if (collision) throw new Error(collision);
     }
 
-    // Apply the reconfigure. Everything from here mutates live state (.env,
-    // proxy routes, the running container), so it is guarded: a port change that
-    // fails to recreate is rolled back to the previous ports/compose/.env so the
-    // app stays reachable (planning §4.1 step 10 — best-effort reopen).
+    // Apply the reconfigure. Everything from here mutates live state (compose
+    // file, .env, proxy routes, the running container), so it is guarded: a
+    // reconfigure that fails to recreate is rolled back to the previous
+    // ports/compose/.env so the app stays reachable (planning §4.1 step 10 —
+    // best-effort reopen).
     try {
+      // Swap in the newly-generated compose only now that we're inside the
+      // guard (finding F2). Regenerating drops the injected agent service, so we
+      // re-inject it. An env-only reconfigure leaves the compose untouched.
+      if (hasPortChange) {
+        this.log(job, 'Updating docker-compose.yml');
+        fs.writeFileSync(composePath, newComposeContent);
+        if (generated.agentDeclaration && this.agentManager) {
+          const agentPaths = entry.agentPaths ?? this.agentManager.detectAgentPaths();
+          this.agentManager.injectAgentService({ ...entry, agentPaths });
+        }
+      }
+
       // Merge the new env vars onto the existing .env: keys not supplied are
       // preserved, and existing generated-secret values are carried over rather
       // than rotated (writeEnvFile treats an already-present value as pinned).
@@ -1131,21 +1146,24 @@ export class AppInstaller {
         this.callbacks.registerRoutes(appName, generated.ports);
       }
     } catch (reconfErr) {
-      // Roll back a failed port change: restore the previous compose/.env,
-      // bring the old container back on the old ports, and re-register the old
-      // routes so the app is reachable again. Env-only reconfigure leaves the
-      // compose and routes untouched, so there is nothing to restore there.
-      if (hasPortChange) {
-        this.log(job, `Reconfigure failed — rolling back "${appName}" to previous ports`);
-        try {
-          if (oldComposeContent !== null) {
-            fs.writeFileSync(composePath, oldComposeContent);
-          }
-          if (oldEnvContent !== null) {
-            fs.writeFileSync(envPath, oldEnvContent, { mode: 0o600 });
-            fs.chmodSync(envPath, 0o600);
-          }
-          this.composeUp(appName, appDir, job, { forceRecreate: true });
+      // Roll back a failed reconfigure so the app stays reachable. Both a
+      // port change and an env-only change rewrite .env and force-recreate the
+      // container, so a bad value (failed healthcheck) or an unbindable port can
+      // leave the app down either way (finding F1). Restore the previous .env,
+      // restore the previous compose + re-register the old routes when a port
+      // change had swapped them, then bring the old container back on the old
+      // config. Best-effort: a failing rollback is logged, not thrown.
+      this.log(job, `Reconfigure failed — rolling back "${appName}"`);
+      try {
+        if (oldEnvContent !== null) {
+          fs.writeFileSync(envPath, oldEnvContent, { mode: 0o600 });
+          fs.chmodSync(envPath, 0o600);
+        }
+        if (hasPortChange && oldComposeContent !== null) {
+          fs.writeFileSync(composePath, oldComposeContent);
+        }
+        this.composeUp(appName, appDir, job, { forceRecreate: true });
+        if (hasPortChange) {
           this.callbacks.registerRoutes(
             appName,
             oldPorts.map((p) => ({
@@ -1157,13 +1175,13 @@ export class AppInstaller {
               rateLimit: p.rateLimit,
             })),
           );
-          await this.registry.updateStatus(appName, 'running');
-        } catch (rollbackErr) {
-          this.log(
-            job,
-            `ROLLBACK FAILED — app "${appName}" may be in a broken state: ${(rollbackErr as Error).message}`,
-          );
         }
+        await this.registry.updateStatus(appName, 'running');
+      } catch (rollbackErr) {
+        this.log(
+          job,
+          `ROLLBACK FAILED — app "${appName}" may be in a broken state: ${(rollbackErr as Error).message}`,
+        );
       }
       throw reconfErr;
     }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -1047,6 +1047,16 @@ export class AppInstaller {
 
     this.log(job, 'Preparing reconfigure');
 
+    // Snapshot the current on-disk state BEFORE any mutation so a failed
+    // recreate can be rolled back. A port change rewrites the live compose file
+    // and swaps proxy routes; if the new container never comes up the app would
+    // otherwise be left unreachable (routes gone, compose/registry mismatched).
+    const envPath = path.join(appDir, '.env');
+    const oldComposeContent =
+      hasPortChange && fs.existsSync(composePath) ? fs.readFileSync(composePath, 'utf-8') : null;
+    const oldEnvContent = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : null;
+    const oldPorts = entry.ports;
+
     // Compute (and validate) the port metadata. Only overwrite the live compose
     // file when a host port actually changed — regenerating drops the injected
     // agent service, so we re-inject it, and an env-only reconfigure must not
@@ -1076,44 +1086,86 @@ export class AppInstaller {
       if (collision) throw new Error(collision);
     }
 
-    // Merge the new env vars onto the existing .env: keys not supplied are
-    // preserved, and existing generated-secret values are carried over rather
-    // than rotated (writeEnvFile treats an already-present value as pinned).
-    this.log(job, 'Writing .env');
-    const mergedEnv = { ...this.readEnvFile(appDir), ...(options.envVars ?? {}) };
-    this.writeEnvFile(appDir, appName, generated, mergedEnv);
+    // Apply the reconfigure. Everything from here mutates live state (.env,
+    // proxy routes, the running container), so it is guarded: a port change that
+    // fails to recreate is rolled back to the previous ports/compose/.env so the
+    // app stays reachable (planning §4.1 step 10 — best-effort reopen).
+    try {
+      // Merge the new env vars onto the existing .env: keys not supplied are
+      // preserved, and existing generated-secret values are carried over rather
+      // than rotated (writeEnvFile treats an already-present value as pinned).
+      this.log(job, 'Writing .env');
+      const mergedEnv = { ...this.readEnvFile(appDir), ...(options.envVars ?? {}) };
+      this.writeEnvFile(appDir, appName, generated, mergedEnv);
 
-    // Deregister old proxy routes before the port mapping changes (the proxy is
-    // bound to the old hostPort).
-    if (hasPortChange) {
-      this.callbacks.deregisterRoutes(appName);
-    }
+      // Deregister old proxy routes before the port mapping changes (the proxy is
+      // bound to the old hostPort).
+      if (hasPortChange) {
+        this.callbacks.deregisterRoutes(appName);
+      }
 
-    // Force-recreate so the container picks up the new .env / port mapping —
-    // compose does not detect an env_file content change on its own. This is an
-    // `up`, not a `down -v`, so named volumes (and their data) survive.
-    this.log(job, 'Recreating container');
-    this.composeUp(appName, appDir, job, { forceRecreate: true });
+      // Force-recreate so the container picks up the new .env / port mapping —
+      // compose does not detect an env_file content change on its own. This is an
+      // `up`, not a `down -v`, so named volumes (and their data) survive.
+      this.log(job, 'Recreating container');
+      this.composeUp(appName, appDir, job, { forceRecreate: true });
 
-    await this.registry.updateStatus(appName, 'running');
+      await this.registry.updateStatus(appName, 'running');
 
-    // Persist the reconfigure: always bump updatedAt so the registry reflects
-    // that the app was reconfigured; refresh the port mappings + re-register
-    // proxy routes only when a host port actually changed.
-    const updatedEntry: AppEntry = { ...entry, updatedAt: new Date().toISOString() };
-    if (hasPortChange) {
-      updatedEntry.ports = generated.ports.map((p) => ({
-        name: p.name,
-        service: p.service,
-        hostPort: p.hostPort,
-        containerPort: p.containerPort,
-        type: p.type,
-        rateLimit: p.rateLimit,
-      }));
-    }
-    await this.registry.upsert(updatedEntry);
-    if (hasPortChange) {
-      this.callbacks.registerRoutes(appName, generated.ports);
+      // Persist the reconfigure: always bump updatedAt so the registry reflects
+      // that the app was reconfigured; refresh the port mappings + re-register
+      // proxy routes only when a host port actually changed.
+      const updatedEntry: AppEntry = { ...entry, updatedAt: new Date().toISOString() };
+      if (hasPortChange) {
+        updatedEntry.ports = generated.ports.map((p) => ({
+          name: p.name,
+          service: p.service,
+          hostPort: p.hostPort,
+          containerPort: p.containerPort,
+          type: p.type,
+          rateLimit: p.rateLimit,
+        }));
+      }
+      await this.registry.upsert(updatedEntry);
+      if (hasPortChange) {
+        this.callbacks.registerRoutes(appName, generated.ports);
+      }
+    } catch (reconfErr) {
+      // Roll back a failed port change: restore the previous compose/.env,
+      // bring the old container back on the old ports, and re-register the old
+      // routes so the app is reachable again. Env-only reconfigure leaves the
+      // compose and routes untouched, so there is nothing to restore there.
+      if (hasPortChange) {
+        this.log(job, `Reconfigure failed — rolling back "${appName}" to previous ports`);
+        try {
+          if (oldComposeContent !== null) {
+            fs.writeFileSync(composePath, oldComposeContent);
+          }
+          if (oldEnvContent !== null) {
+            fs.writeFileSync(envPath, oldEnvContent, { mode: 0o600 });
+            fs.chmodSync(envPath, 0o600);
+          }
+          this.composeUp(appName, appDir, job, { forceRecreate: true });
+          this.callbacks.registerRoutes(
+            appName,
+            oldPorts.map((p) => ({
+              name: p.name,
+              service: p.service,
+              hostPort: p.hostPort,
+              containerPort: p.containerPort,
+              type: p.type,
+              rateLimit: p.rateLimit,
+            })),
+          );
+          await this.registry.updateStatus(appName, 'running');
+        } catch (rollbackErr) {
+          this.log(
+            job,
+            `ROLLBACK FAILED — app "${appName}" may be in a broken state: ${(rollbackErr as Error).message}`,
+          );
+        }
+      }
+      throw reconfErr;
     }
 
     const proxyUrls: Record<string, string> = {};
@@ -1208,6 +1260,10 @@ export class AppInstaller {
     const envPath = path.join(appDir, '.env');
     try {
       fs.writeFileSync(envPath, envLines.join('\n') + '\n', { mode: 0o600 });
+      // writeFileSync's `mode` only applies when the file is created; on
+      // reconfigure the .env already exists, so re-assert 0600 explicitly to
+      // keep secrets owner-only regardless of the file's prior permissions.
+      fs.chmodSync(envPath, 0o600);
     } catch (err) {
       throw new Error(`Failed to write .env: ${(err as Error).message}`);
     }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -1097,9 +1097,12 @@ export class AppInstaller {
 
     await this.registry.updateStatus(appName, 'running');
 
-    // Persist the new port mappings + re-register proxy routes.
+    // Persist the reconfigure: always bump updatedAt so the registry reflects
+    // that the app was reconfigured; refresh the port mappings + re-register
+    // proxy routes only when a host port actually changed.
+    const updatedEntry: AppEntry = { ...entry, updatedAt: new Date().toISOString() };
     if (hasPortChange) {
-      const portEntries: PortEntry[] = generated.ports.map((p) => ({
+      updatedEntry.ports = generated.ports.map((p) => ({
         name: p.name,
         service: p.service,
         hostPort: p.hostPort,
@@ -1107,11 +1110,9 @@ export class AppInstaller {
         type: p.type,
         rateLimit: p.rateLimit,
       }));
-      await this.registry.upsert({
-        ...entry,
-        ports: portEntries,
-        updatedAt: new Date().toISOString(),
-      });
+    }
+    await this.registry.upsert(updatedEntry);
+    if (hasPortChange) {
       this.callbacks.registerRoutes(appName, generated.ports);
     }
 

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -552,6 +552,16 @@ services:
       expect(res.status).toBe(400);
     });
 
+    it('returns 400 for an unknown override port name', async () => {
+      await registry.upsert(makeEntry()); // declares only port "api"
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ ports: { nonexistent: 6100 } });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/[Uu]nknown port name/);
+    });
+
     it('returns 400 when an override port collides with another installed app', async () => {
       await registry.upsert(makeEntry({ name: 'other-app', ports: [
         { name: 'api', service: 'app', hostPort: 6001, containerPort: 6001, type: 'api', rateLimit: 200 },

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -476,4 +476,103 @@ services:
       expect(typeof res.body.updateable).toBe('boolean');
     });
   });
+
+  // ── POST /api/v1/apps/:name/reconfigure ────────────────────────────────
+  describe('POST /api/v1/apps/:name/reconfigure', () => {
+    it('returns 403 for non-admin key', async () => {
+      await registry.upsert(makeEntry());
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${READ_KEY.key}`)
+        .send({ env_vars: { FOO: 'bar' } });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 when app not installed', async () => {
+      const res = await request(app)
+        .post('/api/v1/apps/ghost/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ env_vars: { FOO: 'bar' } });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 400 for a local (symlinked) app', async () => {
+      await registry.upsert(makeEntry({ source: 'local' }));
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ env_vars: { FOO: 'bar' } });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/local/i);
+    });
+
+    it('returns 400 when neither env_vars nor ports is provided', async () => {
+      await registry.upsert(makeEntry());
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({});
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for a banned override port', async () => {
+      await registry.upsert(makeEntry());
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ ports: { api: 443 } });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/banned/i);
+    });
+
+    it('returns 400 for an override port below 1024', async () => {
+      await registry.upsert(makeEntry());
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ ports: { api: 1000 } });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for a non-integer override port', async () => {
+      await registry.upsert(makeEntry());
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ ports: { api: 'nope' } });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for a non-string env var value', async () => {
+      await registry.upsert(makeEntry());
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ env_vars: { FOO: 123 } });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when an override port collides with another installed app', async () => {
+      await registry.upsert(makeEntry({ name: 'other-app', ports: [
+        { name: 'api', service: 'app', hostPort: 6001, containerPort: 6001, type: 'api', rateLimit: 200 },
+      ] }));
+      await registry.upsert(makeEntry({ name: 'test-app' }));
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ ports: { api: 6001 } });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/already used by app "other-app"/);
+    });
+
+    it('returns 202 with a jobId for a valid env-only reconfigure', async () => {
+      await registry.upsert(makeEntry({ source: 'custom' }));
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/reconfigure')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ env_vars: { FEATURE_FLAG: 'on' } });
+      expect(res.status).toBe(202);
+      expect(typeof res.body.jobId).toBe('string');
+    });
+  });
 });

--- a/tests/unit/apps/compose-generator.test.ts
+++ b/tests/unit/apps/compose-generator.test.ts
@@ -920,3 +920,91 @@ services:
     });
   });
 });
+
+// ─── generateCompose() — host-port overrides (issue #267) ───────────────────────
+
+describe('generateCompose() — port overrides', () => {
+  let appDir: string;
+  let outputPath: string;
+
+  beforeEach(() => {
+    appDir = makeTmpDir();
+    outputPath = path.join(makeTmpDir(), 'docker-compose.yml');
+  });
+
+  function generate(
+    yamlContent: string,
+    overrides?: Record<string, number>,
+    appName = 'my-app',
+  ): ReturnType<typeof generateCompose> {
+    const appYaml = parseAppYaml(yamlContent, appDir);
+    return generateCompose(appYaml, appName, appDir, outputPath, overrides);
+  }
+
+  const TWO_PORT_YAML = `
+apiVersion: apps.getpod.ai/v1
+name: my-app
+version: 1.0.0
+commit: "abc123def456abc123def456abc123def456abc1"
+services:
+  web:
+    image: nginx:1.25
+    ports:
+      - name: app
+        host: 8080
+        container: 8080
+        type: api
+      - name: admin
+        host: 9090
+        container: 9090
+        type: api
+`.trim();
+
+  it('uses the app.yaml host port when no override is given', () => {
+    const result = generate(MINIMAL_IMAGE_YAML);
+    expect(result.ports.find((p) => p.name === 'app')?.hostPort).toBe(8080);
+    const compose = readCompose(outputPath);
+    const svc = (compose.services as Record<string, unknown>).web as Record<string, unknown>;
+    expect(svc.ports).toEqual(['8080:8080']);
+  });
+
+  it('overrides the host port for the named port only', () => {
+    const result = generate(TWO_PORT_YAML, { app: 8888 });
+    expect(result.ports.find((p) => p.name === 'app')?.hostPort).toBe(8888);
+    expect(result.ports.find((p) => p.name === 'admin')?.hostPort).toBe(9090);
+    const compose = readCompose(outputPath);
+    const svc = (compose.services as Record<string, unknown>).web as Record<string, unknown>;
+    expect(svc.ports).toEqual(['8888:8080', '9090:9090']);
+  });
+
+  it('keeps the container port unchanged when overriding the host port', () => {
+    const result = generate(MINIMAL_IMAGE_YAML, { app: 8888 });
+    const port = result.ports.find((p) => p.name === 'app');
+    expect(port?.hostPort).toBe(8888);
+    expect(port?.containerPort).toBe(8080);
+  });
+
+  it('rejects a banned override port', () => {
+    expect(() => generate(MINIMAL_IMAGE_YAML, { app: 443 })).toThrow('banned');
+  });
+
+  it('rejects an override port below 1024', () => {
+    expect(() => generate(MINIMAL_IMAGE_YAML, { app: 1000 })).toThrow('below 1024');
+  });
+
+  it('rejects the gateway port (10850) as an override', () => {
+    expect(() => generate(MINIMAL_IMAGE_YAML, { app: 10850 })).toThrow('banned');
+  });
+
+  it('rejects a non-integer override port', () => {
+    expect(() => generate(MINIMAL_IMAGE_YAML, { app: 8080.5 })).toThrow('integer');
+  });
+
+  it('rejects an override for an unknown port name', () => {
+    expect(() => generate(MINIMAL_IMAGE_YAML, { nonexistent: 8888 })).toThrow('unknown port name');
+  });
+
+  it('rejects two ports overridden onto the same host port', () => {
+    expect(() => generate(TWO_PORT_YAML, { app: 7000, admin: 7000 })).toThrow('more than one port');
+  });
+});

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1317,6 +1317,114 @@ services:
       expect(job.error).toMatch(/already used by app "other-app"/);
     });
 
+    it('leaves the live compose untouched when a port change throws before recreate (F2)', async () => {
+      // A collision (or any pre-recreate throw) must not have already rewritten
+      // the live docker-compose.yml — otherwise the file holds the new ports
+      // while the old container/routes are still live (finding F2). Reconfigure
+      // generates to a temp file and only swaps the live compose inside the
+      // guarded section, so a collision leaves the old mapping on disk.
+      const { spawn } = makeRecordingSpawn(5600);
+      const installer = await installReconfApp(spawn);
+      await registry.upsert(makeEntryFor('other-app', 5700));
+
+      const appDir = (await registry.get('reconf-app'))!.installPath;
+      const composePath = path.join(appDir, 'docker-compose.yml');
+      expect(fs.readFileSync(composePath, 'utf-8')).toContain('5600:5600');
+
+      const job = await waitForJob(
+        installer,
+        installer.reconfigure('reconf-app', { portOverrides: { api: 5700 } }),
+        5000,
+      );
+      expect(job.status).toBe('failed');
+
+      // The live compose still holds the ORIGINAL mapping — the failed override
+      // never reached disk.
+      const composeAfter = fs.readFileSync(composePath, 'utf-8');
+      expect(composeAfter).toContain('5600:5600');
+      expect(composeAfter).not.toContain('5700');
+      // Registry unchanged too.
+      const entry = await registry.get('reconf-app');
+      expect(entry?.ports[0].hostPort).toBe(5600);
+    });
+
+    it('rolls back the .env and recreates on a failed env-only reconfigure (F1)', async () => {
+      // An env-only reconfigure rewrites .env and force-recreates the container.
+      // A bad value that fails the recreate must not leave the app down with the
+      // broken .env — the rollback restores the previous .env and brings the old
+      // container back, even though no port changed (finding F1).
+      let forceRecreateCount = 0;
+      const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: reconf-app
+version: 1.0.0
+commit: "abc123def456abc123def456abc123def456abc1"
+services:
+  app:
+    image: nginx:1.25
+    environment:
+      - DB_PASSWORD
+    ports:
+      - name: api
+        host: 5600
+        container: 5600
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:5600/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+        }
+        // First force-recreate (the reconfigure) fails; the rollback's second
+        // recreate succeeds — mirroring a bad env value crashing the container.
+        if (cmd === 'docker' && args.includes('up') && args.includes('--force-recreate')) {
+          forceRecreateCount += 1;
+          if (forceRecreateCount === 1) {
+            return { stdout: '', stderr: 'mocked: container failed healthcheck', status: 1 };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+
+      const installer = makeInstaller(spawn as unknown as typeof successSpawn);
+      const installJob = await waitForJob(
+        installer,
+        installer.install({
+          githubUrl: 'https://github.com/test/reconf-app',
+          commit: 'a'.repeat(40),
+          envVars: { DB_PASSWORD: 'orig-secret' },
+        }),
+        5000,
+      );
+      expect(installJob.status).toBe('completed');
+
+      const appDir = (await registry.get('reconf-app'))!.installPath;
+      const envPath = path.join(appDir, '.env');
+      callbacks.deregistered.length = 0;
+      callbacks.registeredRoutes.length = 0;
+
+      const job = await waitForJob(
+        installer,
+        installer.reconfigure('reconf-app', { envVars: { DB_PASSWORD: 'bad-value' } }),
+        5000,
+      );
+
+      // Reported failed, but rolled back — not left down with the bad .env.
+      expect(job.status).toBe('failed');
+      const envAfter = fs.readFileSync(envPath, 'utf-8');
+      expect(envAfter).toContain('DB_PASSWORD=orig-secret');
+      expect(envAfter).not.toContain('bad-value');
+      // The rollback issued a second force-recreate to bring the old container back.
+      expect(forceRecreateCount).toBe(2);
+      // Env-only path never touches proxy routes (nothing deregistered).
+      expect(callbacks.deregistered).not.toContain('reconf-app');
+    });
+
     it('rolls back to the previous port/compose/routes when the recreate fails', async () => {
       // Install succeeds; the port-change recreate then fails on its FIRST
       // `up --force-recreate`, while the rollback's recreate (the second) is

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1317,6 +1317,91 @@ services:
       expect(job.error).toMatch(/already used by app "other-app"/);
     });
 
+    it('rolls back to the previous port/compose/routes when the recreate fails', async () => {
+      // Install succeeds; the port-change recreate then fails on its FIRST
+      // `up --force-recreate`, while the rollback's recreate (the second) is
+      // allowed to succeed — mirroring a real "new port unbindable" failure.
+      let forceRecreateCount = 0;
+      const calls: Array<{ cmd: string; args: string[] }> = [];
+      const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        calls.push({ cmd, args });
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: reconf-app
+version: 1.0.0
+commit: "abc123def456abc123def456abc123def456abc1"
+services:
+  app:
+    image: nginx:1.25
+    environment:
+      - DB_PASSWORD
+    ports:
+      - name: api
+        host: 5600
+        container: 5600
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:5600/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+        }
+        if (cmd === 'docker' && args.includes('up') && args.includes('--force-recreate')) {
+          forceRecreateCount += 1;
+          if (forceRecreateCount === 1) {
+            return { stdout: '', stderr: 'mocked: host port unbindable', status: 1 };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+
+      const installer = makeInstaller(spawn as unknown as typeof successSpawn);
+      const installJob = await waitForJob(
+        installer,
+        installer.install({
+          githubUrl: 'https://github.com/test/reconf-app',
+          commit: 'a'.repeat(40),
+          envVars: { DB_PASSWORD: 'orig-secret' },
+        }),
+        5000,
+      );
+      expect(installJob.status).toBe('completed');
+
+      const appDir = (await registry.get('reconf-app'))!.installPath;
+      const composePath = path.join(appDir, 'docker-compose.yml');
+      expect(fs.readFileSync(composePath, 'utf-8')).toContain('5600:5600');
+
+      callbacks.deregistered.length = 0;
+      callbacks.registeredRoutes.length = 0;
+
+      const job = await waitForJob(
+        installer,
+        installer.reconfigure('reconf-app', { portOverrides: { api: 5650 } }),
+        5000,
+      );
+
+      // Job is reported failed — but the app is left rolled back, not broken.
+      expect(job.status).toBe('failed');
+      // On-disk compose restored to the OLD port (the new 5650 mapping is gone).
+      const composeAfter = fs.readFileSync(composePath, 'utf-8');
+      expect(composeAfter).toContain('5600:5600');
+      expect(composeAfter).not.toContain('5650');
+      // Registry still holds the OLD port (new ports were never persisted).
+      const entry = await registry.get('reconf-app');
+      expect(entry?.ports[0].hostPort).toBe(5600);
+      // OLD routes are re-registered after the deregister, so the app is reachable.
+      expect(callbacks.deregistered).toContain('reconf-app');
+      const reg = callbacks.registeredRoutes.filter((r) => r.appName === 'reconf-app');
+      expect(reg.length).toBeGreaterThan(0);
+      expect(reg[reg.length - 1].ports[0].hostPort).toBe(5600);
+      // The rollback issued a second force-recreate to bring the old container back.
+      expect(forceRecreateCount).toBe(2);
+    });
+
     it('rejects reconfigure of a local (symlinked) app', async () => {
       const appDir = makeAppDir(srcDir, 'local-reconf');
       const installer = makeInstaller();

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1176,7 +1176,193 @@ services:
       expect(agentMgr.deleteAgentByName).not.toHaveBeenCalled();
     });
   });
+
+  // ─── reconfigure() — env/port changes on an installed app (issue #267) ────
+  describe('reconfigure()', () => {
+    /**
+     * Spawn mock that writes an app.yaml (one api port, a bare secret + a
+     * self-generating secret) on `git checkout`, and records every invocation
+     * so tests can assert docker flags. Emulates a GitHub install so the app is
+     * non-local (reconfigurable) with a real on-disk appDir.
+     */
+    function makeRecordingSpawn(port = 5600) {
+      const calls: Array<{ cmd: string; args: string[] }> = [];
+      const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        calls.push({ cmd, args });
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: reconf-app
+version: 1.0.0
+commit: "abc123def456abc123def456abc123def456abc1"
+services:
+  app:
+    image: nginx:1.25
+    environment:
+      - DB_PASSWORD
+      - SESSION_SECRET=!generate:hex:32
+    ports:
+      - name: api
+        host: ${port}
+        container: ${port}
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:${port}/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      return { spawn, calls };
+    }
+
+    async function installReconfApp(spawn: SpawnFnLike, dbPass = 'orig-secret') {
+      const installer = makeInstaller(spawn as unknown as typeof successSpawn);
+      const jobId = installer.install({
+        githubUrl: 'https://github.com/test/reconf-app',
+        commit: 'a'.repeat(40),
+        envVars: { DB_PASSWORD: dbPass },
+      });
+      const job = await waitForJob(installer, jobId, 5000);
+      expect(job.status).toBe('completed');
+      return installer;
+    }
+
+    it('merges env vars into .env, preserving unsent keys and generated secrets', async () => {
+      const { spawn } = makeRecordingSpawn();
+      const installer = await installReconfApp(spawn);
+      const appDir = (await registry.get('reconf-app'))!.installPath;
+
+      const before = fs.readFileSync(path.join(appDir, '.env'), 'utf-8');
+      const genBefore = before.split('\n').find((l) => l.startsWith('SESSION_SECRET='));
+      expect(before).toContain('DB_PASSWORD=orig-secret');
+      expect(genBefore).toBeDefined();
+
+      const job = await waitForJob(
+        installer,
+        installer.reconfigure('reconf-app', { envVars: { FEATURE_FLAG: 'on' } }),
+        5000,
+      );
+      expect(job.status).toBe('completed');
+
+      const after = fs.readFileSync(path.join(appDir, '.env'), 'utf-8');
+      // Untouched key preserved, generated secret NOT rotated, new key added.
+      expect(after).toContain('DB_PASSWORD=orig-secret');
+      expect(after.split('\n').find((l) => l.startsWith('SESSION_SECRET='))).toBe(genBefore);
+      expect(after).toContain('FEATURE_FLAG=on');
+    });
+
+    it('force-recreates the container and never removes volumes', async () => {
+      const { spawn, calls } = makeRecordingSpawn();
+      const installer = await installReconfApp(spawn);
+      calls.length = 0; // only inspect the reconfigure phase
+
+      const job = await waitForJob(
+        installer,
+        installer.reconfigure('reconf-app', { envVars: { FEATURE_FLAG: 'on' } }),
+        5000,
+      );
+      expect(job.status).toBe('completed');
+
+      const up = calls.find(
+        (c) => c.cmd === 'docker' && c.args.includes('up') && c.args.includes('--force-recreate'),
+      );
+      expect(up).toBeDefined();
+      // Data safety: no reconfigure command may pass -v / --volumes.
+      for (const c of calls) {
+        expect(c.args).not.toContain('-v');
+        expect(c.args).not.toContain('--volumes');
+      }
+    });
+
+    it('overrides the host port, re-registers routes, and updates the registry', async () => {
+      const { spawn } = makeRecordingSpawn(5600);
+      const installer = await installReconfApp(spawn);
+      callbacks.deregistered.length = 0;
+      callbacks.registeredRoutes.length = 0;
+
+      const job = await waitForJob(
+        installer,
+        installer.reconfigure('reconf-app', { portOverrides: { api: 5650 } }),
+        5000,
+      );
+      expect(job.status).toBe('completed');
+
+      expect(callbacks.deregistered).toContain('reconf-app');
+      const reg = callbacks.registeredRoutes.find((r) => r.appName === 'reconf-app');
+      expect(reg?.ports[0].hostPort).toBe(5650);
+
+      const entry = await registry.get('reconf-app');
+      expect(entry?.ports[0].hostPort).toBe(5650);
+
+      const compose = fs.readFileSync(path.join(entry!.installPath, 'docker-compose.yml'), 'utf-8');
+      expect(compose).toContain('5650:5600');
+    });
+
+    it('fails a reconfigure whose port collides with another installed app', async () => {
+      const { spawn } = makeRecordingSpawn(5600);
+      const installer = await installReconfApp(spawn);
+      await registry.upsert(makeEntryFor('other-app', 5700));
+
+      const job = await waitForJob(
+        installer,
+        installer.reconfigure('reconf-app', { portOverrides: { api: 5700 } }),
+        5000,
+      );
+      expect(job.status).toBe('failed');
+      expect(job.error).toMatch(/already used by app "other-app"/);
+    });
+
+    it('rejects reconfigure of a local (symlinked) app', async () => {
+      const appDir = makeAppDir(srcDir, 'local-reconf');
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+
+      const job = await waitForJob(
+        installer,
+        installer.reconfigure('local-reconf', { envVars: { X: 'y' } }),
+        5000,
+      );
+      expect(job.status).toBe('failed');
+      expect(job.error).toMatch(/local path|reinstall/i);
+    });
+
+    it('throws synchronously (409 path) when a job is already in flight', async () => {
+      const { spawn } = makeRecordingSpawn();
+      const installer = await installReconfApp(spawn);
+      // First reconfigure holds the install lock; the second must be rejected.
+      const first = installer.reconfigure('reconf-app', { envVars: { A: '1' } });
+      expect(() => installer.reconfigure('reconf-app', { envVars: { B: '2' } })).toThrow(
+        /already being installed or updated/,
+      );
+      await waitForJob(installer, first, 5000);
+    });
+  });
 });
+
+/** Minimal AppEntry for seeding a collision peer in the registry. */
+function makeEntryFor(name: string, hostPort: number): import('../../../src/apps/registry').AppEntry {
+  return {
+    name,
+    version: '1.0.0',
+    commit: 'abc123def456abc123def456abc123def456abc1',
+    githubUrl: `https://github.com/test/${name}`,
+    installPath: `/tmp/${name}`,
+    ports: [{ name: 'api', service: 'app', hostPort, containerPort: hostPort, type: 'api', rateLimit: 200 }],
+    sockets: {},
+    installedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    status: 'running',
+    source: 'custom',
+  };
+}
+
+/** Loosely-typed spawn used by the recording mock in reconfigure() tests. */
+type SpawnFnLike = (cmd: string, args: string[], opts?: { cwd?: string }) => { stdout: string; stderr: string; status: number };
 
 // ─── Utility ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds `POST /v1/apps/:name/reconfigure` (admin) to change an installed app's env vars and/or host ports and force-recreate the container **in place**, with named volumes preserved, plus a host-port override option on install. This closes the two REST gaps that block an admin UI from managing apps over the gateway API without an uninstall + reinstall (which would lose volume data).

## Related Issue

Closes #267

## Changes Made

- `src/apps/compose-generator.ts`: export `BANNED_PORTS` + new `assertValidHostPort()`; `generateCompose()` gains an optional `portOverrides` map, applied per port name and validated against the banned set, the `< 1024` floor, unknown port names, and in-app host-port collisions.
- `src/apps/installer.ts`: new `reconfigure()` / `runReconfigure()` — read + merge the existing `.env` (unsent keys preserved; existing generated secrets kept, not rotated), regenerate compose only when a port changes (re-injecting the agent service), force-recreate the container, and re-register routes + persist ports when a port changes. Refactored the `.env` writer into a shared `writeEnvFile()` helper (+ `readEnvFile()`) used by install and reconfigure so the format cannot drift. `composeUp()` gains `{ forceRecreate }`. New `findHostPortCollision()` helper shared by install and reconfigure. `install` accepts a `portOverrides` map.
- `src/api/apps-router.ts`: admin-gated `POST /v1/apps/:name/reconfigure` route (400 / 403 / 404 / 409) with shared `parsePortsField` / `parseEnvVarsField` body validation; `install` accepts a `ports` override field.
- `API.md`: new reconfigure endpoint section, both summary tables, and an install `ports` note.

### Data safety

Reconfigure is a `docker compose up --force-recreate`, never a `down -v`, so named volumes and their data survive. A regression test asserts no reconfigure command ever passes `-v` / `--volumes`.

## Testing

- `npm run typecheck`: pass
- `npm test`: 2679 tests pass (one unrelated integration suite, `chat-history-api`, was killed by a jest-worker OOM under parallelism; it passes 27/27 in isolation).
- New tests (+29): compose-generator override cases (apply / banned / `<1024` / non-integer / unknown name / in-app dup), apps-router status codes (403 / 404 / 400×5 / 409 / 202), installer env-merge (preserves unsent keys + generated secret) / force-recreate (no `-v`) / port re-register + registry update / cross-app collision / local rejection / concurrent-409.
- Regression proven on pre-fix code: neutralizing the override assignment turns the "overrides the host port" test red (expected 8888, received 8080), then green once restored.
