### PR TITLE
fix(apps): reconcile app status with live Docker runtime on read

### DIFF
--- a/API.md
+++ b/API.md
@@ -2787,6 +2787,8 @@ curl -H "X-Api-Key: my-key" http://localhost:10850/api/v1/apps | jq
 
 **`status` values:** `running` | `stopped` | `error` | `building`
 
+> **Live status:** `GET /api/v1/apps` and `GET /api/v1/apps/:name` reconcile the stored status against the live Docker runtime (`docker compose ps`) on read, so a container that crashed, was OOM-killed, or was stopped from outside the gateway reports `stopped`/`error` rather than a stale `running`. `running`/`restarting` containers → `running`; a non-zero exit or `dead` container → `error`; no containers or a clean exit → `stopped`. If Docker cannot be queried (daemon down, compose file missing) the last stored status is returned unchanged, and an app mid-install (`building`) is not reconciled.
+
 **`source` values:** `registry` | `custom` | `local`
 
 ---

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -96,7 +96,10 @@ export function createAppsRouter(
   router.get('/v1/apps', async (_req: Request, res: Response) => {
     try {
       const apps = await registry.list();
-      res.json({ apps });
+      // Reconcile each stored status against the live Docker runtime so a
+      // container that crashed/was killed externally no longer reports running.
+      const reconciled = await installer.reconcileStatuses(apps);
+      res.json({ apps: reconciled });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }
@@ -201,7 +204,9 @@ export function createAppsRouter(
         res.status(404).json({ error: `App "${req.params.name}" not found` });
         return;
       }
-      res.json(entry);
+      // Reconcile the stored status against the live Docker runtime before return.
+      const reconciled = await installer.reconcileStatus(entry);
+      res.json(reconciled);
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -408,6 +408,64 @@ export class AppInstaller {
   }
 
   /**
+   * Reconcile one app's stored status against the live Docker runtime and
+   * return the entry with a fresh status. The stored status in `apps.json` is
+   * only written at install/start/stop/reconfigure time, so a container that
+   * crashed, was OOM-killed, or was stopped from outside the gateway leaves the
+   * registry stuck on `running`. This queries the actual container state and
+   * corrects the record.
+   *
+   * Best-effort and fail-safe: if the runtime cannot be queried (docker
+   * unreachable, compose file gone, non-zero exit) the entry is returned
+   * unchanged, so a transient daemon hiccup never fabricates a false `stopped`.
+   * An app in the `building` state is skipped so an in-flight install — which
+   * owns the status and will set `running` on completion — is not clobbered.
+   *
+   * When the live status differs from the stored one it is persisted back to
+   * `apps.json` before returning, so subsequent reads and the boot-time restore
+   * see the truth.
+   */
+  async reconcileStatus(entry: AppEntry): Promise<AppEntry> {
+    const live = await this.queryRuntimeStatus(entry);
+    if (live === entry.status) return entry;
+    await this.registry.updateStatus(entry.name, live);
+    return { ...entry, status: live, updatedAt: new Date().toISOString() };
+  }
+
+  /** Reconcile a list of entries against the Docker runtime, in parallel. See {@link reconcileStatus}. */
+  async reconcileStatuses(entries: AppEntry[]): Promise<AppEntry[]> {
+    return Promise.all(entries.map((e) => this.reconcileStatus(e)));
+  }
+
+  /**
+   * Query the live Docker state for one app and map it to an AppEntry status.
+   * Returns the stored status unchanged when the runtime cannot be determined
+   * (see {@link reconcileStatus} for the fail-safe rationale).
+   *
+   * Uses the async (non-blocking) spawn seam, not spawnSync: this runs on the
+   * read path (`GET /apps`, possibly polled), so it must not freeze the gateway
+   * event loop while `docker compose ps` runs. reconcileStatuses() therefore
+   * genuinely parallelises across apps.
+   */
+  private async queryRuntimeStatus(entry: AppEntry): Promise<AppEntry['status']> {
+    // An install in flight owns the status — don't race it.
+    if (entry.status === 'building') return entry.status;
+    let stdout: string;
+    try {
+      const res = await this.spawnAsync(
+        'docker',
+        ['compose', '-p', entry.name, 'ps', '-a', '--format', 'json'],
+        { cwd: entry.installPath, timeoutMs: 10_000 },
+      );
+      if (res.status !== 0) return entry.status; // can't determine — keep stored
+      stdout = res.stdout ?? '';
+    } catch {
+      return entry.status; // docker missing / spawn failed / timed out — keep stored
+    }
+    return mapContainerStatesToAppStatus(parseComposePs(stdout));
+  }
+
+  /**
    * Bring up containers for every app marked `running` in the registry.
    *
    * Compose has no host-reboot restart policy here, so after the gateway (or
@@ -1613,6 +1671,81 @@ function selectLatest(versions: RegistryVersion[]): RegistryVersion | undefined 
     return withDate.reduce((a, b) => (a.approved_at > b.approved_at ? a : b));
   }
   return versions[versions.length - 1];
+}
+
+// ─── Docker runtime reconciliation helpers ─────────────────────────────────────
+
+/** One container's runtime facts, distilled from `docker compose ps` JSON. */
+export interface ComposePsContainer {
+  /** Lower-cased compose state: running | restarting | exited | dead | created | paused | … */
+  state: string;
+  /** Process exit code (0 when still running or absent). */
+  exitCode: number;
+}
+
+/**
+ * Parse `docker compose ps -a --format json` stdout into a flat container list.
+ * Handles both output shapes compose has shipped: newline-delimited JSON
+ * objects (v2.21+) and a single JSON array (older). Malformed lines and entries
+ * without a string `State` are skipped rather than throwing — a best-effort
+ * parse must never crash the read path.
+ */
+export function parseComposePs(stdout: string): ComposePsContainer[] {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+  const out: ComposePsContainer[] = [];
+  const push = (o: unknown): void => {
+    if (o && typeof o === 'object' && typeof (o as { State?: unknown }).State === 'string') {
+      const rec = o as { State: string; ExitCode?: unknown };
+      out.push({
+        state: rec.State.toLowerCase(),
+        exitCode: typeof rec.ExitCode === 'number' ? rec.ExitCode : 0,
+      });
+    }
+  };
+  // Whole-string JSON array (older compose).
+  if (trimmed.startsWith('[')) {
+    try {
+      const arr = JSON.parse(trimmed) as unknown;
+      if (Array.isArray(arr)) {
+        arr.forEach(push);
+        return out;
+      }
+    } catch {
+      /* fall through to line-by-line parsing */
+    }
+  }
+  // Newline-delimited JSON objects (current compose).
+  for (const line of trimmed.split('\n')) {
+    const l = line.trim();
+    if (!l) continue;
+    try {
+      push(JSON.parse(l));
+    } catch {
+      /* skip a malformed line */
+    }
+  }
+  return out;
+}
+
+/**
+ * Map an app's compose-project container states to a single AppEntry status:
+ *   - no containers                                   → stopped
+ *   - any running / restarting                        → running
+ *   - any dead, or exited with a non-zero exit code   → error   (crash)
+ *   - else (clean exit / created / paused)            → stopped
+ */
+export function mapContainerStatesToAppStatus(
+  containers: ComposePsContainer[],
+): AppEntry['status'] {
+  if (containers.length === 0) return 'stopped';
+  if (containers.some((c) => c.state === 'running' || c.state === 'restarting')) {
+    return 'running';
+  }
+  if (containers.some((c) => c.state === 'dead' || (c.state === 'exited' && c.exitCode !== 0))) {
+    return 'error';
+  }
+  return 'stopped';
 }
 
 // ─── Default spawn implementation ─────────────────────────────────────────────

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -428,7 +428,13 @@ export class AppInstaller {
   async reconcileStatus(entry: AppEntry): Promise<AppEntry> {
     const live = await this.queryRuntimeStatus(entry);
     if (live === entry.status) return entry;
-    await this.registry.updateStatus(entry.name, live);
+    try {
+      await this.registry.updateStatus(entry.name, live);
+    } catch {
+      // Persisting failed (e.g. registry lock contention). Still return the
+      // corrected status so the read is accurate — a later read retries the
+      // write. Never let one app's persist failure reject the whole list.
+    }
     return { ...entry, status: live, updatedAt: new Date().toISOString() };
   }
 

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1641,6 +1641,18 @@ services:
       expect(reconciled.status).toBe('running'); // rejection swallowed, no false flip
     });
 
+    it('still returns the corrected status when the persist write fails', async () => {
+      await registry.upsert({ ...makeEntryFor('persist-fail', 6009), status: 'running' });
+      const installer = makeInstaller(successSpawn, psSpawn('') /* no containers */);
+      // Simulate a registry lock/write failure on persist.
+      jest.spyOn(registry, 'updateStatus').mockRejectedValueOnce(new Error('lock timeout'));
+
+      const reconciled = await installer.reconcileStatus((await registry.get('persist-fail'))!);
+      // Read is still corrected in-memory even though the write failed —
+      // reconcileStatus must never reject and 500 the whole list.
+      expect(reconciled.status).toBe('stopped');
+    });
+
     it('does not reconcile an app in the building state (in-flight install)', async () => {
       await registry.upsert({ ...makeEntryFor('installing-app', 6005), status: 'building' });
       const spawn = psSpawn('');

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { AppInstaller, InstallerCallbacks, JobState } from '../../../src/apps/installer';
+import { AppInstaller, InstallerCallbacks, JobState, parseComposePs, mapContainerStatesToAppStatus } from '../../../src/apps/installer';
 import { AppsRegistry } from '../../../src/apps/registry';
 import { RegistryClient } from '../../../src/apps/registry-client';
 import { ComposePort, ComposeSocket } from '../../../src/apps/compose-generator';
@@ -1570,6 +1570,160 @@ services:
         /already being installed or updated/,
       );
       await waitForJob(installer, first, 5000);
+    });
+  });
+
+  // ─── reconcileStatus() — sync stored status with the live Docker runtime ────
+
+  describe('reconcileStatus()', () => {
+    /**
+     * An ASYNC spawn mock (reconcile uses the non-blocking spawn seam) that
+     * answers `docker compose ps` with a caller-supplied payload and succeeds
+     * (empty) for everything else. `psStatus` simulates the daemon being
+     * unreachable (non-zero exit).
+     */
+    function psSpawn(psStdout: string, psStatus = 0) {
+      return jest.fn(async (_cmd: string, args: string[], _opts?: object) => {
+        if (args.includes('ps')) {
+          return { stdout: psStdout, stderr: psStatus === 0 ? '' : 'boom', status: psStatus };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    const runningPs = JSON.stringify({ State: 'running', ExitCode: 0 });
+    const crashedPs = JSON.stringify({ State: 'exited', ExitCode: 137 });
+
+    it('flips a stale running → stopped when no containers exist (the reported bug)', async () => {
+      await registry.upsert({ ...makeEntryFor('ghost-app', 6001), status: 'running' });
+      const installer = makeInstaller(successSpawn, psSpawn('') /* empty ps = no containers */);
+
+      const reconciled = await installer.reconcileStatus((await registry.get('ghost-app'))!);
+
+      expect(reconciled.status).toBe('stopped');
+      // Persisted, so the next read (and boot restore) see the truth.
+      expect((await registry.get('ghost-app'))?.status).toBe('stopped');
+    });
+
+    it('reports error when a container crashed (exited non-zero)', async () => {
+      await registry.upsert({ ...makeEntryFor('crash-app', 6002), status: 'running' });
+      const installer = makeInstaller(successSpawn, psSpawn(crashedPs));
+
+      const reconciled = await installer.reconcileStatus((await registry.get('crash-app'))!);
+      expect(reconciled.status).toBe('error');
+    });
+
+    it('keeps running when the container is genuinely running', async () => {
+      await registry.upsert({ ...makeEntryFor('live-app', 6003), status: 'running' });
+      const installer = makeInstaller(successSpawn, psSpawn(runningPs));
+
+      const reconciled = await installer.reconcileStatus((await registry.get('live-app'))!);
+      expect(reconciled.status).toBe('running');
+    });
+
+    it('keeps the stored status when Docker cannot be queried (non-zero exit)', async () => {
+      await registry.upsert({ ...makeEntryFor('daemon-down', 6004), status: 'running' });
+      const installer = makeInstaller(successSpawn, psSpawn('', 1) /* daemon unreachable */);
+
+      const reconciled = await installer.reconcileStatus((await registry.get('daemon-down'))!);
+      expect(reconciled.status).toBe('running'); // no false "stopped"
+    });
+
+    it('keeps the stored status when the ps query rejects (timeout)', async () => {
+      await registry.upsert({ ...makeEntryFor('hung-app', 6008), status: 'running' });
+      const rejectingSpawn = jest.fn(async (_cmd: string, args: string[]) => {
+        if (args.includes('ps')) throw new Error('spawn timed out');
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeInstaller(successSpawn, rejectingSpawn);
+
+      const reconciled = await installer.reconcileStatus((await registry.get('hung-app'))!);
+      expect(reconciled.status).toBe('running'); // rejection swallowed, no false flip
+    });
+
+    it('does not reconcile an app in the building state (in-flight install)', async () => {
+      await registry.upsert({ ...makeEntryFor('installing-app', 6005), status: 'building' });
+      const spawn = psSpawn('');
+      const installer = makeInstaller(successSpawn, spawn);
+
+      const reconciled = await installer.reconcileStatus((await registry.get('installing-app'))!);
+      expect(reconciled.status).toBe('building');
+      // ps must not even be queried while building.
+      const psCalls = spawn.mock.calls.filter((c) => (c[1] as string[]).includes('ps'));
+      expect(psCalls).toHaveLength(0);
+    });
+
+    it('reconcileStatuses() maps a mixed list in one pass', async () => {
+      await registry.upsert({ ...makeEntryFor('mixed-live', 6006), status: 'running' });
+      await registry.upsert({ ...makeEntryFor('mixed-dead', 6007), status: 'running' });
+      // Route ps by cwd (installPath differs per app: /tmp/<name>).
+      const spawn = jest.fn(async (_cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (args.includes('ps')) {
+          const stdout = opts?.cwd?.endsWith('mixed-live') ? runningPs : '';
+          return { stdout, stderr: '', status: 0 };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeInstaller(successSpawn, spawn as unknown as typeof successAsyncSpawn);
+
+      const list = await registry.list();
+      const reconciled = await installer.reconcileStatuses(list);
+      const byName = Object.fromEntries(reconciled.map((e) => [e.name, e.status]));
+      expect(byName['mixed-live']).toBe('running');
+      expect(byName['mixed-dead']).toBe('stopped');
+    });
+  });
+
+  // ─── parseComposePs() / mapContainerStatesToAppStatus() — pure helpers ──────
+
+  describe('compose ps parsing + status mapping', () => {
+    it('parses newline-delimited JSON objects (current compose)', () => {
+      const ndjson = [
+        JSON.stringify({ State: 'running', ExitCode: 0 }),
+        JSON.stringify({ State: 'exited', ExitCode: 0 }),
+      ].join('\n');
+      const parsed = parseComposePs(ndjson);
+      expect(parsed).toEqual([
+        { state: 'running', exitCode: 0 },
+        { state: 'exited', exitCode: 0 },
+      ]);
+    });
+
+    it('parses a single JSON array (older compose)', () => {
+      const arr = JSON.stringify([
+        { State: 'Running', ExitCode: 0 },
+        { State: 'Dead', ExitCode: 0 },
+      ]);
+      const parsed = parseComposePs(arr);
+      expect(parsed).toEqual([
+        { state: 'running', exitCode: 0 },
+        { state: 'dead', exitCode: 0 },
+      ]);
+    });
+
+    it('returns [] for empty output and skips malformed lines', () => {
+      expect(parseComposePs('')).toEqual([]);
+      expect(parseComposePs('   \n  ')).toEqual([]);
+      expect(parseComposePs('{not json}\n' + JSON.stringify({ State: 'running' }))).toEqual([
+        { state: 'running', exitCode: 0 },
+      ]);
+    });
+
+    it('maps aggregate states to the right app status', () => {
+      expect(mapContainerStatesToAppStatus([])).toBe('stopped');
+      expect(mapContainerStatesToAppStatus([{ state: 'running', exitCode: 0 }])).toBe('running');
+      expect(mapContainerStatesToAppStatus([{ state: 'restarting', exitCode: 0 }])).toBe('running');
+      // running wins even when a sibling has exited.
+      expect(
+        mapContainerStatesToAppStatus([
+          { state: 'exited', exitCode: 0 },
+          { state: 'running', exitCode: 0 },
+        ]),
+      ).toBe('running');
+      expect(mapContainerStatesToAppStatus([{ state: 'exited', exitCode: 137 }])).toBe('error');
+      expect(mapContainerStatesToAppStatus([{ state: 'dead', exitCode: 0 }])).toBe('error');
+      expect(mapContainerStatesToAppStatus([{ state: 'exited', exitCode: 0 }])).toBe('stopped');
+      expect(mapContainerStatesToAppStatus([{ state: 'created', exitCode: 0 }])).toBe('stopped');
     });
   });
 });


### PR DESCRIPTION
## Summary

`GET /api/v1/apps` (list) and `GET /api/v1/apps/:name` (status) reported the app status stored in `apps.json`, which is written only at install/start/stop/reconfigure time and never reconciled against the live Docker runtime. A container that crashed, was OOM-killed, or was stopped from outside the gateway left the registry — and the `list_apps` / `app_status` MCP tools that wrap these endpoints — reporting a stale `running`.

Closes #277.

## Root cause (proven with a live repro)

- `apps-router.ts` returned `registry.list()` / `registry.get()` verbatim.
- `registry.ts` reads `apps.json`; the `status` field is only mutated by install / `startStopRestart` / update / reconfigure. No Docker query on the read path.
- Live: an app whose container had been removed externally showed `status: running` in `apps.json` while `docker compose -p <app> ps -a` returned zero containers → `list_apps` reported `running` for an app that was not running.

## Fix

Reconcile lazily at read time (no background loop, no new daemon dependency):

- New `AppInstaller.reconcileStatus` / `reconcileStatuses` query `docker compose -p <name> ps -a --format json` at the app's `installPath` via the **non-blocking async spawn seam** (the read path must not freeze the gateway event loop the way `spawnSync` would; `reconcileStatuses` genuinely parallelises across apps).
- `mapContainerStatesToAppStatus`: any `running`/`restarting` → `running`; any `dead` or `exited` with non-zero exit code → `error`; no containers or a clean exit → `stopped`.
- The corrected status is persisted back to `apps.json` when it differs, so subsequent reads and the boot-time restore see the truth.
- **Fail-safe:** if Docker cannot be queried (daemon down, compose file gone, non-zero exit, timeout) the stored status is returned unchanged — a transient hiccup never fabricates a false `stopped`. An app in `building` is skipped so an in-flight install is not clobbered.
- `parseComposePs` handles both output shapes compose has shipped (NDJSON objects and a single JSON array) and skips malformed lines rather than throwing.
- Wired into both `GET /v1/apps` and `GET /v1/apps/:name`; the MCP tools are covered automatically.

## Tests

- `reconcileStatus()`: stale `running` → `stopped` (the reported bug, persisted), crash → `error`, genuinely running stays `running`, daemon-down / timeout keep the stored status (no false `stopped`), `building` skipped (ps never queried), and a mixed-list `reconcileStatuses()` pass.
- Pure-helper coverage for `parseComposePs` (NDJSON + array + malformed) and the state→status mapping.
- **Proven red on the pre-fix code**: neutering the reconcile to a pass-through fails exactly the flip/error/mixed tests with clean assertion errors.

## Verification

- `npm run typecheck` clean
- apps suites: 238/238
- Regression proven to fail on old code
