### PR TITLE
fix(apps): app update removes the freshly-started container (cleanup compose-down collides with new project)

### DIFF
--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -948,6 +948,11 @@ export class AppInstaller {
       this.callbacks.deregisterRoutes(appName);
       this.callbacks.stopSockets(appName);
 
+      // Capture the current (old) image IDs while the old stack is still up, so
+      // we can reclaim exactly those images after the update — without a
+      // `compose down` that would collide with the new stack (issue #283).
+      const oldImageIds = this.captureComposeImageIds(appName, entry.installPath);
+
       // ── Bring old containers down (keeps images for rollback) ─────────────
       this.log(job, 'Stopping old containers');
       this.run(['docker', 'compose', '-p', appName, 'down'], entry.installPath, 120_000);
@@ -981,6 +986,11 @@ export class AppInstaller {
         }
         throw upErr;
       }
+
+      // Capture the new stack's image IDs (still at tmpDir) so image reclamation
+      // below never removes an image the new containers depend on (e.g. when the
+      // old and new versions happen to share a base/image).
+      const newImageIds = this.captureComposeImageIds(appName, tmpDir);
 
       // ── Swap dirs ─────────────────────────────────────────────────────────
       // Swap in place at the recorded install path — NOT path.join(appsDir, appName).
@@ -1023,10 +1033,20 @@ export class AppInstaller {
         await this.callbacks.startSocket(sockPath, sock, sock.scripts, finalDir);
       }
 
-      // ── Clean up old backup (best-effort) ─────────────────────────────────
-      try {
-        this.run(['docker', 'compose', '-p', appName, 'down', '--rmi', 'all'], oldBackupDir, 120_000);
-      } catch { /* non-fatal */ }
+      // ── Reclaim old images (best-effort) ──────────────────────────────────
+      // Do NOT `compose -p <app> down` the backup dir here: `down` selects
+      // resources by the project label, and the freshly-started new stack now
+      // shares `project=<app>`, so it would stop & remove the *new* container
+      // (issue #283). The old containers were already removed by the "Stopping
+      // old containers" step, so only the old images remain to reclaim. Remove
+      // each old image that the new stack does not still depend on.
+      const newImageSet = new Set(newImageIds);
+      for (const imageId of oldImageIds) {
+        if (newImageSet.has(imageId)) continue; // shared with new stack — keep
+        try {
+          this.run(['docker', 'image', 'rm', imageId], os.tmpdir(), 60_000);
+        } catch { /* still in use or already gone — non-fatal */ }
+      }
       this.safeRmrf(oldBackupDir, job, 'old backup dir');
 
       // ── Build result ──────────────────────────────────────────────────────
@@ -1627,6 +1647,30 @@ export class AppInstaller {
       if (!id || !project || project === appName) continue;
       try { this.run(['docker', 'stop', id], os.tmpdir(), 15_000); } catch { /* ignore */ }
       try { this.run(['docker', 'rm', id], os.tmpdir(), 15_000); } catch { /* ignore */ }
+    }
+  }
+
+  /**
+   * Best-effort: capture the image IDs a compose project's services currently
+   * resolve to. Used by {@link update} to reclaim the *previous* version's
+   * images after a successful update WITHOUT running `compose down` — `down`
+   * selects by the `-p <project>` label, and the freshly-started new stack now
+   * shares that label, so a `down` on the old backup dir would tear the new
+   * container back down (issue #283). Returns a de-duplicated list of image
+   * IDs, or `[]` on any error (nothing to reclaim / docker unavailable).
+   */
+  private captureComposeImageIds(appName: string, dir: string): string[] {
+    try {
+      const { stdout } = this.run(
+        ['docker', 'compose', '-p', appName, 'images', '--quiet'],
+        dir,
+        15_000,
+      );
+      return [...new Set(
+        stdout.trim().split('\n').map((s) => s.trim()).filter(Boolean),
+      )];
+    } catch {
+      return [];
     }
   }
 

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -917,6 +917,87 @@ services:
       expect(readEnvFile(after!.installPath)['APP_SECRET']).toBe('keep-me');
     });
 
