### PR TITLE
fix(runner): preserve queued turn across a deferred session restart

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1571,7 +1571,11 @@ export class AgentRunner extends EventEmitter {
             // tool-call gaps), so its flush is driven by `session_idle` instead
             // (below) — flushing on every sub-turn `result` would inject the next
             // message mid-work.
-            if (proc.backend !== 'pty-shell') {
+            // Skip when a deferred restart is armed: this session is about to be
+            // torn down (deferredRestartReady), so draining the queue into it now
+            // would kill the queued turn with the process. The restart handler
+            // re-drives the preserved queue into the fresh session instead.
+            if (proc.backend !== 'pty-shell' && !proc.hasPendingRestart()) {
               this.flushNextTurn(mapKey);
             }
             // Telegram: accumulate image size via stat of local file (FIFO, one per turn)
@@ -1702,7 +1706,12 @@ export class AgentRunner extends EventEmitter {
             // Gateway turn queue: on pty-shell this is the true end of the user's
             // turn (the wrapper only emits it when its own `this.turn` is null, so
             // it never fires between sub-turns) — flush the next queued turn.
-            this.flushNextTurn(mapKey);
+            // Skip when a deferred restart is armed (see the headless `result`
+            // path above): the restart handler re-drives the queue into the fresh
+            // session so the queued turn is not killed with this one.
+            if (!proc.hasPendingRestart()) {
+              this.flushNextTurn(mapKey);
+            }
             typingDoneTimer = setTimeout(() => {
               this.writeTypingDone(mapKey);
               typingDoneTimer = null;
@@ -1758,7 +1767,12 @@ export class AgentRunner extends EventEmitter {
         // now, so release the active slot. If turns were queued behind it, deliver
         // the next one (injectTurn respawns the session) so a crash mid-turn does
         // not strand the messages the user already sent.
-        this.flushNextTurn(mapKey);
+        // Skip on a deferred restart: this exit is the intentional teardown, and
+        // its handler re-drives the queue into the fresh session AFTER deleting
+        // the dead one from the pool — flushing here would reuse the dead proc.
+        if (!proc.hasPendingRestart()) {
+          this.flushNextTurn(mapKey);
+        }
         // LINE: a process exit with a button whose answer never arrived (crash /
         // teardown mid-turn) → surface the interrupted notice so a tap returns it
         // instead of a stale "still thinking". markInterrupted no-ops on a READY
@@ -1775,6 +1789,12 @@ export class AgentRunner extends EventEmitter {
         this.logger.info('Deferred restart: stopping session after turn completed', { mapKey });
         await proc.stop();
         this.sessions.delete(mapKey);
+        // Re-drive any turn queued behind the just-completed turn. The turn-end
+        // and exit flush paths deliberately skipped it (hasPendingRestart guards)
+        // so it was not drained into this now-dead session. Flushing here — after
+        // the dead proc is removed from the pool — re-injects it into a freshly
+        // spawned session instead of losing it with the restart.
+        this.flushNextTurn(mapKey);
       });
     }
 

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -1091,6 +1091,17 @@ export class SessionProcess extends EventEmitter {
     }
   }
 
+  /**
+   * True once a deferred restart has been armed (the session was busy when the
+   * restart was requested, so teardown waits for the current turn to end). The
+   * runner reads this to avoid flushing a queued turn into a session that is
+   * about to be torn down — the queue is re-driven into the fresh session after
+   * the restart instead (see the deferredRestartReady handler in runner.ts).
+   */
+  hasPendingRestart(): boolean {
+    return this._pendingRestart;
+  }
+
   touch(): void {
     this.lastActivityAt = Date.now();
   }

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -4624,4 +4624,51 @@ describe('AgentRunner — gateway turn queue, coalesce, and /stop', () => {
     await new Promise(r => setTimeout(r, 80));
     expect(channelWrites().length).toBe(1);
   }, 15000);
+
+  // U-AR-Q5 (Issue #297): a turn queued behind an in-flight turn must survive a
+  // DEFERRED restart that fires on the same turn-end. Regression: the turn-end
+  // flush drained the queue into the session that the deferred restart then
+  // killed, so the queued turn died with the process and was never re-injected.
+  it('U-AR-Q5: a turn queued behind a deferred-restart turn is preserved, not lost', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    await sendChannelPost(port, 'chat:q5', 'first');
+    await waitForSession(runner, 'chat:q5');
+    await new Promise(r => setTimeout(r, 80)); // coalesce flush + inject turn 1
+    const session = getSessions(runner).get('chat:q5')!;
+    expect(channelWrites().length).toBe(1);
+    expect(channelWrites()[0]).toContain('first');
+
+    // Second message arrives mid-turn → QUEUED behind the in-flight turn.
+    await sendChannelPost(port, 'chat:q5', 'second');
+    await new Promise(r => setTimeout(r, 80));
+    expect(channelWrites().length).toBe(1); // still queued, not injected
+
+    // A CLAUDE.md / workspace change arms a DEFERRED restart on the busy session
+    // (the exact trigger from the incident: a memory write mid-turn).
+    await runner.restartOrDefer();
+    expect(getSessions(runner).has('chat:q5')).toBe(true); // deferred, not stopped yet
+
+    // Turn 1 ends. On the SAME end signal the gateway both (a) would flush the
+    // queued turn and (b) tears the session down for the deferred restart. The
+    // queued 'second' must survive — re-injected into the fresh session, not
+    // killed with the old one.
+    session.emit('output', JSON.stringify({ type: 'result', is_error: false, result: 'done' }));
+    await new Promise(r => setTimeout(r, 250)); // teardown + respawn + re-inject
+
+    // The chat's session is respawned…
+    expect(getSessions(runner).has('chat:q5')).toBe(true);
+    // …and 'second' reached a LIVE session (not the torn-down/killed one). On the
+    // pre-fix code 'second' was written to the old proc that was then killed, so
+    // no live proc ever received it.
+    const liveGotSecond = allProcesses.some(
+      p => !p.killed &&
+        (p.stdin?.write as jest.Mock).mock.calls
+          .map((c: unknown[]) => String(c[0]))
+          .some((w: string) => w.includes('<channel') && w.includes('second')),
+    );
+    expect(liveGotSecond).toBe(true);
+  }, 15000);
 });


