### PR TITLE
fix(apps): report explicit Stop as stopped when a container is signal-killed

### DIFF
--- a/API.md
+++ b/API.md
@@ -2813,7 +2813,7 @@ curl -H "X-Api-Key: my-key" http://localhost:10850/api/v1/apps | jq
 
 **`status` values:** `running` | `stopped` | `error` | `building`
 
-> **Live status:** `GET /api/v1/apps` and `GET /api/v1/apps/:name` reconcile the stored status against the live Docker runtime (`docker compose ps`) on read, so a container that crashed, was OOM-killed, was stopped from outside the gateway, or is stuck in a crash-restart loop reports `stopped`/`error` rather than a stale `running`. A `running` container (or one doing a clean/transient restart) → `running`; a container stuck `restarting` after a non-zero exit (crash-loop), a non-zero exit, or a `dead` container → `error`; no containers or a clean exit → `stopped`. If Docker cannot be queried (daemon down, compose file missing) the last stored status is returned unchanged, and an app mid-install (`building`) is not reconciled.
+> **Live status:** `GET /api/v1/apps` and `GET /api/v1/apps/:name` reconcile the stored status against the live Docker runtime (`docker compose ps`) on read, so a container that crashed, was OOM-killed, was stopped from outside the gateway, or is stuck in a crash-restart loop reports `stopped`/`error` rather than a stale `running`. A `running` container (or one doing a clean/transient restart) → `running`; a container stuck `restarting` after a non-zero exit (crash-loop), an exit with a non-signal non-zero code, or a `dead` container → `error`; no containers, a clean exit, or a container force-killed by an explicit stop (exit 137/SIGKILL or 143/SIGTERM) → `stopped`. If Docker cannot be queried (daemon down, compose file missing) the last stored status is returned unchanged, and an app mid-install (`building`) is not reconciled.
 
 **`source` values:** `registry` | `custom` | `local`
 

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -2750,18 +2750,36 @@ export function parseComposePs(stdout: string): ComposePsContainer[] {
 }
 
 /**
+ * Container exit codes produced by a signal kill rather than a crash: 137 =
+ * 128+9 (SIGKILL), 143 = 128+15 (SIGTERM). `docker compose stop` sends SIGTERM
+ * and, if a container doesn't self-terminate within the grace period, force-kills
+ * it with SIGKILL — so a plainly-`exited` container carrying one of these codes
+ * is the normal result of a stop, not evidence of a failure. Excluded from the
+ * plain-exited → `error` branch below so an explicit Stop reports `stopped`, not
+ * `error`. Genuine crash-loops (a `restarting` container with a non-zero
+ * `restartExitCode`) are caught earlier and are unaffected by this.
+ */
+const STOP_SIGNAL_EXIT_CODES = new Set([137, 143]);
+
+/**
  * Map an app's compose-project container states to a single AppEntry status:
  *   - no containers                                   → stopped
  *   - any restarting after a NON-ZERO exit (crash-loop) → error
  *   - any running / restarting (clean/transient)      → running
- *   - any dead, or exited with a non-zero exit code   → error   (crash)
- *   - else (clean exit / created / paused)            → stopped
+ *   - any dead, or exited with a non-signal non-zero exit code → error (crash)
+ *   - else (clean exit / signal-kill / created / paused) → stopped
  *
  * The crash-loop check comes first and wins over a healthy sibling: a container
  * stuck endlessly restarting on a non-zero exit is not serving, so surfacing it
  * as `error` is more honest than reporting the app `running`. A single clean
  * restart (`Restarting (0) …`) or a container that has already recovered to
  * `running` stays `running` — no flicker for normal transient restarts.
+ *
+ * A plainly-`exited` (non-restarting) container that was killed by a stop signal
+ * (137/143) is treated as stopped, not a crash: it's the expected outcome of an
+ * explicit `docker compose stop` force-killing a container that ignored SIGTERM.
+ * Only `dead`, or an exit with a non-signal non-zero code (a real crash under a
+ * `restart: no` policy), still maps to `error`. See {@link STOP_SIGNAL_EXIT_CODES}.
  */
 export function mapContainerStatesToAppStatus(
   containers: ComposePsContainer[],
@@ -2777,7 +2795,13 @@ export function mapContainerStatesToAppStatus(
   if (containers.some((c) => c.state === 'running' || c.state === 'restarting')) {
     return 'running';
   }
-  if (containers.some((c) => c.state === 'dead' || (c.state === 'exited' && c.exitCode !== 0))) {
+  if (
+    containers.some(
+      (c) =>
+        c.state === 'dead' ||
+        (c.state === 'exited' && c.exitCode !== 0 && !STOP_SIGNAL_EXIT_CODES.has(c.exitCode)),
+    )
+  ) {
     return 'error';
   }
   return 'stopped';

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1802,7 +1802,9 @@ services:
     }
 
     const runningPs = JSON.stringify({ State: 'running', ExitCode: 0 });
-    const crashedPs = JSON.stringify({ State: 'exited', ExitCode: 137 });
+    // A genuine crash under `restart: no`: a non-signal, non-zero exit. (137/143
+    // are stop-signal kills and map to `stopped`, not `error` — see #316.)
+    const crashedPs = JSON.stringify({ State: 'exited', ExitCode: 1 });
 
     it('flips a stale running → stopped when no containers exist (the reported bug)', async () => {
       await registry.upsert({ ...makeEntryFor('ghost-app', 6001), status: 'running' });
@@ -1942,10 +1944,35 @@ services:
           { state: 'running', exitCode: 0 },
         ]),
       ).toBe('running');
-      expect(mapContainerStatesToAppStatus([{ state: 'exited', exitCode: 137 }])).toBe('error');
+      // A real crash under `restart: no` (non-signal, non-zero exit) is error.
+      expect(mapContainerStatesToAppStatus([{ state: 'exited', exitCode: 1 }])).toBe('error');
       expect(mapContainerStatesToAppStatus([{ state: 'dead', exitCode: 0 }])).toBe('error');
       expect(mapContainerStatesToAppStatus([{ state: 'exited', exitCode: 0 }])).toBe('stopped');
       expect(mapContainerStatesToAppStatus([{ state: 'created', exitCode: 0 }])).toBe('stopped');
+    });
+
+    // ─── #316: an explicit Stop that force-kills a container must read `stopped` ──
+    it('treats a signal-killed (137/143) exited container as stopped, not error', () => {
+      // `docker compose stop` SIGKILLs (137) / SIGTERMs (143) a container that
+      // doesn't self-terminate in the grace period — the normal result of a stop,
+      // not a crash. Previously these mapped the app to `error` (bug #316).
+      expect(mapContainerStatesToAppStatus([{ state: 'exited', exitCode: 137 }])).toBe('stopped');
+      expect(mapContainerStatesToAppStatus([{ state: 'exited', exitCode: 143 }])).toBe('stopped');
+      // The exact repro: app+db exit cleanly, the stubborn agent is SIGKILLed.
+      expect(
+        mapContainerStatesToAppStatus([
+          { state: 'exited', exitCode: 0 },
+          { state: 'exited', exitCode: 0 },
+          { state: 'exited', exitCode: 137 },
+        ]),
+      ).toBe('stopped');
+      // A genuine crash sitting alongside a signal-kill still surfaces as error.
+      expect(
+        mapContainerStatesToAppStatus([
+          { state: 'exited', exitCode: 137 },
+          { state: 'exited', exitCode: 1 },
+        ]),
+      ).toBe('error');
     });
 
     // ─── #312: crash-loop must not read as `running` ──────────────────────────


