### PR TITLE
fix(workspace): a memory write must never drop a live session (#321)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1770,7 +1770,7 @@ Read and write an agent's workspace identity files via the API. The gateway's fi
 | Changed file(s) | Effect on running sessions |
 |-----------------|----------------------------|
 | `MEMORY.md`, `USER.md` (memory) | **No session is restarted.** The change applies on each session's next natural spawn. A memory write can never drop a live session. |
-| `SOUL.md`, `AGENTS.md` (identity) | Busy sessions are skipped; idle sessions are **deferred** (respawn on their next message) — never SIGKILLed mid-idle. |
+| `SOUL.md`, `AGENTS.md`, `IDENTITY.md` (identity) | Busy sessions are skipped; idle sessions are **deferred** (respawn on their next message) — never SIGKILLed mid-idle. |
 | `HEARTBEAT.md` / other | Normal restart-or-defer (idle sessions restart now). |
 
 ### GET /api/v1/agents/:agentId/files/:filename

--- a/API.md
+++ b/API.md
@@ -1761,9 +1761,17 @@ curl -X POST \
 
 ## Workspace File API
 
-Read and write an agent's workspace identity files via the API. The gateway's file watcher auto-reloads `CLAUDE.md` after a write.
+Read and write an agent's workspace identity files via the API. The gateway's file watcher recomposes `CLAUDE.md` on disk after a write.
 
 **Allowed filenames:** `SOUL.md`, `USER.md`, `MEMORY.md`, `AGENTS.md`, `HEARTBEAT.md`, `IDENTITY.md`
+
+**How a write reaches running sessions (frozen-at-spawn).** `CLAUDE.md` is read by a session only at spawn — a live process never re-reads it, so a change applies on the session's **next spawn**. The watcher therefore never SIGKILLs a live session just to push a change; it recomposes `CLAUDE.md` and tiers the restart by change class:
+
+| Changed file(s) | Effect on running sessions |
+|-----------------|----------------------------|
+| `MEMORY.md`, `USER.md` (memory) | **No session is restarted.** The change applies on each session's next natural spawn. A memory write can never drop a live session. |
+| `SOUL.md`, `AGENTS.md` (identity) | Busy sessions are skipped; idle sessions are **deferred** (respawn on their next message) — never SIGKILLed mid-idle. |
+| `HEARTBEAT.md` / other | Normal restart-or-defer (idle sessions restart now). |
 
 ### GET /api/v1/agents/:agentId/files/:filename
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2219,9 +2219,25 @@ export class AgentRunner extends EventEmitter {
    *   restarted so the change reaches them on their next spawn. The recomposed
    *   CLAUDE.md is already on disk, so a skipped busy session picks up the
    *   change on its own next natural spawn.
+   * @param opts.deferIdle When true, idle sessions are NOT `stop()`ed now.
+   *   Instead they are added to the runner-level `pendingRestarts` set, so each
+   *   respawns cleanly on its next message (the same lossless mechanism used for
+   *   the image-size-threshold restart) rather than being SIGKILLed mid-idle and
+   *   losing its in-context state. Since CLAUDE.md is frozen-at-spawn, an idle
+   *   bystander gains nothing from an immediate stop — the recomposed file
+   *   applies on its next spawn either way. Use for agent-writable/identity and
+   *   skills changes, where dropping an unrelated idle session is pure downside.
+   *   NB: idle sessions are deferred via `pendingRestarts`, NOT
+   *   `proc.markPendingRestart()` — the latter emits `deferredRestartReady`
+   *   synchronously on an idle process, which stops it immediately (no deferral).
+   * @returns Counts of sessions handled: `immediate` (stopped now), `deferred`
+   *   (armed to restart on next turn/message), `skipped` (left untouched).
    */
-  async restartOrDefer(opts?: { skipBusy?: boolean }): Promise<void> {
+  async restartOrDefer(
+    opts?: { skipBusy?: boolean; deferIdle?: boolean },
+  ): Promise<{ immediate: number; deferred: number; skipped: number }> {
     const skipBusy = opts?.skipBusy ?? false;
+    const deferIdle = opts?.deferIdle ?? false;
     let immediate = 0;
     let deferred = 0;
     let skipped = 0;
@@ -2233,6 +2249,13 @@ export class AgentRunner extends EventEmitter {
           continue;
         }
         proc.markPendingRestart();
+        deferred++;
+      } else if (deferIdle) {
+        // Lossless deferral: leave the idle process running and arm a restart on
+        // its next message (mirrors the image-size-threshold path). Do NOT call
+        // proc.markPendingRestart() here — on an idle process it fires
+        // deferredRestartReady immediately and stops the session.
+        this.pendingRestarts.add(id);
         deferred++;
       } else {
         toStopNow.push(id);
@@ -2246,6 +2269,7 @@ export class AgentRunner extends EventEmitter {
       immediate++;
     }
     this.logger.info('restartOrDefer: sessions restarted', { immediate, deferred, skipped });
+    return { immediate, deferred, skipped };
   }
 
   /**

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1054,15 +1054,25 @@ export class AgentRunner extends EventEmitter {
           });
         }
 
-        // Restart session before this turn if accumulated image size exceeded threshold
+        // Consume a deferred restart before this turn (armed by the image-size
+        // threshold, or by a workspace/skills change that deferred this idle
+        // session). Guard on isProcessing: this same chatId key can be driven by
+        // a web-UI live-view turn (sendMessageToSession) that does NOT hold
+        // turnActive, so the session may be mid-stream here. Stopping it would
+        // truncate that live turn — instead leave the flag armed and consume it
+        // on the next idle turn. In the normal channel flow the session is idle
+        // at this point (turnActive serialises channel turns), so the guard is a
+        // no-op and the restart proceeds as before.
         if (this.pendingRestarts.has(chatId)) {
           const existingSession = this.sessions.get(chatId);
-          if (existingSession) {
-            await existingSession.stop();
-            this.sessions.delete(chatId);
+          if (!existingSession?.isProcessing) {
+            if (existingSession) {
+              await existingSession.stop();
+              this.sessions.delete(chatId);
+            }
+            this.pendingRestarts.delete(chatId);
+            this.imageSizePerChat.delete(chatId);
           }
-          this.pendingRestarts.delete(chatId);
-          this.imageSizePerChat.delete(chatId);
         }
 
         // Route to session process (map key = chatId, actual sessionId passed separately)
@@ -2250,11 +2260,19 @@ export class AgentRunner extends EventEmitter {
         }
         proc.markPendingRestart();
         deferred++;
-      } else if (deferIdle) {
-        // Lossless deferral: leave the idle process running and arm a restart on
-        // its next message (mirrors the image-size-threshold path). Do NOT call
-        // proc.markPendingRestart() here — on an idle process it fires
-        // deferredRestartReady immediately and stops the session.
+      } else if (deferIdle && proc.source !== 'api') {
+        // Lossless deferral for CHANNEL sessions only: leave the idle process
+        // running and arm a restart on its next message (mirrors the
+        // image-size-threshold path). Do NOT call proc.markPendingRestart() here
+        // — on an idle process it fires deferredRestartReady immediately and
+        // stops the session.
+        //
+        // Guard on source: `pendingRestarts` is consumed ONLY in injectTurn (the
+        // channel turn path, keyed by chatId). api / __heartbeat__ sessions are
+        // keyed by sessionId and never flow through injectTurn, so an entry armed
+        // for them would never be consumed — it would leak in the Set and the
+        // change would never reach the session. Fall through to an immediate stop
+        // so those respawn fresh on their next use, exactly as before deferIdle.
         this.pendingRestarts.add(id);
         deferred++;
       } else {

--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -171,19 +171,59 @@ const WATCH_DEBOUNCE_MS = 300;
 
 /**
  * Canonical workspace files the agent is authorized to write itself, per the
- * memory rule (see MEMORY_RULE above). When ONLY these change, a busy session
- * must not be force-restarted: the change most likely came from that very
- * session mid-turn, and a deferred restart would stop it the moment the turn
- * completes (the self-restart footgun). Idle sessions are still restarted so
- * the change reaches them on their next spawn, and the recomposed CLAUDE.md
- * carries the change into every future spawn regardless.
+ * memory rule (see MEMORY_RULE above), split into two tiers by how urgently a
+ * change needs to reach a running session — and, crucially, by the fact that
+ * CLAUDE.md is frozen-at-spawn (a live process never re-reads it; the recomposed
+ * file applies on the next natural spawn regardless).
+ *
+ * MEMORY_FILES — self-authored data the agent writes about itself/the user
+ *   (MEMORY.md, USER.md). A write here is almost always the running session
+ *   curating its own memory mid-work. Since the process already holds what it
+ *   just wrote and every future spawn reads the recomposed CLAUDE.md, restarting
+ *   ANY session (busy or idle) buys nothing — it only drops in-context state and
+ *   forces a SQLite-replay respawn. Memory-only changes therefore restart
+ *   nothing at all (see the watcher callback in src/index.ts).
+ *
+ * IDENTITY_FILES — operator-authored identity (SOUL.md, AGENTS.md). These want
+ *   to reach sessions "soon-ish", but still never justify SIGKILLing an idle
+ *   bystander: a deferred restart (respawn on next message) is lossless and
+ *   applies the change just as correctly.
+ */
+export const MEMORY_FILES = new Set<string>(['MEMORY.md', 'USER.md']);
+export const IDENTITY_FILES = new Set<string>(['SOUL.md', 'AGENTS.md']);
+
+/**
+ * Union of the two tiers — kept for callers that only need "did the agent write
+ * this itself?" (e.g. the busy-session skip guard).
  */
 export const AGENT_WRITABLE_FILES = new Set<string>([
-  'MEMORY.md',
-  'USER.md',
-  'SOUL.md',
-  'AGENTS.md',
+  ...MEMORY_FILES,
+  ...IDENTITY_FILES,
 ]);
+
+/**
+ * How a workspace change should affect already-running sessions. CLAUDE.md is
+ * always recomposed on disk regardless; this only decides the restart strategy.
+ *
+ *  - `none`        Restart nothing. Self-authored memory (MEMORY.md/USER.md):
+ *                  the writing session already holds the change and every future
+ *                  spawn reads the recomposed CLAUDE.md, so a restart is pure
+ *                  downside. A memory write can never drop a live session.
+ *  - `defer-idle`  Operator identity (SOUL.md/AGENTS.md), possibly mixed with
+ *                  memory files: skip busy sessions (self-restart footgun) and
+ *                  defer idle ones (lossless respawn on next message) — never
+ *                  SIGKILL an idle bystander.
+ *  - `restart`     Any non-agent-writable change (HEARTBEAT.md, operator config,
+ *                  etc.) or an empty change list: today's normal restart-or-defer.
+ */
+export type WorkspaceRestartAction = 'none' | 'defer-idle' | 'restart';
+
+export function classifyWorkspaceRestart(changedFiles: string[]): WorkspaceRestartAction {
+  if (changedFiles.length === 0) return 'restart';
+  if (changedFiles.every((f) => MEMORY_FILES.has(f))) return 'none';
+  if (changedFiles.every((f) => AGENT_WRITABLE_FILES.has(f))) return 'defer-idle';
+  return 'restart';
+}
 
 /**
  * Normalize a changed file path to its canonical uppercase basename, resolving

--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -184,13 +184,16 @@ const WATCH_DEBOUNCE_MS = 300;
  *   forces a SQLite-replay respawn. Memory-only changes therefore restart
  *   nothing at all (see the watcher callback in src/index.ts).
  *
- * IDENTITY_FILES — operator-authored identity (SOUL.md, AGENTS.md). These want
- *   to reach sessions "soon-ish", but still never justify SIGKILLing an idle
- *   bystander: a deferred restart (respawn on next message) is lossless and
- *   applies the change just as correctly.
+ * IDENTITY_FILES — operator-authored identity (SOUL.md, AGENTS.md, IDENTITY.md).
+ *   These want to reach sessions "soon-ish", but still never justify SIGKILLing
+ *   an idle bystander: a deferred restart (respawn on next message) is lossless
+ *   and applies the change just as correctly. IDENTITY.md is API-writable and
+ *   composed into CLAUDE.md exactly like SOUL/AGENTS, so it belongs in this tier
+ *   for the same reason — omitting it would SIGKILL idle sessions on an
+ *   IDENTITY.md write while deferring the semantically identical SOUL write.
  */
 export const MEMORY_FILES = new Set<string>(['MEMORY.md', 'USER.md']);
-export const IDENTITY_FILES = new Set<string>(['SOUL.md', 'AGENTS.md']);
+export const IDENTITY_FILES = new Set<string>(['SOUL.md', 'AGENTS.md', 'IDENTITY.md']);
 
 /**
  * Union of the two tiers — kept for callers that only need "did the agent write
@@ -209,8 +212,8 @@ export const AGENT_WRITABLE_FILES = new Set<string>([
  *                  the writing session already holds the change and every future
  *                  spawn reads the recomposed CLAUDE.md, so a restart is pure
  *                  downside. A memory write can never drop a live session.
- *  - `defer-idle`  Operator identity (SOUL.md/AGENTS.md), possibly mixed with
- *                  memory files: skip busy sessions (self-restart footgun) and
+ *  - `defer-idle`  Operator identity (SOUL.md/AGENTS.md/IDENTITY.md), possibly
+ *                  mixed with memory files: skip busy sessions (self-restart footgun) and
  *                  defer idle ones (lossless respawn on next message) — never
  *                  SIGKILL an idle bystander.
  *  - `restart`     Any non-agent-writable change (HEARTBEAT.md, operator config,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import * as os from 'os';
 
 import { loadConfig } from './config/loader';
 import { detectMigration, applyMigration, loadCleanTemplate } from './config/migrator';
-import { loadWorkspace, watchWorkspace, migrateWorkspaceFiles, AGENT_WRITABLE_FILES } from './agent/workspace-loader';
+import { loadWorkspace, watchWorkspace, migrateWorkspaceFiles, classifyWorkspaceRestart } from './agent/workspace-loader';
 import { watchSkills } from './skills';
 import { syncSharedSkills, syncModuleSkills } from './skills/sync';
 import { createWatcher } from './watch/factory';
@@ -335,22 +335,34 @@ async function startAgent(
       if (updated.skillRegistry) {
         runner.setSkillRegistry(updated.skillRegistry);
       }
-      // Recompose always (above). For the restart, distinguish self-written
-      // files: when ONLY agent-writable files changed (MEMORY/USER/SOUL/AGENTS),
-      // the change most likely came from the running session mid-turn, so skip
-      // restarting busy sessions to avoid the self-restart footgun. Idle
-      // sessions are still restarted; any non-agent-writable file (e.g.
-      // HEARTBEAT.md) restores the normal restart-or-defer behavior.
-      const agentWritableOnly =
-        changedFiles.length > 0 &&
-        changedFiles.every((f) => AGENT_WRITABLE_FILES.has(f));
-      logger.info(
-        agentWritableOnly
-          ? 'Updated CLAUDE.md (agent-writable change), restarting idle sessions only'
-          : 'Updated CLAUDE.md, restarting sessions',
-        { files: changedFiles },
-      );
-      await runner.restartOrDefer({ skipBusy: agentWritableOnly });
+      // CLAUDE.md is always recomposed on disk (above) and is frozen-at-spawn —
+      // a live process never re-reads it; every future spawn picks up the new
+      // content regardless. So the restart decision is purely about how urgently
+      // the change must reach *already-running* sessions, tiered by change class.
+      const restartAction = classifyWorkspaceRestart(changedFiles);
+      if (restartAction === 'none') {
+        // Self-authored memory (MEMORY.md/USER.md): the running session already
+        // holds what it just wrote, and every future spawn reads the recomposed
+        // CLAUDE.md. Restarting anything is pure downside (dropped in-context
+        // state + SQLite replay). Restart NOTHING — this is the whole bug fix:
+        // a memory write can never drop a live session again.
+        logger.info('Updated CLAUDE.md (memory-only change), no session restart', {
+          files: changedFiles,
+        });
+      } else if (restartAction === 'defer-idle') {
+        // Operator identity (SOUL.md/AGENTS.md): reach sessions soon-ish, but
+        // never SIGKILL an idle bystander. Skip busy (self-restart footgun) and
+        // defer idle (lossless respawn on next message).
+        logger.info('Updated CLAUDE.md (identity change), deferring restarts', {
+          files: changedFiles,
+        });
+        await runner.restartOrDefer({ skipBusy: true, deferIdle: true });
+      } else {
+        // Non-writable change (HEARTBEAT.md, operator config, anything else):
+        // keep the normal restart-or-defer behavior.
+        logger.info('Updated CLAUDE.md, restarting sessions', { files: changedFiles });
+        await runner.restartOrDefer({ skipBusy: false });
+      }
       scheduler.load(updated.files.heartbeatMd);
     } catch (err) {
       logger.error('Failed to reload workspace', { error: (err as Error).message });
@@ -378,14 +390,17 @@ async function startAgent(
           updated.systemPrompt,
           'utf8',
         );
-        // Stop idle subprocesses now so they pick up the new registry on
-        // next spawn. Busy sessions are left running (skipBusy) rather than
-        // marked for a deferred restart: a session that triggers a SKILL.md
-        // change mid-turn would otherwise stop itself the instant its turn
-        // completes (the self-restart footgun — same guard the workspace
-        // watcher applies above). The recomposed CLAUDE.md is already on disk,
-        // so a skipped busy session picks up the change on its next spawn.
-        await runner.restartOrDefer({ skipBusy: true });
+        // Refresh the skills registry for future spawns without dropping any
+        // live session. Busy sessions are left running (skipBusy) — a session
+        // that triggers a SKILL.md change mid-turn would otherwise stop itself
+        // the instant its turn completes (the self-restart footgun). Idle
+        // sessions are DEFERRED (deferIdle) rather than SIGKILLed: the skills
+        // section of CLAUDE.md is frozen-at-spawn and the registry applies on
+        // next spawn, so killing an idle bystander now buys nothing and only
+        // drops its in-context state. Auto skill-learning writes skills mid-work,
+        // so this keeps unrelated idle sessions alive. Both pick up the change
+        // on their next spawn (busy: next natural spawn; idle: next message).
+        await runner.restartOrDefer({ skipBusy: true, deferIdle: true });
         logger.info('Skills registry updated', {
           count: updated.skillRegistry?.skills.size ?? 0,
         });

--- a/tests/integration/memory-write-no-restart.test.ts
+++ b/tests/integration/memory-write-no-restart.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Integration tests for the memory-write session-drop fix (issue #321):
+ * an agent editing its own MEMORY.md/USER.md must NOT drop any live session.
+ *
+ * The workspace watcher recomposes CLAUDE.md (frozen-at-spawn) on every change,
+ * then decides a restart strategy by change class (classifyWorkspaceRestart):
+ *   - memory-only (MEMORY.md/USER.md) → restart NOTHING (the bug fix)
+ *   - identity (SOUL.md/AGENTS.md)    → skipBusy + deferIdle (never SIGKILL idle)
+ *   - non-writable (HEARTBEAT.md/...) → normal restart-or-defer (unchanged)
+ *
+ * This mirrors the src/index.ts watchWorkspace callback while keeping the
+ * subprocess layer mocked (same child_process jest mock as the runner tests).
+ *
+ * MW1 — MEMORY.md write stops ZERO sessions (idle bystander survives, untouched)
+ * MW2 — SOUL.md (identity) change defers the idle session (armed, not stopped)
+ * MW3 — a non-writable .md change keeps today's behavior (idle session stopped)
+ */
+
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── Mock child_process to prevent real subprocess spawns ──────────────────────
+
+interface MockStdin {
+  writable: boolean;
+  write: jest.Mock;
+}
+
+interface MockChildProcess extends EventEmitter {
+  stdin: MockStdin | null;
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+}
+
+const allProcesses: MockChildProcess[] = [];
+
+function makeMockProcess(): MockChildProcess {
+  const stdin: MockStdin = { writable: true, write: jest.fn() };
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdin = stdin;
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.killed = false;
+  proc.pid = Math.floor(Math.random() * 90000) + 10000;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = true;
+    process.nextTick(() => proc.emit('exit', 0, signal ?? 'SIGTERM'));
+    return true;
+  });
+
+  allProcesses.push(proc);
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn((..._args) => makeMockProcess()),
+}));
+
+// ── Imports (after jest.mock) ─────────────────────────────────────────────────
+
+import { AgentRunner } from '../../src/agent/runner';
+import {
+  loadWorkspace,
+  watchWorkspace,
+  classifyWorkspaceRestart,
+} from '../../src/agent/workspace-loader';
+import { AgentConfig, GatewayConfig } from '../../src/types';
+import { SessionProcess } from '../../src/session/process';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAgentConfig(workspace: string): AgentConfig {
+  return {
+    id: 'alfred',
+    description: 'memory-write integration agent',
+    workspace,
+    env: '',
+    telegram: { botToken: 'test-token' },
+    claude: { model: 'claude-opus-4-6', dangerouslySkipPermissions: false, extraFlags: [] },
+  };
+}
+
+function makeGatewayConfig(): GatewayConfig {
+  return { gateway: { logDir: '/tmp/test-mw-logs', timezone: 'UTC' }, agents: [] };
+}
+
+async function sendChannelPost(port: number, chatId: string, content: string): Promise<void> {
+  await fetch(`http://127.0.0.1:${port}/channel`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      content,
+      meta: { chat_id: chatId, message_id: '1', user: 'tester', ts: new Date().toISOString() },
+    }),
+  });
+}
+
+function getCallbackPort(runner: AgentRunner): number {
+  return (runner as unknown as { callbackPort: number }).callbackPort;
+}
+
+function getSessions(runner: AgentRunner): Map<string, SessionProcess> {
+  return (runner as unknown as { sessions: Map<string, SessionProcess> }).sessions;
+}
+
+function hasPendingRestart(runner: AgentRunner, chatId: string): boolean {
+  return (runner as unknown as { pendingRestarts: Set<string> }).pendingRestarts.has(chatId);
+}
+
+async function waitForCondition(predicate: () => boolean, timeoutMs = 3000, intervalMs = 25): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (predicate()) return;
+    } catch {
+      // keep polling while files settle
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+}
+
+// Faithful mirror of the src/index.ts watchWorkspace callback: always recompose
+// CLAUDE.md, then branch the restart strategy on classifyWorkspaceRestart.
+function wireWorkspaceWatcher(
+  runner: AgentRunner,
+  workspaceDir: string,
+  opts: { mcpToolsDir: string; sharedSkillsDir: string },
+): { close: () => Promise<void> | void } {
+  return watchWorkspace(workspaceDir, async (changedFiles) => {
+    const updated = await loadWorkspace(workspaceDir, opts);
+    await fs.promises.writeFile(path.join(workspaceDir, 'CLAUDE.md'), updated.systemPrompt, 'utf8');
+    const action = classifyWorkspaceRestart(changedFiles);
+    if (action === 'none') {
+      // memory-only: restart nothing
+    } else if (action === 'defer-idle') {
+      await runner.restartOrDefer({ skipBusy: true, deferIdle: true });
+    } else {
+      await runner.restartOrDefer({ skipBusy: false });
+    }
+  });
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+describe('Memory-write session-drop fix (issue #321)', () => {
+  let tmpRoot: string;
+  let workspaceDir: string;
+  let sharedSkillsDir: string;
+  let mcpToolsDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+  let watcher: { close: () => Promise<void> | void };
+
+  beforeEach(() => {
+    process.env.CHANNEL_COALESCE_WINDOW_MS = '20';
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mw-restart-'));
+    workspaceDir = path.join(tmpRoot, 'workspace');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    // Standard workspace files so loadWorkspace succeeds and the watched *.md set
+    // exists before the watcher attaches.
+    fs.writeFileSync(path.join(workspaceDir, 'AGENTS.md'), '# Integration Agent\n');
+    fs.writeFileSync(path.join(workspaceDir, 'SOUL.md'), '# Soul\ninitial identity\n');
+    fs.writeFileSync(path.join(workspaceDir, 'MEMORY.md'), '# Memory\ninitial memory\n');
+    fs.writeFileSync(path.join(workspaceDir, 'HEARTBEAT.md'), '# Heartbeat\ninitial\n');
+    fs.mkdirSync(path.join(workspaceDir, 'skills'), { recursive: true });
+
+    sharedSkillsDir = path.join(tmpRoot, 'shared-skills');
+    fs.mkdirSync(sharedSkillsDir, { recursive: true });
+    mcpToolsDir = path.join(tmpRoot, 'mcp-tools');
+    fs.mkdirSync(mcpToolsDir, { recursive: true });
+
+    agentConfig = makeAgentConfig(workspaceDir);
+    gatewayConfig = makeGatewayConfig();
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    await watcher?.close();
+    if (runner) await runner.stop();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    jest.clearAllMocks();
+    delete process.env.CHANNEL_COALESCE_WINDOW_MS;
+  });
+
+  async function bootIdleSession(chatId: string): Promise<SessionProcess> {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, chatId, 'hello');
+    await new Promise((r) => setTimeout(r, 100));
+    const sess = getSessions(runner).get(chatId)!;
+    expect(sess).toBeDefined();
+    sess.setProcessing(false); // idle bystander
+    return sess;
+  }
+
+  // MW1 — THE bug regression: a MEMORY.md write must stop zero sessions.
+  it('MW1: writing MEMORY.md stops zero sessions (idle bystander survives)', async () => {
+    const sess = await bootIdleSession('chat:mw1');
+    const stopSpy = jest.spyOn(sess, 'stop');
+    const restartSpy = jest.spyOn(runner, 'restartOrDefer');
+
+    watcher = wireWorkspaceWatcher(runner, workspaceDir, { mcpToolsDir, sharedSkillsDir });
+    await new Promise((r) => setTimeout(r, 150));
+
+    fs.writeFileSync(path.join(workspaceDir, 'MEMORY.md'), '# Memory\nfact learned by the agent\n');
+
+    // CLAUDE.md is recomposed with the new memory (frozen-at-spawn contract).
+    await waitForCondition(() =>
+      fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8').includes('fact learned by the agent'),
+    );
+    // Let any (mistaken) restart settle before asserting the negative.
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The whole fix: no restart path is taken, no session is stopped or dropped.
+    expect(restartSpy).not.toHaveBeenCalled();
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:mw1')).toBe(true);
+    expect(hasPendingRestart(runner, 'chat:mw1')).toBe(false);
+  }, 10000);
+
+  // MW2 — identity change defers the idle session (armed, never SIGKILLed).
+  it('MW2: writing SOUL.md defers the idle session (armed, not stopped)', async () => {
+    const sess = await bootIdleSession('chat:mw2');
+    const stopSpy = jest.spyOn(sess, 'stop');
+
+    watcher = wireWorkspaceWatcher(runner, workspaceDir, { mcpToolsDir, sharedSkillsDir });
+    await new Promise((r) => setTimeout(r, 150));
+
+    fs.writeFileSync(path.join(workspaceDir, 'SOUL.md'), '# Soul\nrevised identity\n');
+
+    await waitForCondition(() => hasPendingRestart(runner, 'chat:mw2'));
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:mw2')).toBe(true);
+    const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain('revised identity');
+  }, 10000);
+
+  // MW3 — a non-writable .md change keeps today's behavior (idle stopped).
+  it('MW3: writing a non-writable .md still restarts the idle session (no regression)', async () => {
+    await bootIdleSession('chat:mw3');
+
+    watcher = wireWorkspaceWatcher(runner, workspaceDir, { mcpToolsDir, sharedSkillsDir });
+    await new Promise((r) => setTimeout(r, 150));
+
+    fs.writeFileSync(path.join(workspaceDir, 'HEARTBEAT.md'), '# Heartbeat\nchanged\n');
+
+    // Non-writable change → idle session is stopped and removed (unchanged path).
+    await waitForCondition(() => !getSessions(runner).has('chat:mw3'));
+    expect(getSessions(runner).has('chat:mw3')).toBe(false);
+  }, 10000);
+});

