### PR TITLE
feat(apps): add !default: env marker — prompt-with-default secrets in app.yaml

### DIFF
--- a/API.md
+++ b/API.md
@@ -2926,6 +2926,7 @@ curl -X POST \
   "commit": "abc123def456abc123def456abc123def456abc1",
   "secretKeys": ["DB_PASSWORD"],
   "generatedKeys": [{ "key": "SESSION_SECRET", "encoding": "hex", "bytes": 32 }],
+  "secretDefaults": { "NEXTAUTH_URL": "http://localhost:3737" },
   "ports": [{ "name": "web", "service": "app", "hostPort": 12000, "containerPort": 3000, "type": "web" }],
   "agentDeclaration": null,
   "warnings": []
@@ -2934,6 +2935,7 @@ curl -X POST \
 
 - `secretKeys` — env vars the operator **must** supply (declared as bare keys in `app.yaml`).
 - `generatedKeys` — secrets the gateway fills with a fresh random value at install (declared as `KEY=!generate:<encoding>:<bytes>`); never prompted for.
+- `secretDefaults` — defaults for prompted secrets declared as `KEY=!default:<value>`. The key is still listed in `secretKeys` (prompted and editable), but the value here pre-fills the field; if the operator leaves it blank the default is written to `.env`. Only keys with a declared default appear. Precedence at install: operator-supplied value → default → empty.
 
 **Error responses:**
 

