### PR TITLE
fix(share): dedupe same-request refs instead of rejecting; gate line_image history on success

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1311,6 +1311,11 @@ export class AgentRunner extends EventEmitter {
       // block id — otherwise one sent image lands in the transcript N times and
       // skews the session image catalog's "image N" ordinal.
       const seenLineImageIds = new Set<string>();
+      // A line_image call queued here (id -> media) is only written to history
+      // once its matching tool_result confirms the send succeeded — a failed
+      // attempt followed by a retried, successful one must not leave two copies
+      // of the same image in the transcript.
+      const pendingLineImageMedia = new Map<string, { lineMedia: string[]; channelSrcLine: string }>();
       // Set when an interactive-menu prompt was rendered to the channel this turn,
       // so the result's plain-text auto-forward is skipped (no duplicate message).
       let menuSentThisTurn = false;
@@ -1345,23 +1350,22 @@ export class AgentRunner extends EventEmitter {
                 if (block.type === 'tool_use' && block.name === 'mcp__gateway__line_image') {
                   const lineBlockId = (block as Record<string, unknown>)['id'];
                   const dedupeKey = typeof lineBlockId === 'string' ? lineBlockId : '';
-                  // Skip if this tool_use block was already persisted this turn
+                  // Skip if this tool_use block was already queued this turn
                   // (cumulative assistant snapshots re-emit completed blocks).
                   if (dedupeKey && seenLineImageIds.has(dedupeKey)) continue;
                   const imgPath = typeof block.input?.['image'] === 'string' ? block.input['image'] : '';
                   const mediaRootLine = path.join(this.agentsBaseDir, this.agentConfig.id, 'media') + path.sep;
                   const lineMedia = toRelMediaFiles(imgPath ? [imgPath] : [], mediaRootLine);
-                  if (lineMedia.length) {
-                    if (dedupeKey) seenLineImageIds.add(dedupeKey);
-                    const channelSrcLine = this.channelSourceMap.get(mapKey) ?? 'line';
-                    this.historyDb.insertMessage({
-                      chatId: `${channelSrcLine}-${mapKey}`,
-                      sessionId: actualSessionId,
-                      source: channelSrcLine as HistorySource,
-                      role: 'assistant',
-                      content: '',
-                      mediaFiles: lineMedia,
-                      ts: Date.now(),
+                  if (lineMedia.length && dedupeKey) {
+                    seenLineImageIds.add(dedupeKey);
+                    // Queue instead of writing now — the send can still fail (mint
+                    // error, LINE API error, transient socket blip). Only the
+                    // matching tool_result below commits it to history, so a
+                    // failed attempt followed by a retried success doesn't leave
+                    // two copies of the same image in the transcript.
+                    pendingLineImageMedia.set(dedupeKey, {
+                      lineMedia,
+                      channelSrcLine: this.channelSourceMap.get(mapKey) ?? 'line',
                     });
                   }
                 }
@@ -1408,6 +1412,31 @@ export class AgentRunner extends EventEmitter {
                 if (block.type === 'tool_result' && block.tool_use_id === replyToolUseId && block.is_error) {
                   replyCalled = false;
                   replyToolUseId = null;
+                }
+              }
+            }
+          }
+          // Commit a queued line_image send to history only once its tool_result
+          // confirms success — see the queuing comment above. A failed send is
+          // simply dropped, so a same-image retry never double-writes.
+          if (obj['type'] === 'user' && pendingLineImageMedia.size) {
+            const msg = obj['message'] as { content?: Array<{ type: string; tool_use_id?: string; is_error?: boolean }> } | undefined;
+            if (Array.isArray(msg?.content)) {
+              for (const block of msg!.content) {
+                if (block.type === 'tool_result' && block.tool_use_id && pendingLineImageMedia.has(block.tool_use_id)) {
+                  const pending = pendingLineImageMedia.get(block.tool_use_id)!;
+                  pendingLineImageMedia.delete(block.tool_use_id);
+                  if (!block.is_error) {
+                    this.historyDb.insertMessage({
+                      chatId: `${pending.channelSrcLine}-${mapKey}`,
+                      sessionId: actualSessionId,
+                      source: pending.channelSrcLine as HistorySource,
+                      role: 'assistant',
+                      content: '',
+                      mediaFiles: pending.lineMedia,
+                      ts: Date.now(),
+                    });
+                  }
                 }
               }
             }
@@ -1552,6 +1581,7 @@ export class AgentRunner extends EventEmitter {
             replyCalled = false; // reset for next turn
             replyToolUseId = null;
             seenLineImageIds.clear();
+            pendingLineImageMedia.clear();
             menuSentThisTurn = false;
             menuPromptTextThisTurn = '';
             // In pty-shell mode, a `result` fires after every Claude API sub-turn

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -274,12 +274,16 @@ export function createSharesPrivateRouter(
         return;
       }
       if (!dedupeRef) dedupeRef = `path:${validated.relativePath}`;
-      if (seen.has(dedupeRef)) {
-        res.status(400).json({ error: 'duplicate ref', code: 'duplicate_ref' });
-        return;
+      // Identical refs within one request are legitimate (e.g. line_image mints
+      // the same file for both originalContentUrl and previewImageUrl when no
+      // separate preview is given) — let store.mintShare's own dedupeRef
+      // idempotency (§17.4) collapse them to the same token instead of
+      // rejecting the request outright. Still count each unique file once
+      // toward the total-size limit.
+      if (!seen.has(dedupeRef)) {
+        seen.add(dedupeRef);
+        totalBytes += validated.size;
       }
-      seen.add(dedupeRef);
-      totalBytes += validated.size;
       resolved.push({ dedupeRef, relativePath: validated.relativePath, size: validated.size });
     }
     if (totalBytes > limits.maxTotalBytes) {

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -4308,3 +4308,125 @@ describe('AgentRunner — channel coalescing (US-IMG-COALESCE)', () => {
     expect(buffers.size).toBe(0);
   }, 15000);
 });
+
+// ── line_image transcript history: gate on tool_result success ────────────────
+// Regression coverage for PR #286 fix (2): a line_image tool_use is queued when
+// its assistant block streams in, and only committed to chat history once the
+// matching tool_result confirms the send succeeded. A failed attempt followed by
+// a same-image retry must leave exactly ONE row, not two. Pre-fix, the runner
+// wrote to history the moment the tool_use appeared, so a retry double-posted.
+describe('AgentRunner — line_image history gated on tool_result success', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-line-hist-'));
+    const workspace = path.join(tmpDir, 'agents', 'alfred', 'workspace');
+    agentConfig = makeAgentConfig(workspace);
+    fs.mkdirSync(workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  // Absolute path to a media file the runner will accept (toRelMediaFiles requires
+  // the file to exist and live under <agentsBaseDir>/<agentId>/media/).
+  function writeMedia(name: string): string {
+    const abs = path.join(tmpDir, 'agents', 'alfred', 'media', name);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, 'fake-image');
+    return abs;
+  }
+
+  const assistantLineImage = (toolUseId: string, imageAbs: string) =>
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'tool_use',
+          id: toolUseId,
+          name: 'mcp__gateway__line_image',
+          input: { chat_id: 'U123', image: imageAbs },
+        }],
+      },
+    });
+
+  const toolResult = (toolUseId: string, isError: boolean) =>
+    JSON.stringify({
+      type: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: toolUseId, is_error: isError }],
+      },
+    });
+
+  async function startLineSession(chatId: string): Promise<SessionProcess> {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, chatId, 'please send an image');
+    await new Promise(r => setTimeout(r, 150));
+    (runner as unknown as { channelSourceMap: Map<string, string> }).channelSourceMap.set(chatId, 'line');
+    const session = getSessions(runner).get(chatId);
+    expect(session).toBeDefined();
+    return session!;
+  }
+
+  function lineImageRows(chatId: string): Array<{ role: string; mediaFiles?: string[] }> {
+    const page = runner.getHistoryDb().getMessages(`line-${chatId}`);
+    return (page.messages as Array<{ role: string; mediaFiles?: string[] }>)
+      .filter(m => m.role === 'assistant' && (m.mediaFiles?.length ?? 0) > 0);
+  }
+
+  it('commits a line_image to history once its tool_result confirms success', async () => {
+    const chatId = 'ch:line-ok';
+    const session = await startLineSession(chatId);
+    const img = writeMedia('ok.png');
+
+    session.emit('output', assistantLineImage('toolu_ok', img));
+    session.emit('output', toolResult('toolu_ok', false));
+    await new Promise(r => setTimeout(r, 50));
+
+    const rows = lineImageRows(chatId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.mediaFiles).toEqual(['media/ok.png']);
+  }, 15000);
+
+  it('does NOT write a line_image whose tool_result reports failure', async () => {
+    const chatId = 'ch:line-fail';
+    const session = await startLineSession(chatId);
+    const img = writeMedia('fail.png');
+
+    session.emit('output', assistantLineImage('toolu_fail', img));
+    session.emit('output', toolResult('toolu_fail', true)); // send failed
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(lineImageRows(chatId)).toHaveLength(0);
+  }, 15000);
+
+  // The core regression: a failed send + a same-image retry must not double-post.
+  it('writes exactly one row when a failed send is retried successfully (no double-post)', async () => {
+    const chatId = 'ch:line-retry';
+    const session = await startLineSession(chatId);
+    const img = writeMedia('retry.png');
+
+    // First attempt fails …
+    session.emit('output', assistantLineImage('toolu_a', img));
+    session.emit('output', toolResult('toolu_a', true));
+    // … then the model retries the SAME image with a new tool_use id, and it succeeds.
+    session.emit('output', assistantLineImage('toolu_b', img));
+    session.emit('output', toolResult('toolu_b', false));
+    await new Promise(r => setTimeout(r, 50));
+
+    const rows = lineImageRows(chatId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.mediaFiles).toEqual(['media/retry.png']);
+  }, 15000);
+});

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -224,17 +224,29 @@ describe('image share router', () => {
       expect(noAuth.status).toBe(401);
     });
 
