### PR TITLE
fix(config): treat blank gateway.publicUrl as unset instead of a fatal boot error

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -15,7 +15,6 @@
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "bind": "127.0.0.1",
-    "publicUrl": "",
     "models": [
       { "id": "claude-fable-5[1m]",        "label": "Fable 5 (1M)",     "alias": "fable[1m]",   "contextWindow": 1000000 },
       { "id": "claude-opus-5[1m]",         "label": "Opus 5 (1M)",      "alias": "opus[1m]",    "contextWindow": 1000000 },

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -185,8 +185,14 @@ export function loadConfig(configPath: string): GatewayConfig {
 
   // Interpolate gateway config (fatal if env vars missing here)
   const interpolatedGateway = interpolateObject(config.gateway) as Record<string, unknown>;
-  if (interpolatedGateway.publicUrl !== undefined) {
-    const normalizedPublicUrl = resolveGatewayPublicUrl(interpolatedGateway.publicUrl);
+  const rawPublicUrl = interpolatedGateway.publicUrl;
+  if (typeof rawPublicUrl === 'string' && !rawPublicUrl.trim()) {
+    // Blank/whitespace-only is "not configured", not "invalid". Normalize to
+    // undefined so downstream consumers see a single unset representation and
+    // report "not configured" rather than throwing or emitting a broken link.
+    interpolatedGateway.publicUrl = undefined;
+  } else if (rawPublicUrl !== undefined) {
+    const normalizedPublicUrl = resolveGatewayPublicUrl(rawPublicUrl);
     if (!normalizedPublicUrl) {
       throw new ConfigValidationError(
         'gateway.publicUrl must be an HTTPS URL ending in /gateway with no credentials, query, or fragment ' +

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -230,4 +230,64 @@ describe('config-loader', () => {
       );
     }
   });
+
+  it('treats blank/whitespace/absent gateway.publicUrl as unset (no throw)', () => {
+    const write = (name: string, publicUrl: unknown) => {
+      const configPath = path.join(tmpDir, name);
+      fs.writeFileSync(configPath, JSON.stringify({
+        gateway: { logDir: '/tmp', timezone: 'UTC', publicUrl },
+        agents: [{
+          id: 'test',
+          description: '',
+          workspace: '/tmp',
+          env: '/tmp/.env',
+          telegram: { botToken: 'tok' },
+          claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: false, extraFlags: [] },
+        }],
+      }));
+      return configPath;
+    };
+
+    // Empty string (the value config.template.json used to ship) → unset, boots.
+    expect(loadConfig(write('public-url-empty.json', '')).gateway.publicUrl).toBeUndefined();
+    // Whitespace-only → same as empty.
+    expect(loadConfig(write('public-url-blank.json', '   ')).gateway.publicUrl).toBeUndefined();
+    // Absent key (JSON.stringify drops undefined) → unset, no regression.
+    expect(loadConfig(write('public-url-absent.json', undefined)).gateway.publicUrl).toBeUndefined();
+  });
+
+  it('boots from the shipped config.template.json gateway block', () => {
+    const template = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', '..', 'config.template.json'), 'utf-8'),
+    );
+    // Guard the template fix: the shipped gateway block must not carry a value
+    // the loader rejects. Keep the template's real gateway block, swap in one
+    // minimal agent so agent interpolation needs no env, and satisfy the two
+    // gateway api-key env placeholders so we exercise the real gateway block.
+    const configPath = path.join(tmpDir, 'from-template.json');
+    fs.writeFileSync(configPath, JSON.stringify({
+      gateway: template.gateway,
+      agents: [{
+        id: 'test',
+        description: '',
+        workspace: '/tmp',
+        env: '/tmp/.env',
+        telegram: { botToken: 'tok' },
+        claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: false, extraFlags: [] },
+      }],
+    }));
+    const prevMy = process.env.MY_API_KEY;
+    const prevAdmin = process.env.ADMIN_API_KEY;
+    process.env.MY_API_KEY = 'sk-test-my';
+    process.env.ADMIN_API_KEY = 'sk-test-admin';
+    try {
+      expect(() => loadConfig(configPath)).not.toThrow();
+      expect(loadConfig(configPath).gateway.publicUrl).toBeUndefined();
+    } finally {
+      if (prevMy === undefined) delete process.env.MY_API_KEY;
+      else process.env.MY_API_KEY = prevMy;
+      if (prevAdmin === undefined) delete process.env.ADMIN_API_KEY;
+      else process.env.ADMIN_API_KEY = prevAdmin;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`loadConfig()` guarded `gateway.publicUrl` on `!== undefined`, so an empty string passed the guard, resolved to `null` via `resolveGatewayPublicUrl()`, and was then rejected as *invalid* — throwing `ConfigValidationError` and exiting 1 on **every boot**. `config.template.json` shipped exactly that value (`"publicUrl": ""`), so a default install — and any existing install upgrading — crash-looped forever under the systemd unit's `Restart=always`.

Blank is a supported "not configured" state everywhere else in the codebase (`src/cli-viewer/url.ts`, and README: *"Leave it blank to keep `/cli` disabled"*). Only the loader could not distinguish "resolver said unset" from "resolver said invalid".

Closes #285

## Root cause

```
resolveGatewayPublicUrl(undefined) // → null, but guard is skipped  → boots
resolveGatewayPublicUrl('')        // → null, guard NOT skipped     → throws  ← bug
resolveGatewayPublicUrl('https://host.example.com/gateway') // → normalized → boots
```

`src/config/loader.ts:188` treated the resolver's `null` for a blank string as "invalid" rather than "unset".

## Changes

1. **`src/config/loader.ts`** — blank / whitespace-only `publicUrl` is normalized to `undefined` (one single unset representation) instead of throwing. Genuinely malformed values (no `/gateway` suffix, non-local `http://`, query/fragment/credentials, non-string like `123`/`null`) still throw `ConfigValidationError` exactly as before.
2. **`config.template.json`** — drop the `"publicUrl": ""` key so the shipped template no longer depends on the loader fix to be bootable.
3. **`tests/unit/config-loader.test.ts`** — cover blank / whitespace / absent (all resolve to `undefined`) plus a boot-from-shipped-template guard.

## Testing

- `npm run typecheck` — clean
- `tests/unit/config-loader.test.ts` — 14/14 pass
- Related suites (config-migration, config-watcher, cli-viewer, command-endpoint, share-router, models-registry) — 87/87 pass
- Full suite — 2855/2859 pass; the 4 failures are in unrelated suites (`cron-manager`, `pipeline-mcp`, `pty-menu-probe`) that all pass in isolation (known parallel-worker flakiness)
- **Proven-red**: the blank-case test fails on the pre-fix loader (throws on `""`) and passes after the fix.

## Acceptance criteria

- [x] `gateway.publicUrl: ""` loads successfully and is treated as unset (no throw)
- [x] Whitespace-only values (`"   "`) treated the same as empty
- [x] Absent `publicUrl` key continues to load (no regression)
- [x] Genuinely malformed values still throw `ConfigValidationError`
- [x] Blank resolves to `undefined` (not `""`) so `buildCliUrl()` reports "not configured"
- [x] A gateway started with an unmodified `config.template.json` boots successfully
- [x] `tests/unit/config-loader.test.ts` covers the blank and absent cases

## Out of scope

- Validation rules for genuinely provided URLs (unchanged)
- `/cli` viewer / `buildCliUrl` / `normalizePublicUrl` behaviour (unchanged)
- A migration that rewrites existing `config.json` files (existing installs already carry `publicUrl: ""` and boot correctly with this loader fix)