### PR TITLE
feat(apps): Docker build-cache & orphan image housekeeping (#302)

### DIFF
--- a/API.md
+++ b/API.md
@@ -160,6 +160,7 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 | `GET` | `/api/v1/apps/:name/version` | Key | Check installed vs latest version |
 | `POST` | `/api/v1/apps/:name/update` | Admin | Start async update with rollback → `jobId` |
 | `POST` | `/api/v1/apps/:name/reconfigure` | Admin | Start async env/host-port reconfigure (keeps volumes) → `jobId` |
+| `POST` | `/api/v1/apps/housekeeping` | Admin | Docker build-cache & orphan reclaim report (`mode:"report"`) or safe prune (`mode:"prune"`) |
 | `GET` | `/app/:name/:portName/*` | None | Reverse proxy to installed app |
 
 ### Cron API
@@ -3153,6 +3154,80 @@ Poll the returned `jobId` with `GET /api/v1/apps/jobs/:jobId` to track progress.
 | 403 | Not an admin key |
 | 404 | App not installed |
 | 409 | App is already being installed / updated / reconfigured |
+
+---
+
+### POST /api/v1/apps/housekeeping
+
+Reclaim leaked Docker **build cache** and **dangling images** left behind by app install/update (issue #302). The gateway builds/pulls images on every install and update but never reclaimed the build cache or orphaned layers those operations leave, so a long-lived host leaks steadily. This endpoint surfaces and — on request — reclaims that junk, **safely**.
+
+**Body:** `{ "mode": "report" | "prune" }` (default `"report"`).
+
+- **`report`** — read-only. Returns the reclaimable build cache, the dangling-image count, and the orphaned-volume names. Mutates nothing.
+- **`prune`** — executes **only the safe reclaim**: `docker builder prune -f --filter until=<window>h` (time-filtered, so a concurrent build's fresh layers survive) and `docker image prune -f` (dangling `<none>` layers only — **never `-a`**). Returns which reclaims ran plus a fresh report.
+
+**Safety floor (always enforced, regardless of config):**
+
+- Never `docker system prune -a`, never `docker image/builder prune -a`.
+- **Never** an automatic `docker volume prune` — orphaned volumes can hold real app data, so they are **reported but never auto-deleted**.
+- Never touches another app's tagged images.
+
+```bash
+# Report only
+curl -s -X POST -H "Authorization: Bearer $ADMIN_KEY" \
+  -H 'Content-Type: application/json' -d '{"mode":"report"}' \
+  http://localhost:10850/api/v1/apps/housekeeping | jq
+
+# Safe prune (build cache + dangling images only)
+curl -s -X POST -H "Authorization: Bearer $ADMIN_KEY" \
+  -H 'Content-Type: application/json' -d '{"mode":"prune"}' \
+  http://localhost:10850/api/v1/apps/housekeeping | jq
+```
+
+**Report response:**
+
+```json
+{
+  "mode": "report",
+  "report": {
+    "buildCacheReclaimable": "1.457GB",
+    "danglingImageCount": 0,
+    "orphanVolumes": ["orphan_vol_a", "orphan_vol_b"]
+  }
+}
+```
+
+**Prune response:**
+
+```json
+{
+  "mode": "prune",
+  "pruned": { "buildCache": true, "danglingImages": true },
+  "report": { "buildCacheReclaimable": "0B", "danglingImageCount": 0, "orphanVolumes": ["orphan_vol_a"] }
+}
+```
+
+The same reclaim runs **automatically** after every successful install/update (best-effort — a prune failure never fails the parent operation). It is gated by `gateway.appHousekeeping` in the config:
+
+```jsonc
+"gateway": {
+  "appHousekeeping": {
+    "buildCachePrune": true,        // default on
+    "buildCacheMaxAgeHours": 168,   // 7-day window
+    "danglingImagePrune": true      // safe subset (no -a)
+    // volumes are report-only — no auto-delete key on purpose
+  }
+}
+```
+
+Set all toggles to `false` to make the automatic path issue **zero** prune calls. (The manual `prune` mode above is an explicit operator action and always runs the safe reclaim.)
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | `mode` is neither `report` nor `prune` |
+| 403 | Not an admin key |
 
 ---
 

--- a/config.template.json
+++ b/config.template.json
@@ -10,7 +10,7 @@
       "claude.dangerouslySkipPermissions"
     ]
   },
-  "configVersion": "1.0.15",
+  "configVersion": "1.0.16",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
@@ -50,6 +50,11 @@
     "headless": true,
     "selfHealing": {
       "autoRecover": false
+    },
+    "appHousekeeping": {
+      "buildCachePrune": true,
+      "buildCacheMaxAgeHours": 168,
+      "danglingImagePrune": true
     }
   },
   "agents": [

--- a/mcp/tools/apps/client.ts
+++ b/mcp/tools/apps/client.ts
@@ -79,4 +79,8 @@ export class AppsClient {
   async startStop(name: string, action: 'start' | 'stop' | 'restart'): Promise<unknown> {
     return this.request('POST', `/${encodeURIComponent(name)}/${action}`);
   }
+
+  async housekeeping(mode: 'report' | 'prune'): Promise<unknown> {
+    return this.request('POST', '/housekeeping', { mode });
+  }
 }

--- a/mcp/tools/apps/module.ts
+++ b/mcp/tools/apps/module.ts
@@ -149,6 +149,21 @@ export class AppsModule implements ToolModule {
           additionalProperties: false,
         },
       },
