### PR TITLE
fix(apps): capture bind-mount data dirs under the app dir in backup/restore

### DIFF
--- a/API.md
+++ b/API.md
@@ -161,8 +161,8 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 | `POST` | `/api/v1/apps/:name/update` | Admin | Start async update with rollback → `jobId` |
 | `POST` | `/api/v1/apps/:name/reconfigure` | Admin | Start async env/host-port reconfigure (keeps volumes) → `jobId` |
 | `POST` | `/api/v1/apps/housekeeping` | Admin | Docker build-cache & orphan reclaim report (`mode:"report"`) or safe prune (`mode:"prune"`) |
-| `POST` | `/api/v1/apps/:name/backup` | Admin | Start async volume+config snapshot → `jobId` |
-| `POST` | `/api/v1/apps/:name/restore` | Admin | Restore volumes+config from a backup → `jobId` |
+| `POST` | `/api/v1/apps/:name/backup` | Admin | Start async snapshot of volumes, bind-mount data dirs & config → `jobId` |
+| `POST` | `/api/v1/apps/:name/restore` | Admin | Restore volumes, bind-mount data dirs & config from a backup → `jobId` |
 | `GET` | `/api/v1/apps/:name/backups` | Key | List backups (newest first) |
 | `DELETE` | `/api/v1/apps/:name/backups/:id` | Admin | Delete one backup |
 | `GET` | `/app/:name/:portName/*` | None | Reverse proxy to installed app |

--- a/mcp/tools/apps/module.ts
+++ b/mcp/tools/apps/module.ts
@@ -166,7 +166,7 @@ export class AppsModule implements ToolModule {
       },
       {
         name: 'backup_app',
-        description: 'Back up an installed app — a permission-safe snapshot of its Docker named volumes + config (.env/app.yaml) into a single archive. The app is briefly stopped for a consistent snapshot and restarted afterward. Returns a jobId; poll with poll_install_job. Older backups beyond the retention limit are pruned automatically.',
+        description: 'Back up an installed app — a permission-safe snapshot of its Docker named volumes, bind-mount data directories under the app dir, and config (.env/app.yaml) into a single archive. The app is briefly stopped for a consistent snapshot and restarted afterward. Returns a jobId; poll with poll_install_job. Older backups beyond the retention limit are pruned automatically.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -178,7 +178,7 @@ export class AppsModule implements ToolModule {
       },
       {
         name: 'restore_app',
-        description: "Restore an app's volumes + config from a prior backup, then start it on the restored data. Restoring a backup from a different app version is allowed but may warn about schema/migration mismatch. Returns a jobId; poll with poll_install_job. Use list_backups to pick a backup_id.",
+        description: "Restore an app's Docker named volumes, bind-mount data directories under the app dir, and config from a prior backup, then start it on the restored data. Restoring a backup from a different app version is allowed but may warn about schema/migration mismatch. Returns a jobId; poll with poll_install_job. Use list_backups to pick a backup_id.",
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -72,6 +72,12 @@ export interface BackupMetadata {
   appVersion: string;
   createdAt: string; // ISO 8601
   volumes: string[];
+  /**
+   * App-dir-relative bind-mount source directories captured in this backup
+   * (e.g. `data/photos`, `postgres/pgdata`). Optional for backward
+   * compatibility with backups taken before bind-mount capture existed.
+   */
+  bindMounts?: string[];
   sizeBytes: number;
 }
 
@@ -651,6 +657,7 @@ export class AppInstaller {
     }
 
     const volumes = this.discoverVolumes(appName, appDir);
+    const bindMounts = this.discoverBindMounts(appName, appDir);
     const wasRunning = (await this.queryRuntimeStatus(entry)) === 'running';
     const staging = fs.mkdtempSync(path.join(os.tmpdir(), `bkp-${appName}-`));
 
@@ -677,6 +684,34 @@ export class AppInstaller {
         );
       }
 
