### PR TITLE
feat(apps): lower backup retention default to 3 + age-based daily cleanup

### DIFF
--- a/API.md
+++ b/API.md
@@ -167,6 +167,8 @@ Sessions are stored at `sessions/api-{chat_id}/` — symmetric with `telegram-{i
 | `DELETE` | `/api/v1/apps/:name/backups/:id` | Admin | Delete one backup |
 | `GET` | `/app/:name/:portName/*` | None | Reverse proxy to installed app |
 
+Backup retention (`gateway.appBackup`): backups are pruned by the **union** of a count cap and an age cap — a backup is removed when it exceeds `retention` (keep N newest per app, default **3**, `0` = unbounded) **or** is older than `maxAgeDays` (default **30**, `0` = disabled). Pruning runs after each successful backup and once per day via a scheduler at `cleanupHour` (0-23, default `0`) in `cleanupTimezone` (IANA, default `"UTC"`).
+
 ### Cron API
 
 | Method | Path | Auth | Description |

--- a/config.template.json
+++ b/config.template.json
@@ -48,7 +48,10 @@
       "cleanupTimezone": "UTC"
     },
     "appBackup": {
-      "retention": 10,
+      "retention": 3,
+      "maxAgeDays": 30,
+      "cleanupHour": 0,
+      "cleanupTimezone": "UTC",
       "autoBackupBeforeUninstall": true,
       "autoBackupBeforeUpdate": true
     },

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -16,6 +16,7 @@ import {
   AgentDeclaration,
 } from './compose-generator';
 import { AgentManager } from './agent-manager';
+import { msUntilNextHour } from '../history/cleanup';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -53,8 +54,14 @@ export interface InstallResult {
 
 /** Per-app backup policy (mirrors `gateway.appBackup` in the gateway config). */
 export interface AppBackupConfig {
-  /** Keep the N most recent backups per app; older are pruned. Default 10. */
+  /** Keep the N most recent backups per app; older are pruned. Default 3. 0 = unbounded. */
   retention?: number;
+  /** Prune backups older than N days. Default 30. 0 = disabled. */
+  maxAgeDays?: number;
+  /** Hour (0-23, in cleanupTimezone) the daily backup prune runs. Default 0. */
+  cleanupHour?: number;
+  /** IANA timezone for cleanupHour. Default "UTC". */
+  cleanupTimezone?: string;
   /** Auto-snapshot before uninstall. Default true. */
   autoBackupBeforeUninstall?: boolean;
   /** Auto-snapshot before update. Default true. */
@@ -199,8 +206,12 @@ const DEFAULT_APPS_DIR = path.join(os.homedir(), '.claude-gateway', 'apps');
 // which removes only `<appsDir>/<app>/`.
 const APP_BACKUPS_DIRNAME = '.backups';
 // Default per-app backup ceiling when config omits it. The N most recent are
-// kept; older archives are pruned after each successful backup.
-const DEFAULT_BACKUP_RETENTION = 10;
+// kept; older archives are pruned after each successful backup and by the daily
+// scheduler.
+const DEFAULT_BACKUP_RETENTION = 3;
+// Default age ceiling (days) when config omits it. Backups older than this are
+// pruned regardless of count. 0 disables age pruning.
+const DEFAULT_BACKUP_MAX_AGE_DAYS = 30;
 // Wall-clock ceiling for a single helper-container tar (backup or restore) of
 // one volume. A few hundred MB tars in seconds; this only bounds a pathological
 // hang so a stuck helper never wedges a backup job forever.
@@ -219,6 +230,22 @@ const RESTORE_COMPOSE_TIMEOUT_MS = 180_000;
 const RESTORE_MAX_CONCURRENCY = 4;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
 const APP_NAME_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
+
+/**
+ * Validate an IANA timezone from config before it reaches `Intl.DateTimeFormat`.
+ * An invalid string would otherwise throw a RangeError inside the daily-cleanup
+ * scheduler at boot — config is untrusted input, so a typo must degrade to UTC,
+ * never crash the gateway.
+ */
+function isValidTimezone(tz: string | undefined): tz is string {
+  if (typeof tz !== 'string' || tz.length === 0) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
 // Disallow '..' in owner/repo segments — prevents path traversal via edge-case git URL parsing.
 const GITHUB_URL_RE = /^https:\/\/github\.com\/(?!.*\.\.)[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*(\.git)?$/;
 
@@ -251,6 +278,18 @@ export class AppInstaller {
         appBackupConfig?.retention !== undefined && appBackupConfig.retention >= 0
           ? Math.floor(appBackupConfig.retention)
           : DEFAULT_BACKUP_RETENTION,
+      maxAgeDays:
+        appBackupConfig?.maxAgeDays !== undefined && appBackupConfig.maxAgeDays >= 0
+          ? Math.floor(appBackupConfig.maxAgeDays)
+          : DEFAULT_BACKUP_MAX_AGE_DAYS,
+      cleanupHour:
+        appBackupConfig?.cleanupHour !== undefined &&
+        Number.isInteger(appBackupConfig.cleanupHour) &&
+        appBackupConfig.cleanupHour >= 0 &&
+        appBackupConfig.cleanupHour <= 23
+          ? appBackupConfig.cleanupHour
+          : 0,
+      cleanupTimezone: isValidTimezone(appBackupConfig?.cleanupTimezone) ? appBackupConfig!.cleanupTimezone! : 'UTC',
       autoBackupBeforeUninstall: appBackupConfig?.autoBackupBeforeUninstall ?? true,
       autoBackupBeforeUpdate: appBackupConfig?.autoBackupBeforeUpdate ?? true,
     };
@@ -966,14 +1005,85 @@ export class AppInstaller {
     }
   }
 
-  /** Keep the N most recent backups per app (by createdAt); prune older. */
-  private pruneBackups(appName: string): void {
-    const retention = this.appBackupConfig.retention;
-    if (retention <= 0) return; // 0 = unbounded
+  /**
+   * Prune an app's backups by the union policy (issue #310): a backup is
+   * deleted when it is beyond the retention count **OR** older than
+   * `maxAgeDays` — whichever matches. `retention === 0` disables the count cap;
+   * `maxAgeDays === 0` disables the age cap. Runs after each successful backup
+   * and from the daily scheduler.
+   */
+  private pruneBackups(appName: string, now = Date.now()): void {
+    const { retention, maxAgeDays } = this.appBackupConfig;
+    if (retention <= 0 && maxAgeDays <= 0) return; // both caps disabled
     const all = this.listBackups(appName); // newest first
-    for (const stale of all.slice(retention)) {
-      this.deleteBackup(appName, stale.id);
+    const doomed = new Set<string>();
+    // Count cap: everything past the N newest.
+    if (retention > 0) {
+      for (const stale of all.slice(retention)) doomed.add(stale.id);
     }
+    // Age cap: anything older than the cutoff (union — dedupe via the set).
+    if (maxAgeDays > 0) {
+      const cutoff = now - maxAgeDays * 24 * 60 * 60 * 1000;
+      for (const b of all) {
+        const created = Date.parse(b.createdAt);
+        if (!Number.isNaN(created) && created < cutoff) doomed.add(b.id);
+      }
+    }
+    for (const id of doomed) this.deleteBackup(appName, id);
+  }
+
+  /**
+   * Prune **every** app's backups by the union policy. Enumerates the backup
+   * subdirs under `.backups/` (skipping anything that is not a valid app name),
+   * so it also reaches apps that are no longer being backed up. Best-effort:
+   * a failure on one app never aborts the sweep.
+   */
+  cleanupAllBackups(now = Date.now()): void {
+    const { retention, maxAgeDays } = this.appBackupConfig;
+    if (retention <= 0 && maxAgeDays <= 0) return; // both caps disabled
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(this.backupsDir, { withFileTypes: true });
+    } catch {
+      return; // no backups dir yet — nothing to prune
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (!APP_NAME_RE.test(entry.name)) continue; // skip stray dirs
+      try {
+        this.pruneBackups(entry.name, now);
+      } catch {
+        /* best-effort — one bad app must not abort the sweep */
+      }
+    }
+  }
+
+  /**
+   * Start the daily backup-cleanup scheduler (issue #310). Fires once per day at
+   * `cleanupHour` in `cleanupTimezone`, pruning all apps by the union policy.
+   * Returns a cancel function. No-op (returns a noop canceller) when both caps
+   * are disabled. The timer is `unref`'d so it never holds the event loop open.
+   */
+  startBackupCleanup(): () => void {
+    const { retention, maxAgeDays, cleanupHour, cleanupTimezone } = this.appBackupConfig;
+    if (retention <= 0 && maxAgeDays <= 0) return () => {};
+    let timer: ReturnType<typeof setTimeout>;
+    const schedule = () => {
+      const delay = msUntilNextHour(cleanupHour, cleanupTimezone);
+      timer = setTimeout(() => {
+        try {
+          this.cleanupAllBackups();
+        } catch {
+          /* best-effort */
+        }
+        schedule(); // reschedule for the next day
+      }, delay);
+      if (typeof (timer as NodeJS.Timeout).unref === 'function') {
+        (timer as NodeJS.Timeout).unref();
+      }
+    };
+    schedule();
+    return () => clearTimeout(timer);
   }
 
   private appBackupDir(appName: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -592,6 +592,11 @@ async function main(): Promise<void> {
     config.gateway?.appBackup,
   );
 
+  // Daily backup-cleanup scheduler (issue #310): prunes every app's backups by
+  // the retention-count + max-age union policy. Timer is unref'd, so it never
+  // keeps the process alive.
+  appInstaller.startBackupCleanup();
+
   // Start gateway router
   const router = new GatewayRouter(agentRunners, agentConfigs, undefined, config, cronManager, CONFIG_PATH, appsRegistry, appInstaller, registryClient);
   await router.start(PORT);

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,11 +217,15 @@ export interface GatewayConfig {
      * Per-app backup/restore policy. A backup is a permission-safe snapshot of
      * an app's Docker named volumes + config (`.env`/`app.yaml`) into a single
      * archive; restore returns exact inner ownership via helper-container tar.
-     * Absent = defaults below (feature on with a 10-backup ceiling and safety
-     * hooks enabled). Set the flags to false to opt out of the auto-hooks.
+     * Absent = defaults below (feature on with a 3-backup ceiling, a 30-day age
+     * cap, and safety hooks enabled). Set the flags to false to opt out of the
+     * auto-hooks.
      */
     appBackup?: {
-      retention?: number;                 // keep N most recent per app, default 10
+      retention?: number;                 // keep N most recent per app, default 3 (0 = unbounded)
+      maxAgeDays?: number;                // prune backups older than N days, default 30 (0 = disabled)
+      cleanupHour?: number;               // 0-23 daily prune hour, default 0
+      cleanupTimezone?: string;           // IANA timezone for cleanupHour, default "UTC"
       autoBackupBeforeUninstall?: boolean; // default true
       autoBackupBeforeUpdate?: boolean;    // default true
     };

--- a/tests/unit/apps/backup.test.ts
+++ b/tests/unit/apps/backup.test.ts
@@ -515,4 +515,110 @@ describe('AppInstaller — backup/restore', () => {
     expect(flat.some((l) => l.includes('bind-0.tar.gz'))).toBe(false); // no bind restore attempted
     expect(flat.some((l) => l.includes('tar xzf /backup/data.tar.gz'))).toBe(true); // volume still restored
   });
+
+  // ── Retention age/union cleanup (issue #310) ────────────────────────────────
+
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  /** Write a backup manifest + archive straight to disk with a chosen createdAt. */
+  function seedBackup(app: string, id: string, createdAt: string): void {
+    const dir = path.join(backupsDir, app);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${id}.tar.gz`), 'ARCHIVE');
+    fs.writeFileSync(
+      path.join(dir, `${id}.json`),
+      JSON.stringify({ id, appName: app, appVersion: '1.0.0', createdAt, volumes: [], sizeBytes: 8 }),
+    );
+  }
+
+  function backupIds(installer: AppInstaller, app: string): string[] {
+    return installer.listBackups(app).map((b) => b.id);
+  }
+
+  it('U-AGE-DEFAULT: retention defaults to 3 and maxAgeDays to 30', () => {
+    const installer = makeInstaller(jest.fn());
+    // 5 recent backups (all within 30 days) → count cap 3 keeps the 3 newest.
+    const now = Date.parse('2026-06-01T00:00:00.000Z');
+    for (let i = 0; i < 5; i++) {
+      seedBackup('shop', `b${i}`, new Date(now - i * DAY_MS).toISOString());
+    }
+    installer.cleanupAllBackups(now);
+    expect(backupIds(installer, 'shop').sort()).toEqual(['b0', 'b1', 'b2']);
+  });
+
+  it('U-AGE-1: prunes backups older than maxAgeDays even under the count cap', () => {
+    const installer = makeInstaller(jest.fn(), { retention: 10, maxAgeDays: 30 });
+    const now = Date.parse('2026-06-01T00:00:00.000Z');
+    seedBackup('shop', 'fresh', new Date(now - 5 * DAY_MS).toISOString());
+    seedBackup('shop', 'stale', new Date(now - 45 * DAY_MS).toISOString());
+    installer.cleanupAllBackups(now);
+    // retention=10 keeps all by count, but the 45-day-old one is age-expired.
+    expect(backupIds(installer, 'shop')).toEqual(['fresh']);
+  });
+
+  it('U-AGE-2: union — a backup beyond count OR older than maxAge is deleted, once', () => {
+    const installer = makeInstaller(jest.fn(), { retention: 2, maxAgeDays: 30 });
+    const now = Date.parse('2026-06-01T00:00:00.000Z');
+    // newest→oldest: n0,n1 (fresh, within count) | n2 (fresh but past count) | old (past count AND age)
+    seedBackup('shop', 'n0', new Date(now - 1 * DAY_MS).toISOString());
+    seedBackup('shop', 'n1', new Date(now - 2 * DAY_MS).toISOString());
+    seedBackup('shop', 'n2', new Date(now - 3 * DAY_MS).toISOString()); // count overflow only
+    seedBackup('shop', 'old', new Date(now - 60 * DAY_MS).toISOString()); // count + age
+    installer.cleanupAllBackups(now);
+    // count cap keeps n0,n1; n2 dropped by count; old dropped by both (deleted once).
+    expect(backupIds(installer, 'shop').sort()).toEqual(['n0', 'n1']);
+    // Archive + manifest both gone for the doomed ids (no partial/double delete).
+    expect(fs.existsSync(path.join(backupsDir, 'shop', 'old.tar.gz'))).toBe(false);
+    expect(fs.existsSync(path.join(backupsDir, 'shop', 'old.json'))).toBe(false);
+  });
+
+  it('U-AGE-3: maxAgeDays=0 disables age pruning (count-only preserved)', () => {
+    const installer = makeInstaller(jest.fn(), { retention: 10, maxAgeDays: 0 });
+    const now = Date.parse('2026-06-01T00:00:00.000Z');
+    seedBackup('shop', 'ancient', new Date(now - 400 * DAY_MS).toISOString());
+    installer.cleanupAllBackups(now);
+    // Age cap off, count cap not exceeded → the ancient backup survives.
+    expect(backupIds(installer, 'shop')).toEqual(['ancient']);
+  });
+
+  it('U-AGE-4: daily sweep prunes every app dir under .backups/', () => {
+    const installer = makeInstaller(jest.fn(), { retention: 1, maxAgeDays: 0 });
+    const now = Date.parse('2026-06-01T00:00:00.000Z');
+    for (const app of ['shop', 'blog']) {
+      seedBackup(app, 'keep', new Date(now - 1 * DAY_MS).toISOString());
+      seedBackup(app, 'drop', new Date(now - 2 * DAY_MS).toISOString());
+    }
+    // A stray non-app-name dir must be skipped, not throw.
+    fs.mkdirSync(path.join(backupsDir, 'Not_An_App'), { recursive: true });
+    installer.cleanupAllBackups(now);
+    expect(backupIds(installer, 'shop')).toEqual(['keep']);
+    expect(backupIds(installer, 'blog')).toEqual(['keep']);
+  });
+
+  it('U-AGE-TZ: an invalid cleanupTimezone degrades to UTC instead of crashing the scheduler', () => {
+    // A typo'd IANA zone would make Intl.DateTimeFormat throw at boot; the guard
+    // must fall back to UTC so startBackupCleanup never throws.
+    const installer = makeInstaller(jest.fn(), {
+      retention: 3,
+      maxAgeDays: 30,
+      cleanupTimezone: 'Not/A_Zone',
+    });
+    let cancel: () => void = () => {};
+    expect(() => {
+      cancel = installer.startBackupCleanup();
+    }).not.toThrow();
+    cancel();
+  });
+
+  it('U-AGE-5: startBackupCleanup returns a no-op canceller when both caps are disabled', () => {
+    const installer = makeInstaller(jest.fn(), { retention: 0, maxAgeDays: 0 });
+    const now = Date.parse('2026-06-01T00:00:00.000Z');
+    seedBackup('shop', 'a', new Date(now - 999 * DAY_MS).toISOString());
+    const cancel = installer.startBackupCleanup();
+    expect(typeof cancel).toBe('function');
+    cancel(); // must not throw
+    // Nothing scheduled/pruned: both caps off → sweep is a no-op.
+    installer.cleanupAllBackups(now);
+    expect(backupIds(installer, 'shop')).toEqual(['a']);
+  });
 });


### PR DESCRIPTION
## Summary

Backup retention was **count-only** (`DEFAULT_BACKUP_RETENTION = 10`), pruned solely as a side effect of taking a *new* backup. This PR lowers the default ceiling and adds age-based cleanup plus a daily scheduler, per #310.

Changes:
- **Default retention 10 → 3** (`DEFAULT_BACKUP_RETENTION`).
- **New `gateway.appBackup.maxAgeDays`** (default **30**, `0` = disabled): prune backups older than N days.
- **Union semantics:** `pruneBackups` now deletes a backup when it exceeds the retention count **OR** is older than `maxAgeDays` — deduped via a `Set` so a backup matching both conditions is deleted exactly once.
- **Daily scheduler** `startBackupCleanup()` — mirrors the existing `gateway.history` cleanup: reuses `msUntilNextHour` from `src/history/cleanup.ts`, fires once per day at `cleanupHour` (0-23, default `0`) in `cleanupTimezone` (IANA, default `"UTC"`), `unref`'d so it never holds the event loop open. It sweeps **every** app dir under `.backups/` (validated against `APP_NAME_RE`), so apps that are no longer being backed up are still pruned.
- Wired in `src/index.ts` after the installer is constructed.

## Config

```jsonc
"appBackup": {
  "retention": 3,        // keep N newest per app (0 = unbounded)
  "maxAgeDays": 30,      // prune older than N days (0 = disabled)
  "cleanupHour": 0,      // 0-23, daily prune hour
  "cleanupTimezone": "UTC"
}
```

Both caps disabled (`retention === 0 && maxAgeDays === 0`) → prune and scheduler are no-ops.

## Files

- `src/apps/installer.ts` — union prune, `cleanupAllBackups`, `startBackupCleanup`, config resolution, `isValidTimezone` guard.
- `src/index.ts` — start the daily scheduler.
- `src/types.ts`, `config.template.json` — new config fields + lowered default.
- `API.md` — retention-policy note.
- `tests/unit/apps/backup.test.ts` — 7 new tests (U-AGE-*).

## Tests

- **Proven-red:** `U-AGE-1` fails when the age branch is neutralized — confirms the new logic is exercised, not vacuously green.
- Union + dedupe (`U-AGE-2`), `maxAgeDays=0` preserves count-only behavior (`U-AGE-3`), daily sweep across multiple app dirs skipping stray dirs (`U-AGE-4`), no-op scheduler when both caps off (`U-AGE-5`), defaults resolve to 3/30 (`U-AGE-DEFAULT`).
- **Self-review hardening:** an invalid `cleanupTimezone` in config would throw `RangeError` in the scheduler at boot; `isValidTimezone` degrades it to UTC (`U-AGE-TZ`).
- `backup.test.ts`: **26/26** green. Full suite: **0 test failures**. `npm run typecheck` clean.

Closes #310