+      {
+        name: 'docker_housekeeping',
+        description: 'Reclaim leaked Docker build cache and dangling images left behind by app install/update. mode "report" (default) returns a read-only reclaim report: reclaimable build cache, dangling image count, and orphan volume names. mode "prune" executes ONLY the safe reclaim (build cache older than the configured window + dangling <none> images) — it NEVER removes another app\'s tagged images, and NEVER deletes a volume. Orphan volumes are reported but never auto-deleted (they can hold real app data).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            mode: {
+              type: 'string',
+              enum: ['report', 'prune'],
+              description: 'report (default) = read-only reclaim report; prune = execute the safe reclaim (build cache + dangling images only)',
+            },
+          },
+          additionalProperties: false,
+        },
+      },
     ];
   }
 
@@ -224,6 +239,12 @@ export class AppsModule implements ToolModule {
         const appName = args['name'] as string;
         const action = args['action'] as 'start' | 'stop' | 'restart';
         const data = await client.startStop(appName, action);
+        return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+      }
+
+      case 'docker_housekeeping': {
+        const mode = (args['mode'] as 'report' | 'prune' | undefined) ?? 'report';
+        const data = await client.housekeeping(mode);
         return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
       }
 

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -387,5 +387,35 @@ export function createAppsRouter(
     }
   });
 
