### PR TITLE
fix(app-agent): seed a writable ~/.claude.json instead of read-only mount (fixes Not logged in)

### DIFF
--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -89,6 +89,18 @@ export class AgentManager {
     let uid = 1000;
     try { uid = os.userInfo().uid; } catch { /* use 1000 */ }
 
+    // Claude Code rewrites ~/.claude.json atomically at startup (write temp +
+    // rename over the target). Bind-mounting the host file at its real path makes
+    // that rename fail with `Device or resource busy` (a mountpoint cannot be
+    // replaced via rename, regardless of ro/rw), so the session cannot persist the
+    // auth state carried by settings.json's env block and falls back to
+    // "Not logged in". Instead we bind-mount the host file to a read-only *seed*
+    // path (host file never mutated) and copy it into a writable ~/.claude.json at
+    // container start (see `command` below) so the atomic rewrite succeeds. The
+    // copy targets the literal homeDir: container-start HOME is `/`, but the
+    // gateway runs turns with `docker exec -e HOME=<homeDir>` (see process.ts).
+    const claudeJsonSeed = `${homeDir}/.claude.json.seed`;
+
     // Mount the agent's media directory into the container at the SAME absolute
     // path as the host. The gateway hands the agent uploaded-image paths (and the
     // browser-screenshot dir) as raw host paths under <agentsDir>/<agentName>/media
@@ -118,7 +130,10 @@ export class AgentManager {
     const agentService = {
       build: { context: entry.installPath, dockerfile: 'Dockerfile.agent' },
       user: `${uid}:${uid}`,
-      command: `sleep infinity`,
+      // Seed a writable ~/.claude.json from the read-only seed mount, then idle.
+      // `cp` overwrites on every (re)start so the container always picks up the
+      // current host auth; `exec` keeps the container's PID 1 as sleep.
+      command: `sh -c 'cp ${claudeJsonSeed} ${homeDir}/.claude.json && exec sleep infinity'`,
       container_name: `${entry.name}-agent`,
       restart: 'unless-stopped',
       cap_drop: ['ALL'],
@@ -128,7 +143,7 @@ export class AgentManager {
         `${claudeBin}:${claudeBin}:ro`,
         `${nodeBin}:/usr/bin/node:ro`,
         `${npmRoot}:${npmRoot}:ro`,
-        `${homeDir}/.claude.json:${homeDir}/.claude.json:ro`,
+        `${homeDir}/.claude.json:${claudeJsonSeed}:ro`,
         `${homeDir}/.claude/settings.json:${homeDir}/.claude/settings.json:ro`,
         `${workspaceDir}:/workspace`,
         `${agentMediaSource}:${agentMediaDir}:rw`,

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -136,8 +136,43 @@ describe('AgentManager', () => {
       expect(volumes).toBeDefined();
       expect(volumes.some((v) => v.includes('claude') && v.endsWith(':ro'))).toBe(true);
       expect(volumes.some((v) => v.endsWith(':/workspace'))).toBe(true);
-      expect(volumes.some((v) => v.includes('.claude.json') && v.endsWith(':ro'))).toBe(true);
+      // ~/.claude.json is mounted read-only to a *seed* path (copied to a writable
+      // file at container start — see the regression test below), not at its real path.
+      expect(volumes.some((v) => v.includes('.claude.json.seed') && v.endsWith(':ro'))).toBe(true);
       expect(volumes.some((v) => v.includes('settings.json') && v.endsWith(':ro'))).toBe(true);
+    });
+
+    it('seeds a writable ~/.claude.json via copy instead of a read-only mount at its real path (regression: app-agent "Not logged in")', () => {
+      // Claude Code rewrites ~/.claude.json atomically at startup (write temp +
+      // rename over the target). Bind-mounting the host file at its real container
+      // path makes that rename fail with EBUSY, so auth state is never persisted
+      // and every app-agent turn returns "Not logged in · Please run /login".
+      // Fix: mount the host file read-only to a seed path (host file untouched) and
+      // copy it into a writable ~/.claude.json at container start.
+      const entry = makeEntry(tmpDir);
+      manager.injectAgentService(entry);
+
+      const composePath = path.join(entry.installPath, 'docker-compose.yml');
+      const composed = yaml.load(fs.readFileSync(composePath, 'utf-8')) as Record<string, unknown>;
+      const services = composed['services'] as Record<string, unknown>;
+      const agentSvc = services['agent'] as Record<string, unknown>;
+      const volumes = agentSvc['volumes'] as string[];
+      const home = os.homedir();
+
+      // The host ~/.claude.json must NOT be bind-mounted at its real container
+      // path (that is the mountpoint whose atomic-rename fails).
+      const realPathMount = volumes.find((v) => v.split(':')[1] === `${home}/.claude.json`);
+      expect(realPathMount).toBeUndefined();
+
+      // It is mounted read-only to a seed path, sourced from the host file.
+      const seedMount = volumes.find((v) => v.split(':')[1] === `${home}/.claude.json.seed`);
+      expect(seedMount).toBeDefined();
+      expect(seedMount!.endsWith(':ro')).toBe(true);
+      expect(seedMount!.split(':')[0]).toBe(`${home}/.claude.json`);
+
+      // The container copies the seed into a writable ~/.claude.json at start.
+      const command = agentSvc['command'] as string;
+      expect(command).toContain(`cp ${home}/.claude.json.seed ${home}/.claude.json`);
     });
 
     it('mounts the agent media dir at the identical host path (:rw) and pre-creates it', () => {


### PR DESCRIPTION
## Summary

Fixes #288 — every **app-agent** (an agent running inside its app's Docker container) replied `Not logged in · Please run /login` on **all channels** (LINE, Telegram, Discord, web/api).

**Root cause:** `injectAgentService()` bind-mounted the host `~/.claude.json` **read-only at its real path**. Claude Code rewrites that file atomically at startup (write temp → `rename()` over the target). Renaming over a bind-mount point fails with `Device or resource busy` (a mountpoint cannot be replaced via rename, regardless of `ro`/`rw`), so the auth state carried by `settings.json`'s `env` block is never persisted and the session falls back to unauthenticated.

**Fix (copy, not read-only mount):**
- Mount the host `~/.claude.json` read-only to a **seed path** (`~/.claude.json.seed`) — the host file is never mutated.
- Copy the seed into a **writable** `~/.claude.json` at container start via the service `command`, so Claude Code's atomic rewrite succeeds.
- `settings.json` stays `:ro` (only read at runtime).

The copy targets the literal `homeDir` because container-start `HOME` is `/`, while the gateway runs turns with `docker exec -e HOME=<homeDir>` (`src/session/process.ts`). This preserves the existing design intent ("app-agent reuses the host login") while making the file writable.

## Live proof (real app-agent container, same `docker exec -e HOME=/home/ubuntu` the gateway uses)

| Home config | Result |
| --- | --- |
| `.claude.json` **copied** into a writable HOME | ✅ authenticated turn returns `OK` |
| `.claude.json` as the current **read-only bind-mount** | ❌ `Not logged in · Please run /login` |

Same binary, base image, and token — the only variable is writable-copy vs read-only-mount.

## Tests

- Added a regression test (`tests/unit/apps/agent-manager.test.ts`) asserting the generated `docker-compose.yml`:
  - does **not** mount `.claude.json` at its real path,
  - mounts it read-only to `.claude.json.seed` (sourced from the host file),
  - copies the seed into `~/.claude.json` at container start.
- **Verified the regression test fails on the pre-fix code** (reverted `src` only → 2 tests fail; restored → all green).
- `npm run typecheck`: clean.
- `npm test`: 2782 tests pass (the one suite-run SIGTERM was a full-suite worker resource kill unrelated to this change — `agent-runner.test.ts` passes 128/128 in isolation).

## Blast radius

Structural to the app-agent container path — independent of channel and of any specific app. `habit-hero-bot` is currently the only app-agent, so it is the only one affected today; any future app-agent on any channel would hit the same bug.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
