### PR TITLE
[Fix] Strip AI-generated code-fence wrapper in agent_create

### DIFF
--- a/mcp/tools/agent/handlers.ts
+++ b/mcp/tools/agent/handlers.ts
@@ -16,6 +16,13 @@ export const TELEGRAM_USER_ID_REGEX = /^\d{6,15}$/;
 export const DISCORD_USER_ID_REGEX = /^\d{17,19}$/;
 
 const FILENAME_SAFE_REGEX = /^[A-Z][A-Z0-9_-]*\.md$/i;
+
+// A whole line that is *only* a Markdown code fence, after trimming (which also
+// drops a trailing \r on CRLF input and surrounding spaces). FENCE_LINE_REGEX
+// matches both an opener (```markdown, ```ts) and a bare fence (```);
+// FENCE_CLOSE_REGEX matches only the bare closing fence.
+const FENCE_LINE_REGEX = /^```[\w-]*$/;
+const FENCE_CLOSE_REGEX = /^```$/;
 const STANDARD_STUB_FILES = ['HEARTBEAT.md', 'MEMORY.md', 'SOUL.md', 'USER.md'];
 
 // ---------------------------------------------------------------------------
@@ -117,7 +124,7 @@ function firstNonEmptyLine(text: string): string {
   for (const line of text.split('\n')) {
     // Skip pure code-fence lines (```markdown, ```ts, ``` …) so a stray wrapper
     // fence never leaks into a derived value such as the agent description.
-    if (/^```[\w-]*$/.test(line.trim())) continue;
+    if (FENCE_LINE_REGEX.test(line.trim())) continue;
     const trimmed = line.replace(/^#+\s*/, '').trim();
     if (trimmed) return trimmed;
   }
@@ -131,6 +138,14 @@ function firstNonEmptyLine(text: string): string {
  * the last non-empty line is a bare closing fence (```), so partial/unbalanced
  * fences are left untouched. Inner/legitimate fenced blocks are preserved;
  * unfenced content is returned unchanged.
+ *
+ * Known limitation (F2): a *legitimate* document whose first non-empty line
+ * opens a fenced block and whose last non-empty line closes a different one —
+ * two independent blocks with prose stripped away in between — is
+ * indistinguishable at the line level from a single outer wrapper, so its outer
+ * fences are peeled. This is accepted: real AGENTS.md/SOUL.md content opens with
+ * a heading, not a code fence, so the false-positive shape does not occur in
+ * practice. See test "AMH-fence-g" which locks this behavior.
  */
 function stripOuterCodeFence(text: string): string {
   const lines = text.split('\n');
@@ -141,8 +156,8 @@ function stripOuterCodeFence(text: string): string {
   while (last >= 0 && lines[last].trim() === '') last--;
   if (first >= last) return text; // need at least two non-empty lines
 
-  const isOpener = /^```[\w-]*$/.test(lines[first].trim());
-  const isCloser = /^```$/.test(lines[last].trim());
+  const isOpener = FENCE_LINE_REGEX.test(lines[first].trim());
+  const isCloser = FENCE_CLOSE_REGEX.test(lines[last].trim());
   if (!isOpener || !isCloser) return text; // not a clean wrapper — leave as-is
 
   return lines.slice(first + 1, last).join('\n').trim();

--- a/mcp/tools/agent/handlers.ts
+++ b/mcp/tools/agent/handlers.ts
@@ -115,10 +115,37 @@ export async function verifyDiscordToken(token: string): Promise<{ ok: boolean; 
 
 function firstNonEmptyLine(text: string): string {
   for (const line of text.split('\n')) {
+    // Skip pure code-fence lines (```markdown, ```ts, ``` …) so a stray wrapper
+    // fence never leaks into a derived value such as the agent description.
+    if (/^```[\w-]*$/.test(line.trim())) continue;
     const trimmed = line.replace(/^#+\s*/, '').trim();
     if (trimmed) return trimmed;
   }
   return text.trim().slice(0, 80);
+}
+
+/**
+ * Remove a single outer Markdown code-fence wrapper that a generating LLM may
+ * have wrapped whole-document output in (e.g. ```markdown … ```). Only strips
+ * when BOTH the first non-empty line is a fence opener (```lang or bare ```) AND
+ * the last non-empty line is a bare closing fence (```), so partial/unbalanced
+ * fences are left untouched. Inner/legitimate fenced blocks are preserved;
+ * unfenced content is returned unchanged.
+ */
+function stripOuterCodeFence(text: string): string {
+  const lines = text.split('\n');
+
+  let first = 0;
+  while (first < lines.length && lines[first].trim() === '') first++;
+  let last = lines.length - 1;
+  while (last >= 0 && lines[last].trim() === '') last--;
+  if (first >= last) return text; // need at least two non-empty lines
+
+  const isOpener = /^```[\w-]*$/.test(lines[first].trim());
+  const isCloser = /^```$/.test(lines[last].trim());
+  if (!isOpener || !isCloser) return text; // not a clean wrapper — leave as-is
+
+  return lines.slice(first + 1, last).join('\n').trim();
 }
 
 function envVarName(agentId: string, channel: 'telegram' | 'discord'): string {
@@ -215,16 +242,20 @@ export async function createAgent(args: CreateAgentArgs): Promise<string> {
   fs.mkdirSync(wsDir, { recursive: true });
 
   // 8. Write workspace files
+  // AI-generated *_md content is stored verbatim, so strip any outer code-fence
+  // wrapper the generating model may have added before it reaches disk AND the
+  // firstNonEmptyLine(agentsMdContent) description derivation below.
   const agentsMdContent =
-    args.agents_md ??
-    `# Agent: ${agentId.charAt(0).toUpperCase() + agentId.slice(1)}\n\n${description}`;
+    args.agents_md !== undefined
+      ? stripOuterCodeFence(args.agents_md)
+      : `# Agent: ${agentId.charAt(0).toUpperCase() + agentId.slice(1)}\n\n${description}`;
   fs.writeFileSync(path.join(wsDir, 'AGENTS.md'), agentsMdContent, 'utf8');
 
   if (args.soul_md) {
-    fs.writeFileSync(path.join(wsDir, 'SOUL.md'), args.soul_md, 'utf8');
+    fs.writeFileSync(path.join(wsDir, 'SOUL.md'), stripOuterCodeFence(args.soul_md), 'utf8');
   }
   if (args.user_md) {
-    fs.writeFileSync(path.join(wsDir, 'USER.md'), args.user_md, 'utf8');
+    fs.writeFileSync(path.join(wsDir, 'USER.md'), stripOuterCodeFence(args.user_md), 'utf8');
   }
 
   // Write stub files for any standard files not yet present

--- a/mcp/tools/agent/handlers.ts
+++ b/mcp/tools/agent/handlers.ts
@@ -260,8 +260,13 @@ export async function createAgent(args: CreateAgentArgs): Promise<string> {
   // AI-generated *_md content is stored verbatim, so strip any outer code-fence
   // wrapper the generating model may have added before it reaches disk AND the
   // firstNonEmptyLine(agentsMdContent) description derivation below.
+  // Guard with a typeof check (not `!== undefined`): args is external MCP input
+  // cast from `unknown`, so a caller can send `agents_md: null`. A bare null
+  // would reach stripOuterCodeFence and throw on `.split`; the typeof gate falls
+  // back to the default stub for both null and undefined, matching the prior
+  // `??` behavior while still stripping a real string wrapper.
   const agentsMdContent =
-    args.agents_md !== undefined
+    typeof args.agents_md === 'string'
       ? stripOuterCodeFence(args.agents_md)
       : `# Agent: ${agentId.charAt(0).toUpperCase() + agentId.slice(1)}\n\n${description}`;
   fs.writeFileSync(path.join(wsDir, 'AGENTS.md'), agentsMdContent, 'utf8');

--- a/tests/unit/agent-mcp-handlers.test.ts
+++ b/tests/unit/agent-mcp-handlers.test.ts
@@ -466,6 +466,23 @@ describe('createAgent — agents_md code-fence stripping', () => {
     expect(written).not.toMatch(/```/);
     expect(descOf('crlf')).toBe('Agent: Foo');
   });
+
+  it('AMH-fence-i: agents_md: null (malformed MCP input) → default stub, no throw', async () => {
+    mockTelegramOk();
+    // createAgent receives args cast from `unknown` (external MCP JSON), so a
+    // caller can send `agents_md: null`. The typeof guard must fall back to the
+    // default stub rather than reach stripOuterCodeFence and throw on .split.
+    await createAgent({
+      id: 'nullmd',
+      description: 'A null agent.',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      agents_md: null,
+    } as unknown as Parameters<typeof createAgent>[0]);
+
+    expect(agentsMd('nullmd')).toBe('# Agent: Nullmd\n\nA null agent.');
+    expect(descOf('nullmd')).toBe('Agent: Nullmd');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/agent-mcp-handlers.test.ts
+++ b/tests/unit/agent-mcp-handlers.test.ts
@@ -322,6 +322,116 @@ describe('createAgent — optional fields', () => {
 });
 
 // ---------------------------------------------------------------------------
+// createAgent — code-fence stripping (issue #271)
+// ---------------------------------------------------------------------------
+
+describe('createAgent — agents_md code-fence stripping', () => {
+  function descOf(id: string): string {
+    const cfg = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+    return cfg.agents.find((a: { id: string }) => a.id === id).description;
+  }
+  function agentsMd(id: string): string {
+    const wsDir = path.join(tmpDir, 'agents', id, 'workspace');
+    return fs.readFileSync(path.join(wsDir, 'AGENTS.md'), 'utf8');
+  }
+
+  it('AMH-fence-a: fenced agents_md → clean file + clean description', async () => {
+    mockTelegramOk();
+    await createAgent({
+      id: 'fenced',
+      description: 'x',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      agents_md: '```markdown\n# Agent: Foo\n\nBar baz\n```',
+    });
+
+    expect(agentsMd('fenced')).toBe('# Agent: Foo\n\nBar baz');
+    expect(agentsMd('fenced')).not.toContain('```');
+    expect(descOf('fenced')).toBe('Agent: Foo');
+  });
+
+  it('AMH-fence-b: unfenced agents_md → written unchanged (no regression)', async () => {
+    mockTelegramOk();
+    const raw = '# Agent: Foo\n\nBar';
+    await createAgent({
+      id: 'plain',
+      description: 'x',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      agents_md: raw,
+    });
+
+    expect(agentsMd('plain')).toBe(raw);
+    expect(descOf('plain')).toBe('Agent: Foo');
+  });
+
+  it('AMH-fence-c: inner code block preserved when outer wrapper stripped', async () => {
+    mockTelegramOk();
+    await createAgent({
+      id: 'inner',
+      description: 'x',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      agents_md: '```markdown\n# Agent: Foo\n\n```ts\nx();\n```\n```',
+    });
+
+    const written = agentsMd('inner');
+    // Outer wrapper gone…
+    expect(written.startsWith('# Agent: Foo')).toBe(true);
+    // …but the inner fenced snippet survives intact.
+    expect(written).toContain('```ts\nx();\n```');
+    expect(descOf('inner')).toBe('Agent: Foo');
+  });
+
+  it('AMH-fence-d: opener without matching closer → left untouched (fail-safe)', async () => {
+    mockTelegramOk();
+    const raw = '```markdown\n# Agent: Foo';
+    await createAgent({
+      id: 'partial',
+      description: 'x',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      agents_md: raw,
+    });
+
+    // No closing fence → not a clean wrapper → file kept verbatim…
+    expect(agentsMd('partial')).toBe(raw);
+    // …but the description still skips the stray fence line (layer-2 hardening).
+    expect(descOf('partial')).toBe('Agent: Foo');
+  });
+
+  it('AMH-fence-e: bare ``` opener/closer is stripped', async () => {
+    mockTelegramOk();
+    await createAgent({
+      id: 'bare',
+      description: 'x',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      agents_md: '```\n# Agent: Foo\n```',
+    });
+
+    expect(agentsMd('bare')).toBe('# Agent: Foo');
+    expect(descOf('bare')).toBe('Agent: Foo');
+  });
+
+  it('AMH-fence-f: soul_md / user_md wrappers are also stripped', async () => {
+    mockTelegramOk();
+    await createAgent({
+      id: 'soulfence',
+      description: 'x',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      soul_md: '```markdown\nSoul body\n```',
+      user_md: '```md\nUser body\n```',
+    });
+
+    const wsDir = path.join(tmpDir, 'agents', 'soulfence', 'workspace');
+    expect(fs.readFileSync(path.join(wsDir, 'SOUL.md'), 'utf8')).toBe('Soul body');
+    expect(fs.readFileSync(path.join(wsDir, 'USER.md'), 'utf8')).toBe('User body');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createAgent — validation errors (no network calls expected)
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/agent-mcp-handlers.test.ts
+++ b/tests/unit/agent-mcp-handlers.test.ts
@@ -429,6 +429,43 @@ describe('createAgent — agents_md code-fence stripping', () => {
     expect(fs.readFileSync(path.join(wsDir, 'SOUL.md'), 'utf8')).toBe('Soul body');
     expect(fs.readFileSync(path.join(wsDir, 'USER.md'), 'utf8')).toBe('User body');
   });
+
+  it('AMH-fence-g: two-block false-positive (F2) — locks the accepted limitation', async () => {
+    mockTelegramOk();
+    // Content that legitimately OPENS with one fenced block and CLOSES with a
+    // different one is indistinguishable from a single outer wrapper at the line
+    // level, so its outer fences are peeled. This test pins that accepted
+    // behavior (see stripOuterCodeFence F2 note). Real AGENTS.md opens with a
+    // heading, so this shape does not occur in practice.
+    await createAgent({
+      id: 'twoblock',
+      description: 'x',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      agents_md: '```ts\na();\n```\n\nprose\n\n```ts\nb();\n```',
+    });
+
+    // Outer fence lines are removed; the middle survives verbatim.
+    expect(agentsMd('twoblock')).toBe('a();\n```\n\nprose\n\n```ts\nb();');
+  });
+
+  it('AMH-fence-h: CRLF line endings + trailing spaces on fence lines → still stripped', async () => {
+    mockTelegramOk();
+    // A generator may emit \r\n and/or pad the fence line with spaces. .trim()
+    // in the scanner normalizes both, so the wrapper is still recognized.
+    await createAgent({
+      id: 'crlf',
+      description: 'x',
+      channel: 'telegram',
+      bot_token: VALID_TG_TOKEN,
+      agents_md: '```markdown  \r\n# Agent: Foo\r\n\r\nBar\r\n```  \r\n',
+    });
+
+    const written = agentsMd('crlf');
+    expect(written.startsWith('# Agent: Foo')).toBe(true);
+    expect(written).not.toMatch(/```/);
+    expect(descOf('crlf')).toBe('Agent: Foo');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`agent_create` stored the AI-generated `agents_md` **verbatim**. When the generating model wrapped the whole document in a ` ```markdown … ``` ` fence, that fence leaked into **both** the written `AGENTS.md` file and the derived `description` (via `firstNonEmptyLine`) — surfacing as a garbage ` ```markdown ` subtitle on agent cards. One unsanitized input (`agentsMdContent`) fed two corrupted outputs. This strips a single outer code-fence wrapper at the ingestion point, before it reaches disk **and** the description derivation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor / Tech debt
- [ ] Documentation

## Related Issues
Closes #271

## Before / After
![Before/after — agent_create code-fence strip: description goes from "```markdown" (garbage) to "Agent: Foo" (clean)](https://github.com/yuuyui/claude-gateway/releases/download/screenshots-issue-271/271-before-after.png)

## Changes Made
- `mcp/tools/agent/handlers.ts`:
  - Add `stripOuterCodeFence()` — removes a single outer wrapper **only** when the first non-empty line is a fence opener (` ```lang ` or bare ` ``` `) **and** the last non-empty line is a bare closing fence. Partial/unbalanced fences are left untouched (fail-safe); inner/legitimate fenced blocks are preserved.
  - Apply it to `agents_md`, `soul_md` and `user_md` before writing to disk.
  - Harden `firstNonEmptyLine()` to skip pure fence lines (2nd layer — guards the description even if a malformed wrapper isn't stripped).
- `tests/unit/agent-mcp-handlers.test.ts`: add `AMH-fence-a..f` — fenced→clean, unfenced→unchanged, inner block preserved, opener-only fail-safe, bare fence, soul/user wrappers.

## Out of Scope (per issue)
Retroactive repair of already-corrupted agents, consumer-side (getpod) stripping, and the REST create path — `src/api/router.ts` builds `AGENTS.md` from a structured `description` field, so no fence can leak there.

## How to Test
1. Checkout this branch.
2. `node_modules/.bin/tsc` — clean build.
3. `node_modules/.bin/jest tests/unit/agent-mcp-handlers.test.ts`.

Expected: **39/39 pass** (incl. the 6 new `AMH-fence` cases); `tsc` clean. Full suite: 2712 pass; the only reds are pre-existing `telegram-plugin-process.test.ts` load-timeout flakes (green 6/6 when run in isolation — unrelated to this pure-string change).

## Checklist
- [x] Reviewed my own code
- [x] Tests pass (target suite 39/39; `tsc` clean)
- [x] No console errors
