### PR TITLE
feat(workspace): memory budget discipline — loud over-budget banner (#323)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1773,6 +1773,16 @@ Read and write an agent's workspace identity files via the API. The gateway's fi
 | `SOUL.md`, `AGENTS.md`, `IDENTITY.md` (identity) | Busy sessions are skipped; idle sessions are **deferred** (respawn on their next message) — never SIGKILLed mid-idle. |
 | `HEARTBEAT.md` / other | Normal restart-or-defer (idle sessions restart now). |
 
+**Memory budget (`gateway.memory`).** Self-authored memory files (`MEMORY.md`, `USER.md`) that exceed a **soft char budget** get a loud, actionable over-budget banner prepended to their `CLAUDE.md` section at compose time — instead of a silent `[TRUNCATED]` — so the agent consolidates on its next spawn (frozen-at-spawn, no restart). The soft budget sits well under the hard per-file limit (still applied as a context safety net); the banner is the primary signal for memory files. Config (global, injected by migration at `configVersion` `1.0.19`):
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `memoryBudgetChars` | `8000` | Soft budget for `MEMORY.md` (`0` = disabled). |
+| `userBudgetChars` | `3000` | Soft budget for `USER.md` (`0` = disabled). |
+| `overBudget` | `"warn"` | Banner severity: `"warn"` (⚠️) or `"error"` (🛑, stronger wording). An unknown value falls back to `"warn"`. |
+
+A memory file under its budget composes cleanly (no banner). Non-memory files are unaffected. A hard-reject memory tool (refuse an over-budget write) is a planned follow-up; v1 is the compose banner only.
+
 ### GET /api/v1/agents/:agentId/files/:filename
 
 Read a workspace file. Returns empty `content` if the file does not exist yet (not a 404).

--- a/README.md
+++ b/README.md
@@ -369,6 +369,30 @@ Controls [skill self-improvement](#skill-self-improvement) — agents learning r
 
 Per-agent overrides are supported under the agent's own `skillLearning` block; unset fields fall back to the gateway default.
 
+### `gateway.memory`
+
+Memory budget discipline. Self-authored memory files (`MEMORY.md`, `USER.md`) that exceed a **soft** char budget get a loud over-budget banner prepended to their `CLAUDE.md` section at compose time — instead of a silent `[TRUNCATED]` — nudging the agent to consolidate. The banner reaches the agent on its next spawn (frozen-at-spawn, no restart) and self-heals once the file is back under budget. The banner lives only in the composed `CLAUDE.md`; the source file on disk is never rewritten with it.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `memoryBudgetChars` | `8000` | Soft budget for `MEMORY.md` (`0` = disabled) |
+| `userBudgetChars` | `3000` | Soft budget for `USER.md` (`0` = disabled) |
+| `overBudget` | `"warn"` | Banner severity: `warn` (⚠️) or `error` (🛑, stronger wording); an unknown value falls back to `warn` |
+
+```json
+{
+  "gateway": {
+    "memory": {
+      "memoryBudgetChars": 8000,
+      "userBudgetChars": 3000,
+      "overBudget": "warn"
+    }
+  }
+}
+```
+
+The soft budget sits well under the hard per-file limit (still applied as a context safety net); the banner is the primary over-budget signal for memory files.
+
 ### `gateway.bind`
 
 Network interface the HTTP/WebSocket server binds to. Defaults to `127.0.0.1` (localhost-only), so the dashboard and API are **not** exposed to the local network out of the box. Set to `0.0.0.0` to listen on all interfaces (for example when a containerized reverse proxy needs to reach the gateway). The `GATEWAY_BIND` environment variable, when set, takes precedence over this field.

--- a/config.template.json
+++ b/config.template.json
@@ -10,7 +10,7 @@
       "claude.dangerouslySkipPermissions"
     ]
   },
-  "configVersion": "1.0.18",
+  "configVersion": "1.0.19",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
@@ -76,6 +76,11 @@
       "pruneHour": 3,
       "pruneTimezone": "UTC",
       "notify": true
+    },
+    "memory": {
+      "memoryBudgetChars": 8000,
+      "userBudgetChars": 3000,
+      "overBudget": "warn"
     }
   },
   "agents": [

--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -54,6 +54,73 @@ function truncateFile(content: string): { content: string; truncated: boolean } 
   return { content, truncated: false };
 }
 