+  /**
+   * POST /api/v1/apps/housekeeping — Docker build-cache & orphan housekeeping (issue #302).
+   * Body: `{ mode?: 'report' | 'prune' }` (default 'report').
+   *   - report: read-only — reclaimable build cache, dangling image count, orphan volumes.
+   *   - prune:  executes ONLY the safe reclaim (build cache + dangling images). It never
+   *             removes another app's tagged images, and never deletes a volume.
+   * Orphan volumes are reported but NEVER auto-deleted. Admin-gated.
+   */
+  router.post('/v1/apps/housekeeping', (req: Request, res: Response) => {
+    const authed = req as AuthedRequest;
+    if (!isAdmin(authed.apiKey)) {
+      res.status(403).json({ error: 'Admin access required for housekeeping' });
+      return;
+    }
+    const mode = ((req.body as Record<string, unknown> | undefined)?.mode as string) ?? 'report';
+    if (mode !== 'report' && mode !== 'prune') {
+      res.status(400).json({ error: `Invalid mode "${mode}" — expected "report" or "prune"` });
+      return;
+    }
+    try {
+      if (mode === 'prune') {
+        res.json(installer.housekeepingPrune());
+      } else {
+        res.json({ mode: 'report', report: installer.housekeepingReport() });
+      }
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   return router;
 }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -87,6 +87,36 @@ export interface JobState {
   updatedAt: number;
 }
 
+/**
+ * Docker housekeeping toggles (issue #302). Mirrors
+ * `GatewayConfig['gateway']['appHousekeeping']`; all fields optional so an
+ * absent config resolves to the conservative defaults in
+ * {@link AppInstaller.resolveHousekeeping}.
+ */
+export interface AppHousekeepingConfig {
+  buildCachePrune?: boolean;
+  buildCacheMaxAgeHours?: number;
+  danglingImagePrune?: boolean;
+}
+
+/** Read-only reclaim report (issue #302). Volumes are reported, never deleted. */
+export interface HousekeepingReport {
+  /** Human-readable reclaimable build cache from `docker system df` (e.g. "1.457GB"); '' if unknown. */
+  buildCacheReclaimable: string;
+  /** Count of dangling `<none>` images with no container. */
+  danglingImageCount: number;
+  /** Orphaned volume names (LINKS=0). Report-only — NEVER auto-deleted. */
+  orphanVolumes: string[];
+}
+
+/** Result of a manual housekeeping call. */
+export interface HousekeepingResult {
+  mode: 'report' | 'prune';
+  /** Which safe reclaims actually ran (prune mode only). */
+  pruned: { buildCache: boolean; danglingImages: boolean };
+  report: HousekeepingReport;
+}
+
 export interface InstallerCallbacks {
   registerRoutes(appName: string, ports: ComposePort[]): void;
   deregisterRoutes(appName: string): void;
@@ -152,6 +182,7 @@ export class AppInstaller {
     appsDir?: string,
     private readonly agentManager?: AgentManager,
     private readonly spawnAsync: AsyncSpawnFn = defaultAsyncSpawn,
+    private readonly housekeepingConfig: AppHousekeepingConfig = {},
   ) {
     this.appsDir = appsDir ?? DEFAULT_APPS_DIR;
   }
@@ -806,6 +837,10 @@ export class AppInstaller {
     await this.registry.updateStatus(appName, 'running');
     this.log(job, 'Containers healthy');
 
+    // ── Housekeeping: reclaim leaked build cache + dangling images ────────
+    // Best-effort, config-gated, after the new stack is up (issue #302).
+    this.pruneAfterBuild(job);
+
     // ── Register proxy routes ─────────────────────────────────────────────
     this.callbacks.registerRoutes(appName, generated.ports);
 
@@ -960,6 +995,9 @@ export class AppInstaller {
       // we can reclaim exactly those images after the update — without a
       // `compose down` that would collide with the new stack (issue #283).
       const oldImageIds = this.captureComposeImageIds(appName, entry.installPath);
+      // Also capture the app's declared image refs (repo:tag) so a superseded
+      // *pulled* tag can be reclaimed after the update (issue #302).
+      const oldImageRefs = this.captureComposeImageRefs(appName, entry.installPath);
 
       // ── Bring old containers down (keeps images for rollback) ─────────────
       this.log(job, 'Stopping old containers');
@@ -999,6 +1037,7 @@ export class AppInstaller {
       // below never removes an image the new containers depend on (e.g. when the
       // old and new versions happen to share a base/image).
       const newImageIds = this.captureComposeImageIds(appName, tmpDir);
+      const newImageRefs = this.captureComposeImageRefs(appName, tmpDir);
 
       // ── Swap dirs ─────────────────────────────────────────────────────────
       // Swap in place at the recorded install path — NOT path.join(appsDir, appName).
@@ -1055,7 +1094,15 @@ export class AppInstaller {
           this.run(['docker', 'image', 'rm', imageId], os.tmpdir(), 60_000);
         } catch { /* still in use or already gone — non-fatal */ }
       }
+      // Reclaim a superseded *pulled* tag the image-ID reclaim above can't
+      // (a pulled image with >1 repo tag isn't removable by ID) — only this
+      // app's own prior refs the new stack no longer uses (issue #302).
+      this.reclaimSupersededTags(job, oldImageRefs, newImageRefs);
       this.safeRmrf(oldBackupDir, job, 'old backup dir');
+
+      // ── Housekeeping: reclaim leaked build cache + dangling images ────────
+      // Best-effort, config-gated, after the image reclaim (issue #302).
+      this.pruneAfterBuild(job);
 
       // ── Build result ──────────────────────────────────────────────────────
       const proxyUrls: Record<string, string> = {};
@@ -1691,6 +1738,179 @@ export class AppInstaller {
     } catch {
       return [];
     }
+  }
+
+  /**
+   * Image references (repo:tag) an app's compose file declares, e.g.
+   * "ghcr.io/x/monitor:1.1". Used to reclaim a superseded *pulled* tag on
+   * update — a tag bump the image-ID reclaim misses, because a pulled image
+   * carrying more than one repo tag cannot be removed by ID (issue #302).
+   * Best-effort — returns [] on any error.
+   */
+  private captureComposeImageRefs(appName: string, dir: string): string[] {
+    try {
+      const { stdout } = this.run(
+        ['docker', 'compose', '-p', appName, 'config', '--images'],
+        dir,
+        15_000,
+      );
+      return [...new Set(
+        stdout.trim().split('\n').map((s) => s.trim()).filter(Boolean),
+      )];
+    } catch {
+      return [];
+    }
+  }
+
+  // ─── Docker housekeeping (issue #302) ───────────────────────────────────────
+
+  /** Resolve the housekeeping toggles against their conservative defaults. */
+  private resolveHousekeeping(): {
+    buildCachePrune: boolean;
+    buildCacheMaxAgeHours: number;
+    danglingImagePrune: boolean;
+  } {
+    const hk = this.housekeepingConfig ?? {};
+    return {
+      buildCachePrune: hk.buildCachePrune ?? true,
+      buildCacheMaxAgeHours: hk.buildCacheMaxAgeHours ?? 168,
+      danglingImagePrune: hk.danglingImagePrune ?? true,
+    };
+  }
+
+  /**
+   * Best-effort Docker housekeeping after a successful build (install + update).
+   * Reclaims ONLY provably-unreferenced junk:
+   *   - build cache older than the configured window — time-filtered on purpose
+   *     so a concurrent build's fresh layers are never evicted;
+   *   - dangling `<none>` images with no container (safe by definition).
+   * Gated by config (all toggles off ⇒ no prune calls). Every prune is wrapped
+   * so a failure NEVER fails the parent install/update. Enforces the safety
+   * floor: no `-a`, no `system prune`, no volume prune (issue #302).
+   */
+  private pruneAfterBuild(job: JobState): void {
+    const hk = this.resolveHousekeeping();
+    if (hk.buildCachePrune) {
+      try {
+        this.run(
+          ['docker', 'builder', 'prune', '-f', '--filter', `until=${hk.buildCacheMaxAgeHours}h`],
+          os.tmpdir(),
+          120_000,
+        );
+        this.log(job, `Build cache pruned (older than ${hk.buildCacheMaxAgeHours}h)`);
+      } catch (err) {
+        this.log(job, `Build-cache prune skipped (non-fatal): ${(err as Error).message}`);
+      }
+    }
+    if (hk.danglingImagePrune) {
+      try {
+        // `image prune -f` (NEVER `-a`) — removes only untagged <none> layers
+        // with no container, so tagged images of other stopped apps survive.
+        this.run(['docker', 'image', 'prune', '-f'], os.tmpdir(), 120_000);
+        this.log(job, 'Dangling images pruned');
+      } catch (err) {
+        this.log(job, `Dangling-image prune skipped (non-fatal): ${(err as Error).message}`);
+      }
+    }
+  }
+
+  /**
+   * Reclaim this app's own superseded pulled tags after an update (issue #302).
+   * The image-ID reclaim misses a pulled-tag bump (e.g. monitor:1.1 → :1.2.0):
+   * a pulled image with more than one repo tag can't be removed by ID. Remove
+   * exactly the app's prior refs that the NEW stack no longer references.
+   * `image rm <ref>` fails safely (and is caught) when a container still uses
+   * the image, so an in-use image is never yanked. Only this app's own tags are
+   * ever touched — never a blanket prune.
+   */
+  private reclaimSupersededTags(
+    job: JobState,
+    oldImageRefs: string[],
+    newImageRefs: string[],
+  ): void {
+    const newRefSet = new Set(newImageRefs);
+    for (const ref of oldImageRefs) {
+      if (newRefSet.has(ref)) continue; // still used by new stack — keep
+      try {
+        this.run(['docker', 'image', 'rm', ref], os.tmpdir(), 60_000);
+        this.log(job, `Reclaimed superseded image tag ${ref}`);
+      } catch {
+        /* in use / already gone — non-fatal */
+      }
+    }
+  }
+
+  /** Read-only reclaim report (issue #302). Best-effort; never mutates state. */
+  housekeepingReport(): HousekeepingReport {
+    return this.buildHousekeepingReport();
+  }
+
+  /**
+   * Execute the SAFE reclaim (build cache + dangling images only) and return a
+   * fresh report. This is an explicit operator action, so it runs regardless of
+   * the auto-path config toggles — but it still honors the fixed safety floor:
+   * never `-a`, never `system prune`, never a volume/auto delete. The build-cache
+   * window uses the configured value (default 168h).
+   */
+  housekeepingPrune(): HousekeepingResult {
+    const hk = this.resolveHousekeeping();
+    const pruned = { buildCache: false, danglingImages: false };
+    try {
+      this.run(
+        ['docker', 'builder', 'prune', '-f', '--filter', `until=${hk.buildCacheMaxAgeHours}h`],
+        os.tmpdir(),
+        120_000,
+      );
+      pruned.buildCache = true;
+    } catch {
+      /* best-effort */
+    }
+    try {
+      this.run(['docker', 'image', 'prune', '-f'], os.tmpdir(), 120_000);
+      pruned.danglingImages = true;
+    } catch {
+      /* best-effort */
+    }
+    return { mode: 'prune', pruned, report: this.buildHousekeepingReport() };
+  }
+
+  private buildHousekeepingReport(): HousekeepingReport {
+    return {
+      buildCacheReclaimable: this.readBuildCacheReclaimable(),
+      danglingImageCount: this.splitLines(
+        this.safeRunStdout(['docker', 'image', 'ls', '--filter', 'dangling=true', '--quiet']),
+      ).length,
+      orphanVolumes: this.splitLines(
+        this.safeRunStdout(['docker', 'volume', 'ls', '--filter', 'dangling=true', '--quiet']),
+      ),
+    };
+  }
+
+  /** `docker` stdout, or '' on any error (report helpers must never throw). */
+  private safeRunStdout(args: string[], timeoutMs = 30_000): string {
+    try {
+      return this.run(args, os.tmpdir(), timeoutMs).stdout;
+    } catch {
+      return '';
+    }
+  }
+
+  private splitLines(s: string): string[] {
+    return s.trim().split('\n').map((x) => x.trim()).filter(Boolean);
+  }
+
+  /** Reclaimable build-cache size from the `docker system df` "Build Cache" row. */
+  private readBuildCacheReclaimable(): string {
+    const out = this.safeRunStdout([
+      'docker', 'system', 'df', '--format', '{{.Type}}\t{{.Reclaimable}}',
+    ]);
+    for (const line of this.splitLines(out)) {
+      const tab = line.indexOf('\t');
+      if (tab < 0) continue;
+      const type = line.slice(0, tab).trim().toLowerCase();
+      if (type.includes('build cache')) return line.slice(tab + 1).trim();
+    }
+    return '';
   }
 
   private run(

--- a/src/index.ts
+++ b/src/index.ts
@@ -587,6 +587,8 @@ async function main(): Promise<void> {
     undefined,
     undefined,
     agentManager,
+    undefined,
+    config.gateway.appHousekeeping,
   );
 
   // Start gateway router

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,24 @@ export interface GatewayConfig {
       cleanupHour?: number;      // 0-23, default 0
       cleanupTimezone?: string;  // IANA timezone, default "UTC"
     };
+    /**
+     * App-store Docker housekeeping (issue #302). Best-effort reclaim of the
+     * build cache and dangling `<none>` images left behind by every app
+     * install/update. Each toggle defaults on with a conservative time window;
+     * set all toggles off to make the feature issue zero prune calls. There is
+     * deliberately NO volume auto-delete toggle — orphaned volumes can hold real
+     * app data and are report-only. The safety floor is fixed regardless of
+     * config: never `system prune`, never `image/builder prune -a`, never an
+     * automatic volume prune.
+     */
+    appHousekeeping?: {
+      /** Prune build cache older than the window after a successful build. Default true. */
+      buildCachePrune?: boolean;
+      /** Age window (hours) for the build-cache prune — only frees cache older than this, so a concurrent build's fresh layers survive. Default 168 (7d). */
+      buildCacheMaxAgeHours?: number;
+      /** Prune dangling `<none>` images with no container (safe subset — never `-a`). Default true. */
+      danglingImagePrune?: boolean;
+    };
   };
   agents: AgentConfig[];
 }

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -635,4 +635,83 @@ services:
       expect(typeof res.body.jobId).toBe('string');
     });
   });
