### PR TITLE
fix(app-agent): harden PATH before probing for the claude binary

### DIFF
--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import { execSync } from 'node:child_process';
 import yaml from 'js-yaml';
 import { AppsRegistry, AppEntry } from './registry';
+import { pathWithNativeBin } from '../session/claude-bin';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -52,10 +53,21 @@ export class AgentManager {
   /**
    * Detect host binary paths for injection into the agent container.
    * Runs once at install time; results stored in apps.json.
+   *
+   * The PATH is hardened with the native-installer bin dir before probing, the
+   * same way process.ts hardens a spawned child's PATH. Without it, execSync
+   * inherits the gateway's own PATH — under systemd that omits ~/.local/bin, so
+   * `which claude` misses the native install and can return a compat wrapper
+   * script instead. Mounting that wrapper into the container is fatal: it only
+   * re-probes host paths that were never mounted, so it exits 1 on every turn.
    */
   detectAgentPaths(): AgentPaths {
+    const hardenedPath = pathWithNativeBin();
     const run = (cmd: string): string =>
-      execSync(cmd, { encoding: 'utf-8' }).toString().trim();
+      execSync(cmd, {
+        encoding: 'utf-8',
+        env: { ...process.env, ...(hardenedPath ? { PATH: hardenedPath } : {}) },
+      }).toString().trim();
 
     const claudeBin = run('which claude');
     const realClaudeBin = fs.realpathSync(claudeBin);


### PR DESCRIPTION
Fixes #338

## Problem

App-agents crash-loop on every message — `session subprocess exited {code: 1}` → `Scheduling session restart in 5000ms`, forever. The agent log ends with the message a host *wrapper script* prints:

```
claude: binary not found (searched: ~/.local/bin/claude, ~/.local/share/claude/versions/*, ~/.nvm/.../claude)
```

`detectAgentPaths()` resolves the binary with `execSync('which claude')`. That inherits the gateway's own PATH, and under systemd the PATH omits `~/.local/bin`:

```
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
```

so `which` never sees the native-installer symlink and can return a legacy `/usr/local/bin/claude` compat wrapper instead. Being a regular file, `realpathSync` returns it unchanged — so the wrapper, not the binary, is what gets bind-mounted. Inside the container it re-probes `$HOME/.local` paths that were never mounted and exits 1.

## Fix

`src/session/claude-bin.ts` already carries `pathWithNativeBin()` for exactly this, and `process.ts` already applies it when spawning. `detectAgentPaths()` is the remaining probe site that never got it — this just wires it up.

```diff
+    const hardenedPath = pathWithNativeBin();
     const run = (cmd: string): string =>
-      execSync(cmd, { encoding: 'utf-8' }).toString().trim();
+      execSync(cmd, {
+        encoding: 'utf-8',
+        env: { ...process.env, ...(hardenedPath ? { PATH: hardenedPath } : {}) },
+      }).toString().trim();
```

With the native bin dir on PATH, `which claude` resolves `~/.local/bin/claude`, and the existing `realpathSync` follows that symlink to the real binary — so the existing mount line already does the right thing. No new fields, no type changes, no config migration.

## Verification

Under a replicated systemd PATH:

```
before   which claude -> /usr/local/bin/claude                        ← wrapper, crash-loops
after    claudeBin    -> ~/.local/share/claude/versions/2.1.235       ← real ELF
```

Throwaway container with the resulting mount (`--user 1000:1000 --cap-drop ALL --security-opt no-new-privileges`): the binary runs, `2.1.235 (Claude Code)`, rc 0.

```
tsc --noEmit      clean
jest tests/unit/  152 suites, 3022 tests passing
```

No test changes needed.

## Notes for reviewers — deliberately left out of scope

Two adjacent issues surfaced while diagnosing this. Neither is required to fix the crash-loop, so both are left for a maintainer call rather than bundled here:

1. **Bind-mounts under `$HOME` get root-owned parents.** Docker auto-creates `~/.local` and `~/.local/share` as `root:root`, and with `cap_drop: ALL` uid 1000 then cannot `mkdir ~/.local/state/claude` (verified). Whether that actually degrades a session is **not** demonstrated — `claude --version` succeeds and a live agent responds normally with those dirs root-owned. Mounting the binary at a fixed container path outside `$HOME` would sidestep it if it ever proves to matter.
2. **Stored `agentPaths` wins over re-detection** on update (`installer.ts`, `!agentPaths` guard) and reconfigure (`?? detectAgentPaths()`), so an app installed by an older gateway keeps the bad path until it is reinstalled rather than healing on update.

Also worth noting: `AgentPaths` in `agent-manager.ts` and the inline literal typing `AppEntry.agentPaths` in `registry.ts:29` are duplicates that have already drifted — the latter carries a `claudeVersion?: string` that nothing reads.