### PR DESCRIPTION
## Summary

Fixes an explicit **Stop** reporting an app's status as `error` instead of `stopped` whenever one of its containers has to be force-killed (SIGKILL/exit 137 or SIGTERM/exit 143) when it doesn't self-terminate within the `docker compose stop` grace period.

`startStopRestart(app, 'stop')` correctly writes `stopped`, but the next status read (`reconcileStatus` → `queryRuntimeStatus` → `mapContainerStatesToAppStatus`) re-derives status from live `docker compose ps` and overwrites it: a plainly-`exited` container with a non-zero exit code mapped the whole app to `error`, without distinguishing a real crash from a stop-induced signal kill.

Closes #316

## Root cause

`src/apps/installer.ts` → `mapContainerStatesToAppStatus()`: the plain-exited branch treated **any** non-zero exit as `error`. Exit 137 (128+9, SIGKILL) and 143 (128+15, SIGTERM) are the expected outcome of a stop force-killing a stubborn container — not a crash.

## Fix

Narrow the plain-exited `error` classification to exclude the stop-signal codes (137/143) via a new `STOP_SIGNAL_EXIT_CODES` set. A cleanly-`exited` container killed by a stop signal now maps to `stopped`; a `dead` container, or an exit with a **non-signal** non-zero code (a genuine crash under `restart: no`), still maps to `error`. The crash-loop path (`restarting` + non-zero `restartExitCode`) from #312/#314 is checked first and is unaffected — no regression.

## Live evidence (reproduced on the running daemon)

```
POST /apps/habit-hero/stop
docker compose -p habit-hero ps -a:
  habit-hero-agent | exited | exit=137   (SIGKILLed on stop timeout)
  habit-hero-app   | exited | exit=0
  habit-hero-db    | exited | exit=0
GET /apps → habit-hero: "error"   ← the bug (expected "stopped")
```

## Tests

- Updated two existing tests that encoded the buggy assumption (used exit 137 as a "crash" example) to use a genuine non-signal crash (exit 1).
- New regression test `treats a signal-killed (137/143) exited container as stopped, not error`: covers exited(137) alone, exited(143) alone, the exact mixed `exited(0)+exited(0)+exited(137)` repro, and a mixed signal-kill + real crash still → `error`.
- **Proven-red**: reverting the fix makes the new test fail (exited(137) → `error`), confirming the regression is real.
- `npm run typecheck` clean · `installer.test.ts` 84/84 · full suite green (pre-existing parallel-worker teardown flake only, `workspace-loader` passes isolated 20/20).

## Docs

- `API.md`: updated the live-status reconciliation note to state that a container force-killed by an explicit stop (137/143) reports `stopped`, and only a non-signal non-zero exit / `dead` reports `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
