### PR TITLE
Persist channel reply-tool turns to the resumable session store (#331)

### DIFF
--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -19,6 +19,16 @@ import {
 
 export const MAX_HISTORY_MESSAGES = 50;
 
+// The MCP reply tools that deliver an agent's user-facing message to a channel.
+// Their text lives in the tool_use `input.text`, not in an assistant text block,
+// so it is never captured by `assistantBuffer` — the reply is delivered to the
+// user but was previously never mirrored into the resumable session store.
+const CHANNEL_REPLY_TOOLS = new Set([
+  'mcp__gateway__telegram_reply',
+  'mcp__gateway__discord_reply',
+  'mcp__gateway__line_reply',
+]);
+
 /**
  * Resolve the per-spawn history re-injection cap with precedence
  * per-agent → global → MAX_HISTORY_MESSAGES. Non-finite or negative values are
@@ -101,6 +111,10 @@ export class SessionProcess extends EventEmitter {
   // Real model from Claude stream, updated per turn. Persisted to SessionMeta.
   _lastModel = '';
   private thinkingRecoveryCount = 0;
+  // tool_use ids of channel replies already mirrored to sessionStore, so a reply
+  // is persisted exactly once even though its tool_use block can recur across the
+  // partial + final stream events of the same turn.
+  private persistedReplyToolIds = new Set<string>();
   // Binary path last spawned and the last non-empty stderr line, retained so a
   // fatal `Session max restarts reached` names what actually failed (e.g. an
   // unresolvable `claude` binary) instead of ending in silence. `stderrBuffer`
@@ -674,6 +688,10 @@ export class SessionProcess extends EventEmitter {
     // CODING_TOOLS and TOOL_LABELS imported from shared utility above
 
     let assistantBuffer = '';
+    // Reply-tool texts already mirrored to the store during the CURRENT turn, so
+    // the end-of-turn assistantBuffer persist can skip an identical narration
+    // text block and avoid writing the same message twice. Cleared each turn.
+    const replyTextsThisTurn = new Set<string>();
     // Track partial message text to avoid double-counting when --include-partial-messages is active.
     // Each partial `type: 'assistant'` event contains the FULL text so far, not a delta.
     let lastPartialText = '';
@@ -730,6 +748,36 @@ export class SessionProcess extends EventEmitter {
                 if (this.queryMode) { this._queryBuffer += delta; } else { assistantBuffer += delta; }
               }
               lastPartialText = '';
+            }
+
+            // Mirror channel replies (telegram_reply/discord_reply/line_reply) into
+            // the resumable session store at delivery time. The user-facing text is
+            // carried in the tool_use input, not a text block, so assistantBuffer
+            // never sees it — without this, a turn whose entire output is a reply
+            // tool call (e.g. a long synthesized report, or any background-event or
+            // reply-tool-only turn) is delivered to the user yet lost from the store
+            // and vanishes on resume. Persisting here — keyed off the tool_use event,
+            // not the end-of-turn 'result' — also survives a subprocess that exits
+            // before the turn completes. Only act on the final (non-partial) message,
+            // where the tool_use input is fully materialised.
+            if (!isPartial && !this.queryMode && this.source !== 'api') {
+              for (const block of obj.message.content) {
+                if (
+                  block.type === 'tool_use' &&
+                  typeof block.name === 'string' &&
+                  CHANNEL_REPLY_TOOLS.has(block.name) &&
+                  typeof block.id === 'string' &&
+                  !this.persistedReplyToolIds.has(block.id)
+                ) {
+                  const input = block.input as { text?: unknown } | undefined;
+                  const replyText = typeof input?.text === 'string' ? input.text.trim() : '';
+                  if (replyText) {
+                    this.persistedReplyToolIds.add(block.id);
+                    replyTextsThisTurn.add(replyText);
+                    this.appendToStore({ role: 'assistant', content: replyText, ts: Date.now() }).catch(() => {});
+                  }
+                }
+              }
             }
 
             if (!this.queryMode) {
@@ -810,12 +858,16 @@ export class SessionProcess extends EventEmitter {
               if (assistantBuffer.trim()) {
                 // For non-API sessions (Telegram/Discord), persist here via appendTelegramMessage.
                 // For API sessions, runner.ts already persists via appendMessage — skip to avoid double-write.
-                if (this.source !== 'api') {
+                // Skip when this exact text was already mirrored as a channel reply
+                // in this turn, so a narration text block that duplicates the reply
+                // is not stored twice.
+                if (this.source !== 'api' && !replyTextsThisTurn.has(assistantBuffer.trim())) {
                   const assistantMsg = { role: 'assistant' as const, content: assistantBuffer.trim(), ts: Date.now() };
                   this.appendToStore(assistantMsg).catch(() => {});
                 }
                 assistantBuffer = '';
               }
+              replyTextsThisTurn.clear();
               // Emit tokenUsage using message_start context (accurate per-call context window usage)
               // rather than result.usage which is cumulative across all sub-calls in the turn.
               const usage = obj.usage as { output_tokens?: number } | undefined;

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1076,6 +1076,109 @@ describe('SessionProcess', () => {
   });
 
   // --------------------------------------------------------------------------
+  // U-SP-20: Channel reply-tool turns are mirrored to the resumable session store
+  //          (regression for #331 — reply text lives in tool_use.input, not a
+  //           text block, so assistantBuffer never captured it and the turn was
+  //           lost on resume).
+  // --------------------------------------------------------------------------
+  it('U-SP-20a: a reply-tool-only turn is persisted even with no result event', async () => {
+    const sp = new SessionProcess('chat:reply-only', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // Final assistant message whose ONLY output is a telegram_reply tool call —
+    // no text block, and (critically) NO subsequent 'result' event, mirroring a
+    // long report delivered to the user right before the subprocess exits.
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'toolu_report_1', name: 'mcp__gateway__telegram_reply', input: { chat_id: '111', text: 'FULL REPORT: 2 HIGH + 4 MEDIUM findings…' } },
+        ],
+      },
+      stop_reason: 'tool_use',
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const messages = await sessionStore.loadTelegramSession('alfred', 'chat:reply-only', 'chat:reply-only');
+    const assistant = messages.filter(m => m.role === 'assistant');
+    expect(assistant.length).toBe(1);
+    expect(assistant[0].content).toBe('FULL REPORT: 2 HIGH + 4 MEDIUM findings…');
+  });
+
+  it('U-SP-20b: the same reply tool_use is persisted exactly once across partial + final events', async () => {
+    const sp = new SessionProcess('chat:reply-once', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // Partial message carrying the reply tool_use (input still streaming)…
+    const partial = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_dup', name: 'mcp__gateway__telegram_reply', input: { text: 'hi there' } }] },
+      stop_reason: null,
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(partial + '\n'));
+    // …then the final message with the SAME tool_use id.
+    const final = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_dup', name: 'mcp__gateway__telegram_reply', input: { text: 'hi there' } }] },
+      stop_reason: 'tool_use',
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(final + '\n'));
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const messages = await sessionStore.loadTelegramSession('alfred', 'chat:reply-once', 'chat:reply-once');
+    expect(messages.filter(m => m.role === 'assistant' && m.content === 'hi there').length).toBe(1);
+  });
+
+  it('U-SP-20c: a narration text block that duplicates the reply text is not double-written', async () => {
+    const sp = new SessionProcess('chat:reply-dup', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    // Same text emitted BOTH as a visible text block and as the reply tool input.
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Done ✅' },
+          { type: 'tool_use', id: 'toolu_same', name: 'mcp__gateway__telegram_reply', input: { text: 'Done ✅' } },
+        ],
+      },
+      stop_reason: 'tool_use',
+    });
+    lastProcess!.stdout!.emit('data', Buffer.from(line + '\n'));
+    // Result event flushes assistantBuffer (the 'Done ✅' text block).
+    lastProcess!.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'Done ✅' }) + '\n'));
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const messages = await sessionStore.loadTelegramSession('alfred', 'chat:reply-dup', 'chat:reply-dup');
+    expect(messages.filter(m => m.role === 'assistant' && m.content === 'Done ✅').length).toBe(1);
+  });
+
+  it('U-SP-20d: a normal text-only turn is still persisted exactly once (no regression)', async () => {
+    const sp = new SessionProcess('chat:plain', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    lastProcess!.stdout!.emit('data', Buffer.from(JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'plain answer' }] },
+      stop_reason: 'end_turn',
+    }) + '\n'));
+    lastProcess!.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'plain answer' }) + '\n'));
+
+    await new Promise(r => setTimeout(r, 200));
+
+    const messages = await sessionStore.loadTelegramSession('alfred', 'chat:plain', 'chat:plain');
+    const assistant = messages.filter(m => m.role === 'assistant');
+    expect(assistant.length).toBe(1);
+    expect(assistant[0].content).toBe('plain answer');
+  });
+
+  // --------------------------------------------------------------------------
   // U-SP-19: Partial messages don't spam status file with "thinking"
   // --------------------------------------------------------------------------
   it('U-SP-19: partial text-only messages do not write thinking status', async () => {


### PR DESCRIPTION
Closes #331.

## Root cause (corrected — proven with production evidence)

The issue body attributed the gap to `streamMessage.done()` (`runner.ts:3560`). That path is **dead** — `streamMessage` has no callers in `src`. The only channel-side assistant persistence is the transcript tailer in `src/session/process.ts`, which persists `assistantBuffer` on each `result` event.

`assistantBuffer` accumulates **only `block.type === 'text'`**. When an agent delivers its user-facing message via a channel reply tool (`mcp__gateway__telegram_reply` / `discord_reply` / `line_reply`), the text lives in the `tool_use.input.text` — never in a text block — so `assistantBuffer` stays empty and nothing is written to `sessionStore`. A turn whose entire output is a reply tool call is delivered to the user yet **absent from the resume window**, so after a restart the model loses work it just did.

### Live production reproduction (session `9478d252`)

An agent's code-review report was delivered via `telegram_reply` at 16:34, then the subprocess exited (code 0) at 17:06 and respawned. Forensics on the on-disk store + log:

- The report header text is **absent from the entire 401-message `sessionStore`** (0 hits).
- Last `result` event before exit: **16:29:15** (the prior turn). **Zero** `result` events fired in the 40-minute window that delivered the report → `appendToStore` never ran.
- On resume the store ended at the 16:29 turn; the agent hit "scratchpad empty — findings lost" and had to re-run the reviewers.

Two compounding misses: (a) reply text not in `assistantBuffer`; (b) no `result` before exit.

## Fix

`src/session/process.ts` — mirror reply-tool text into `sessionStore` **at the moment the reply `tool_use` is observed** (final/non-partial message), independent of the `result` event, so it is durable even if the subprocess exits before the turn completes. Idempotent via the `tool_use` id (partial + final stream events share it); a narration text block that exactly duplicates the reply is not written twice.

## Tests (`tests/unit/session-process.test.ts`)

- **U-SP-20a** — reply-tool-only turn with **no `result` event** → persisted (proven to FAIL pre-fix).
- **U-SP-20b** — same `tool_use` id across partial + final → persisted exactly once (proven to FAIL pre-fix).
- **U-SP-20c** — narration text block duplicating the reply → not double-written.
- **U-SP-20d** — normal text-only turn → still persisted exactly once (no regression).

## Acceptance criteria

- [x] A reply-tool / background-driven assistant turn is written to `sessionStore` and appears in `loadTelegramSession(...)`.
- [x] Present in the last-`MAX_HISTORY_MESSAGES` resume window after restart.
- [x] Normal channel turns persisted exactly once (no duplicate assistant messages).
- [x] Regression test simulates the background/reply-tool turn and asserts presence + no double-write.

## Gates

- typecheck clean
- full suite **3153/3153** pass (lone `chat-history-api` suite-fail is the known flaky worker-kill; passes 27/27 standalone)
- regression **proven-red** on pre-fix code