### PR TITLE
docs(apps): document required port `host` field in app.yaml authoring guides

### DIFF
--- a/API.md
+++ b/API.md
@@ -3179,6 +3179,7 @@ services:
     ports:
       - name: web
         container: 4000
+        host: 4000
         type: web
         rate_limit: 200
 ```
@@ -3207,10 +3208,20 @@ services:
 | `entrypoint` | Override container entrypoint |
 | `environment` | Static env vars (`KEY=value`), secret keys to prompt for (`KEY` without `=`), or self-generating secrets (`KEY=!generate:<encoding>:<bytes>`) |
 | `volumes` | Volume mounts (named volumes or host paths within app dir) |
-| `ports` | Array of port declarations (see below) |
+| `ports` | Array of port declarations (see **Port fields** below) |
 | `depends_on` | Service dependency list |
 | `healthcheck` | Docker healthcheck (test, interval, timeout, retries) |
 | `gateway_api` | Host script bridge via Unix socket (see below) |
+
+**Port fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Port identifier used in the proxy path (`/app/:name/:portName`). Unique within the service. |
+| `container` | Yes | Port the app listens on **inside** the container. Integer `>= 1024`, not a banned port (`22`, `80`, `443`, `10850`), unique within the service. |
+| `host` | Yes | Port exposed on the **host**. Integer `>= 1024`, not a banned port (`22`, `80`, `443`, `10850`), unique within the service. A manifest with a port that has no integer `host` is rejected at install/inspect (`ports["<name>"].host is required and must be an integer`). Default it to the same value as `container`; the installer can override it via the install/reconfigure `ports` field. |
+| `type` | No | `api` (strips the `/app/:name/:portName` prefix before forwarding) or `web` (preserves the full path, required for SPAs). |
+| `rate_limit` | No | Requests per second for this port (positive number, default 200). |
 
 **Banned fields:** `network_mode: host`, `privileged`, `cap_add`. The gateway always injects `cap_drop: ALL`, `restart: unless-stopped`, `env_file: .env`, and resource limits.
 

--- a/mcp/tools/apps/skills/create-app-yaml/SKILL.md
+++ b/mcp/tools/apps/skills/create-app-yaml/SKILL.md
@@ -52,7 +52,8 @@ services:
     build: .                        # or ./subdir if not root
     ports:
       - name: <api|web>
-        container: <port>
+        container: <port>           # port the app listens on inside the container
+        host: <port>                # REQUIRED — host port to expose (default: same as container)
         type: <api|web>             # api = REST/backend, web = serves HTML
         rate_limit: 60              # requests per second
     environment:
@@ -66,6 +67,11 @@ services:
       timeout: 10s
       retries: 3
 ```
+
+Rules for `host` (required on every port):
+- `host` is the port exposed on the machine; `container` is the port the app listens on inside the container. Every declared port **must** have an integer `host` — the gateway rejects a manifest without it (`ports["<name>"].host is required and must be an integer`), so a host-less app fails to install.
+- Default `host` to the same value as `container` unless that port is already taken.
+- `host` must be `>= 1024`, must not be a banned port (`22`, `80`, `443`, `10850`), and must be unique across the app's ports. The user can override it at install time, but the field must be present.
 
 Rules for port type:
 - `type: web` if Dockerfile serves static HTML, runs Next.js/React/Vite, or uses nginx/caddy
@@ -88,6 +94,7 @@ Show the generated `app.yaml` to the user and explain:
 2. They can add a `healthcheck:` if the service has a health endpoint
 3. If the app has an agent, they can add an `agent:` service block
 4. The `rate_limit` is requests per second — adjust to match expected load
+5. **Validate before publishing** — run `POST /api/v1/apps/inspect` with `local_path` (or the `inspect_app` MCP tool) pointed at the app directory. This runs the same manifest validation as install without needing a pinned commit, so a missing `host` or other schema error is caught locally instead of failing the install wizard after publish.
 
 ---
 

