### PR TITLE
fix(apps): guard start/stop/restart against in-flight jobs + map busy to 409

### DIFF
--- a/API.md
+++ b/API.md
@@ -3053,7 +3053,10 @@ curl -X DELETE \
 
 ### POST /api/v1/apps/:name/start|stop|restart
 
-Start, stop, or restart an installed app's containers.
+Start, stop, or restart an installed app's containers. Admin key required. Runs
+synchronously and responds `200` once `docker compose` completes — there is no
+`jobId` to poll. `stop`/`start` are idempotent (stopping an already-stopped app
+or starting an already-running one is a clean no-op).
 
 ```bash
 curl -X POST \
@@ -3064,6 +3067,11 @@ curl -X POST \
 ```json
 { "name": "agent-note", "action": "restart" }
 ```
+
+**Errors:** `403` if the key is not an admin key · `404` if the app is not
+installed (or `:action` is not one of `start`/`stop`/`restart`) · `409` if a
+mutating job (install/update/reconfigure/backup/restore) is currently in
+progress for the app · `500` on an underlying `docker compose` failure.
 
 ---
 

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -249,11 +249,12 @@ export function createAppsRouter(
         res.json({ name: req.params.name, action });
       } catch (err) {
         const msg = (err as Error).message;
-        if (msg.includes('not installed')) {
-          res.status(404).json({ error: msg });
-        } else {
-          res.status(500).json({ error: msg });
-        }
+        const status = msg.includes('not installed')
+          ? 404
+          : msg.includes('busy')
+            ? 409
+            : 500;
+        res.status(status).json({ error: msg });
       }
     },
   );

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -1110,13 +1110,26 @@ export class AppInstaller {
     const entry = await this.registry.get(appName);
     if (!entry) throw new Error(`App "${appName}" is not installed`);
 
-    if (action === 'stop') {
-      this.run(['docker', 'compose', '-p', appName, 'stop'], entry.installPath, 60_000);
-      await this.registry.updateStatus(appName, 'stopped');
-    } else {
-      // start / restart: stop conflicting containers and wait for healthcheck
-      this.composeUp(appName, entry.installPath);
-      await this.registry.updateStatus(appName, 'running');
+    // Refuse while a mutating job (install/update/reconfigure/backup/restore)
+    // holds this app, and claim the same per-app mutex for the duration so those
+    // jobs cannot start mid-operation — otherwise `docker compose stop`/`up`
+    // here races the containers an install is bringing up. Mirrors the guard in
+    // backup()/restore(); the HTTP layer maps this "busy" message to 409.
+    if (this.installingNames.has(appName)) {
+      throw new Error(`App "${appName}" is busy (install/update/backup in progress)`);
+    }
+    this.installingNames.add(appName);
+    try {
+      if (action === 'stop') {
+        this.run(['docker', 'compose', '-p', appName, 'stop'], entry.installPath, 60_000);
+        await this.registry.updateStatus(appName, 'stopped');
+      } else {
+        // start / restart: stop conflicting containers and wait for healthcheck
+        this.composeUp(appName, entry.installPath);
+        await this.registry.updateStatus(appName, 'running');
+      }
+    } finally {
+      this.installingNames.delete(appName);
     }
   }
 

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -449,6 +449,52 @@ services:
         .set('Authorization', `Bearer ${ADMIN_KEY.key}`);
       expect(res.status).toBe(404);
     });
+
+    it('stops a running app → 200 and registry status becomes stopped', async () => {
+      await registry.upsert(makeEntry({ status: 'running' }));
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/stop')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ name: 'test-app', action: 'stop' });
+      expect((await registry.get('test-app'))?.status).toBe('stopped');
+    });
+
+    it('starts a stopped app → 200 and registry status becomes running', async () => {
+      await registry.upsert(makeEntry({ status: 'stopped' }));
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/start')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ name: 'test-app', action: 'start' });
+      expect((await registry.get('test-app'))?.status).toBe('running');
+    });
+
+    it('restarts an app → 200 and registry status becomes running', async () => {
+      await registry.upsert(makeEntry({ status: 'stopped' }));
+      const res = await request(app)
+        .post('/api/v1/apps/test-app/restart')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ name: 'test-app', action: 'restart' });
+      expect((await registry.get('test-app'))?.status).toBe('running');
+    });
+
+    it('returns 409 when a mutating job holds the app', async () => {
+      await registry.upsert(makeEntry());
+      const { installer } = makeInstaller(registry);
+      const busyApp = express();
+      busyApp.use(express.json());
+      busyApp.use('/api', createAppsRouter(registry, installer, registryClient, API_KEYS));
+      // Simulate an install/update/backup holding the per-app mutex.
+      (installer as unknown as { installingNames: Set<string> }).installingNames.add('test-app');
+      const res = await request(busyApp)
+        .post('/api/v1/apps/test-app/stop')
+        .set('Authorization', `Bearer ${ADMIN_KEY.key}`);
+      expect(res.status).toBe(409);
+      // The app was never touched — status stays as it was.
+      expect((await registry.get('test-app'))?.status).toBe('running');
+    });
   });
 
   // ── GET /api/v1/apps/:name/version ─────────────────────────────────────

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -619,6 +619,19 @@ services:
       const entry = await registry.get('my-app');
       expect(entry?.status).toBe('running');
     });
+
+    it('throws "busy" when a mutating job holds the app', async () => {
+      const appDir = makeAppDir(srcDir, 'my-app');
+      const installer = makeInstaller();
+      const jobId = installer.install({ localPath: appDir });
+      await waitForJob(installer, jobId, 5000);
+
+      // Simulate an install/update/backup in flight on the same app.
+      (installer as unknown as { installingNames: Set<string> }).installingNames.add('my-app');
+      await expect(installer.startStopRestart('my-app', 'stop')).rejects.toThrow('busy');
+      // Guard rejected before touching the app — status is unchanged.
+      expect((await registry.get('my-app'))?.status).toBe('running');
+    });
   });
 
   // ─── restoreRunningApps() ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Issue #313 asked to expose `start`/`stop`/`restart` for installed apps via the public REST API. On investigation, those routes **already exist** and are documented:

- Route: `POST /v1/apps/:name/:action(start|stop|restart)` (`apps-router.ts`), wired since the original app-store feature (#91).
- Admin-gated, `404` on unknown app / invalid action, documented in `API.md` (route tables + detail section), and covered by existing 403/404 tests.

So rather than duplicate the feature, this PR closes the two real gaps the issue's acceptance criteria and proposed approach pointed at:

1. **Concurrency safety (latent bug).** `startStopRestart()` did **not** participate in the per-app mutex (`installingNames`) that `install`/`update`/`reconfigure`/`backup`/`restore` all hold. Calling `stop`/`start`/`restart` while one of those jobs was in flight let `docker compose stop`/`up` race the containers the job was managing. It now claims the same mutex for its duration and refuses with a `busy` error when a mutating job already holds the app — mirroring `backup()`/`restore()`.
2. **`409` mapping.** The route now maps that `busy` error to `409`, matching the `/backup` + `/restore` convention: not-installed → `404`, busy → `409`, else → `500`.

## Changes

- `src/apps/installer.ts` — `startStopRestart()` claims/releases `installingNames` (try/finally) and throws `busy` when the app is already held.
- `src/api/apps-router.ts` — start/stop/restart catch block maps `busy` → `409`.
- `API.md` — document the endpoint's `200` (synchronous, no `jobId`), idempotency, and the `403/404/409/500` error shapes.

## Tests

- `installer`: `startStopRestart` throws `busy` when the mutex is held, leaving the app untouched (status unchanged).
- `apps-router`: happy-path `stop`/`start`/`restart` → `200` + correct registry status transition; `409` when a mutating job holds the app.
- **Regression proven:** neutralizing the busy guard turns exactly the two `busy`/`409` tests red; restoring it makes them green. (Happy-path tests stay green either way — the route already returned `200`.)

## Verification

- `npm run typecheck` clean.
- Affected suites (`apps-router` + `installer`) 138/138.
- Full suite 2920/2920 assertions pass (one unrelated suite-level teardown flake in `api-router.test.ts`, confirmed 62/62 green in isolation).

## Acceptance criteria (issue #313)

All six criteria were already met by the existing route; this PR additionally makes the "does not error destructively" criterion return a clear `409` for the in-flight-job case and adds the previously-missing happy-path + 409 coverage.

Closes #313