### PR TITLE
fix(apps): swap app dir at recorded installPath, not appName (issue #275)

### DIFF
--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -919,8 +919,13 @@ export class AppInstaller {
       }
 
       // ── Swap dirs ─────────────────────────────────────────────────────────
+      // Swap in place at the recorded install path — NOT path.join(appsDir, appName).
+      // For legacy installs the on-disk dir is named after the source repo/URL
+      // basename, so `installPath` basename can differ from the app name. Using
+      // the app name here throws ENOENT (issue #275). `entry.installPath` is the
+      // authoritative location the `down`/rollback steps above already use.
       this.log(job, 'Swapping app directories');
-      const finalDir = path.join(this.appsDir, appName);
+      const finalDir = entry.installPath;
       const oldBackupDir = `${finalDir}-old-${crypto.randomUUID()}`;
       fs.renameSync(finalDir, oldBackupDir);
       fs.renameSync(tmpDir, finalDir);

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -880,6 +880,43 @@ services:
       expect(readEnvFile(entry!.installPath)['APP_SECRET']).toBe('keep-me');
     });
 
+    it('updates an app whose on-disk dir name ≠ app.yaml name (legacy install, issue #275)', async () => {
+      // Legacy installs named the on-disk dir after the source repo basename,
+      // so installPath basename can differ from the app name. The dir-swap must
+      // key off entry.installPath (like the down/rollback steps), not the app
+      // name — otherwise it throws ENOENT renaming a non-existent apps/<name>.
+      const githubUrl = 'https://github.com/test/cc-monitor-appstore';
+      const { state, spawn } = makeGitState('cc-monitor', 5403);
+      const installer = makeInstaller(spawn);
+
+      state.head = 'a'.repeat(40);
+      state.version = '1.0.0';
+      await waitForJob(installer, installer.install({ githubUrl, envVars: { APP_SECRET: 'keep-me' } }), 5000);
+
+      // Simulate the legacy on-disk layout: rename the installed dir to the repo
+      // basename and repoint the registry's installPath at it (dir name ≠ name).
+      const entry = await registry.get('cc-monitor');
+      const legacyDir = path.join(appsDir, 'cc-monitor-appstore');
+      fs.renameSync(entry!.installPath, legacyDir);
+      await registry.upsert({ ...entry!, installPath: legacyDir });
+      expect(fs.existsSync(path.join(appsDir, 'cc-monitor'))).toBe(false);
+
+      // Update must complete end-to-end (previously threw ENOENT at the swap).
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      const job = await waitForJob(installer, installer.update('cc-monitor'), 5000);
+      expect(job.status).toBe('completed');
+
+      const after = await registry.get('cc-monitor');
+      expect(after?.commit).toBe('b'.repeat(40));
+      expect(after?.version).toBe('2.0.0');
+      // Registry installPath stays at the real (legacy) directory, still on disk.
+      expect(after?.installPath).toBe(legacyDir);
+      expect(fs.existsSync(legacyDir)).toBe(true);
+      // Secret (and therefore volumes) preserved via the .env copy-forward.
+      expect(readEnvFile(after!.installPath)['APP_SECRET']).toBe('keep-me');
+    });
+
     it('is a no-op when the custom app is already at HEAD', async () => {
       const githubUrl = 'https://github.com/test/steady-app';
       const { state, spawn } = makeGitState('steady-app', 5401);


### PR DESCRIPTION
## Summary

App **update** failed at the final "Swapping app directories" step with `ENOENT: no such file or directory, rename` for any app whose **on-disk directory name differs from its `app.yaml` `name`** (legacy installs whose dir was named after the source repo/URL basename).

The swap derived the target path from the app **name** instead of the registry's recorded **`installPath`**:

```js
// src/apps/installer.ts (before)
const finalDir = path.join(this.appsDir, appName);   // → apps/<name>, may not exist
fs.renameSync(finalDir, oldBackupDir);               // ENOENT when dir name ≠ name
```

The failure landed **after** the new containers had already started, leaving the app half-updated: new container running, registry stuck on the old version, "Update available" badge stuck, and every retry failing identically at the same spot.

The same function is already self-inconsistent — the `down`/rollback steps a few lines earlier correctly use `entry.installPath`. The swap was the only step reconstructing the path from `appName`.

## Fix

```js
const finalDir = entry.installPath;   // authoritative dir, matches down/rollback
```

`entry.installPath` is the authoritative location used for teardown/rollback everywhere else in the file. This keeps the updated version at the real directory and leaves the registry `installPath` stable and correct. Freshly-installed apps (dir name == name) are unaffected — `entry.installPath` equals `apps/<name>` there.

## Testing

- **Regression test** (`tests/unit/apps/installer.test.ts`): an update where `installPath` basename ≠ `name` now completes end-to-end (registry advances, `installPath` still points at the real dir, `.env`/secrets preserved). **Proven to fail (ENOENT at the swap) on the pre-fix code** by reverting the one-line fix.
- `npm run typecheck` clean.
- Apps suite 224/224; full unit suite 2704 tests, 0 assertion failures.

## Scope note

The "nice-to-have" recovery of an already half-applied instance (registry version < running container) is intentionally **out of scope** here — this fix prevents the half-applied state from occurring going forward. An instance already stuck can be unblocked by this fix on the next update, or manually per the issue's note.

Closes #275