-    test('rejects traversal, duplicates and over-count before minting', async () => {
+    test('rejects traversal and over-count before minting', async () => {
       const post = (refs: unknown[]) =>
         request().post('/api/v1/shares').set(AUTH_A1).send({ agent_id: AGENT, session_id: SESSION, refs });
 
       expect((await post([{ path: '../../etc/passwd' }])).status).toBe(400);
-      const dup = await post([{ path: `${SESSION}/ok.png` }, { path: `${SESSION}/ok.png` }]);
-      expect(dup.status).toBe(400);
-      expect(dup.body.code).toBe('duplicate_ref');
       const many = await post(Array.from({ length: 6 }, (_, i) => ({ path: `${SESSION}/x${i}.png` })));
       expect(many.status).toBe(400);
       expect(many.body.code).toBe('too_many_refs');
+    });
+
+    test('same ref twice in one request dedupes to the SAME token instead of rejecting', async () => {
+      const res = await request()
+        .post('/api/v1/shares')
+        .set(AUTH_A1)
+        .send({
+          agent_id: AGENT,
+          session_id: SESSION,
+          refs: [{ path: `${SESSION}/ok.png` }, { path: `${SESSION}/ok.png` }],
+        });
+      expect(res.status).toBe(201);
+      const [first, second] = res.body.items as Array<{ token: string; share_id: string }>;
+      expect(second.token).toBe(first.token);
+      expect(second.share_id).toBe(first.share_id);
     });
 
     test('registration persists the prompt, capped at 500 chars', async () => {


### PR DESCRIPTION
## Summary

Two bugs found while debugging why LINE image sends never worked after #279:

1. **`line_image` always failed to mint a share URL** — `share-router.ts`'s `/api/v1/shares` handler rejects a request outright with `duplicate_ref` (400) if the same ref appears twice in one call. `line_image` (`mcp/tools/line/module.ts`) mints the same file for both `originalContentUrl` and `previewImageUrl` in one request whenever no separate `preview` is given (the normal case) — so every LINE image send failed with `line_image: failed to mint share URL — duplicate_ref: duplicate ref`.

   `store.mintShare()` already has the right behavior for this: an idempotent `dedupeRef` cache (§17.4, `MINT_DEDUPE_WINDOW_MS`) that returns the *same token* for a repeated ref instead of erroring — which is exactly what the `line_image` code comment says should happen ("Identical refs dedupe to the same token within the store's idempotency window"). The router's own pre-check just never let requests reach that logic.

   Fix: still count each unique ref once toward `maxTotalBytes`, but stop rejecting the duplicate — let it flow through to `mintShare`, which dedupes it correctly.

2. **Once `line_image` could succeed, a duplicate-image-in-transcript bug surfaced** — `runner.ts` wrote a `line_image` send to chat history (and therefore the session image catalog / web transcript) as soon as the `tool_use` block appeared in the stream, regardless of whether the send actually succeeded. A transient failure (e.g. a LINE API socket error) followed by a same-image retry produced two history rows for one image, so it rendered twice on the web.

   Fix: queue the pending send keyed by tool_use id, and only commit it to history once the matching `tool_result` confirms success (`!is_error`) — mirroring the existing pattern just above it that detects a failed reply-tool call.

Both fixes verified live against a real LINE chat (image sends now succeed, and stopped double-posting on retry).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `tests/unit/share-router.test.ts` — updated the test that asserted the old reject-on-duplicate behavior (`rejects traversal, duplicates and over-count before minting`) into two tests: one for the still-rejected cases (traversal, over-count), and a new one asserting same-request duplicates now mint the *same token* instead of erroring
- [x] `tests/unit/line-image.test.ts` — passes unchanged (it mocks the share bridge, so it exercises the client-side contract; the new server-side test above covers the real HTTP path)
- [x] Full `npm run test:unit` — 2634/2635 passing; the one failure (`agent-runner.test.ts` US4-05) does not reproduce on a clean rerun and is unrelated to this change (restart-pending tracking after `query()` rejection — a different subsystem). A second full run instead flaked on an unrelated `pty-stream-registry` test. Neither touches `share-router.ts` or the `line_image` history path; both reproduce independently of this diff.
- [x] Manual: sent images through a live LINE chat before/after — confirmed both the mint failure and the duplicate-transcript issue are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)