### PR TITLE
ci(release): install mcp (bun) deps before unit tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Problem

The `v1.6.0` release job failed at **Run unit tests**, blocking the npm publish. `tests/unit/line-image.test.ts` (added in #279) mocks the physical module `mcp/node_modules/@line/bot-sdk`, but the release workflow ran `npm ci` only — it never installs the `mcp/` dependencies (those come from `bun install --cwd mcp` in `postinstall`, and bun was not present on the runner). So the test failed to run:

```
Cannot find module '../../mcp/node_modules/@line/bot-sdk'
```

The repo has no separate PR-CI workflow, so this only surfaced at release time (v1.6.0 is the first release carrying that test).

## Fix

Add `oven-sh/setup-bun` (SHA-pinned) before `npm ci`, so `postinstall` installs the mcp deps and mcp-tool tests run against the real packages — aligning the release runner with local dev.

## Verification

- Reproduced the exact CI error locally by hiding `mcp/node_modules/@line/bot-sdk`, then confirmed the test passes with it present (3/3).
- `release.yml` is valid YAML.