+
+  // ─── POST /api/v1/apps/housekeeping (#302) ────────────────────────────────
+  describe('POST /api/v1/apps/housekeeping', () => {
+    function reportSpawn() {
+      return jest.fn((_cmd: string, args: string[]) => {
+        if (args.includes('df')) {
+          return { stdout: 'Images\t0B\nBuild Cache\t1.457GB\n', stderr: '', status: 0 };
+        }
+        if (args.includes('volume') && args.includes('ls')) {
+          return { stdout: 'orphan_a\n', stderr: '', status: 0 };
+        }
+        if (args.includes('image') && args.includes('ls')) {
+          return { stdout: 'sha_1\nsha_2\n', stderr: '', status: 0 };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    it('returns 403 for a non-admin key', async () => {
+      const res = await request(app)
+        .post('/api/v1/apps/housekeeping')
+        .set('Authorization', `Bearer ${READ_KEY.key}`)
+        .send({ mode: 'report' });
+      expect(res.status).toBe(403);
+    });
+
+    it('report mode returns a read-only reclaim report', async () => {
+      const spawn = reportSpawn();
+      const hkApp = makeApp(registry, registryClient, spawn);
+      const res = await request(hkApp)
+        .post('/api/v1/apps/housekeeping')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ mode: 'report' });
+      expect(res.status).toBe(200);
+      expect(res.body.mode).toBe('report');
+      expect(res.body.report.buildCacheReclaimable).toBe('1.457GB');
+      expect(res.body.report.danglingImageCount).toBe(2);
+      expect(res.body.report.orphanVolumes).toEqual(['orphan_a']);
+      // read-only: no prune issued
+      const args = spawn.mock.calls.map((c) => c[1] as string[]);
+      expect(args.some((a) => a.includes('prune'))).toBe(false);
+    });
+
+    it('defaults to report mode when no body is sent', async () => {
+      const spawn = reportSpawn();
+      const hkApp = makeApp(registry, registryClient, spawn);
+      const res = await request(hkApp)
+        .post('/api/v1/apps/housekeeping')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`);
+      expect(res.status).toBe(200);
+      expect(res.body.mode).toBe('report');
+    });
+
+    it('prune mode executes the safe reclaim only', async () => {
+      const spawn = reportSpawn();
+      const hkApp = makeApp(registry, registryClient, spawn);
+      const res = await request(hkApp)
+        .post('/api/v1/apps/housekeeping')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ mode: 'prune' });
+      expect(res.status).toBe(200);
+      expect(res.body.mode).toBe('prune');
+      expect(res.body.pruned).toEqual({ buildCache: true, danglingImages: true });
+      const args = spawn.mock.calls.map((c) => c[1] as string[]);
+      expect(args).toContainEqual(['builder', 'prune', '-f', '--filter', 'until=168h']);
+      expect(args).toContainEqual(['image', 'prune', '-f']);
+      // safety floor — never `-a`, never a volume prune
+      expect(args.some((a) => a.includes('-a'))).toBe(false);
+      expect(args.some((a) => a.includes('volume') && a.includes('prune'))).toBe(false);
+    });
+
+    it('rejects an invalid mode with 400', async () => {
+      const res = await request(app)
+        .post('/api/v1/apps/housekeeping')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`)
+        .send({ mode: 'nuke' });
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/tests/unit/apps-module.test.ts
+++ b/tests/unit/apps-module.test.ts
@@ -53,5 +53,23 @@ describe('AppsModule', () => {
       const desc = (inspect!.description ?? '').toLowerCase();
       expect(desc).toContain('secret');
     });
+
+    // #302: a docker_housekeeping tool must exist with report/prune modes and
+    // must advertise the safety floor (no other-app image or volume deletion).
+    it('exposes a docker_housekeeping tool with report/prune modes', () => {
+      const tools = new AppsModule().getTools();
+      const hk = tools.find((t) => t.name === 'docker_housekeeping');
+      expect(hk).toBeDefined();
+
+      const props = (hk!.inputSchema as {
+        properties: Record<string, { enum?: string[] }>;
+      }).properties;
+      expect(props['mode']?.enum).toEqual(['report', 'prune']);
+
+      const desc = (hk!.description ?? '').toLowerCase();
+      expect(desc).toContain('build cache');
+      // must signal that volumes are never auto-deleted
+      expect(desc).toContain('volume');
+    });
   });
 });

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1894,6 +1894,156 @@ services:
       expect(mapContainerStatesToAppStatus([{ state: 'created', exitCode: 0 }])).toBe('stopped');
     });
   });