--- a/tests/unit/apps/docs-port-host.test.ts
+++ b/tests/unit/apps/docs-port-host.test.ts
@@ -1,0 +1,71 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { processAppYaml } from '../../../src/apps/compose-generator';
+
+// Drift guard: the app-authoring docs must teach a `ports:` block that the
+// gateway's own validator (validatePorts, reachable via processAppYaml and the
+// POST /api/v1/apps/inspect path) actually accepts. Historically both docs
+// omitted the required `host` field, so any app.yaml authored by following the
+// docs failed at inspect/install with:
+//   Service "app".ports["web"].host is required and must be an integer
+// These tests fail on the pre-fix docs and pass once `host` is documented.
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+const API_MD = path.join(REPO_ROOT, 'API.md');
+const SKILL_MD = path.join(
+  REPO_ROOT,
+  'mcp',
+  'tools',
+  'apps',
+  'skills',
+  'create-app-yaml',
+  'SKILL.md',
+);
+
+/** Extract every ```yaml … ``` fenced block from a Markdown file. */
+function extractYamlBlocks(markdown: string): string[] {
+  const blocks: string[] = [];
+  const re = /```ya?ml\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(markdown)) !== null) {
+    blocks.push(m[1]);
+  }
+  return blocks;
+}
+
+describe('app.yaml authoring docs — required port host field', () => {
+  it('API.md minimal example is accepted by the real validator', () => {
+    const md = fs.readFileSync(API_MD, 'utf-8');
+    // The minimal app.yaml example is the only yaml block that declares both a
+    // top-level manifest (`apiVersion:`) and a concrete container port.
+    const example = extractYamlBlocks(md).find(
+      (b) => b.includes('apiVersion:') && b.includes('container:'),
+    );
+    expect(example).toBeDefined();
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-port-host-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'app.yaml'), example as string, 'utf-8');
+      // Throws "ports[...].host is required" if the documented example omits host.
+      expect(() =>
+        processAppYaml(dir, 'my-app', path.join(dir, 'out.yml')),
+      ).not.toThrow();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('create-app-yaml SKILL.md port template declares a host field', () => {
+    const md = fs.readFileSync(SKILL_MD, 'utf-8');
+    // The template uses placeholders (e.g. `container: <port>`) so it cannot be
+    // fed to the validator directly — assert structurally that the ports block
+    // teaches a `host` key.
+    const template = extractYamlBlocks(md).find((b) => b.includes('ports:'));
+    expect(template).toBeDefined();
+
+    const portsIdx = (template as string).indexOf('ports:');
+    const portsSection = (template as string).slice(portsIdx);
+    expect(portsSection).toMatch(/^\s*host:/m);
+  });
+});

--- a/tests/unit/apps/docs-port-host.test.ts
+++ b/tests/unit/apps/docs-port-host.test.ts
@@ -35,24 +35,27 @@ function extractYamlBlocks(markdown: string): string[] {
 }
 
 describe('app.yaml authoring docs — required port host field', () => {
-  it('API.md minimal example is accepted by the real validator', () => {
+  it('every app.yaml example in API.md is accepted by the real validator', () => {
     const md = fs.readFileSync(API_MD, 'utf-8');
-    // The minimal app.yaml example is the only yaml block that declares both a
-    // top-level manifest (`apiVersion:`) and a concrete container port.
-    const example = extractYamlBlocks(md).find(
+    // Validate EVERY manifest-style block (declares both a top-level
+    // `apiVersion:` and a concrete `container:` port), not just the first — so
+    // a second host-less example added to API.md later is also caught.
+    const examples = extractYamlBlocks(md).filter(
       (b) => b.includes('apiVersion:') && b.includes('container:'),
     );
-    expect(example).toBeDefined();
+    expect(examples.length).toBeGreaterThan(0);
 
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-port-host-'));
-    try {
-      fs.writeFileSync(path.join(dir, 'app.yaml'), example as string, 'utf-8');
-      // Throws "ports[...].host is required" if the documented example omits host.
-      expect(() =>
-        processAppYaml(dir, 'my-app', path.join(dir, 'out.yml')),
-      ).not.toThrow();
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+    for (const example of examples) {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-port-host-'));
+      try {
+        fs.writeFileSync(path.join(dir, 'app.yaml'), example, 'utf-8');
+        // Throws "ports[...].host is required" if the example omits host.
+        expect(() =>
+          processAppYaml(dir, 'my-app', path.join(dir, 'out.yml')),
+        ).not.toThrow();
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

The gateway's own app-authoring docs — the `create-app-yaml` skill template and the `app.yaml` reference in `API.md` — taught a `ports:` block that omitted the required `host` field. But `validatePorts` (also run on the read-only `POST /api/v1/apps/inspect` path) requires an integer `host` on every declared port, so any `app.yaml` authored by following the docs failed at inspect/install with `Service "app".ports["<name>"].host is required and must be an integer`. This PR fixes the docs (the `host`-required rule is intentional and unchanged).

## Related Issue

Closes #269

## Changes Made

- `mcp/tools/apps/skills/create-app-yaml/SKILL.md`: add `host` to the port template; document the rule (`host` required, integer `>= 1024`, not banned `22`/`80`/`443`/`10850`, unique per service, defaults to `container`); add a "validate before publishing" step pointing at `POST /api/v1/apps/inspect` with `local_path`.
- `API.md`: add `host` to the minimal `app.yaml` example and add a **Port fields** subtable that marks `host` required and documents the floor/banned/uniqueness rules (resolves the dangling "(see below)").
- `tests/unit/apps/docs-port-host.test.ts`: drift-guard test — extracts the documented `API.md` example and runs it through the real `processAppYaml`/`validatePorts`, and asserts the `SKILL.md` port template declares `host`.

## Testing

- Regression test **proven to fail on the pre-fix docs** (reverting only the two doc files makes both assertions fail with the "host is required" throw), and passes with the fix.
- `npm run typecheck`: pass
- `tests/unit/apps`: 226/226 pass
- Full unit suite: 2692 tests pass; the 3 flaky suite failures (`socket-server`, `pty-menu-probe`, one integration) are the known parallel-worker OOM/SIGTERM races and pass in isolation — this change touches only docs + one test file, no product code.

## Out of Scope

- Changing `validatePorts` to auto-default `host` from `container` — the explicit-`host` requirement is intentional (prevents silent host-port collisions between apps).