+// ── Memory budget discipline (issue #323) ────────────────────────────────────
+// Self-authored memory (MEMORY.md/USER.md) that grows past a SOFT budget gets a
+// loud, actionable over-budget banner at compose time instead of a silent
+// truncation, so the owning agent consolidates on its next spawn. The soft
+// budget is well under the hard FILE_CHAR_LIMIT (still applied as a context
+// safety net); the banner fires long before the hard cut.
+
+export type OverBudgetMode = 'warn' | 'error';
+
+export interface MemoryBudgetConfig {
+  memoryBudgetChars: number; // soft budget for MEMORY.md
+  userBudgetChars: number; // soft budget for USER.md
+  overBudget: OverBudgetMode; // banner severity at compose
+}
+
+const DEFAULT_MEMORY_BUDGET_CHARS = 8_000;
+const DEFAULT_USER_BUDGET_CHARS = 3_000;
+
+export const DEFAULT_MEMORY_BUDGET: MemoryBudgetConfig = {
+  memoryBudgetChars: DEFAULT_MEMORY_BUDGET_CHARS,
+  userBudgetChars: DEFAULT_USER_BUDGET_CHARS,
+  overBudget: 'warn',
+};
+
+/**
+ * Resolve a (possibly partial or malformed) memory-budget config into a complete
+ * one, falling back to the documented defaults. An unknown `overBudget` value or
+ * a non-numeric / negative budget is treated as "not set" and defaulted, so bad
+ * operator config never throws at compose (fail-safe, mirrors #310's tz guard).
+ */
+export function resolveMemoryBudget(cfg?: Partial<MemoryBudgetConfig>): MemoryBudgetConfig {
+  const overBudget: OverBudgetMode = cfg?.overBudget === 'error' ? 'error' : 'warn';
+  const memoryBudgetChars =
+    typeof cfg?.memoryBudgetChars === 'number' && cfg.memoryBudgetChars >= 0
+      ? cfg.memoryBudgetChars
+      : DEFAULT_MEMORY_BUDGET_CHARS;
+  const userBudgetChars =
+    typeof cfg?.userBudgetChars === 'number' && cfg.userBudgetChars >= 0
+      ? cfg.userBudgetChars
+      : DEFAULT_USER_BUDGET_CHARS;
+  return { memoryBudgetChars, userBudgetChars, overBudget };
+}
+
+/**
+ * Prepend a loud over-budget banner to a memory file's composed content when it
+ * exceeds its soft budget. Returns the content unchanged when under budget (or
+ * when the budget is 0 / disabled). The hard FILE_CHAR_LIMIT truncation is
+ * applied separately afterwards as a context safety net.
+ */
+function applyMemoryBudget(
+  content: string,
+  budgetChars: number,
+  label: string,
+  mode: OverBudgetMode,
+): { content: string; overBudget: boolean } {
+  if (budgetChars <= 0 || content.length <= budgetChars) {
+    return { content, overBudget: false };
+  }
+  const icon = mode === 'error' ? '🛑' : '⚠️';
+  const action = mode === 'error' ? 'MUST consolidate now' : 'consolidate';
+  const banner =
+    `${icon} ${label} OVER BUDGET: ${content.length}/${budgetChars} chars — ${action}: ` +
+    `keep the highest-value facts, remove stale or duplicate entries. ` +
+    `Edits apply on the next session spawn (frozen-at-spawn), no restart.\n\n`;
+  return { content: banner + content, overBudget: true };
+}
+
 /**
  * Migrate workspace files from legacy lowercase names to uppercase canonical names.
  * - If lowercase exists and uppercase does NOT: rename lowercase → uppercase
@@ -89,6 +156,12 @@ export interface LoadWorkspaceOptions {
   mcpToolsDir?: string;
   sharedSkillsDir?: string;
   logger?: { warn: (msg: string) => void };
+  /**
+   * Soft per-file char budgets for MEMORY.md/USER.md. When omitted, the
+   * documented defaults (DEFAULT_MEMORY_BUDGET) apply — so callers and tests
+   * that don't pass it are unaffected.
+   */
+  memoryBudget?: Partial<MemoryBudgetConfig>;
 }
 
 /**
@@ -117,12 +190,20 @@ export async function loadWorkspace(workspaceDir: string, opts?: LoadWorkspaceOp
     return r.content;
   };
 
+  // Memory files (MEMORY.md/USER.md) get a loud over-budget banner at their soft
+  // budget BEFORE the hard-limit truncation, so the agent gets an actionable
+  // signal instead of a silent [TRUNCATED]. The banner sits at the top of the
+  // section, so it survives even if the hard cap later trims the tail.
+  const budget = resolveMemoryBudget(opts?.memoryBudget);
+  const memoryBudgeted = applyMemoryBudget(rawMemory, budget.memoryBudgetChars, 'MEMORY.md', budget.overBudget);
+  const userBudgeted = applyMemoryBudget(rawUser, budget.userBudgetChars, 'USER.md', budget.overBudget);
+
   const agentMd = truncateResult(rawAgent);
   const identityMd = truncateResult(rawIdentity);
   const soulMd = truncateResult(rawSoul);
-  const userMd = truncateResult(rawUser);
+  const userMd = truncateResult(userBudgeted.content);
   const heartbeatMd = truncateResult(rawHeartbeat);
-  const memoryMd = truncateResult(rawMemory);
+  const memoryMd = truncateResult(memoryBudgeted.content);
 
   // Load agent skills
   const skillRegistry = loadSkills({

--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -66,7 +66,10 @@ export type OverBudgetMode = 'warn' | 'error';
 export interface MemoryBudgetConfig {
   memoryBudgetChars: number; // soft budget for MEMORY.md
   userBudgetChars: number; // soft budget for USER.md
-  overBudget: OverBudgetMode; // banner severity at compose
+  // Compose-banner severity only in v1: 'warn' (⚠️) vs 'error' (🛑 + stronger
+  // wording). Neither rejects the write — a hard-reject memory tool is a planned
+  // follow-up; at compose there is nothing to reject.
+  overBudget: OverBudgetMode;
 }
 
 const DEFAULT_MEMORY_BUDGET_CHARS = 8_000;
@@ -193,7 +196,9 @@ export async function loadWorkspace(workspaceDir: string, opts?: LoadWorkspaceOp
   // Memory files (MEMORY.md/USER.md) get a loud over-budget banner at their soft
   // budget BEFORE the hard-limit truncation, so the agent gets an actionable
   // signal instead of a silent [TRUNCATED]. The banner sits at the top of the
-  // section, so it survives even if the hard cap later trims the tail.
+  // section, so the per-file FILE_CHAR_LIMIT truncation (which trims the tail)
+  // always leaves it intact. (An extreme TOTAL_CHAR_LIMIT overflow could still
+  // slice it, but that path already truncates the whole prompt.)
   const budget = resolveMemoryBudget(opts?.memoryBudget);
   const memoryBudgeted = applyMemoryBudget(rawMemory, budget.memoryBudgetChars, 'MEMORY.md', budget.overBudget);
   const userBudgeted = applyMemoryBudget(rawUser, budget.userBudgetChars, 'USER.md', budget.overBudget);

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,9 +182,10 @@ async function startAgent(
   logger.info('Initialising agent', { id: agentConfig.id });
 
   // Soft memory budgets for MEMORY.md/USER.md compose banners (issue #323).
-  // loadWorkspace defaults these when undefined, so passing the raw config
-  // (possibly absent) is safe.
-  const memoryBudget = gatewayConfig.gateway.memory;
+  // Per-agent config wins field-by-field over the global gateway default
+  // (mirrors the skillLearning override). loadWorkspace defaults any unset
+  // field, so a fully-absent config is safe.
+  const memoryBudget = { ...gatewayConfig.gateway.memory, ...agentConfig.memory };
 
   // Ensure workspace directory exists (may be absent for newly created agents)
   try {
@@ -617,7 +618,7 @@ async function main(): Promise<void> {
           mcpToolsDir: ctx.mcpToolsDir,
           sharedSkillsDir: ctx.sharedSkillsDir,
           logger,
-          memoryBudget: config.gateway.memory,
+          memoryBudget: { ...config.gateway.memory, ...agentConfig.memory },
         });
         const claudeMdPath = path.join(agentConfig.workspace, 'CLAUDE.md');
         await fs.promises.writeFile(claudeMdPath, updated.systemPrompt, 'utf8');

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,11 @@ async function startAgent(
   const logger = createLogger(agentConfig.id, logDir);
   logger.info('Initialising agent', { id: agentConfig.id });
 
+  // Soft memory budgets for MEMORY.md/USER.md compose banners (issue #323).
+  // loadWorkspace defaults these when undefined, so passing the raw config
+  // (possibly absent) is safe.
+  const memoryBudget = gatewayConfig.gateway.memory;
+
   // Ensure workspace directory exists (may be absent for newly created agents)
   try {
     fs.mkdirSync(agentConfig.workspace, { recursive: true });
@@ -235,6 +240,7 @@ async function startAgent(
       mcpToolsDir,
       sharedSkillsDir,
       logger,
+      memoryBudget,
     });
   } catch (err) {
     const reason = (err as Error).message;
@@ -325,6 +331,7 @@ async function startAgent(
         mcpToolsDir,
         sharedSkillsDir,
         logger,
+        memoryBudget,
       });
       // Always rewrite CLAUDE.md so the next spawn picks up the new content.
       await fs.promises.writeFile(
@@ -380,6 +387,7 @@ async function startAgent(
           mcpToolsDir,
           sharedSkillsDir,
           logger,
+          memoryBudget,
         });
         if (updated.skillRegistry) {
           runner.setSkillRegistry(updated.skillRegistry);
@@ -609,6 +617,7 @@ async function main(): Promise<void> {
           mcpToolsDir: ctx.mcpToolsDir,
           sharedSkillsDir: ctx.sharedSkillsDir,
           logger,
+          memoryBudget: config.gateway.memory,
         });
         const claudeMdPath = path.join(agentConfig.workspace, 'CLAUDE.md');
         await fs.promises.writeFile(claudeMdPath, updated.systemPrompt, 'utf8');

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,6 +253,19 @@ export interface GatewayConfig {
       pruneTimezone?: string;    // IANA timezone for pruneHour, default "UTC"
       notify?: boolean;          // Telegram push when a skill is auto-written, default true (diary always on)
     };
+    /**
+     * Memory budget discipline (issue #323). Self-authored memory files
+     * (MEMORY.md/USER.md) that exceed their SOFT char budget get a loud
+     * over-budget banner at compose time instead of a silent truncation, so the
+     * agent consolidates on its next spawn (frozen-at-spawn — no restart). Soft
+     * budgets sit well under the hard per-file limit; the banner is the primary
+     * signal for memory files.
+     */
+    memory?: {
+      memoryBudgetChars?: number;    // soft budget for MEMORY.md, default 8000 (0 = disabled)
+      userBudgetChars?: number;      // soft budget for USER.md, default 3000 (0 = disabled)
+      overBudget?: 'warn' | 'error'; // compose banner severity, default "warn"
+    };
   };
   agents: AgentConfig[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,8 @@ export interface AgentConfig {
   history?: HistoryConfig;
   /** Per-agent skill-learning override (wins over the global gateway default). */
   skillLearning?: GatewayConfig['gateway']['skillLearning'];
+  /** Per-agent memory-budget override (field-level over the global gateway default). */
+  memory?: GatewayConfig['gateway']['memory'];
   /** Avatar filename relative to agent dir, e.g. "avatar.png". null = no avatar. */
   avatar?: string;
 }

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -79,6 +79,30 @@ describe('config-migrator', () => {
       expect(target.newField).toBe('value');
       expect(added).toContain('newField');
     });
+
+    it('adds gateway.memory (issue #323) to a predating config, preserving existing overrides', () => {
+      const target: Record<string, unknown> = {
+        gateway: { logDir: '/logs', skillLearning: { enabled: false } },
+      };
+      const template: Record<string, unknown> = {
+        gateway: {
+          logDir: '/default',
+          skillLearning: { enabled: true },
+          memory: { memoryBudgetChars: 8000, userBudgetChars: 3000, overBudget: 'warn' },
+        },
+      };
+      const added: string[] = [];
+
+      deepMerge(target, template, '', added);
+
+      const gw = target.gateway as Record<string, unknown>;
+      // memory block injected with template defaults
+      expect(gw.memory).toEqual({ memoryBudgetChars: 8000, userBudgetChars: 3000, overBudget: 'warn' });
+      expect(added.some((f) => f.startsWith('gateway.memory'))).toBe(true);
+      // existing user overrides are NOT clobbered
+      expect((gw.skillLearning as Record<string, unknown>).enabled).toBe(false);
+      expect(gw.logDir).toBe('/logs');
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -171,6 +171,17 @@ describe('workspace-loader', () => {
     });
   });
 
+  it('U-BUDGET-9: per-agent override wins field-by-field over the global default', () => {
+    // Mirrors src/index.ts: `{ ...global, ...agent }` then resolveMemoryBudget.
+    const global = { memoryBudgetChars: 8_000, userBudgetChars: 3_000, overBudget: 'warn' as OverBudgetMode };
+    const agent = { memoryBudgetChars: 40_000 }; // an agent with a large curated memory
+    expect(resolveMemoryBudget({ ...global, ...agent })).toEqual({
+      memoryBudgetChars: 40_000, // agent wins
+      userBudgetChars: 3_000, // global fills the rest
+      overBudget: 'warn',
+    });
+  });
+
   // -------------------------------------------------------------------------
   // U-WL-05: Total context exceeds 150,000 chars
   // -------------------------------------------------------------------------

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -9,6 +9,9 @@ import {
   MEMORY_FILES,
   IDENTITY_FILES,
   classifyWorkspaceRestart,
+  resolveMemoryBudget,
+  DEFAULT_MEMORY_BUDGET,
+  OverBudgetMode,
   MissingRequiredFileError,
 } from '../../src/agent/workspace-loader';
 import { waitFor } from '../helpers/wait-for';
@@ -53,6 +56,119 @@ describe('workspace-loader', () => {
     expect(result.files.memoryMd.length).toBeLessThanOrEqual(20_000 + 60); // +marker length
     expect(result.files.memoryMd).toContain('[TRUNCATED');
     expect(result.truncated).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Memory budget discipline (issue #323): an over-budget memory file gets a
+  // loud OVER BUDGET banner at compose instead of a silent truncation.
+  // -------------------------------------------------------------------------
+  const makeBudgetWs = (files: Record<string, string>): string => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-budget-'));
+    fs.writeFileSync(path.join(dir, 'AGENTS.md'), files['AGENTS.md'] ?? '# Agent');
+    for (const [name, content] of Object.entries(files)) {
+      if (name === 'AGENTS.md') continue;
+      fs.writeFileSync(path.join(dir, name), content);
+    }
+    return dir;
+  };
+
+  it('U-BUDGET-1: MEMORY.md over soft budget gets a loud OVER BUDGET banner (not silent truncate)', async () => {
+    const dir = makeBudgetWs({ 'MEMORY.md': 'M'.repeat(9_000) }); // > 8000 soft, < 20000 hard
+    try {
+      const result = await loadWorkspace(dir, { memoryBudget: { memoryBudgetChars: 8_000 } });
+      expect(result.files.memoryMd).toContain('MEMORY.md OVER BUDGET');
+      expect(result.files.memoryMd).toContain('⚠️');
+      expect(result.files.memoryMd).toContain('consolidate');
+      // Under the hard 20k cap → not truncated; full content kept after the banner.
+      expect(result.files.memoryMd).not.toContain('[TRUNCATED');
+      expect(result.systemPrompt).toContain('MEMORY.md OVER BUDGET');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('U-BUDGET-2: MEMORY.md under budget composes clean (no banner)', async () => {
+    const dir = makeBudgetWs({ 'MEMORY.md': 'a small curated memory' });
+    try {
+      const result = await loadWorkspace(dir, { memoryBudget: { memoryBudgetChars: 8_000 } });
+      expect(result.files.memoryMd).not.toContain('OVER BUDGET');
+      expect(result.files.memoryMd).toBe('a small curated memory');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('U-BUDGET-3: USER.md over its own (smaller) budget gets the banner', async () => {
+    const dir = makeBudgetWs({ 'USER.md': 'U'.repeat(4_000) }); // > 3000 soft
+    try {
+      const result = await loadWorkspace(dir, { memoryBudget: { userBudgetChars: 3_000 } });
+      expect(result.files.userMd).toContain('USER.md OVER BUDGET');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('U-BUDGET-4: non-memory files never get a budget banner (only the hard truncate)', async () => {
+    // SOUL.md is larger than the memory budget but is NOT a memory file.
+    const dir = makeBudgetWs({ 'SOUL.md': 'S'.repeat(9_000) });
+    try {
+      const result = await loadWorkspace(dir, { memoryBudget: { memoryBudgetChars: 8_000 } });
+      expect(result.files.soulMd).not.toContain('OVER BUDGET');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('U-BUDGET-5: overBudget "error" mode uses the stronger banner', async () => {
+    const dir = makeBudgetWs({ 'MEMORY.md': 'M'.repeat(9_000) });
+    try {
+      const result = await loadWorkspace(dir, {
+        memoryBudget: { memoryBudgetChars: 8_000, overBudget: 'error' },
+      });
+      expect(result.files.memoryMd).toContain('🛑');
+      expect(result.files.memoryMd).toContain('MUST consolidate');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('U-BUDGET-6: budget 0 disables the banner (opt-out)', async () => {
+    const dir = makeBudgetWs({ 'MEMORY.md': 'M'.repeat(9_000) });
+    try {
+      const result = await loadWorkspace(dir, { memoryBudget: { memoryBudgetChars: 0 } });
+      expect(result.files.memoryMd).not.toContain('OVER BUDGET');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('U-BUDGET-7: default budget (no opts) still banners a large MEMORY.md', async () => {
+    const dir = makeBudgetWs({ 'MEMORY.md': 'M'.repeat(9_000) });
+    try {
+      const result = await loadWorkspace(dir); // no memoryBudget → defaults (8000)
+      expect(result.files.memoryMd).toContain('OVER BUDGET');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('U-BUDGET-8: resolveMemoryBudget fills defaults and rejects invalid values (fail-safe)', () => {
+    expect(resolveMemoryBudget(undefined)).toEqual(DEFAULT_MEMORY_BUDGET);
+    // Unknown overBudget → warn
+    expect(resolveMemoryBudget({ overBudget: 'nonsense' as OverBudgetMode }).overBudget).toBe('warn');
+    // Negative / NaN budgets → defaults
+    expect(resolveMemoryBudget({ memoryBudgetChars: -5 }).memoryBudgetChars).toBe(
+      DEFAULT_MEMORY_BUDGET.memoryBudgetChars,
+    );
+    expect(resolveMemoryBudget({ userBudgetChars: NaN }).userBudgetChars).toBe(
+      DEFAULT_MEMORY_BUDGET.userBudgetChars,
+    );
+    // Valid partial is honored
+    expect(resolveMemoryBudget({ overBudget: 'error', memoryBudgetChars: 100 })).toEqual({
+      memoryBudgetChars: 100,
+      userBudgetChars: 3_000,
+      overBudget: 'error',
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adopts Hermes-style memory discipline (Part B of the memory/dreaming plan): replace the **silent** `[TRUNCATED]` of self-authored memory files (`MEMORY.md`, `USER.md`) with a **loud, actionable over-budget banner** at compose time, so the owning agent consolidates instead of bloating memory unbounded (a real workspace `MEMORY.md` had grown to ~164 KB, silently cut at the hard limit).

Frozen-at-spawn (#321): the banner reaches the agent on its next spawn with **no restart**, and self-heals once the file is consolidated back under budget. The banner lives only in the composed `CLAUDE.md` — the source `MEMORY.md` on disk is never rewritten with it.

This is the v1 "guard-only" (compose banner) approach. A memory MCP tool that hard-rejects an over-budget write is a deliberate follow-up.

## Changes

- **`workspace-loader.ts`**: `applyMemoryBudget()` prepends a `⚠️`/`🛑 OVER BUDGET` banner when a memory file exceeds its **soft** budget (well under the hard `FILE_CHAR_LIMIT`, which is retained as a context safety net). `resolveMemoryBudget()` fills defaults and fail-safes invalid/negative/unknown values (mirrors #310's tz guard). Threaded through `LoadWorkspaceOptions`; defaults apply when omitted, so other callers/tests are unaffected.
- **Config `gateway.memory`** (`memoryBudgetChars` 8000, `userBudgetChars` 3000, `overBudget` "warn") added to the template; injected into existing configs by the migrator at `configVersion` `1.0.19`.
- **`index.ts`**: pass the resolved budget to all `loadWorkspace` call sites.
- **`API.md`**: document the budget behavior + config table.

## Testing

- `npm run typecheck` clean; full suite green (**3102 passed**; the lone suite-level failure is the pre-existing `socket-server` teardown flake — 17/17 standalone, not in this diff).
- New unit tests: over-budget → banner (MEMORY/USER, warn/error severity); under-budget → clean; non-memory files unaffected; budget `0` disables; `resolveMemoryBudget` fail-safe; migration injects `gateway.memory` without clobbering overrides.
- **Proven-red**: neutralized the banner logic and the resolver guard inline and confirmed the corresponding tests fail, then restored.

## Notes

- Scope is Part B (memory budget) only. Nightly dreaming consolidation (Part C) and a hard-reject memory tool (B1a) are separate follow-ups.

Closes #323.