+    it('reclaims the old image without a compose-down that tears down the new container (issue #283)', async () => {
+      // The cleanup after a successful update must NOT run
+      // `compose -p <app> down --rmi all` on the backup dir: `down` selects by
+      // the project label, which the freshly-started new stack now shares, so it
+      // would remove the *new* container (leaving status 'running' with nothing
+      // up). It must instead reclaim only the *old* image via `docker image rm`.
+      const githubUrl = 'https://github.com/test/img-app';
+      const appName = 'img-app';
+      const port = 5405;
+      const state = { head: 'a'.repeat(40), version: '1.0.0' };
+      const dockerCalls: Array<{ args: string[]; cwd?: string }> = [];
+
+      const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: nginx:1.25
+    ports:
+      - name: api
+        host: ${port}
+        container: ${port}
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:${port}/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+          return { stdout: '', stderr: '', status: 0 };
+        }
+        if (cmd === 'docker') {
+          dockerCalls.push({ args, cwd: opts?.cwd });
+          // `docker compose -p <app> images --quiet` → a distinct image id per
+          // stack, keyed off the working dir (new stack builds under a
+          // `cg-update-*` tmp dir; the old stack lives under appsDir).
+          if (args.includes('images') && args.includes('--quiet')) {
+            const isNew = (opts?.cwd ?? '').includes('cg-update-');
+            return { stdout: `${isNew ? 'sha-new' : 'sha-old'}\n`, stderr: '', status: 0 };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+
+      const installer = makeInstaller(spawn);
+      state.head = 'a'.repeat(40);
+      state.version = '1.0.0';
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+
+      dockerCalls.length = 0; // only inspect update-phase docker calls
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+      expect(job.status).toBe('completed');
+
+      // (a) No compose-down against the post-swap backup dir — the bug that tore
+      // down the freshly-started new container.
+      const downOnBackup = dockerCalls.filter(
+        (c) => c.args.includes('compose') && c.args.includes('down') && (c.cwd ?? '').includes('-old-'),
+      );
+      expect(downOnBackup).toHaveLength(0);
+      // …and no `--rmi`-bearing compose-down anywhere in the update.
+      expect(dockerCalls.some((c) => c.args.includes('down') && c.args.includes('--rmi'))).toBe(false);
+
+      // (b) The old image IS reclaimed, and the new stack's image is left alone.
+      const imageRmTargets = dockerCalls
+        .filter((c) => c.args[0] === 'image' && c.args[1] === 'rm')
+        .map((c) => c.args[2]);
+      expect(imageRmTargets).toContain('sha-old');
+      expect(imageRmTargets).not.toContain('sha-new');
+    });
+
     it('is a no-op when the custom app is already at HEAD', async () => {
       const githubUrl = 'https://github.com/test/steady-app';
       const { state, spawn } = makeGitState('steady-app', 5401);


### PR DESCRIPTION
Closes #283

## Problem

Updating a registry app leaves it with **no running container** even though the job reports success and the registry marks the app `running`. Running **Reconfigure** afterward re-creates the container — the current workaround.

Reproduced 100% on a live pod (gateway 1.5.8) with `cc-monitor` v1.1.0 → v1.2.0: after the update, `docker ps -a` shows no `cc-monitor` container (removed, not exited), while `GET /api/v1/apps/cc-monitor` returns `status: running`.

## Root cause

The post-update cleanup ran, in the old backup dir:

```ts
docker compose -p <app> down --rmi all   // src/apps/installer.ts:1028 (pre-fix)
```

`docker compose down` selects resources **by the `-p <project>` label**, not by the compose file / working directory. By this point the update has already:

1. `down`-ed the **old** stack ("Stopping old containers"),
2. brought the **new** stack up via `composeUp` — which carries `project=<app>`,
3. swapped dirs and written `status: 'running'`.

So the cleanup's `down` — meant to reap the already-gone old containers — instead stops & removes the **new** container (plus its network and, via `--rmi all`, images). Because `status: 'running'` was already persisted, the UI reports "running" with nothing up.

## Fix

The old containers are already gone after step 1, so the cleanup's only real job is reclaiming the **old image**. Replace the project-colliding `compose down` with a **targeted image removal** that never touches containers:

- capture the old stack's image IDs **before** taking it down (while it is still up),
- capture the new stack's image IDs **after** it comes up,
- `docker image rm` each old image the new stack does **not** still depend on (best-effort — an in-use or already-gone image is non-fatal),
- keep `safeRmrf(oldBackupDir)` for the directory (no compose invocation).

New helper `captureComposeImageIds(appName, dir)` wraps `docker compose -p <app> images --quiet` (best-effort, `[]` on error).

## Acceptance criteria

- [x] After an update, the new container stays **Up** — no `compose down` touches the shared project name.
- [x] Registry `status` reflects the real container state (paired with the runtime reconcile from #278; the container now genuinely stays running).
- [x] Old image(s) are still reclaimed (no image leak per update).
- [x] Regression coverage for the update → still-running path.

## Testing

- New regression test `installer.test.ts` — asserts the update runs **no** `--rmi` compose-down and **no** compose-down against the `-old-*` backup dir, and that the old image is reclaimed via `docker image rm` while the new image is left intact. **Proven to fail on the pre-fix code** (old code records `compose -p <app> down --rmi all` in the backup dir).
- `npm run typecheck` clean.
- Full unit suite green (apps suites 109/109; touched `installer.test.ts` + `apps-router.test.ts`).

## Scope

Only the **update** cleanup path changes. Uninstall/rollback paths still use `compose down --rmi all` intentionally (they operate on the app's own live project), and are untouched.