### PR TITLE
fix(apps): report crash-looping containers as error, not running

### DIFF
--- a/API.md
+++ b/API.md
@@ -2813,7 +2813,7 @@ curl -H "X-Api-Key: my-key" http://localhost:10850/api/v1/apps | jq
 
 **`status` values:** `running` | `stopped` | `error` | `building`
 
-> **Live status:** `GET /api/v1/apps` and `GET /api/v1/apps/:name` reconcile the stored status against the live Docker runtime (`docker compose ps`) on read, so a container that crashed, was OOM-killed, or was stopped from outside the gateway reports `stopped`/`error` rather than a stale `running`. `running`/`restarting` containers → `running`; a non-zero exit or `dead` container → `error`; no containers or a clean exit → `stopped`. If Docker cannot be queried (daemon down, compose file missing) the last stored status is returned unchanged, and an app mid-install (`building`) is not reconciled.
+> **Live status:** `GET /api/v1/apps` and `GET /api/v1/apps/:name` reconcile the stored status against the live Docker runtime (`docker compose ps`) on read, so a container that crashed, was OOM-killed, was stopped from outside the gateway, or is stuck in a crash-restart loop reports `stopped`/`error` rather than a stale `running`. A `running` container (or one doing a clean/transient restart) → `running`; a container stuck `restarting` after a non-zero exit (crash-loop), a non-zero exit, or a `dead` container → `error`; no containers or a clean exit → `stopped`. If Docker cannot be queried (daemon down, compose file missing) the last stored status is returned unchanged, and an app mid-install (`building`) is not reconciled.
 
 **`source` values:** `registry` | `custom` | `local`
 

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -2673,6 +2673,14 @@ export interface ComposePsContainer {
   state: string;
   /** Process exit code (0 when still running or absent). */
   exitCode: number;
+  /**
+   * Last exit code of a `restarting` container, parsed from the human-readable
+   * `Status` string (`"Restarting (N) …"`). Undefined when the container is not
+   * restarting or the code could not be parsed. Docker leaves the structured
+   * `ExitCode` field at 0 while a container is restarting, so this is the only
+   * signal that separates a crash-loop (N≠0) from a healthy transient restart (N=0).
+   */
+  restartExitCode?: number;
 }
 
 /**
@@ -2688,11 +2696,19 @@ export function parseComposePs(stdout: string): ComposePsContainer[] {
   const out: ComposePsContainer[] = [];
   const push = (o: unknown): void => {
     if (o && typeof o === 'object' && typeof (o as { State?: unknown }).State === 'string') {
-      const rec = o as { State: string; ExitCode?: unknown };
-      out.push({
+      const rec = o as { State: string; ExitCode?: unknown; Status?: unknown };
+      const container: ComposePsContainer = {
         state: rec.State.toLowerCase(),
         exitCode: typeof rec.ExitCode === 'number' ? rec.ExitCode : 0,
-      });
+      };
+      // A restarting container's last exit code lives only in the Status string
+      // ("Restarting (N) …"); the ExitCode field reads 0 while restarting. Capture
+      // N so the status mapper can tell a crash-loop (N≠0) from a healthy restart.
+      if (typeof rec.Status === 'string') {
+        const m = /restarting \((\d+)\)/i.exec(rec.Status);
+        if (m) container.restartExitCode = Number(m[1]);
+      }
+      out.push(container);
     }
   };
   // Whole-string JSON array (older compose).
@@ -2723,14 +2739,28 @@ export function parseComposePs(stdout: string): ComposePsContainer[] {
 /**
  * Map an app's compose-project container states to a single AppEntry status:
  *   - no containers                                   → stopped
- *   - any running / restarting                        → running
+ *   - any restarting after a NON-ZERO exit (crash-loop) → error
+ *   - any running / restarting (clean/transient)      → running
  *   - any dead, or exited with a non-zero exit code   → error   (crash)
  *   - else (clean exit / created / paused)            → stopped
+ *
+ * The crash-loop check comes first and wins over a healthy sibling: a container
+ * stuck endlessly restarting on a non-zero exit is not serving, so surfacing it
+ * as `error` is more honest than reporting the app `running`. A single clean
+ * restart (`Restarting (0) …`) or a container that has already recovered to
+ * `running` stays `running` — no flicker for normal transient restarts.
  */
 export function mapContainerStatesToAppStatus(
   containers: ComposePsContainer[],
 ): AppEntry['status'] {
   if (containers.length === 0) return 'stopped';
+  if (
+    containers.some(
+      (c) => c.state === 'restarting' && c.restartExitCode !== undefined && c.restartExitCode !== 0,
+    )
+  ) {
+    return 'error';
+  }
   if (containers.some((c) => c.state === 'running' || c.state === 'restarting')) {
     return 'running';
   }

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1934,6 +1934,59 @@ services:
       expect(mapContainerStatesToAppStatus([{ state: 'exited', exitCode: 0 }])).toBe('stopped');
       expect(mapContainerStatesToAppStatus([{ state: 'created', exitCode: 0 }])).toBe('stopped');
     });
