### PR TITLE
fix(app-agent): merge config entry on reconcile so channel config survives restart

### DIFF
--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -316,7 +316,13 @@ export class AgentManager {
       const config = this.readConfig();
       const idx = config.agents.findIndex((a) => a['id'] === agentId);
       if (idx >= 0) {
-        config.agents[idx] = entry;
+        // Merge — never replace. `entry` carries only the app-managed fields
+        // rebuilt from the app declaration (id/type/container/claudeBin/workspace/…);
+        // spreading it over the existing entry refreshes those while preserving
+        // any operator-added keys — crucially the `line`/`telegram`/`discord`
+        // channel blocks configured after install. A full replace here wiped
+        // those on every reconcile/restart, silently disconnecting the channel.
+        config.agents[idx] = { ...config.agents[idx], ...entry };
       } else {
         config.agents.push(entry);
       }

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -282,6 +282,59 @@ describe('AgentManager', () => {
       expect(matching).toHaveLength(1);
     });
 
+    // Regression (#294): channel config (line/telegram/discord) added to an
+    // app-agent entry AFTER install must survive reconcile/upsert. The old code
+    // did `config.agents[idx] = entry` (full replace) with an entry rebuilt from
+    // the app declaration that carries no channel blocks, so every gateway
+    // restart silently wiped them — disconnecting the agent's LINE/Telegram/Discord.
+    it('preserves operator-added channel config (line/telegram/discord) on re-upsert while refreshing app-managed fields', async () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      // Simulate an already-installed app-agent whose channel config was added
+      // after install, plus a stale app-managed field (container) to prove the
+      // merge still refreshes declaration-owned fields.
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          gateway: { logDir: 'logs', timezone: 'UTC' },
+          agents: [
+            {
+              id: 'my-agent',
+              type: 'app-agent',
+              container: 'stale-container',
+              line: { channelSecret: 'sec-123', channelAccessToken: 'tok-abc', slowResponseThreshold: 45 },
+              telegram: { botToken: 'tg-token' },
+              discord: { botToken: 'dc-token' },
+            },
+          ],
+        }),
+        'utf-8',
+      );
+
+      const entry = makeEntry(tmpDir); // agentDeclaration.name === 'my-agent', container my-app-agent
+      await manager.upsertAgent(entry);
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        agents: Array<Record<string, unknown>>;
+      };
+      const agentEntry = config.agents.find((a) => a['id'] === 'my-agent');
+      expect(agentEntry).toBeDefined();
+
+      // Channel blocks survive the reconcile (the actual regression).
+      expect(agentEntry!['line']).toEqual({
+        channelSecret: 'sec-123',
+        channelAccessToken: 'tok-abc',
+        slowResponseThreshold: 45,
+      });
+      expect(agentEntry!['telegram']).toEqual({ botToken: 'tg-token' });
+      expect(agentEntry!['discord']).toEqual({ botToken: 'dc-token' });
+
+      // App-managed fields are still refreshed from the declaration (not left stale).
+      expect(agentEntry!['container']).toBe('my-app-agent');
+      expect(agentEntry!['type']).toBe('app-agent');
+      // Still a single entry — merge, not append.
+      expect(config.agents.filter((a) => a['id'] === 'my-agent')).toHaveLength(1);
+    });
+
     it('updates symlink if it already exists', async () => {
       const entry = makeEntry(tmpDir);
       await manager.upsertAgent(entry);


### PR DESCRIPTION
## What

`upsertConfigEntry()` did `config.agents[idx] = entry` — a **full replace** — with an entry rebuilt from the app declaration that carries only app-managed fields (`id/type/description/container/claudeBin/workspace/env/allow_tools/claude`) and **no `line`/`telegram`/`discord` block**. Since `reconcileAgents()` runs on **every gateway startup** (`src/index.ts:650`), any channel config added to an app-agent *after* install was silently wiped on the next restart.

Fixes #294.

## Why it broke LINE specifically

- `src/agent/runner.ts:2350-2351` — `startLineReply()` returns early when `line.channelSecret`/`channelAccessToken` are missing → `this.lineReply` stays `null` (silent, no log).
- `src/agent/runner.ts:1667-1668` — LINE reply delivery is gated on `this.lineReply`; null → the answer never reaches LINE.
- `src/api/line-webhook-router.ts:259,262,298` — the webhook resolves the target agent via `line.channelSecret`; gone → inbound LINE can't be routed.
- The web/API path returns the turn result directly and does **not** use the channel block, which is why it kept working (the agent runtime was healthy — the config was stripped).

## Fix

Merge the app-managed fields onto the existing entry instead of replacing it:

```ts
config.agents[idx] = { ...config.agents[idx], ...entry };
```

Declaration-owned fields still refresh from the app; operator-added keys (channel blocks and any other non-declared fields) are preserved. Single choke point — covers reconcile, install, and update. First install still pushes a clean entry (no channel config yet).

## Not new in any recent release

The full-replace originates in commit `c06112b` (#91, app store, 2026-05-24) — present in all versions. It surfaces on any restart (deploy, crash-restart, config reload).

## Test

Regression test in `tests/unit/apps/agent-manager.test.ts`: seeds an app-agent entry with `line`/`telegram`/`discord` + a stale `container`, runs `upsertAgent`, asserts the channel blocks survive and the app-managed field refreshes to `my-app-agent`. **Verified it FAILS on the pre-fix full-replace code** (`line` block → `undefined`) and passes on the fix.

- `npm run typecheck` — clean
- Full suite — 2890/2890 tests pass (one unrelated integration suite flaked under parallel worker load; passes 27/27 standalone)

## Acceptance criteria

- [x] Channel config preserved across restart / reconcile
- [x] App-managed fields still refresh from the declaration
- [x] Existing broken state recovers (once the block is present, restart keeps it — no per-restart manual re-entry)
- [x] No behavior/authorization weakened (merge only preserves existing keys)
- [x] Regression test fails on old code