+      // Bind-mount data dirs under the app dir (not Docker named volumes).
+      // Archive each with the same root-helper tar so ownership (e.g. the
+      // postgres uid) survives without host-side cp/sudo. Indexed filenames
+      // avoid collisions between paths that flatten to the same name.
+      const bindDir = path.join(staging, 'binds');
+      fs.mkdirSync(bindDir, { recursive: true });
+      const capturedBinds: string[] = [];
+      for (const rel of bindMounts) {
+        const abs = path.join(appDir, rel);
+        if (!fs.existsSync(abs)) {
+          log(`Bind mount "${rel}" missing on disk — skipping`);
+          continue;
+        }
+        log(`Archiving bind mount "${rel}"`);
+        this.run(
+          [
+            'docker', 'run', '--rm',
+            '-v', `${abs}:/data:ro`,
+            '-v', `${bindDir}:/backup`,
+            BACKUP_HELPER_IMAGE,
+            'tar', 'czf', `/backup/bind-${capturedBinds.length}.tar.gz`, '-C', '/data', '.',
+          ],
+          undefined,
+          VOLUME_TAR_TIMEOUT_MS,
+        );
+        capturedBinds.push(rel);
+      }
+
       // Config (owned by the gateway user, copied on the host).
       const cfgDir = path.join(staging, 'config');
       fs.mkdirSync(cfgDir, { recursive: true });
@@ -693,6 +728,7 @@ export class AppInstaller {
         appVersion: entry.version,
         createdAt: new Date().toISOString(),
         volumes,
+        bindMounts: capturedBinds,
         sizeBytes: 0,
       };
       fs.writeFileSync(path.join(staging, 'metadata.json'), JSON.stringify(meta, null, 2));