### PR DESCRIPTION
## What

A channel turn **queued behind an in-flight turn** was **silently lost** when that turn ended at the same instant a **deferred restart** fired. Reproduced live on `claude-research`: a message queued at 08:39:53 was injected into the session at 08:40:37 — the same moment the deferred restart stopped it — and the process was killed 1 s later (exit 129) before it could run. The turn was never re-injected.

Closes #297.

## Root cause (`src/agent/runner.ts`)

On a turn-end signal two reactions raced on the **same** session:

1. **Flush the next queued turn** — `flushNextTurn()` at the headless `result` path (`:1575`) and the pty-shell `session_idle` path (`:1705`) `shift()`s the queued entry and injects it into the **current** session.
2. **Tear the session down** — the `deferredRestartReady` handler (`:1773`) `stop()`s + deletes that session, fired from `SessionProcess.setProcessing(false)` when `_pendingRestart` is set.

The flush drained the queue into the session that (2) immediately killed. The turn died with the process, and since the queue was already emptied, the post-stop `exit`-handler recovery flush (`:1761`) — the one that saves messages across a *crash* — found nothing to re-inject.

## Fix

Give each flush path a single, non-overlapping owner:

- **`SessionProcess.hasPendingRestart()`** — exposes `_pendingRestart`.
- **Guard the turn-end flushes** (`:1575`, `:1705`) **and the exit-handler flush** (`:1761`): skip when a restart is armed, so the queue is never drained into a session about to be torn down.
- **`deferredRestartReady` handler**: after `stop()` + `sessions.delete()`, call `flushNextTurn()` — re-driving the preserved queue into a **freshly spawned** session (mirroring the crash-recovery path).

Net: a turn queued behind a deferred-restart turn is re-injected into the new session instead of being killed with the old one. Normal queueing and crash recovery are unchanged — the guards are no-ops when no restart is pending. No double-injection (only one owner flushes per teardown) and no duplicate history record.

## Test

`tests/unit/agent-runner.test.ts` → **U-AR-Q5**: queues a message behind an in-flight turn, arms a deferred restart (`restartOrDefer`), ends the turn, and asserts (a) the chat's session is respawned and (b) the queued `second` reaches a **live** (non-killed) session.

**Verified it FAILS on the pre-fix code** — `expect(getSessions(runner).has('chat:q5')).toBe(true)` → `false` (session not respawned; queued turn lost) — and passes on the fix.

- `tsc --noEmit` — clean
- Full suite — **2891/2891 tests pass** (one unrelated integration suite, `chat-history-api`, flakes under parallel worker load; passes 27/27 standalone — same known flake as prior PRs).

## Acceptance criteria

- [x] Queued turn delivered after a deferred restart (not dropped)
- [x] Queued turn lands in a live, freshly spawned session — never the torn-down one
- [x] Normal queueing and crash-recovery re-injection unchanged
- [x] Regression test fails on pre-fix code, passes on fix
- [x] No new silent loss, no double-injection