--- a/tests/integration/skills-hot-reload.test.ts
+++ b/tests/integration/skills-hot-reload.test.ts
@@ -147,8 +147,11 @@ function deleteSkillFile(dir: string, name: string): void {
 // Replicates the inline watcher callback in src/index.ts so the integration
 // test exercises the same sequence (reload -> setSkillRegistry ->
 // write CLAUDE.md -> restartOrDefer). Must stay a faithful mirror of the
-// production callback, including the skipBusy:true guard on the skills path
-// (skipping busy sessions avoids the self-restart footgun — see HR6).
+// production callback, including the { skipBusy: true, deferIdle: true } guard
+// on the skills path: skipBusy avoids the self-restart footgun for the busy
+// authoring session (see HR6), and deferIdle keeps idle bystanders alive
+// (armed for a lossless respawn on their next message) instead of SIGKILLing
+// them for zero benefit — CLAUDE.md's skills section is frozen-at-spawn.
 function wireSkillsWatcher(
   runner: AgentRunner,
   workspaceDir: string,
@@ -172,9 +175,15 @@ function wireSkillsWatcher(
         updated.systemPrompt,
         'utf8',
       );
-      await runner.restartOrDefer({ skipBusy: true });
+      await runner.restartOrDefer({ skipBusy: true, deferIdle: true });
     },
   });
