### PR TITLE
fix(npm): exclude mcp/node_modules from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "lib/",
     "resource/",
     "mcp/",
+    "!mcp/node_modules",
+    "!mcp/node_modules/**",
     "README.md",
     "config.template.json"
   ],


### PR DESCRIPTION
## Problem

After #281 made the release workflow install mcp deps (bun) for the unit tests, the `files` allowlist entry `mcp/` swept the freshly-created `mcp/node_modules` — full of bun's hard-linked files — into the npm tarball (~11.3k files). npm rejected the publish:

```
npm error code E415
npm error 415 Unsupported Media Type - PUT .../@0xmaxma%2fclaude-gateway - Hard link is not allowed
```

## Fix

`mcp` ships as **source** (consumers install its deps via `postinstall`), so `mcp/node_modules` must never be packaged. Add `!mcp/node_modules` negations to `files`.

## Verification

`npm pack --dry-run`: mcp/node_modules entries 0, mcp source (`server.ts`, `tools/**`, `package.json`) still present, total files ~11.3k → 307.