--- a/mcp/tools/apps/module.ts
+++ b/mcp/tools/apps/module.ts
@@ -78,7 +78,7 @@ export class AppsModule implements ToolModule {
       },
       {
         name: 'inspect_app',
-        description: 'Preview an install source WITHOUT installing: fetch and parse the app.yaml and return the required secrets (secretKeys, must be provided) and auto-generated secrets (generatedKeys, filled by the gateway), plus name, version, ports, and warnings. Call this BEFORE install_app for a GitHub URL — such apps have no registry entry, so browse_registry cannot reveal their required secrets. Pass github_url (+ optional commit), registry_app (+ optional version), or local_path.',
+        description: 'Preview an install source WITHOUT installing: fetch and parse the app.yaml and return the required secrets (secretKeys, must be provided) and auto-generated secrets (generatedKeys, filled by the gateway), plus name, version, ports, and warnings. Also returns secretDefaults — defaults for prompt-with-default secrets declared as KEY=!default:<value>: the key is still in secretKeys (prompted/editable) but this default pre-fills the field and is written to .env when left blank. Call this BEFORE install_app for a GitHub URL — such apps have no registry entry, so browse_registry cannot reveal their required secrets. Pass github_url (+ optional commit), registry_app (+ optional version), or local_path.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/mcp/tools/apps/skills/create-app-yaml/SKILL.md
+++ b/mcp/tools/apps/skills/create-app-yaml/SKILL.md
@@ -80,6 +80,9 @@ Rules for port type:
 Rules for environment variables:
 - If the Dockerfile has `ENV FOO=bar` → `FOO=bar` (has default)
 - If you see `ARG FOO` or `ENV FOO` with no value → `FOO` (secret, no default — installer prompts for it)
+- If the value has a **sensible default the operator should still be able to override** (e.g. `NEXTAUTH_URL`, a public base URL, a tunable timeout) → `FOO=!default:<value>`. It is prompted like a bare key (visible and editable in the install UI, pre-filled with `<value>`), but if the operator leaves it blank the default is written to `.env` — so the app never boots with an empty required field.
+  - The value is taken verbatim and may contain `:` and `/` — e.g. `NEXTAUTH_URL=!default:http://localhost:3737`.
+  - Prefer this over a bare `FOO` whenever a good default exists, and over a static `FOO=value` whenever the operator should be able to change it at install.
 - If the value is a **per-install random string** the user cannot meaningfully supply (session secret, DB password, internal API token) → `FOO=!generate:<encoding>:<bytes>`. The installer fills it with a fresh random value automatically, so the install never stalls asking for it.
   - Encodings: `hex`, `base64`, `base64url` (use `base64url` when the value is embedded in a URL or connection string — it has no `+` `/` `=`). Length is `8`–`512` bytes.
   - Examples: `NEXTAUTH_SECRET=!generate:base64:32`, `DB_PASSWORD=!generate:base64url:24`

--- a/mcp/tools/apps/skills/install-app/SKILL.md
+++ b/mcp/tools/apps/skills/install-app/SKILL.md
@@ -54,23 +54,32 @@ Call `inspect_app` with the same source you will install (`github_url` [+ `commi
 - `generatedKeys` — secrets the gateway **auto-generates** at install time
   (declared as `KEY=!generate:...`). Do **not** prompt for these; just note they
   will be generated.
+- `secretDefaults` — defaults for prompt-with-default secrets (declared as
+  `KEY=!default:<value>`). These keys still appear in `secretKeys`, so prompt for
+  them — but **pre-fill the default** and tell the user they can keep it. If they
+  leave it blank, the default is written to `.env` (operator value → default →
+  empty).
 
 This is essential for a **GitHub-URL** install: such apps have no registry entry,
 so `browse_registry` cannot reveal their secrets — only `inspect_app` can.
 
-If `inspect_app` reports `secretKeys`, prompt the user for each:
+If `inspect_app` reports `secretKeys`, prompt the user for each (showing the
+default from `secretDefaults` when one exists):
 
 ```
 This app requires the following environment variables:
   MY_API_KEY — (no default)
   SOME_TOKEN — (no default)
+  NEXTAUTH_URL — default: http://localhost:3737 (press enter to keep)
 
 Please provide values, e.g.:
   MY_API_KEY=xxx
   SOME_TOKEN=yyy
 ```
 
-Wait for the user's reply. Parse key=value pairs.
+Wait for the user's reply. Parse key=value pairs. For a key with a default, an
+omitted or blank value means "use the default" — do not send an empty string
+expecting the app to fail.
 
 If `secretKeys` is empty (only `generatedKeys`, or no secrets at all), proceed
 immediately — do not invent secrets or ask for ones the app did not declare.

--- a/src/apps/compose-generator.ts
+++ b/src/apps/compose-generator.ts
@@ -115,6 +115,14 @@ export interface GeneratedCompose {
    * prompted for.
    */
   generatedKeys: GeneratedKey[];
+  /**
+   * Default values for prompted secrets declared in app.yaml as
+   * `KEY=!default:<value>`. The key is still pushed to {@link secretKeys} (so
+   * it is prompted and editable in the install UI), but carries a default that
+   * pre-fills the field and is written to `.env` when the installer supplies no
+   * value. Keyed by env var name; only keys with a declared default appear.
+   */
+  secretDefaults: Record<string, string>;
   agentDeclaration: AgentDeclaration | null;
   warnings: string[];
 }
@@ -162,6 +170,24 @@ const GENERATE_PREFIX = '!generate:';
 const GEN_ENCODINGS = new Set<GeneratorEncoding>(['hex', 'base64', 'base64url']);
 const GEN_MIN_BYTES = 8;
 const GEN_MAX_BYTES = 512;
+
+// An app.yaml env entry of the form `KEY=!default:<value>` declares a prompted
+// secret that carries a default. The key is still prompted (and editable) at
+// install, but the default pre-fills the field and is written to `.env` when
+// the installer supplies no value. `<value>` is taken verbatim — it may contain
+// `:` and `/` (e.g. a URL), so it is sliced, never split.
+const DEFAULT_PREFIX = '!default:';
+
+/**
+ * Parse a default marker value (`!default:<value>`). Returns the raw default
+ * (everything after the prefix, unmodified) or null when `value` is not a
+ * marker at all. The value is intentionally not validated or split so URLs and
+ * other colon/slash-bearing defaults survive intact.
+ */
+export function parseDefaultMarker(value: string): string | null {
+  if (!value.startsWith(DEFAULT_PREFIX)) return null;
+  return value.slice(DEFAULT_PREFIX.length);
+}
 
 /**
  * Parse a generator marker value (`!generate:<encoding>:<bytes>`).
@@ -293,6 +319,7 @@ export function generateCompose(
     sockets: [],
     secretKeys: [],
     generatedKeys: [],
+    secretDefaults: {},
     agentDeclaration: null,
     warnings: [],
   };
@@ -400,11 +427,20 @@ export function generateCompose(
         const key = envEntry.slice(0, eqIdx).trim();
         const value = envEntry.slice(eqIdx + 1);
         const gen = parseGeneratorMarker(svcName, key, value);
+        const def = gen === null ? parseDefaultMarker(value) : null;
         if (gen) {
           // Self-generating secret — filled at install, kept out of compose
           if (!result.generatedKeys.some((g) => g.key === key)) {
             result.generatedKeys.push({ key, encoding: gen.encoding, bytes: gen.bytes });
           }
+        } else if (def !== null) {
+          // Prompt-with-default secret — prompted like a bare key, but the
+          // default pre-fills the field and backfills .env when left blank.
+          // Kept out of the static compose environment block.
+          if (!result.secretKeys.includes(key)) {
+            result.secretKeys.push(key);
+          }
+          result.secretDefaults[key] = def;
         } else {
           staticEnv.push(envEntry);
         }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -65,6 +65,13 @@ export interface InspectResult {
   commit: string;
   secretKeys: string[];
   generatedKeys: GeneratedKey[];
+  /**
+   * Default values for prompted secrets declared with `KEY=!default:<value>`.
+   * Surfaced so install UIs can pre-fill the editable field; keyed by env var
+   * name, only keys with a declared default appear. See
+   * {@link GeneratedCompose.secretDefaults}.
+   */
+  secretDefaults: Record<string, string>;
   ports: ComposePort[];
   agentDeclaration: AgentDeclaration | null;
   warnings: string[];
@@ -251,6 +258,7 @@ export class AppInstaller {
         commit,
         secretKeys: generated.secretKeys,
         generatedKeys: generated.generatedKeys,
+        secretDefaults: generated.secretDefaults,
         ports: generated.ports,
         agentDeclaration: generated.agentDeclaration,
         warnings: generated.warnings,
@@ -1328,7 +1336,10 @@ export class AppInstaller {
   private writeEnvFile(
     appDir: string,
     appName: string,
-    generated: Pick<GeneratedCompose, 'ports' | 'secretKeys' | 'generatedKeys'>,
+    generated: Pick<
+      GeneratedCompose,
+      'ports' | 'secretKeys' | 'generatedKeys' | 'secretDefaults'
+    >,
     envVars: Record<string, string>,
   ): string[] {
     const merged: Record<string, string> = { ...envVars };
@@ -1340,9 +1351,17 @@ export class AppInstaller {
     }
 
     const envLines: string[] = [];
+    const secretDefaults = generated.secretDefaults ?? {};
     for (const key of generated.secretKeys) {
-      const val = (merged[key] ?? '').replace(/[\r\n]/g, '');
-      envLines.push(`${key}=${val}`);
+      // Precedence: operator-supplied value → declared default → empty. An
+      // empty operator value (UI always sends the field, possibly blank) falls
+      // through to the default, matching how generated keys treat '' as unset.
+      const provided = merged[key];
+      const raw =
+        provided !== undefined && provided !== ''
+          ? provided
+          : secretDefaults[key] ?? '';
+      envLines.push(`${key}=${raw.replace(/[\r\n]/g, '')}`);
     }
     const generatedKeySet = new Set(generated.generatedKeys.map((g) => g.key));
     const generatedNames: string[] = [];

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -298,6 +298,56 @@ services:
       // No install happened.
       expect(await registry.get('secretful-app')).toBeUndefined();
     });
+
+    /** Spawn whose app.yaml declares a prompt-with-default secret. */
+    function inspectSpawnWithDefault(head: string) {
+      return (cmd: string, args: string[], opts?: object) => {
+        const cwd = (opts as { cwd?: string } | undefined)?.cwd;
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && cwd) {
+          fs.writeFileSync(
+            path.join(cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: defaultful-app
+version: 1.0.0
+commit: "${head}"
+services:
+  app:
+    image: nginx:1.25
+    environment:
+      - NEXTAUTH_URL=!default:http://localhost:3737
+    ports:
+      - name: api
+        host: 5401
+        container: 5401
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:5401/health
+      interval: 30s
+`.trim(),
+            'utf-8',
+          );
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      };
+    }
+
+    it('surfaces secretDefaults for a prompt-with-default secret', async () => {
+      const head = 'abcdef0123456789abcdef0123456789abcdef02';
+      const inspectApp = makeApp(registry, registryClient, inspectSpawnWithDefault(head));
+      const res = await request(inspectApp)
+        .post('/api/v1/apps/inspect')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ github_url: 'https://github.com/test/defaultful-app' });
+      expect(res.status).toBe(200);
+      // Still prompted (visible/editable)…
+      expect(res.body.secretKeys).toEqual(['NEXTAUTH_URL']);
+      // …and the default is surfaced for UI pre-fill, URL intact.
+      expect(res.body.secretDefaults).toEqual({ NEXTAUTH_URL: 'http://localhost:3737' });
+    });
   });
 
   // ── GET /api/v1/apps/jobs/:jobId ───────────────────────────────────────