+
+    // ─── #312: crash-loop must not read as `running` ──────────────────────────
+    it('parses the restarting exit code out of the Status string', () => {
+      // Docker leaves ExitCode=0 while restarting; the real code is only in Status.
+      const ndjson = [
+        JSON.stringify({ State: 'restarting', ExitCode: 0, Status: 'Restarting (1) 3 seconds ago' }),
+        JSON.stringify({
+          State: 'restarting',
+          ExitCode: 0,
+          Status: 'Restarting (0) Less than a second ago',
+        }),
+        JSON.stringify({ State: 'running', ExitCode: 0, Status: 'Up 2 minutes' }),
+      ].join('\n');
+      expect(parseComposePs(ndjson)).toEqual([
+        { state: 'restarting', exitCode: 0, restartExitCode: 1 },
+        { state: 'restarting', exitCode: 0, restartExitCode: 0 },
+        { state: 'running', exitCode: 0 },
+      ]);
+    });
+
+    it('reports a crash-looping (restarting after non-zero exit) container as error', () => {
+      // The regression: a single container endlessly restarting on exit 1.
+      expect(
+        mapContainerStatesToAppStatus([
+          { state: 'restarting', exitCode: 0, restartExitCode: 1 },
+        ]),
+      ).toBe('error');
+      // The issue's live scenario: db + app both crash-looping.
+      expect(
+        mapContainerStatesToAppStatus([
+          { state: 'restarting', exitCode: 0, restartExitCode: 1 },
+          { state: 'restarting', exitCode: 0, restartExitCode: 1 },
+        ]),
+      ).toBe('error');
+      // A crash-looping dependency wins over a healthy sibling — surface the fault.
+      expect(
+        mapContainerStatesToAppStatus([
+          { state: 'running', exitCode: 0 },
+          { state: 'restarting', exitCode: 0, restartExitCode: 1 },
+        ]),
+      ).toBe('error');
+    });
+
+    it('keeps a clean/transient restart reported as running (no false error)', () => {
+      // Clean exit (0) being restarted by `restart: always` — still healthy.
+      expect(
+        mapContainerStatesToAppStatus([
+          { state: 'restarting', exitCode: 0, restartExitCode: 0 },
+        ]),
+      ).toBe('running');
+      // Restarting with no parseable code (first instant) falls back to running.
+      expect(mapContainerStatesToAppStatus([{ state: 'restarting', exitCode: 0 }])).toBe('running');
+    });
   });
 
   // ─── Docker housekeeping (#302) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`mapContainerStatesToAppStatus()` mapped Docker's `restarting` container state straight to the app-level `running` status, so an app whose container is stuck in an infinite crash-restart loop was reported (and shown in the Apps UI as a green "Running" badge) as healthy while it served nothing. The false-positive propagated to `GET /v1/apps` and `GET /v1/apps/:name`.

## Root cause (proven live)
Reproduced on a real Docker crash-loop (`busybox` + `command: sh -c "exit 1"` + `restart: always`):

```
State=restarting  ExitCode=0  Status="Restarting (1) 3 seconds ago"
```

Docker leaves the structured **`ExitCode` field at 0 while a container is restarting** — the real last exit code appears **only inside the human-readable `Status` string** (`Restarting (N) …`). The old mapping treated every `restarting` container as `running`, and even keying off `ExitCode` would not have worked (it reads 0).

## Fix
- `parseComposePs()` now parses `Restarting (N)` out of the `Status` string into a new optional `restartExitCode` on `ComposePsContainer`.
- `mapContainerStatesToAppStatus()` maps a container stuck `restarting` after a **non-zero** exit → `error`. A clean/transient restart (`Restarting (0)`) or an already-recovered `running` container still → `running` (no flicker). The crash-loop check wins over a healthy sibling, so a crash-looping dependency is surfaced rather than hidden.

Verified live: clean exit shows `Restarting (0)` → `running`; crash-loop shows `Restarting (1)` → `error`.

## Tests
- Status-string parse (`Restarting (N)` → `restartExitCode`).
- Crash-loop → `error` (single, both-crashing, and mixed-with-healthy-sibling).
- Clean/transient restart and unparseable-code restart → `running` (no regression).
- **Regression test proven to FAIL on the pre-fix mapping** (returned `running` where `error` is required).

Gates: `npm run typecheck` clean; full suite `2953/2953` pass (the lone reported FAIL, `chat-history-api.test.ts`, is a pre-existing flaky worker-kill — passes 27/27 standalone, untouched by this change).

Docs: updated the `status` reconciliation note in `API.md`.

## Out of scope
- The postgres data-dir corruption that triggered the investigation (app-level, not a gateway bug).
- Any new start/stop/restart API surface.

Closes #312