+
+  // ─── Docker housekeeping (#302) ─────────────────────────────────────────────
+  describe('Docker housekeeping (#302)', () => {
+    /** A spawn mock that records every call and always succeeds. */
+    function recordingSpawn() {
+      return jest.fn((_cmd: string, _args: string[], _opts?: object) => ({
+        stdout: '',
+        stderr: '',
+        status: 0,
+      }));
+    }
+
+    /** All docker arg-arrays recorded by a spawn mock. */
+    function dockerArgs(spy: ReturnType<typeof recordingSpawn>): string[][] {
+      return spy.mock.calls
+        .filter((c) => c[0] === 'docker')
+        .map((c) => c[1] as string[]);
+    }
+
+    function makeHkInstaller(
+      spawnFn: ReturnType<typeof recordingSpawn>,
+      hk?: ConstructorParameters<typeof AppInstaller>[7],
+    ) {
+      return new AppInstaller(
+        registry,
+        new RegistryClient(),
+        callbacks,
+        spawnFn,
+        appsDir,
+        undefined,
+        successAsyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
+        hk,
+      );
+    }
+
+    // Regression (proven-red): the current code issues NO prune after a build.
+    it('prunes build cache + dangling images after a successful install (default config)', async () => {
+      const appDir = makeAppDir(srcDir, 'hk-app');
+      const spawn = recordingSpawn();
+      const installer = makeHkInstaller(spawn);
+      const job = await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+      expect(job.status).toBe('completed');
+
+      const args = dockerArgs(spawn);
+      // build-cache prune, time-filtered to the default 168h window
+      expect(args).toContainEqual(['builder', 'prune', '-f', '--filter', 'until=168h']);
+      // dangling-image prune — the SAFE subset, never `-a`
+      expect(args).toContainEqual(['image', 'prune', '-f']);
+    });
+
+    // Safety floor — the destructive flags must appear NOWHERE.
+    it('never issues -a prune, system prune, or any volume prune', async () => {
+      const appDir = makeAppDir(srcDir, 'hk-safe');
+      const spawn = recordingSpawn();
+      const installer = makeHkInstaller(spawn);
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+
+      const args = dockerArgs(spawn);
+      const has = (pred: (a: string[]) => boolean) => args.some(pred);
+      // no `prune -a` anywhere (builder or image)
+      expect(has((a) => a.includes('prune') && a.includes('-a'))).toBe(false);
+      // no `docker system prune`
+      expect(has((a) => a.includes('system') && a.includes('prune'))).toBe(false);
+      // no automatic `docker volume prune`
+      expect(has((a) => a.includes('volume') && a.includes('prune'))).toBe(false);
+    });
+
+    it('honors the configured build-cache window', async () => {
+      const appDir = makeAppDir(srcDir, 'hk-window');
+      const spawn = recordingSpawn();
+      const installer = makeHkInstaller(spawn, { buildCacheMaxAgeHours: 24 });
+      await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+
+      const args = dockerArgs(spawn);
+      expect(args).toContainEqual(['builder', 'prune', '-f', '--filter', 'until=24h']);
+    });
+
+    it('issues zero prune calls when the feature is fully disabled', async () => {
+      const appDir = makeAppDir(srcDir, 'hk-off');
+      const spawn = recordingSpawn();
+      const installer = makeHkInstaller(spawn, {
+        buildCachePrune: false,
+        danglingImagePrune: false,
+      });
+      const job = await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+      expect(job.status).toBe('completed');
+
+      const args = dockerArgs(spawn);
+      expect(args.some((a) => a.includes('prune'))).toBe(false);
+    });
+
+    it('is best-effort: a prune failure never fails the install', async () => {
+      const appDir = makeAppDir(srcDir, 'hk-besteffort');
+      // Fail specifically on any `prune` command; everything else succeeds.
+      const spawn = jest.fn((_cmd: string, args: string[], _opts?: object) => {
+        if (args.includes('prune')) {
+          return { stdout: '', stderr: 'mocked prune failure', status: 1 };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeHkInstaller(spawn as unknown as ReturnType<typeof recordingSpawn>);
+      const job = await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+      expect(job.status).toBe('completed');
+      // the prune WAS attempted (proving the best-effort path executed)
+      expect(dockerArgs(spawn as unknown as ReturnType<typeof recordingSpawn>)
+        .some((a) => a.includes('prune'))).toBe(true);
+    });
+
+    it('housekeepingReport() returns a read-only report and issues no prune', () => {
+      const spawn = jest.fn((_cmd: string, args: string[], _opts?: object) => {
+        if (args.includes('df')) {
+          return { stdout: 'Images\t0B\nBuild Cache\t1.457GB\nLocal Volumes\t170MB\n', stderr: '', status: 0 };
+        }
+        if (args.includes('volume') && args.includes('ls')) {
+          return { stdout: 'orphan_a\norphan_b\n', stderr: '', status: 0 };
+        }
+        if (args.includes('image') && args.includes('ls')) {
+          return { stdout: 'sha_1\nsha_2\nsha_3\n', stderr: '', status: 0 };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeHkInstaller(spawn as unknown as ReturnType<typeof recordingSpawn>);
+
+      const report = installer.housekeepingReport();
+      expect(report.buildCacheReclaimable).toBe('1.457GB');
+      expect(report.danglingImageCount).toBe(3);
+      expect(report.orphanVolumes).toEqual(['orphan_a', 'orphan_b']);
+
+      // report is read-only — no prune of any kind
+      const args = dockerArgs(spawn as unknown as ReturnType<typeof recordingSpawn>);
+      expect(args.some((a) => a.includes('prune'))).toBe(false);
+    });
+
+    it('housekeepingPrune() runs the safe reclaim only (build cache + dangling)', () => {
+      const spawn = recordingSpawn();
+      const installer = makeHkInstaller(spawn);
+
+      const result = installer.housekeepingPrune();
+      expect(result.mode).toBe('prune');
+      expect(result.pruned).toEqual({ buildCache: true, danglingImages: true });
+
+      const args = dockerArgs(spawn);
+      expect(args).toContainEqual(['builder', 'prune', '-f', '--filter', 'until=168h']);
+      expect(args).toContainEqual(['image', 'prune', '-f']);
+      // safety floor holds for the manual path too
+      expect(args.some((a) => a.includes('prune') && a.includes('-a'))).toBe(false);
+      expect(args.some((a) => a.includes('system') && a.includes('prune'))).toBe(false);
+      expect(args.some((a) => a.includes('volume') && a.includes('prune'))).toBe(false);
+    });
+  });
 });
 
 /** Minimal AppEntry for seeding a collision peer in the registry. */


### PR DESCRIPTION
## Summary

The gateway builds/pulls Docker images on every app **install** and **update** but never reclaimed the build cache or orphaned layers those operations leave behind, so a long-lived host leaks steadily (**1.457 GB** of reclaimable build cache observed on the live host). This adds a **safe, opt-outable housekeeping pass** wired into the install/update path, plus a **manual report/prune API + MCP tool**.

Closes #302.

## What changed

- **Auto reclaim after a successful build** (install + update), best-effort & config-gated:
  - `docker builder prune -f --filter until=<window>h` (default **168h/7d**) — time-filtered so a concurrent build's fresh layers survive.
  - `docker image prune -f` — dangling `<none>` layers only, **never `-a`**, so tagged images of other stopped apps are untouched.
  - A prune failure **never** fails the parent install/update (wrapped, logged).
- **Superseded pulled-tag reclaim** (update path): reclaims *this app's own* prior image refs the new stack no longer references — the tag bump (`:1.1` → `:1.2.0`) the image-ID reclaim can't catch. Only this app's own tags; `image rm` fails safely when a container still uses the image.
- **Orphaned volumes**: reported, **never auto-deleted** (they can hold real app data).
- **Manual API** `POST /api/v1/apps/housekeeping` (admin): `mode:"report"` (read-only) or `mode:"prune"` (safe reclaim only). MCP tool `docker_housekeeping` with the same modes.
- **Config** `gateway.appHousekeeping` (all toggles off ⇒ **zero** prune calls). Added to `config.template.json`; `configVersion` 1.0.15 → 1.0.16.

## Safety floor (enforced regardless of config)

- Never `docker system prune -a`.
- Never `docker image/builder prune -a`.
- Never an automatic `docker volume prune`.
- Build-cache prune is **always** time-filtered.
- Every prune is best-effort.

Tests assert these never appear in the issued commands.

## Tests

- **Regression (proven-red)**: the "prune args issued after build" assertions **fail on the pre-fix code** (no prune is issued after a build today) and pass after the change — verified by neutralizing `pruneAfterBuild` and observing the auto-path tests go red.
- Unit coverage: exact prune args + window, config-off ⇒ zero prune calls, best-effort (prune throws ⇒ install still completes), no `-a`/`system prune`/`volume prune` anywhere, `housekeepingReport()`/`housekeepingPrune()` behavior, the API endpoint (report/prune/admin-gate/invalid-mode), and the `docker_housekeeping` MCP tool contract.
- **Gates green**: `npm run typecheck` clean; full suite **2935/2935** pass (one unrelated suite, `api-sessions-rename`, reports a flaky worker SIGTERM under parallel load — passes 6/6 standalone).

## Files

`src/apps/installer.ts` (core), `src/api/apps-router.ts` (endpoint), `src/types.ts` + `config.template.json` (config), `src/index.ts` (wiring), `mcp/tools/apps/{client,module}.ts` (MCP tool), `API.md` (docs) + 3 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)