--- a/tests/unit/apps/compose-generator.test.ts
+++ b/tests/unit/apps/compose-generator.test.ts
@@ -575,6 +575,46 @@ services:
     });
   });
 
+  describe('prompt-with-default secrets (!default:)', () => {
+    const yamlWithDefault = `
+apiVersion: apps.getpod.ai/v1
+name: my-app
+version: 1.0.0
+commit: "abc123def456abc123def456abc123def456abc1"
+services:
+  web:
+    image: nginx:1.25
+    environment:
+      - NEXTAUTH_URL=!default:http://localhost:3737
+      - PLAIN_SECRET
+      - APP_ENV=production
+`.trim();
+
+    it('prompts the default key (appears in secretKeys) and records its default', () => {
+      const result = generate(yamlWithDefault);
+      // Still prompted/visible like a bare key…
+      expect(result.secretKeys).toContain('NEXTAUTH_URL');
+      // …but carries the declared default. A URL keeps its `:` and `/` intact.
+      expect(result.secretDefaults['NEXTAUTH_URL']).toBe('http://localhost:3737');
+    });
+
+    it('keeps the default key out of the static compose environment block', () => {
+      generate(yamlWithDefault);
+      const compose = readCompose(outputPath);
+      const svc = (compose.services as Record<string, unknown>).web as Record<string, unknown>;
+      const env = (svc.environment as string[]) ?? [];
+      expect(env.some((e) => e.startsWith('NEXTAUTH_URL'))).toBe(false);
+      // a genuine static var still passes through
+      expect(env).toContain('APP_ENV=production');
+    });
+
+    it('leaves bare keys with no default out of secretDefaults', () => {
+      const result = generate(yamlWithDefault);
+      expect(result.secretKeys).toContain('PLAIN_SECRET');
+      expect(result.secretDefaults['PLAIN_SECRET']).toBeUndefined();
+    });
+  });
+
   describe('volumes', () => {
     it('declares named volumes in top-level volumes section', () => {
       const y = `

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -376,6 +376,81 @@ services:
       expect(readEnv(newDir)['GEN_HEX']).toBe(original);
     });
 
+    // ── Prompt-with-default secrets (!default:) ──────────────────────────────
+    function makeDefaultAppDir(dir: string, appName: string, port = 5010): string {
+      const appDir = path.join(dir, appName);
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(appDir, 'app.yaml'),
+        `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: 1.0.0
+commit: "abc123def456abc123def456abc123def456abc1"
+services:
+  app:
+    image: nginx:1.25
+    environment:
+      - NEXTAUTH_URL=!default:http://localhost:3737
+      - PLAIN_KEY
+    ports:
+      - name: api
+        host: ${port}
+        container: ${port}
+        type: api
+`.trim(),
+        'utf-8',
+      );
+      return appDir;
+    }
+
+    it('writes the declared default to .env when no operator value is supplied', async () => {
+      const appDir = makeDefaultAppDir(srcDir, 'default-app');
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+
+      const env = readEnv(appDir);
+      // URL default survives intact — the `:` and `/` are not truncated.
+      expect(env['NEXTAUTH_URL']).toBe('http://localhost:3737');
+      // A bare key with no default still writes an empty value (unchanged).
+      expect(env['PLAIN_KEY']).toBe('');
+    });
+
+    it('lets an operator-supplied value win over the default', async () => {
+      const appDir = makeDefaultAppDir(srcDir, 'default-app', 5011);
+      const installer = makeInstaller();
+      await waitForJob(
+        installer,
+        installer.install({ localPath: appDir, envVars: { NEXTAUTH_URL: 'https://prod.example.com' } }),
+        5000,
+      );
+
+      const env = readEnv(appDir);
+      expect(env['NEXTAUTH_URL']).toBe('https://prod.example.com');
+    });
+
+    it('falls back to the default when the operator value is blank', async () => {
+      const appDir = makeDefaultAppDir(srcDir, 'default-app', 5012);
+      const installer = makeInstaller();
+      await waitForJob(
+        installer,
+        installer.install({ localPath: appDir, envVars: { NEXTAUTH_URL: '' } }),
+        5000,
+      );
+
+      const env = readEnv(appDir);
+      expect(env['NEXTAUTH_URL']).toBe('http://localhost:3737');
+    });
+
+    it('reports a default key in job result secretKeys (still prompted)', async () => {
+      const appDir = makeDefaultAppDir(srcDir, 'default-app', 5013);
+      const installer = makeInstaller();
+      const job = await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+
+      const secretKeys = (job.result as { secretKeys: string[] }).secretKeys;
+      expect(secretKeys).toContain('NEXTAUTH_URL');
+    });
+
     it('fails when local_path has no app.yaml', async () => {
       const outsidePath = path.join(tmpDir, 'evil-app');
       fs.mkdirSync(outsidePath);


### PR DESCRIPTION
## Summary

Adds a fourth `app.yaml` environment mode — **prompt-with-default** — declared with a `!default:<value>` marker. It renders as a normal prompted secret in the install UI (visible and editable), but carries a default that pre-fills the field and is written to `.env` whenever the installer supplies no value. This removes the "empty required field" papercut for env vars that have a sensible default but should still be overridable per install (e.g. `NEXTAUTH_URL`).

Closes #300

## Changes

- **`src/apps/compose-generator.ts`** — `parseDefaultMarker()` + `secretDefaults: Record<string,string>` on `GeneratedCompose`. A `!default:` entry pushes the key into `secretKeys` (still prompted/visible) **and** records `secretDefaults[key]`, keeping it out of the static compose `environment` block. The value is **sliced, not split**, so a URL default (`:` and `/`) survives intact.
- **`src/apps/installer.ts`** — `InspectResult.secretDefaults` threaded through the inspect path; `writeEnvFile` precedence is **operator-supplied value → declared default → empty**. A blank operator value falls through to the default (consistent with how generated keys treat `''` as unset).
- **`src/api/apps-router.ts`** — `/v1/apps/inspect` returns the whole result object, so `secretDefaults` surfaces automatically (no code change needed; verified by test).
- **`mcp/tools/apps/module.ts`** — `inspect_app` description documents `secretDefaults`.
- **Docs** — `API.md`, `create-app-yaml` SKILL, `install-app` SKILL updated for the `!default:` marker and the `secretDefaults` field.

## Data model (backward compatible)

`secretKeys` stays `string[]`. `secretDefaults` is a new `Record<string,string>` containing only keys with a declared default.

## Acceptance criteria

- [x] `- KEY=!default:<value>`: `KEY` in `secretKeys`, `secretDefaults[KEY] === <value>`, and **not** in the static compose `environment` block.
- [x] Install with no operator value → `.env` contains `KEY=<default>`.
- [x] Install with an operator-supplied value → operator value wins.
- [x] Blank operator value → falls back to the default.
- [x] A bare key with no default still writes `KEY=` (empty) — unchanged.
- [x] `inspect` / `inspect_app` response includes `secretDefaults`.
- [x] `!default:` value may contain `:` and `/` (URL) without truncation.
- [x] Docs updated: `API.md`, `create-app-yaml`, `install-app`, `inspect_app`.

## Tests (regression — proven to fail on pre-fix code)

- **parser** (`tests/unit/apps/compose-generator.test.ts`): `!default:http://…` → key in `secretKeys`, default recorded, not in static env.
- **writeEnvFile** (`tests/unit/apps/installer.test.ts`, via full local install): default written when blank; operator value overrides; blank falls back.
- **inspect** (`tests/unit/api/apps-router.test.ts`): inspect response carries `secretDefaults`.

Proven-red: neutralizing the runtime branch turns 6 of the new tests red at the assertion level; restoring the fix greens them.

**Gates:** `npm run typecheck` clean · full suite **2923/2923** (the lone suite-level blip is the documented `skills-watcher` parallel-teardown flake — green in isolation, 0 test failures).

## Note — cross-repo sequencing

Apps that adopt `!default:` (e.g. `0xMaxMa/app-habit-hero`) must ship **after** this feature deploys. On an old gateway the marker string is parsed as a static env value and baked in literally — so the gateway change lands and deploys first, then the app manifests adopt the marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)