+}
+
+// Read the runner's private pendingRestarts set (armed idle sessions that will
+// respawn on their next message). Used to assert deferral instead of stop.
+function hasPendingRestart(runner: AgentRunner, chatId: string): boolean {
+  return (runner as unknown as { pendingRestarts: Set<string> }).pendingRestarts.has(chatId);
 }
 
 async function waitForCondition(
@@ -255,9 +264,11 @@ describe('Skills hot-reload end-to-end', () => {
   }
 
   // --------------------------------------------------------------------------
-  // HR1 — add shared skill triggers restart of idle session
+  // HR1 — add shared skill DEFERS idle session (armed, not SIGKILLed) + updates
+  //       CLAUDE.md. The idle bystander stays in the pool and respawns on its
+  //       next message; killing it now would buy nothing (frozen-at-spawn).
   // --------------------------------------------------------------------------
-  it('HR1: adding a shared skill stops idle session and updates CLAUDE.md', async () => {
+  it('HR1: adding a shared skill defers idle session (not stopped) and updates CLAUDE.md', async () => {
     await bootRunnerWithIdleSession('chat:hr1');
     watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
 
@@ -265,7 +276,10 @@ describe('Skills hot-reload end-to-end', () => {
     await new Promise((r) => setTimeout(r, 150));
     writeSkillFile(sharedSkillsDir, 'hr1-skill');
 
-    await waitForCondition(() => !getSessions(runner).has('chat:hr1'));
+    // The onChange armed a deferred restart rather than stopping the session.
+    await waitForCondition(() => hasPendingRestart(runner, 'chat:hr1'));
+    // Idle bystander is NOT dropped from the pool — it is still alive, armed.
+    expect(getSessions(runner).has('chat:hr1')).toBe(true);
 
     const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
     expect(claudeMd).toContain('/hr1-skill');
@@ -273,9 +287,9 @@ describe('Skills hot-reload end-to-end', () => {
   }, 10000);
 
   // --------------------------------------------------------------------------
-  // HR2 — modifying a shared skill triggers restart
+  // HR2 — modifying a shared skill defers idle session (not stopped)
   // --------------------------------------------------------------------------
-  it('HR2: modifying a shared skill stops idle session', async () => {
+  it('HR2: modifying a shared skill defers idle session (not stopped)', async () => {
     // Seed the skill BEFORE the watcher so the "add" event doesn't fire.
     writeSkillFile(sharedSkillsDir, 'hr2-skill');
 
@@ -290,16 +304,17 @@ describe('Skills hot-reload end-to-end', () => {
       `---\nname: hr2-skill\ndescription: updated description\nuser-invocable: true\n---\n\n# hr2-skill v2\n`,
     );
 
-    await waitForCondition(() => !getSessions(runner).has('chat:hr2'));
+    await waitForCondition(() => hasPendingRestart(runner, 'chat:hr2'));
+    expect(getSessions(runner).has('chat:hr2')).toBe(true);
 
     const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
     expect(claudeMd).toContain('updated description');
   }, 10000);
 
   // --------------------------------------------------------------------------
-  // HR3 — deleting a shared skill triggers restart
+  // HR3 — deleting a shared skill defers idle session + removes from CLAUDE.md
   // --------------------------------------------------------------------------
-  it('HR3: deleting a shared skill stops idle session and removes skill from CLAUDE.md', async () => {
+  it('HR3: deleting a shared skill defers idle session and removes skill from CLAUDE.md', async () => {
     writeSkillFile(sharedSkillsDir, 'hr3-skill');
 
     await bootRunnerWithIdleSession('chat:hr3');
@@ -308,7 +323,8 @@ describe('Skills hot-reload end-to-end', () => {
 
     deleteSkillFile(sharedSkillsDir, 'hr3-skill');
 
-    await waitForCondition(() => !getSessions(runner).has('chat:hr3'));
+    await waitForCondition(() => hasPendingRestart(runner, 'chat:hr3'));
+    expect(getSessions(runner).has('chat:hr3')).toBe(true);
 
     const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
     expect(claudeMd).not.toContain('/hr3-skill');
@@ -344,9 +360,9 @@ describe('Skills hot-reload end-to-end', () => {
   }, 10000);
 
   // --------------------------------------------------------------------------
-  // HR5 — workspace-dir skill change also triggers restart
+  // HR5 — workspace-dir skill change also defers the idle session
   // --------------------------------------------------------------------------
-  it('HR5: skill added under workspace skills dir also triggers restart', async () => {
+  it('HR5: skill added under workspace skills dir also defers idle session', async () => {
     await bootRunnerWithIdleSession('chat:hr5');
     watcher = wireSkillsWatcher(runner, workspaceDir, sharedSkillsDir, mcpToolsDir);
     await new Promise((r) => setTimeout(r, 150));
@@ -355,7 +371,8 @@ describe('Skills hot-reload end-to-end', () => {
     const workspaceSkillsDir = path.join(workspaceDir, 'skills');
     writeSkillFile(workspaceSkillsDir, 'hr5-skill');
 
-    await waitForCondition(() => !getSessions(runner).has('chat:hr5'));
+    await waitForCondition(() => hasPendingRestart(runner, 'chat:hr5'));
+    expect(getSessions(runner).has('chat:hr5')).toBe(true);
 
     const claudeMd = fs.readFileSync(path.join(workspaceDir, 'CLAUDE.md'), 'utf8');
     expect(claudeMd).toContain('/hr5-skill');

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -641,7 +641,11 @@ describe('AgentRunner — restartOrDefer', () => {
     await runner.start();
 
     expect(getSessions(runner).size).toBe(0);
-    await expect(runner.restartOrDefer()).resolves.toBeUndefined();
+    await expect(runner.restartOrDefer()).resolves.toEqual({
+      immediate: 0,
+      deferred: 0,
+      skipped: 0,
+    });
     expect(getSessions(runner).size).toBe(0);
   }, 15000);
 
@@ -736,6 +740,67 @@ describe('AgentRunner — restartOrDefer', () => {
     sessB.setProcessing(false);
     await new Promise(r => setTimeout(r, 50));
     expect(getSessions(runner).has('chat:b')).toBe(true);
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS8: deferIdle — idle session is NOT stopped now; it is armed in
+  //      pendingRestarts to respawn losslessly on its next message (issue #321).
+  // --------------------------------------------------------------------------
+  it('RS8: deferIdle defers idle sessions (armed, not stopped) instead of SIGKILL', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:idle', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:idle')!;
+    sess.setProcessing(false); // idle bystander
+    const stopSpy = jest.spyOn(sess, 'stop');
+    const pending = (runner as unknown as { pendingRestarts: Set<string> }).pendingRestarts;
+
+    const counts = await runner.restartOrDefer({ deferIdle: true });
+
+    // Idle session is neither stopped nor removed — it stays alive, armed.
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:idle')).toBe(true);
+    expect(pending.has('chat:idle')).toBe(true);
+    expect(counts).toEqual({ immediate: 0, deferred: 1, skipped: 0 });
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS9: skipBusy + deferIdle (the memory/skills change combo) — busy skipped,
+  //      idle deferred; ZERO immediate stops. This is the acceptance shape for
+  //      "a memory/skills write drops no live session".
+  // --------------------------------------------------------------------------
+  it('RS9: skipBusy+deferIdle stops nothing (busy skipped, idle deferred)', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:idle', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+    await sendChannelPost(port, 'chat:busy', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const idle = getSessions(runner).get('chat:idle')!;
+    const busy = getSessions(runner).get('chat:busy')!;
+    idle.setProcessing(false);
+    busy.setProcessing(true);
+    const idleStop = jest.spyOn(idle, 'stop');
+    const busyStop = jest.spyOn(busy, 'stop');
+    const pending = (runner as unknown as { pendingRestarts: Set<string> }).pendingRestarts;
+
+    const counts = await runner.restartOrDefer({ skipBusy: true, deferIdle: true });
+
+    // Nothing SIGKILLed: idle deferred, busy skipped.
+    expect(idleStop).not.toHaveBeenCalled();
+    expect(busyStop).not.toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:idle')).toBe(true);
+    expect(getSessions(runner).has('chat:busy')).toBe(true);
+    expect(pending.has('chat:idle')).toBe(true);
+    expect(pending.has('chat:busy')).toBe(false); // busy was skipped, not armed
+    expect(counts).toEqual({ immediate: 0, deferred: 1, skipped: 1 });
   }, 15000);
 });
 

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -802,6 +802,75 @@ describe('AgentRunner — restartOrDefer', () => {
     expect(pending.has('chat:busy')).toBe(false); // busy was skipped, not armed
     expect(counts).toEqual({ immediate: 0, deferred: 1, skipped: 1 });
   }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS10: deferIdle must NOT arm api/__heartbeat__ sessions. Their key never
+  //       flows through injectTurn (the only pendingRestarts consumer), so an
+  //       entry there would leak forever and the change would never reach them.
+  //       They are stopped now instead, so they respawn fresh (as before #321).
+  // --------------------------------------------------------------------------
+  it('RS10: deferIdle stops an idle api session now (not armed) — key is never consumed', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:api', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:api')!;
+    sess.setProcessing(false); // idle
+    // Simulate an api/__heartbeat__ session (keyed by sessionId, not a chatId).
+    (sess as unknown as { source: string }).source = 'api';
+    const stopSpy = jest.spyOn(sess, 'stop');
+    const pending = (runner as unknown as { pendingRestarts: Set<string> }).pendingRestarts;
+
+    const counts = await runner.restartOrDefer({ deferIdle: true });
+
+    // Stopped now (respawn fresh), NOT armed in pendingRestarts (no leak).
+    expect(stopSpy).toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:api')).toBe(false);
+    expect(pending.has('chat:api')).toBe(false);
+    expect(counts).toEqual({ immediate: 1, deferred: 0, skipped: 0 });
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS11: consume guard — a deferred restart must NOT be consumed while the
+  //       session is mid-turn. The same chatId key can be streaming a web-UI
+  //       live-view turn (sendMessageToSession, which does not hold turnActive),
+  //       so an unguarded stop() at the injectTurn consume would truncate it.
+  //       The flag stays armed and is consumed on the next idle turn instead.
+  // --------------------------------------------------------------------------
+  it('RS11: an armed restart is not consumed mid-turn (web-UI live view), stays armed', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:web', 'hi');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:web')!;
+    const pending = (runner as unknown as { pendingRestarts: Set<string> }).pendingRestarts;
+    const stopSpy = jest.spyOn(sess, 'stop');
+
+    // Arm a deferred restart and simulate a concurrent web-UI turn on this key
+    // (isProcessing = true, no turnActive).
+    pending.add('chat:web');
+    sess.setProcessing(true);
+
+    // Drive the consume path as an incoming channel message would (injectTurn is
+    // fire-and-forget/void).
+    (runner as unknown as {
+      injectTurn: (c: string, s: string, e: Array<{ content?: string; meta?: Record<string, string> }>) => void;
+    }).injectTurn('chat:web', 'telegram', [
+      { content: 'concurrent channel message', meta: { chat_id: 'chat:web', message_id: '9', user: 't', ts: new Date().toISOString() } },
+    ]);
+    await new Promise(r => setTimeout(r, 200));
+
+    // The mid-turn session was NOT stopped, and the restart is still armed.
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:web')).toBe(true);
+    expect(pending.has('chat:web')).toBe(true);
+  }, 15000);
 });
 
 // ── Typing error notification tests ───────────────────────────────────────────

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -290,15 +290,16 @@ describe('workspace-loader', () => {
   // -------------------------------------------------------------------------
   // Self-restart footgun guard: agent-writable files skip busy-session restart
   // -------------------------------------------------------------------------
-  it('AGENT_WRITABLE_FILES: contains all 4 memory-rule files, not HEARTBEAT/IDENTITY/CLAUDE', () => {
-    // Files the memory rule authorizes the agent to write
+  it('AGENT_WRITABLE_FILES: contains the memory + identity tiers (incl. IDENTITY.md), not HEARTBEAT/CLAUDE', () => {
+    // Memory-rule files the agent writes about itself/the user
     expect(AGENT_WRITABLE_FILES.has('MEMORY.md')).toBe(true);
     expect(AGENT_WRITABLE_FILES.has('USER.md')).toBe(true);
+    // Operator identity composed into CLAUDE.md — deferred, never SIGKILLed idle
     expect(AGENT_WRITABLE_FILES.has('SOUL.md')).toBe(true);
     expect(AGENT_WRITABLE_FILES.has('AGENTS.md')).toBe(true);
-    // Files NOT self-written → still trigger a normal restart-or-defer
+    expect(AGENT_WRITABLE_FILES.has('IDENTITY.md')).toBe(true);
+    // Files outside both tiers → still trigger a normal restart-or-defer
     expect(AGENT_WRITABLE_FILES.has('HEARTBEAT.md')).toBe(false);
-    expect(AGENT_WRITABLE_FILES.has('IDENTITY.md')).toBe(false);
     expect(AGENT_WRITABLE_FILES.has('CLAUDE.md')).toBe(false);
   });
 
@@ -307,7 +308,7 @@ describe('workspace-loader', () => {
   // -------------------------------------------------------------------------
   it('MEMORY_FILES/IDENTITY_FILES: partition the writable set correctly', () => {
     expect([...MEMORY_FILES].sort()).toEqual(['MEMORY.md', 'USER.md']);
-    expect([...IDENTITY_FILES].sort()).toEqual(['AGENTS.md', 'SOUL.md']);
+    expect([...IDENTITY_FILES].sort()).toEqual(['AGENTS.md', 'IDENTITY.md', 'SOUL.md']);
     // The two tiers are disjoint and their union is exactly AGENT_WRITABLE_FILES.
     for (const f of MEMORY_FILES) expect(IDENTITY_FILES.has(f)).toBe(false);
     expect([...AGENT_WRITABLE_FILES].sort()).toEqual(
@@ -328,6 +329,11 @@ describe('workspace-loader', () => {
   it('classifyWorkspaceRestart: identity change (or mixed with memory) defers idle', () => {
     expect(classifyWorkspaceRestart(['SOUL.md'])).toBe('defer-idle');
     expect(classifyWorkspaceRestart(['AGENTS.md'])).toBe('defer-idle');
+    // IDENTITY.md is API-writable + composed into CLAUDE.md exactly like
+    // SOUL/AGENTS, so it must defer idle sessions — not SIGKILL them (issue #321
+    // follow-up: it was previously omitted from the identity tier).
+    expect(classifyWorkspaceRestart(['IDENTITY.md'])).toBe('defer-idle');
+    expect(classifyWorkspaceRestart(['SOUL.md', 'IDENTITY.md'])).toBe('defer-idle');
     // A mix of memory + identity is NOT memory-only → must not restart nothing;
     // identity presence pulls it into the deferred tier.
     expect(classifyWorkspaceRestart(['MEMORY.md', 'SOUL.md'])).toBe('defer-idle');
@@ -357,6 +363,39 @@ describe('workspace-loader', () => {
         expect(all).toContain('MEMORY.md');
         // self-written-only change → every changed file is agent-writable
         expect(all.every((f) => AGENT_WRITABLE_FILES.has(f))).toBe(true);
+      } finally {
+        handle.close();
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it('watchWorkspace: a lowercase memory.md write reaches classify() as MEMORY.md → none (end-to-end)', async () => {
+    // Guards the full path: a lowercase alias write must be canonicalized to
+    // MEMORY.md before classifyWorkspaceRestart sees it, so it classifies 'none'
+    // (restart nothing) — not mis-routed to 'restart' because 'memory.md' is not
+    // a MEMORY_FILES member. Proves the two halves (canonicalize + classify)
+    // compose correctly through the real watcher.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-lc-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), '# Agent');
+
+      const batches: string[][] = [];
+      const handle = watchWorkspace(tmpDir, (changed) => { batches.push(changed); });
+
+      try {
+        await handle.ready;
+        // Lowercase alias write — the watcher auto-renames to MEMORY.md.
+        fs.writeFileSync(path.join(tmpDir, 'memory.md'), 'a fact the agent learned');
+        await waitFor(() => batches.flat().includes('MEMORY.md'), 5000);
+
+        const changed = batches.flat();
+        // Canonicalized, not the raw lowercase name.
+        expect(changed).toContain('MEMORY.md');
+        expect(changed).not.toContain('memory.md');
+        // And the canonical batch classifies as a memory-only change (no restart).
+        expect(classifyWorkspaceRestart(changed)).toBe('none');
       } finally {
         handle.close();
       }

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -6,6 +6,9 @@ import {
   migrateWorkspaceFiles,
   watchWorkspace,
   AGENT_WRITABLE_FILES,
+  MEMORY_FILES,
+  IDENTITY_FILES,
+  classifyWorkspaceRestart,
   MissingRequiredFileError,
 } from '../../src/agent/workspace-loader';
 import { waitFor } from '../helpers/wait-for';
@@ -297,6 +300,43 @@ describe('workspace-loader', () => {
     expect(AGENT_WRITABLE_FILES.has('HEARTBEAT.md')).toBe(false);
     expect(AGENT_WRITABLE_FILES.has('IDENTITY.md')).toBe(false);
     expect(AGENT_WRITABLE_FILES.has('CLAUDE.md')).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Tiered writable sets: memory vs identity (issue #321)
+  // -------------------------------------------------------------------------
+  it('MEMORY_FILES/IDENTITY_FILES: partition the writable set correctly', () => {
+    expect([...MEMORY_FILES].sort()).toEqual(['MEMORY.md', 'USER.md']);
+    expect([...IDENTITY_FILES].sort()).toEqual(['AGENTS.md', 'SOUL.md']);
+    // The two tiers are disjoint and their union is exactly AGENT_WRITABLE_FILES.
+    for (const f of MEMORY_FILES) expect(IDENTITY_FILES.has(f)).toBe(false);
+    expect([...AGENT_WRITABLE_FILES].sort()).toEqual(
+      [...MEMORY_FILES, ...IDENTITY_FILES].sort(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // classifyWorkspaceRestart — the change-class → restart-strategy decision
+  // that fixes the memory-write session-drop bug (issue #321).
+  // -------------------------------------------------------------------------
+  it('classifyWorkspaceRestart: memory-only change restarts NOTHING (none)', () => {
+    expect(classifyWorkspaceRestart(['MEMORY.md'])).toBe('none');
+    expect(classifyWorkspaceRestart(['USER.md'])).toBe('none');
+    expect(classifyWorkspaceRestart(['MEMORY.md', 'USER.md'])).toBe('none');
+  });
+
+  it('classifyWorkspaceRestart: identity change (or mixed with memory) defers idle', () => {
+    expect(classifyWorkspaceRestart(['SOUL.md'])).toBe('defer-idle');
+    expect(classifyWorkspaceRestart(['AGENTS.md'])).toBe('defer-idle');
+    // A mix of memory + identity is NOT memory-only → must not restart nothing;
+    // identity presence pulls it into the deferred tier.
+    expect(classifyWorkspaceRestart(['MEMORY.md', 'SOUL.md'])).toBe('defer-idle');
+  });
+
+  it('classifyWorkspaceRestart: non-writable or empty change → normal restart', () => {
+    expect(classifyWorkspaceRestart(['HEARTBEAT.md'])).toBe('restart');
+    expect(classifyWorkspaceRestart(['MEMORY.md', 'HEARTBEAT.md'])).toBe('restart');
+    expect(classifyWorkspaceRestart([])).toBe('restart');
   });
 
   it('watchWorkspace: onChange receives canonical changed filename (MEMORY.md)', async () => {


### PR DESCRIPTION
## Summary

Fixes the reported bug where an agent updating its own `MEMORY.md`/`USER.md` drops live sessions. The workspace watcher recomposed `CLAUDE.md` and called `restartOrDefer({ skipBusy: true })`, which **immediately `stop()`ed (SIGKILL) every idle session** in the pool while sparing only the busy authoring session. Since `CLAUDE.md` is **frozen-at-spawn** (a live process never re-reads it — the recomposed file applies on the next natural spawn), the restart bought nothing and was pure downside (dropped in-context state + SQLite-replay respawn).

This is Part A / P0 of planning-63 — it ships alone; the memory-budget and dreaming parts are separate later phases.

Closes #321

## Root cause (verified against `main`)

- `src/index.ts` workspace callback: always rewrites `CLAUDE.md`, then `restartOrDefer({ skipBusy: agentWritableOnly })`.
- `src/agent/runner.ts` `restartOrDefer`: busy sessions are skipped/deferred, but **idle sessions are unconditionally `stop()`ed + deleted** — no path spares them.
- Design pitfall found during grounding: a naive "mark idle as pending-restart" does **not** defer — `SessionProcess.markPendingRestart()` on an idle process emits `deferredRestartReady` synchronously, whose handler stops it immediately. The correct lossless deferral is the runner-level `pendingRestarts` set (respawn on next message), the same mechanism used for the image-size-threshold restart.

## Changes

- **`workspace-loader.ts`** — split `AGENT_WRITABLE_FILES` into `MEMORY_FILES {MEMORY.md, USER.md}` and `IDENTITY_FILES {SOUL.md, AGENTS.md}` (union preserved for existing callers); add pure `classifyWorkspaceRestart(changedFiles) → 'none' | 'defer-idle' | 'restart'`.
- **`runner.ts`** — `restartOrDefer` gains a `deferIdle` option (idle → `pendingRestarts.add`, lossless respawn on next message, never SIGKILL) and now returns `{ immediate, deferred, skipped }` for observability.
- **`index.ts`** — workspace callback branches on change class: memory-only → **restart nothing**; identity → `{ skipBusy: true, deferIdle: true }`; non-writable → unchanged normal restart-or-defer.
- **`index.ts`** — skills `onChange` uses `{ skipBusy: true, deferIdle: true }` too (same footgun; auto skill-learning writes skills mid-work and would otherwise churn idle bystanders).
- **`API.md`** — documents the frozen-at-spawn / no-restart-on-memory contract as a change-class table.

## Tests

- **Unit** — `classifyWorkspaceRestart` (memory→none, identity/mixed→defer-idle, non-writable/empty→restart); tier-set partition; `restartOrDefer` RS8 (deferIdle arms idle, no stop) + RS9 (skipBusy+deferIdle stops nothing).
- **Integration** — new `tests/integration/memory-write-no-restart.test.ts`: **MW1** proves a `MEMORY.md` write stops zero sessions (spy on `proc.stop()`), **MW2** identity defers idle, **MW3** non-writable still restarts (no regression). `skills-hot-reload` HR1/HR2/HR3/HR5 flipped from stop → defer.
- **Proven-red** — neutralizing the memory guard makes MW1 + the classifier test red; neutralizing `deferIdle` makes RS8/RS9/MW2/HR1 red (idle actually SIGKILLed). Both restored.
- Full suite: **165 suites / 3107 tests green**; typecheck clean.

## Acceptance criteria (issue #321)

1. ✅ Editing `MEMORY.md`/`USER.md` stops zero sessions (busy/idle-authoring/idle-bystander).
2. ✅ `CLAUDE.md` still recomposed on disk; next spawn reads updated memory.
3. ✅ Identity changes defer idle bystanders (never SIGKILL); respawn on next message.
4. ✅ Skill add/modify/delete no longer SIGKILLs idle bystanders; busy still skipped; CLAUDE.md skills section refreshed.
5. ✅ Non-writable workspace changes keep prior behavior.
6. ✅ Full suite green; each new guard proven-red; typecheck clean; API.md updated.