@@ -714,7 +750,10 @@ export class AppInstaller {
       fs.writeFileSync(path.join(outDir, `${id}.json`), JSON.stringify(meta, null, 2));
 
       this.pruneBackups(appName);
-      log(`Backup "${id}" complete (${sizeBytes} bytes, ${volumes.length} volume(s))`);
+      log(
+        `Backup "${id}" complete (${sizeBytes} bytes, ${volumes.length} volume(s), ` +
+          `${capturedBinds.length} bind mount(s))`,
+      );
       return { id, createdAt: meta.createdAt, sizeBytes, appVersion: meta.appVersion };
     } finally {
       try {
@@ -800,6 +839,39 @@ export class AppInstaller {
         );
       }
 
+      // Restore bind-mount data dirs under the app dir. Indexed filenames match
+      // performBackup's capture order. Each restored path is re-checked to stay
+      // under the app dir (defense-in-depth against a tampered metadata path).
+      const bindDir = path.join(staging, 'binds');
+      const bindMounts = meta.bindMounts ?? [];
+      bindMounts.forEach((rel, i) => {
+        const abs = path.resolve(appDir, rel);
+        const base = appDir.endsWith(path.sep) ? appDir : appDir + path.sep;
+        if (abs !== appDir && !abs.startsWith(base)) {
+          log(`WARNING: bind mount "${rel}" escapes the app dir — skipping`);
+          return;
+        }
+        const tarball = path.join(bindDir, `bind-${i}.tar.gz`);
+        if (!fs.existsSync(tarball)) {
+          log(`WARNING: bind mount "${rel}" missing from backup — skipping`);
+          return;
+        }
+        log(`Restoring bind mount "${rel}"`);
+        this.run(
+          [
+            'docker', 'run', '--rm',
+            '-v', `${abs}:/data`,
+            '-v', `${bindDir}:/backup`,
+            BACKUP_HELPER_IMAGE,
+            'sh', '-c',
+            // Wipe the live bind dir, then untar the snapshot (uid/gid preserved).
+            `rm -rf /data/* /data/..?* 2>/dev/null; tar xzf /backup/bind-${i}.tar.gz -C /data`,
+          ],
+          undefined,
+          VOLUME_TAR_TIMEOUT_MS,
+        );
+      });
+
       // Restore config that carries generated secrets, so the app boots with the
       // same credentials the volume data was created under.
       this.copyIfExists(path.join(staging, 'config', '.env'), path.join(appDir, '.env'));
@@ -840,6 +912,44 @@ export class AppInstaller {
         .split('\n')
         .map((s) => s.trim())
         .filter((s) => s.length > 0);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Discover bind-mount source directories that live **under the app dir**
+   * (e.g. `./data/photos` → `data/photos`). These hold app-owned data that is
+   * not a Docker named volume, so {@link discoverVolumes} never reports them —
+   * yet they are deleted on uninstall and must be captured in a backup.
+   *
+   * Returns app-dir-relative POSIX paths, deduped and sorted. Bind mounts whose
+   * source resolves outside the app dir (shared host resources such as a
+   * read-only `~/.claude/projects`) are intentionally excluded. Best-effort:
+   * returns `[]` on any failure, mirroring {@link discoverVolumes}.
+   */
+  private discoverBindMounts(appName: string, appDir: string): string[] {
+    try {
+      const { stdout } = this.run(
+        ['docker', 'compose', '-p', appName, 'config', '--format', 'json'],
+        appDir,
+        30_000,
+      );
+      const parsed = JSON.parse(stdout) as {
+        services?: Record<string, { volumes?: Array<{ type?: string; source?: string }> }>;
+      };
+      const base = appDir.endsWith(path.sep) ? appDir : appDir + path.sep;
+      const rels = new Set<string>();
+      for (const svc of Object.values(parsed.services ?? {})) {
+        for (const vol of svc.volumes ?? []) {
+          if (vol.type !== 'bind' || typeof vol.source !== 'string') continue;
+          const abs = path.resolve(vol.source);
+          if (abs !== appDir && !abs.startsWith(base)) continue; // outside app dir
+          const rel = path.relative(appDir, abs);
+          if (rel.length > 0) rels.add(rel.split(path.sep).join('/'));
+        }
+      }
+      return Array.from(rels).sort();
     } catch {
       return [];
     }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -938,14 +938,25 @@ export class AppInstaller {
       const parsed = JSON.parse(stdout) as {
         services?: Record<string, { volumes?: Array<{ type?: string; source?: string }> }>;
       };
-      const base = appDir.endsWith(path.sep) ? appDir : appDir + path.sep;
+      // Local-dev installs symlink the app dir into appsDir, and the generated
+      // compose resolves bind sources against the symlink's *realpath*. Match a
+      // source that sits under either the symlink path or its target, so those
+      // bind mounts are not wrongly excluded.
+      const bases = [appDir];
+      try {
+        const real = fs.realpathSync(appDir);
+        if (real !== appDir) bases.push(real);
+      } catch {
+        /* app dir unreadable — fall back to the literal path */
+      }
       const rels = new Set<string>();
       for (const svc of Object.values(parsed.services ?? {})) {
         for (const vol of svc.volumes ?? []) {
           if (vol.type !== 'bind' || typeof vol.source !== 'string') continue;
           const abs = path.resolve(appDir, vol.source);
-          if (abs !== appDir && !abs.startsWith(base)) continue; // outside app dir
-          const rel = path.relative(appDir, abs);
+          const matched = bases.find((b) => abs === b || abs.startsWith(b + path.sep));
+          if (!matched) continue; // outside the app dir
+          const rel = path.relative(matched, abs);
           if (rel.length > 0) rels.add(rel.split(path.sep).join('/'));
         }
       }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -943,7 +943,7 @@ export class AppInstaller {
       for (const svc of Object.values(parsed.services ?? {})) {
         for (const vol of svc.volumes ?? []) {
           if (vol.type !== 'bind' || typeof vol.source !== 'string') continue;
-          const abs = path.resolve(vol.source);
+          const abs = path.resolve(appDir, vol.source);
           if (abs !== appDir && !abs.startsWith(base)) continue; // outside app dir
           const rel = path.relative(appDir, abs);
           if (rel.length > 0) rels.add(rel.split(path.sep).join('/'));

--- a/tests/unit/apps/backup.test.ts
+++ b/tests/unit/apps/backup.test.ts
@@ -46,7 +46,12 @@ function makeCallLog() {
 
 function backupSpawn(
   calls: string[][],
-  opts: { volumes?: string[]; failVolumeTar?: boolean; restoreMeta?: Record<string, unknown> } = {},
+  opts: {
+    volumes?: string[];
+    failVolumeTar?: boolean;
+    restoreMeta?: Record<string, unknown>;
+    bindSources?: string[]; // absolute bind-mount sources for `config --format json`
+  } = {},
 ) {
   const volumes = opts.volumes ?? ['data'];
   return jest.fn((cmd: string, args: string[], _o?: object) => {
@@ -55,6 +60,14 @@ function backupSpawn(
     // docker compose -p <app> config --volumes
     if (args.includes('config') && args.includes('--volumes')) {
       return { stdout: volumes.join('\n') + '\n', stderr: '', status: 0 };
+    }
+    // docker compose -p <app> config --format json  → bind-mount discovery
+    if (args.includes('config') && args.includes('json')) {
+      const services: Record<string, { volumes: Array<{ type: string; source: string }> }> = {};
+      (opts.bindSources ?? []).forEach((src, i) => {
+        services[`svc${i}`] = { volumes: [{ type: 'bind', source: src }] };
+      });
+      return { stdout: JSON.stringify({ services }), stderr: '', status: 0 };
     }
     // Volume helper backup: docker run … tar czf /backup/<vol>.tar.gz …
     const isVolumeHelperTar =
@@ -80,6 +93,13 @@ function backupSpawn(
       fs.writeFileSync(path.join(staging, 'metadata.json'), JSON.stringify(meta));
       for (const v of (meta.volumes as string[] | undefined) ?? volumes) {
         fs.writeFileSync(path.join(staging, 'volumes', `${v}.tar.gz`), 'V');
+      }
+      const binds = (meta.bindMounts as string[] | undefined) ?? [];
+      if (binds.length > 0) {
+        fs.mkdirSync(path.join(staging, 'binds'), { recursive: true });
+        binds.forEach((_rel, i) => {
+          fs.writeFileSync(path.join(staging, 'binds', `bind-${i}.tar.gz`), 'B');
+        });
       }
       fs.writeFileSync(path.join(staging, 'config', '.env'), 'SECRET=restored');
       return { stdout: '', stderr: '', status: 0 };
@@ -320,5 +340,149 @@ describe('AppInstaller — backup/restore', () => {
     await installer.uninstall('shop');
     const flat = joinCalls(calls);
     expect(flat.some((l) => l.includes('tar czf /backup/'))).toBe(false);
+  });
+
+  // ── Bind-mount capture (data dirs under the app dir, not named volumes) ──────
+
+  function readSidecar(app: string, id: string): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(path.join(backupsDir, app, `${id}.json`), 'utf-8'));
+  }
+
+  it('U-BK-BIND-1: backup helper-tars each bind-mount dir under the app dir and records them', async () => {
+    const { calls } = makeCallLog();
+    const appDir = path.join(appsDir, 'shop');
+    const photoSrc = path.join(appDir, 'data', 'photos');
+    const pgSrc = path.join(appDir, 'postgres', 'pgdata');
+    const installer = makeInstaller(
+      backupSpawn(calls, { volumes: [], bindSources: [photoSrc, pgSrc] }),
+    );
+    await seedApp('shop', 'stopped');
+    fs.mkdirSync(photoSrc, { recursive: true });
+    fs.mkdirSync(pgSrc, { recursive: true });
+
+    const job = await waitForJob(installer, installer.backup('shop'));
+    expect(job.status).toBe('completed');
+
+    const flat = joinCalls(calls);
+    // read-only helper mount of the ABSOLUTE bind source, tar into indexed file
+    expect(flat.some((l) => l.includes(`-v ${photoSrc}:/data:ro`) && l.includes('tar czf /backup/bind-0.tar.gz'))).toBe(true);
+    expect(flat.some((l) => l.includes(`-v ${pgSrc}:/data:ro`) && l.includes('tar czf /backup/bind-1.tar.gz'))).toBe(true);
+    // relative paths recorded in metadata (sorted)
+    const meta = readSidecar('shop', job.backup!.id);
+    expect(meta.bindMounts).toEqual(['data/photos', 'postgres/pgdata']);
+  });
+
+  it('U-BK-BIND-2: bind mounts OUTSIDE the app dir are excluded', async () => {
+    const { calls } = makeCallLog();
+    const appDir = path.join(appsDir, 'shop');
+    const inside = path.join(appDir, 'data', 'photos');
+    const outside = path.join(tmpDir, 'shared', 'claude-projects'); // sibling, not under appDir
+    const installer = makeInstaller(
+      backupSpawn(calls, { volumes: [], bindSources: [inside, outside] }),
+    );
+    await seedApp('shop', 'stopped');
+    fs.mkdirSync(inside, { recursive: true });
+    fs.mkdirSync(outside, { recursive: true });
+
+    const job = await waitForJob(installer, installer.backup('shop'));
+    expect(job.status).toBe('completed');
+
+    const flat = joinCalls(calls);
+    expect(flat.some((l) => l.includes(`-v ${inside}:/data:ro`))).toBe(true);
+    expect(flat.some((l) => l.includes(outside))).toBe(false); // never touched
+    const meta = readSidecar('shop', job.backup!.id);
+    expect(meta.bindMounts).toEqual(['data/photos']);
+  });
+
+  it('U-BK-BIND-3: a declared bind dir missing on disk is skipped, not fatal', async () => {
+    const { calls } = makeCallLog();
+    const appDir = path.join(appsDir, 'shop');
+    const present = path.join(appDir, 'data', 'photos');
+    const missing = path.join(appDir, 'postgres', 'pgdata'); // never created on disk
+    const installer = makeInstaller(
+      backupSpawn(calls, { volumes: [], bindSources: [present, missing] }),
+    );
+    await seedApp('shop', 'stopped');
+    fs.mkdirSync(present, { recursive: true });
+
+    const job = await waitForJob(installer, installer.backup('shop'));
+    expect(job.status).toBe('completed');
+    const meta = readSidecar('shop', job.backup!.id);
+    expect(meta.bindMounts).toEqual(['data/photos']); // only the present one
+  });
+
+  it('U-RS-BIND-1: restore wipes+untars each recorded bind dir into a read-write mount', async () => {
+    const { calls } = makeCallLog();
+    const appDir = path.join(appsDir, 'shop');
+    const photoAbs = path.join(appDir, 'data', 'photos');
+    const installer = makeInstaller(
+      backupSpawn(calls, {
+        volumes: [],
+        restoreMeta: {
+          id: 'bk1', appName: 'shop', appVersion: '1.0.0',
+          createdAt: '2026-01-01T00:00:00.000Z', volumes: [],
+          bindMounts: ['data/photos'], sizeBytes: 5,
+        },
+      }),
+    );
+    await seedApp('shop', 'stopped');
+    const dir = path.join(backupsDir, 'shop');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'bk1.tar.gz'), 'ARCHIVE');
+
+    const job = await waitForJob(installer, installer.restore('shop', 'bk1'));
+    expect(job.status).toBe('completed');
+    const flat = joinCalls(calls);
+    // rw mount of the absolute path + wipe + untar of the indexed bind archive
+    expect(flat.some((l) => l.includes(`-v ${photoAbs}:/data `) && l.includes('tar xzf /backup/bind-0.tar.gz'))).toBe(true);
+    expect(flat.some((l) => l.includes('rm -rf /data/*') && l.includes('bind-0.tar.gz'))).toBe(true);
+  });
+
+  it('U-RS-BIND-SEC: a metadata bind path escaping the app dir is skipped (traversal guard)', async () => {
+    const { calls } = makeCallLog();
+    const installer = makeInstaller(
+      backupSpawn(calls, {
+        volumes: [],
+        restoreMeta: {
+          id: 'evil', appName: 'shop', appVersion: '1.0.0',
+          createdAt: '2026-01-01T00:00:00.000Z', volumes: [],
+          bindMounts: ['../../../../etc/cron.d'], sizeBytes: 5,
+        },
+      }),
+    );
+    await seedApp('shop', 'stopped');
+    const dir = path.join(backupsDir, 'shop');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'evil.tar.gz'), 'ARCHIVE');
+
+    const job = await waitForJob(installer, installer.restore('shop', 'evil'));
+    expect(job.status).toBe('completed');
+    expect(job.logs.join('\n')).toMatch(/escapes the app dir/i);
+    const flat = joinCalls(calls);
+    // no helper container ever mounted the escaping path
+    expect(flat.some((l) => l.includes('/etc/cron.d'))).toBe(false);
+  });
+
+  it('U-RS-BIND-BACKCOMPAT: an old backup without bindMounts restores with no bind step', async () => {
+    const { calls } = makeCallLog();
+    const installer = makeInstaller(
+      backupSpawn(calls, {
+        volumes: ['data'],
+        restoreMeta: {
+          id: 'old', appName: 'shop', appVersion: '1.0.0',
+          createdAt: '2026-01-01T00:00:00.000Z', volumes: ['data'], sizeBytes: 5,
+        }, // no bindMounts field at all
+      }),
+    );
+    await seedApp('shop', 'stopped');
+    const dir = path.join(backupsDir, 'shop');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'old.tar.gz'), 'ARCHIVE');
+
+    const job = await waitForJob(installer, installer.restore('shop', 'old'));
+    expect(job.status).toBe('completed');
+    const flat = joinCalls(calls);
+    expect(flat.some((l) => l.includes('bind-0.tar.gz'))).toBe(false); // no bind restore attempted
+    expect(flat.some((l) => l.includes('tar xzf /backup/data.tar.gz'))).toBe(true); // volume still restored
   });
 });

--- a/tests/unit/apps/backup.test.ts
+++ b/tests/unit/apps/backup.test.ts
@@ -411,6 +411,36 @@ describe('AppInstaller — backup/restore', () => {
     expect(meta.bindMounts).toEqual(['data/photos']); // only the present one
   });
 
+  it('U-BK-BIND-SYMLINK: a local-dev symlinked app dir captures binds resolved to the realpath', async () => {
+    const { calls } = makeCallLog();
+    // Local install symlinks appsDir/<name> → the real project dir, and the
+    // generated compose resolves bind sources against that realpath.
+    const realTarget = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'proj-')));
+    const appDir = path.join(appsDir, 'shop');
+    fs.symlinkSync(realTarget, appDir);
+    fs.writeFileSync(path.join(appDir, '.env'), 'DB_PASSWORD=secret\n');
+    fs.writeFileSync(path.join(appDir, 'app.yaml'), 'name: shop\nversion: 1.0.0\n');
+    const photoReal = path.join(realTarget, 'data', 'photos'); // realpath-based source
+    fs.mkdirSync(photoReal, { recursive: true });
+
+    const installer = makeInstaller(backupSpawn(calls, { volumes: [], bindSources: [photoReal] }));
+    await registry.upsert({
+      name: 'shop', version: '1.0.0', commit: 'a'.repeat(40), githubUrl: '',
+      installPath: appDir, ports: [], sockets: {},
+      installedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+      status: 'stopped', source: 'local', agentDeclaration: null,
+    });
+
+    const job = await waitForJob(installer, installer.backup('shop'));
+    expect(job.status).toBe('completed');
+    const meta = readSidecar('shop', job.backup!.id);
+    // realpath source under the symlink target is still recognized and recorded
+    expect(meta.bindMounts).toEqual(['data/photos']);
+    const flat = joinCalls(calls);
+    expect(flat.some((l) => l.includes('tar czf /backup/bind-0.tar.gz'))).toBe(true);
+    fs.rmSync(realTarget, { recursive: true, force: true });
+  });
+
   it('U-RS-BIND-1: restore wipes+untars each recorded bind dir into a read-write mount', async () => {
     const { calls } = makeCallLog();
     const appDir = path.join(appsDir, 'shop');


### PR DESCRIPTION
## Summary
Per-app backup (added in #303) archived only Docker **named volumes**, so an app that stores data as **relative bind mounts under its app dir** (e.g. `./data/photos`, `./postgres/pgdata`) produced a config-only backup — and uninstall then permanently deleted the data. This captures those bind-mount directories too.

## Related Issue
Closes #306

## Changes Made
- `src/apps/installer.ts`:
  - New `discoverBindMounts(appName, appDir)` — parses `docker compose config --format json` and collects bind sources resolving **under the app dir**; binds outside it (shared host resources) are excluded. Best-effort `[]` on failure, mirroring `discoverVolumes`.
  - `performBackup` archives each discovered bind dir with the **same root-helper tar** used for named volumes (ownership preserved, no host `cp`/`sudo`); records relative paths in new optional `BackupMetadata.bindMounts`.
  - `performRestore` wipes + re-extracts each recorded bind dir via a root helper, with a **path-traversal guard** keeping each path under the app dir.
- `tests/unit/apps/backup.test.ts`: 6 new tests (capture, external-exclusion, missing-dir skip, restore, traversal guard, old-backup backward-compat).
- `API.md`, `mcp/tools/apps/module.ts`: backup/restore descriptions now mention bind-mount data dirs.

## Testing
- `npm run typecheck`: pass
- `npm test`: 153 suites / 2964 tests pass (1 unrelated suite-level teardown flake, green in isolation)
- **Regression test proven to fail on pre-fix code** (bind capture + restore + traversal guard all red when the fix is neutralized; backward-compat stays green).
- **Real-docker e2e**: a compose app with a bind mount under its app dir, seeded uid `999:999` mode `640` → backup → corrupt (delete data, add junk, chown root, wreck `.env`) → restore → verified content restored, **owner `999:999` and mode `640` preserved**, junk removed, `.env` restored.