### PR TITLE
fix(runner): surface MediaStore path for inbound channel images so app-agents can read them

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1013,8 +1013,15 @@ export class AgentRunner extends EventEmitter {
             try {
               const rel = MediaStore.copyToMedia(this.agentsBaseDir, this.agentConfig.id, `${channelSource}-${chatId}`, meta['image_path']);
               mediaFiles.push(rel);
+              // Surface the MediaStore copy to the agent instead of the raw staging
+              // path. app-agents run in a container where only the MediaStore dir is
+              // bind-mounted at an identical absolute path; the raw source (/tmp for
+              // LINE, <workspace>/.*-state for TG/Discord) is invisible inside it.
+              // Mutating meta['image_path'] here (same object as entry.meta) makes the
+              // channel XML and image-size tracker below both use the readable path.
+              meta['image_path'] = MediaStore.resolvePath(this.agentsBaseDir, this.agentConfig.id, rel);
             } catch {
-              // Non-fatal — continue without media
+              // Non-fatal — leave the original path so host agents still read it
             }
           }
           this.historyDb.insertMessage({

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -4330,6 +4330,35 @@ describe('AgentRunner — channel coalescing (US-IMG-COALESCE)', () => {
     await runner.stop();
     expect(buffers.size).toBe(0);
   }, 15000);
+
+  // Regression (#292): an inbound channel image is staged at a path the app-agent
+  // container cannot see (LINE downloads to host /tmp; TG/Discord to
+  // <workspace>/.*-state). The runner already copies the file into the agent's
+  // MediaStore (bind-mounted at an identical absolute path inside the container) —
+  // it must surface THAT path to the agent, not the raw staging path.
+  // Pre-fix, the channel XML carried the raw staging path → this test fails.
+  it('surfaces the container-readable MediaStore path for an inbound image, not the raw staging path', async () => {
+    // Stage the image OUTSIDE the agent's media dir, mimicking LINE's host /tmp
+    // download (a location not bind-mounted into an app-agent container).
+    const rawStaging = path.join(tmpDir, 'raw-staging.jpg');
+    fs.writeFileSync(rawStaging, Buffer.alloc(64));
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    await postImage(port, 'chat:cl-mediapath', rawStaging, '', '1');
+    await new Promise(r => setTimeout(r, 450)); // let the debounce window flush
+
+    const turn = turnWritesOf().find(w => w.includes('image_path='));
+    expect(turn).toBeDefined();
+    // The agent is told the MediaStore copy (readable inside the container): it
+    // lives under media/<channel>-<chatId>/ with copyToMedia's timestamp prefix …
+    expect(turn).toContain(`${path.sep}media${path.sep}telegram-chat:cl-mediapath${path.sep}`);
+    expect(turn).toContain('raw-staging.jpg'); // basename preserved by copyToMedia
+    // … and NOT the raw host staging path the container cannot read.
+    expect(turn).not.toContain(`image_path="${rawStaging}"`);
+  }, 15000);
 });
 
 // ── line_image transcript history: gate on tool_result success ────────────────


### PR DESCRIPTION
## What

Surface the **MediaStore** copy of an inbound channel image to the agent instead of the raw staging path, so **app-agents** (agents running inside a Docker container) can actually Read the image.

Closes #292.

## Why

The LINE webhook downloads an inbound image to host `os.tmpdir()` (`/tmp`), and Telegram/Discord stage theirs under `<workspace>/.telegram-state` / `.discord-state`. `AgentRunner.routeChannelTurn()` then handed that **raw** path to the agent through the channel XML (`meta['image_path']`).

For an app-agent the container's `/tmp` is an isolated tmpfs and the workspace is mounted at `/workspace` — neither matches the host path. The only inbound-media location bind-mounted at an **identical absolute path** inside the container is the agent's MediaStore dir (`.../agents/<id>/media`). So the agent was told to Read a path it cannot see and reported the image as missing.

Proven on a live app-agent container: host `/tmp` held the `line-img-*.jpg`; `docker exec … ls /tmp` inside the container showed none; `docker inspect` confirmed only the MediaStore dir is mounted at the same absolute path. (Web/api uploads already work precisely because they resolve through MediaStore.)

## How

`routeChannelTurn()` already calls `MediaStore.copyToMedia(...)` (for the history DB). After a successful copy, rewrite `meta['image_path']` to the resolved absolute MediaStore path. Because `meta` is the same object as `entry.meta`, both downstream consumers — the channel XML shown to the agent (`buildChannelXml`) and the image-size tracker (`pendingImagePaths` → `stat`) — pick up the readable path automatically.

- Single choke point that runs for **every** channel → fixes Telegram/Discord/LINE app-agents at once.
- On copy failure the original path is preserved → **host agents don't regress**.
- The API/streaming path is untouched — it already resolves through MediaStore (`resolveMediaPaths`).

```
src/agent/runner.ts             |  9 ++++++++-  (+8 −1)
tests/unit/agent-runner.test.ts | 29 +++++++++++++++++++++++++++++
```

## Test

- New regression test `surfaces the container-readable MediaStore path for an inbound image…` asserts the surfaced `image_path` lives under `media/<channel>-<chatId>/` (not the raw staging path).
- **Proven to fail on the pre-fix code**: reverting only the `src/` change makes the test fail (`Expected substring: "/media/telegram-chat:cl-mediapath/"` absent), then restoring it passes.
- `npm run typecheck` clean.
- Full `npm test`: **2907/2907 tests pass**. (One suite, `webhooks-router.test.ts`, was reported failed by a flaky jest **worker SIGABRT** under parallel load with zero assertion failures; it passes 9/9 in isolation — unrelated to this change.)
- `agent-runner.test.ts` (the modified file) passes 133/133 in isolation.
