### PR TITLE
fix(pty): clear the TUI input fully before pasting so a stale draft can't concatenate

### DIFF
--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -41,6 +41,13 @@ const HEARTBEAT_LIVENESS_QUIET_MS = 45_000;
 const SUBMIT_ENTER_DELAY_MS = 300;
 const SUBMIT_RETRY_AFTER_MS = 4000;
 const MAX_ENTER_RETRIES = 2;
+// Robust pre-paste input clear. A single Ctrl+U clears only ONE input line, so a
+// stale MULTI-line draft left by a prior swallowed Enter would survive partially
+// and concatenate with the next paste (two messages merged into one turn). We send
+// Ctrl+U in a bounded loop until the input draft reads empty. Each Ctrl+U at an
+// already-empty prompt is a harmless no-op.
+const INPUT_CLEAR_MAX_KEYS = 8;
+const INPUT_CLEAR_SETTLE_MS = 60;
 const FALLBACK_IDLE_QUIET_MS = 2000;
 const DIALOG_ACTION_COOLDOWN_MS = 2000;
 // An interactive select menu must be stable (no PTY output) this long before we
@@ -547,10 +554,14 @@ class Driver {
       return;
     }
     // Clear any stale text sitting in the input line first — e.g. history the
-    // probe's Up fallback recalled that an abandoned round couldn't restore —
-    // so it is never prepended to this message (review round 2, finding 3).
-    // A no-op at an empty idle prompt.
-    this.host.writeRaw('\x15');
+    // probe's Up fallback recalled that an abandoned round couldn't restore, or a
+    // prior turn's paste whose Enter was swallowed — so it is never prepended to
+    // this message (review round 2, finding 3; issue #296). A single Ctrl+U only
+    // clears one line, so a MULTI-line stale draft would survive partially and
+    // concatenate with the paste below — clearInput() loops until the input is
+    // empty. A no-op at an already-empty idle prompt.
+    await this.clearInput();
+    if (this.abortIfInterrupted()) return;
     if (NO_BRACKETED_PASTE) {
       // Fallback: sanitizeUserText() strips all CR, so '\r' below is the only
       // submit trigger — safe for multiline text without bracketed paste.
@@ -569,6 +580,28 @@ class Driver {
     if (this.abortIfInterrupted()) return;
     this.host.writeRaw('\r');
     if (this.turn) this.turn.submittedAt = Date.now();
+  }
+
+  /**
+   * Clear the PTY input line COMPLETELY before pasting a new turn. A single Ctrl+U
+   * clears only the current input line; a stale multi-line draft (left when a prior
+   * paste's Enter was swallowed) would otherwise keep its earlier line(s) and the
+   * next paste would land after them — merging two messages into one turn (#296).
+   *
+   * Sends Ctrl+U in a bounded loop, stopping as soon as the screen's input draft
+   * reads empty, or at INPUT_CLEAR_MAX_KEYS. Only the confirmed-empty read stops
+   * the loop — a keystroke whose redraw hasn't reached our screen model yet simply
+   * costs one more Ctrl+U (a harmless no-op at an empty prompt), never an early
+   * stop that leaves a remnant behind. At an already-empty prompt this sends a
+   * single no-op Ctrl+U and returns.
+   */
+  private async clearInput(): Promise<void> {
+    for (let i = 0; i < INPUT_CLEAR_MAX_KEYS; i++) {
+      this.host.writeRaw('\x15'); // Ctrl+U: clear one input line
+      await new Promise((r) => setTimeout(r, INPUT_CLEAR_SETTLE_MS));
+      if (this.screen.inputDraft() === '') return; // input empty → done
+    }
+    logWarn(`clearInput: input still non-empty after ${INPUT_CLEAR_MAX_KEYS} Ctrl+U — proceeding`);
   }
 
   // Sends Ctrl+U to clear the PTY input line, drains the queue, and returns true.
@@ -750,9 +783,17 @@ class Driver {
         && this.screen.hasPrompt()
         && !(turn.fromMenuSelection && this.screen.interactivePromptBlocking())
         && this.screen.quietMs() > 1500
-        && this.tailer.seenRecords === turn.recordsAtStart) {
-      // Only retry if no new records have appeared since this turn started —
-      // a delta > 0 means claude already started writing output.
+        && (this.tailer.seenRecords === turn.recordsAtStart
+            || this.screen.inputDraft() !== '')) {
+      // Retry the swallowed Enter when either (a) no new records have appeared
+      // since this turn started — a delta > 0 normally means Claude began writing
+      // output — OR (b) the input draft is still visibly on screen. (b) is the
+      // definitive, record-independent signal: text sitting in the input has not
+      // been submitted, no matter what records say. The plain `seenRecords`
+      // equality alone self-disabled the retry whenever a PRIOR overlapping turn
+      // had written records (its count inflates seenRecords past recordsAtStart),
+      // leaving a genuinely-unsubmitted draft stuck until the watchdog or the next
+      // paste collided with it (#296).
       //
       // The interactivePromptBlocking() suppression applies ONLY to a
       // menu-selection turn: there a live menu genuinely can still be on

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -596,6 +596,14 @@ class Driver {
    * single no-op Ctrl+U and returns.
    */
   private async clearInput(): Promise<void> {
+    // Fast path (the common case): the input is already empty, so send a single
+    // Ctrl+U as a harmless no-op — exactly the pre-#296 behavior — and skip the
+    // settle loop entirely so a clean submit gains no latency.
+    if (this.screen.inputDraft() === '') {
+      this.host.writeRaw('\x15');
+      return;
+    }
+    // A draft is present: clear it a line at a time until the input reads empty.
     for (let i = 0; i < INPUT_CLEAR_MAX_KEYS; i++) {
       this.host.writeRaw('\x15'); // Ctrl+U: clear one input line
       await new Promise((r) => setTimeout(r, INPUT_CLEAR_SETTLE_MS));

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -445,6 +445,39 @@ export class ScreenModel {
     return TUI_PROMPT_RE.test(this.text());
   }
 
+  /**
+   * The user's current input draft — the text sitting after the last `❯ ` caret,
+   * across any continuation lines, up to the surrounding border / status bar.
+   * Returns '' when the input is empty (a bare caret, or the dim "Try …"
+   * placeholder Claude shows at an empty prompt).
+   *
+   * Used by the wrapper to (a) clear a stale multi-line draft COMPLETELY before
+   * pasting a new turn — a single Ctrl+U clears only one input line, so a leftover
+   * draft (e.g. from a prior swallowed Enter) would otherwise concatenate with the
+   * next paste and merge two messages into one turn — and (b) detect a swallowed
+   * Enter (the pasted text is still on screen) independently of transcript records,
+   * which a prior overlapping turn can otherwise poison.
+   */
+  inputDraft(): string {
+    const lines = this.text().split('\n');
+    let idx = -1;
+    for (let i = 0; i < lines.length; i++) if (/❯ /.test(lines[i])) idx = i;
+    if (idx === -1) return '';
+    const parts: string[] = [];
+    const first = lines[idx].replace(/^.*?❯ ?/, '');
+    if (first.trim()) parts.push(first.trim());
+    for (let j = idx + 1; j < lines.length; j++) {
+      const l = lines[j].trim();
+      // Stop at a blank line, a box/rule border, or the status bar below the input.
+      if (l === '' || /^[─╭╮╰╯│]/.test(l) || /^(Model:|Context:|Session:|⏵)/.test(l)) break;
+      parts.push(l);
+    }
+    const draft = parts.join('\n').trim();
+    // The empty-input placeholder is dim helper text, never a real user draft.
+    if (draft.startsWith('Try "') || draft.startsWith('for shortcuts')) return '';
+    return draft;
+  }
+
   detectDialog(): DialogKind | null {
     // Scan only the bottom region: a real modal dialog renders there, while a
     // reply/history quoting "Bypass Permissions mode … Yes, I accept" sits in the

--- a/tests/helpers/mock-claude-tui-input.js
+++ b/tests/helpers/mock-claude-tui-input.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Fake Claude Code TUI for testing the wrapper's pre-paste input clearing
+ * (issue #296). Unlike mock-claude-tui.js (whose stdin machine clears the whole
+ * buffer on Ctrl+U and REPLACES it on paste), this mock models the real TUI's
+ * line-aware input so the concatenation bug can be reproduced faithfully:
+ *
+ *   - Ctrl+U (\x15)         removes only the LAST line of the input buffer
+ *                           (a single Ctrl+U cannot clear a multi-line draft).
+ *   - bracketed paste       APPENDS to whatever is already in the buffer
+ *                           (so a leftover draft concatenates with the paste).
+ *   - Enter (\r)            submits the buffer: logs it to FAKE_TUI_INPUT_LOG,
+ *                           writes a transcript turn_duration to end the turn,
+ *                           then clears the buffer and returns to idle.
+ *
+ * FAKE_TUI_STALE_DRAFT pre-seeds the input buffer with a stuck draft (use a
+ * literal "\n" to separate lines) — simulating a prior paste whose Enter was
+ * swallowed. The buffer is rendered as "❯ <line1>\n<line2>…" so the wrapper's
+ * ScreenModel.inputDraft() sees it exactly as the real TUI would.
+ */
+
+const {
+  handleAuthShim,
+  parseSessionId,
+  makeTranscriptWriter,
+  makeFileLogger,
+} = require('./mock-tui-core');
+
+const args = process.argv.slice(2);
+handleAuthShim(args);
+
+const writeTranscript = makeTranscriptWriter(parseSessionId(args));
+const logInput = makeFileLogger('FAKE_TUI_INPUT_LOG');
+
+// Pre-seeded stale draft (literal "\n" → real newlines), else empty.
+let buffer = (process.env.FAKE_TUI_STALE_DRAFT || '').replace(/\\n/g, '\n');
+let busy = false;
+
+function render() {
+  const body = busy
+    ? 'esc to interrupt\r\n❯ ' + buffer.split('\n').join('\r\n')
+    : '❯ ' + buffer.split('\n').join('\r\n');
+  process.stdout.write('\x1b[2J\x1b[H' + body);
+}
+
+// ── stdin state machine: line-aware Ctrl+U + append-on-paste ────────────────
+const State = { NORMAL: 0, CSI: 1, PASTE: 2, PASTE_CSI: 3 };
+let state = State.NORMAL;
+let pasteContent = '';
+
+if (process.stdin.setRawMode) process.stdin.setRawMode(true);
+process.stdin.resume();
+
+function onEnter() {
+  const text = buffer;
+  if (!text.trim()) { render(); return; }
+  logInput(text);
+  buffer = '';
+  busy = true;
+  render();
+  // Brief busy, then end the turn via the transcript (turn_duration).
+  setTimeout(() => {
+    busy = false;
+    writeTranscript(text);
+    render();
+  }, 250);
+}
+
+function ctrlU() {
+  // Remove only the last line — a single Ctrl+U cannot clear a multi-line draft.
+  buffer = buffer.includes('\n') ? buffer.slice(0, buffer.lastIndexOf('\n')) : '';
+  render();
+}
+
+function appendPaste(content) {
+  buffer += content; // APPEND — a leftover draft concatenates with the paste.
+  render();
+}
+
+process.stdin.on('data', (chunk) => {
+  const bytes = chunk.toString('binary');
+  for (let i = 0; i < bytes.length; i++) {
+    const ch = bytes[i];
+    switch (state) {
+      case State.NORMAL:
+        if (ch === '\x1b') {
+          const rest = bytes.slice(i + 1);
+          if (rest.startsWith('[A') || rest.startsWith('[B')) { i += 2; break; }
+          state = State.CSI;
+        } else if (ch === '\x15') {
+          ctrlU();
+        } else if (ch === '\r') {
+          onEnter();
+        }
+        // printable chars outside a paste are ignored (wrapper only pastes)
+        break;
+      case State.CSI:
+        if (ch === '[') {
+          const rest = bytes.slice(i + 1);
+          if (rest.startsWith('200~')) { state = State.PASTE; pasteContent = ''; i += 4; }
+          else if (rest.startsWith('201~')) { state = State.NORMAL; i += 4; }
+          else {
+            let j = i + 1;
+            while (j < bytes.length && !/[A-Za-z~]/.test(bytes[j])) j++;
+            i = j; state = State.NORMAL;
+          }
+        } else { state = State.NORMAL; }
+        break;
+      case State.PASTE:
+        if (ch === '\x1b') state = State.PASTE_CSI;
+        else pasteContent += ch;
+        break;
+      case State.PASTE_CSI:
+        if (ch === '[') {
+          const rest = bytes.slice(i + 1);
+          if (rest.startsWith('201~')) { appendPaste(pasteContent); pasteContent = ''; state = State.NORMAL; i += 4; }
+          else { pasteContent += '\x1b['; state = State.PASTE; }
+        } else { pasteContent += '\x1b' + ch; state = State.PASTE; }
+        break;
+    }
+  }
+});
+
+process.on('SIGINT', () => process.exit(0));
+process.on('SIGTERM', () => process.exit(0));
+
+render();

--- a/tests/integration/pty-input-clear.test.ts
+++ b/tests/integration/pty-input-clear.test.ts
@@ -1,0 +1,79 @@
+/**
+ * I-PTY-INPUT-CLEAR: the wrapper clears the TUI input COMPLETELY before pasting
+ * a new turn (issue #296).
+ *
+ * A single Ctrl+U clears only one input line, so a stale MULTI-line draft left by
+ * a prior swallowed Enter would keep its earlier line(s) and the next paste would
+ * land after them — merging two messages into one garbled turn (proven from a live
+ * transcript: a message's first line survived and the next message concatenated
+ * onto it).
+ *
+ * Spawns the real claude-pty-shell.js wrapper with CLAUDE_REAL_BIN pointing at
+ * mock-claude-tui-input.js, a fake TUI that models line-aware input: Ctrl+U removes
+ * only the last line, a bracketed paste APPENDS to the buffer, and Enter logs the
+ * submitted buffer to FAKE_TUI_INPUT_LOG. FAKE_TUI_STALE_DRAFT pre-seeds a stuck
+ * draft. We assert on the submitted text.
+ */
+
+import { ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { makeTurnJson, readLogLines, spawnWrapper, waitForLogEntries, waitMs } from '../helpers/pty-harness';
+
+const MOCK_TUI_BIN = path.resolve(__dirname, '../helpers/mock-claude-tui-input.js');
+
+describe('I-PTY-INPUT-CLEAR: input is cleared fully before a paste', () => {
+  let wrapper: ChildProcess;
+  let inputLog: string;
+
+  beforeEach(() => {
+    inputLog = path.join(os.tmpdir(), `pty-input-clear-${Date.now()}-${Math.floor(process.hrtime()[1] % 1e6)}.log`);
+  });
+
+  afterEach(() => {
+    wrapper?.kill('SIGTERM');
+    if (fs.existsSync(inputLog)) fs.unlinkSync(inputLog);
+  });
+
+  function start(extraEnv: Record<string, string> = {}): void {
+    wrapper = spawnWrapper(MOCK_TUI_BIN, { FAKE_TUI_INPUT_LOG: inputLog, ...extraEnv });
+  }
+
+  /**
+   * I-PTY-INPUT-01 (proven-red centerpiece): a stale 2-line draft is left in the
+   * input; the next message must submit ON ITS OWN — never concatenated onto the
+   * leftover. On the pre-fix wrapper the single Ctrl+U clears only line 2, the
+   * paste appends after line 1, and the submitted text is "STALEONE<msg>".
+   */
+  it('I-PTY-INPUT-01: does not concatenate a stale multi-line draft with the next message', async () => {
+    start({ FAKE_TUI_STALE_DRAFT: 'STALEONE\\nSTALETWO' });
+    await waitMs(2500); // wrapper + fake TUI ready (stale draft sitting in the input)
+
+    wrapper.stdin!.write(makeTurnJson('FRESHMESSAGE'));
+
+    const lines = await waitForLogEntries(inputLog, 1, 8000);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const submitted = lines[0];
+    // The submitted turn is exactly the new message — no leftover draft prepended.
+    expect(submitted).toBe('FRESHMESSAGE');
+    expect(submitted).not.toContain('STALEONE');
+    expect(submitted).not.toContain('STALETWO');
+  }, 20000);
+
+  /**
+   * I-PTY-INPUT-02: the clear is a no-op on the normal path — an empty prompt with
+   * no stale draft submits the message unchanged (clearInput() must not corrupt or
+   * drop a clean submission).
+   */
+  it('I-PTY-INPUT-02: submits a clean message unchanged when the input starts empty', async () => {
+    start();
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('HELLO_WORLD'));
+
+    const lines = await waitForLogEntries(inputLog, 1, 8000);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(lines[0]).toBe('HELLO_WORLD');
+  }, 20000);
+});


### PR DESCRIPTION
## What & why

On the PTY backend (`headless: false`) a channel message could get **stuck in the Claude TUI input** unsubmitted, and the next message was then **pasted onto the stale draft** — merging two messages into one garbled turn. Users saw a raw `<channel …>` envelope sitting in the input, and occasionally a message ran twice or two messages ran mashed together.

Closes #296.

## Root cause (proven from a live transcript)

The same `message_id` appeared as a user record **twice** — once clean, once concatenated with a *later* message where only the **first line** of the stale message survived:

```
clean:    <channel … id="AAA" …>line one
line two</channel>

garbled:  <channel … id="AAA" …>line one <channel … id="BBB" …>later text</channel>
```

`typeAndSubmit()` in `src/shell/claude-pty-shell.ts` pastes the message via bracketed paste then a separate Enter, and clears the input first with a **single Ctrl+U** — which clears only **one input line**. When a prior paste's Enter was swallowed (the paste landed while Claude was still working — a turn-boundary desync, since the busy marker `'esc to interrupt'` is absent on recent Claude builds so `isBusy()` reads false), its text lingered as a multi-line draft. The single Ctrl+U removed only the cursor line, leaving line one, and the new paste concatenated after it. The swallowed-Enter retry did not recover because its guard `seenRecords === recordsAtStart` is already false once a prior overlapping turn has written transcript records.

## The fix

1. **`ScreenModel.inputDraft()`** (`screen.ts`) — returns the text after the last `❯ ` caret (across continuation lines, before the border/status bar), `''` when empty.
2. **`clearInput()`** (`claude-pty-shell.ts`) — replaces the single pre-paste Ctrl+U with a bounded loop that sends Ctrl+U until `inputDraft()` reads empty. Only a confirmed-empty read stops the loop, so a redraw that hasn't arrived yet just costs one more Ctrl+U (a harmless no-op at an empty prompt) rather than an early stop that leaves a remnant. A stale multi-line draft can no longer survive to concatenate.
3. **Retry hardening** — the swallowed-Enter retry now also fires when `inputDraft()` is non-empty: a record-independent proof that the paste never submitted, so a prior overlapping turn's records can no longer self-disable the retry.

Scope is PTY-only; the headless path and the gateway-layer turn queue are untouched.

## Testing

- **Regression test proven to fail on the pre-fix code** (`tests/integration/pty-input-clear.test.ts`): a stale 2-line draft + a new message must submit the new message **alone**. On the pre-fix wrapper the single Ctrl+U leaves line one and the submitted text is `"STALEONEFRESHMESSAGE"` (verified red by reverting the fix); after the fix it is `"FRESHMESSAGE"`. A second case verifies a clean empty-prompt submit is unchanged.
- A faithful line-aware fake TUI (`tests/helpers/mock-claude-tui-input.js`) models the real behavior: Ctrl+U clears one line, a bracketed paste appends, `FAKE_TUI_STALE_DRAFT` pre-seeds a stuck draft.
- `npm run typecheck` clean; full suite **2909/2909**. (`api-sessions-create` and `I-PTY-MENU-13` flake only under parallel-worker load — both green in isolation.)

## Notes for the reviewer

- The retry hardening (#3) is a strictly-more-permissive guard (`… || inputDraft() !== ''`) with a clear record-independent rationale; a standalone repro would require modeling two overlapping turns, so it rides on the existing retry tests staying green rather than a dedicated case.
- `inputDraft()`'s empty-detection tolerates the dim `Try "…"` placeholder; if a future TUI build changes it, the worst case is a couple of extra no-op Ctrl+U (bounded by `INPUT_CLEAR_MAX_KEYS`), never a wrong submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
