### PR TITLE
fix(dreaming): make reviewer spawn failures observable (dead diagnostic log + discarded stderr)

### DIFF
--- a/src/agent/dreaming/index.ts
+++ b/src/agent/dreaming/index.ts
@@ -261,11 +261,13 @@ export class DreamingManager {
         this.deps.spawnFn,
       );
     } catch (err) {
-      // runDreamReviewer is not supposed to throw, but if it does, surface the
-      // cause instead of swallowing it silently — an outcome=error run with no
-      // diagnostics is undebuggable. Compaction + route-out already committed
-      // this tick, so note that they succeeded even though the reviewer failed.
-      this.log('dream: reviewer failed; keeping compaction/route-out results', {
+      // Defensive only: runDreamReviewer is contracted NEVER to throw — it converts
+      // every spawn failure into a `timedOut` result. The #352 catch that logged
+      // here was therefore dead code. Keep a minimal guard so a future contract
+      // break still audits instead of crashing, but the REAL reviewer-failure
+      // diagnostic lives on the reachable branch below (#353).
+      this.log('dream: reviewer threw unexpectedly (contract violation)', {
+        agentId: this.deps.agentId,
         error: err instanceof Error ? err.message : String(err),
         compacted: compactedCount,
       });
@@ -281,6 +283,22 @@ export class DreamingManager {
       : proposals.length > 0
         ? 'proposed'
         : 'no-changes';
+
+    // Surface WHY the reviewer produced no usable output (#353). This was
+    // previously invisible: makeClaudeSpawn discarded stderr and collapsed
+    // timeout / spawn-error / non-zero-exit into a lone `timedOut`, and the #352
+    // reviewer-catch log above was unreachable (runDreamReviewer never throws).
+    // Log the distinguishable reason HERE, on the branch that actually fires, so
+    // the next dream night records the real cause (timeout vs API 429 vs …).
+    if (review.timedOut || review.failureReason) {
+      this.log('dream: reviewer produced no usable output', {
+        agentId: this.deps.agentId,
+        outcome,
+        failureReason: review.failureReason ?? 'unknown',
+        stderrTail: review.stderrTail,
+        compacted: compactedCount,
+      });
+    }
 
     // AUTO MODE (K4): apply the ops to memory through the safe applier (backup +
     // ordered anchor re-resolution + bounded-loss + net-negative + append-only

--- a/src/agent/dreaming/reviewer.ts
+++ b/src/agent/dreaming/reviewer.ts
@@ -232,16 +232,29 @@ export async function runDreamReviewer(
 
   let stdout = '';
   let timedOut = false;
+  let failureReason: string | undefined;
+  let stderrTail: string | undefined;
   try {
     const r = await spawn([], prompt);
     stdout = r.stdout;
     timedOut = r.timedOut ?? false;
-  } catch {
-    return { summary: '', proposals: [], tokensSpent: 0, timedOut: true };
+    failureReason = r.failureReason;
+    stderrTail = r.stderrTail;
+  } catch (err) {
+    // Contracted never to throw, but if an injected spawn does, capture why (#353).
+    return {
+      summary: '',
+      proposals: [],
+      tokensSpent: 0,
+      timedOut: true,
+      failureReason: `spawn-throw: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 
   if (timedOut || !stdout.trim()) {
-    return { summary: '', proposals: [], tokensSpent: 0, timedOut };
+    // Carry the diagnostics up so dreamOnce can log WHY (timeout / non-zero exit /
+    // API error on stderr) instead of recording an opaque error (#353).
+    return { summary: '', proposals: [], tokensSpent: 0, timedOut, failureReason, stderrTail };
   }
 
   const { resultText, tokens } = parseEnvelope(stdout);

--- a/src/agent/dreaming/types.ts
+++ b/src/agent/dreaming/types.ts
@@ -113,6 +113,15 @@ export interface DreamReviewResult {
   /** Tokens the reviewer spent (input+output), for the net-token ledger. 0 if unknown. */
   tokensSpent: number;
   timedOut?: boolean;
+  /**
+   * Diagnostics (#353) for a failed run: WHY the reviewer produced no usable
+   * output (e.g. 'timeout', 'spawn-error: …', 'nonzero-exit:1', 'spawn-throw: …')
+   * and a bounded tail of the child's stderr (an API error such as
+   * overloaded_error). Absent on success. Logged by dreamOnce so an
+   * `outcome=error` run is debuggable instead of opaque.
+   */
+  failureReason?: string;
+  stderrTail?: string;
 }
 
 export type DreamOutcome =

--- a/src/agent/skill-learning/reviewer.ts
+++ b/src/agent/skill-learning/reviewer.ts
@@ -33,8 +33,20 @@ export interface ReviewerResult {
   timedOut?: boolean;
 }
 
-/** Injectable spawn: given argv + stdin, resolve with the process stdout. */
-export type ClaudeSpawnFn = (args: string[], stdin: string) => Promise<{ stdout: string; timedOut?: boolean }>;
+/**
+ * Injectable spawn: given argv + stdin, resolve with the process stdout.
+ *
+ * `failureReason` / `stderrTail` are diagnostics (#353): previously every failure
+ * mode collapsed into a bare `timedOut` and the child's stderr was discarded, so
+ * an `outcome=error` dream run was undebuggable. These optional fields let a caller
+ * log WHY a spawn failed (timeout vs spawn-error vs non-zero exit + the API error on
+ * stderr) without changing the success contract — consumers that only read
+ * `{ stdout, timedOut }` are unaffected.
+ */
+export type ClaudeSpawnFn = (
+  args: string[],
+  stdin: string,
+) => Promise<{ stdout: string; timedOut?: boolean; failureReason?: string; stderrTail?: string }>;
 
 const SYSTEM_PROMPT = `You are a skill-distillation reviewer for an AI agent. You are given a finished work transcript and the agent's existing skills. Decide whether the transcript reveals a REUSABLE procedure worth capturing as a skill so future similar tasks are faster.
 
@@ -84,7 +96,16 @@ export function makeClaudeSpawn(reviewModel: string): ClaudeSpawnFn {
     return new Promise((resolve) => {
       let done = false;
       let out = '';
-      const finish = (r: { stdout: string; timedOut?: boolean }): void => {
+      // Bounded stderr tail (#353): capture enough to surface an API error
+      // (e.g. 429 / overloaded_error) without letting a chatty child balloon
+      // memory. Keep consuming the stream even after the cap so it never blocks.
+      let errOut = '';
+      const STDERR_TAIL_CAP = 2_000;
+      const tail = (): string | undefined => {
+        const t = errOut.slice(-STDERR_TAIL_CAP).trim();
+        return t.length ? t : undefined;
+      };
+      const finish = (r: { stdout: string; timedOut?: boolean; failureReason?: string; stderrTail?: string }): void => {
         if (done) return;
         done = true;
         clearTimeout(timer);
@@ -96,17 +117,43 @@ export function makeClaudeSpawn(reviewModel: string): ClaudeSpawnFn {
         } catch {
           /* already gone */
         }
-        finish({ stdout: '', timedOut: true });
+        finish({ stdout: '', timedOut: true, failureReason: 'timeout', stderrTail: tail() });
       }, REVIEWER_TIMEOUT_MS);
       const child = spawn(claudeBin, args, {
-        stdio: ['pipe', 'pipe', 'ignore'],
+        // Pipe stderr (was 'ignore') so a spawn/API failure's real message is
+        // recoverable instead of silently dropped (#353).
+        stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env, PATH: pathWithNativeBin() ?? process.env.PATH },
       });
       child.stdout?.on('data', (d) => {
         out += String(d);
       });
-      child.on('error', () => finish({ stdout: '', timedOut: true }));
-      child.on('close', () => finish({ stdout: out }));
+      child.stderr?.on('data', (d) => {
+        if (errOut.length < STDERR_TAIL_CAP * 4) errOut += String(d);
+      });
+      child.on('error', (err) =>
+        finish({
+          stdout: '',
+          timedOut: true,
+          failureReason: `spawn-error: ${err instanceof Error ? err.message : String(err)}`,
+          stderrTail: tail(),
+        }),
+      );
+      child.on('close', (code) => {
+        // Clean exit WITH output = success (unchanged). Empty stdout — typically a
+        // non-zero exit whose real error went to stderr — is now surfaced with the
+        // exit code + stderr tail instead of an opaque empty result. `timedOut`
+        // stays falsy on this path, so downstream outcome classification is unchanged.
+        if (out.trim()) {
+          finish({ stdout: out });
+        } else {
+          finish({
+            stdout: '',
+            failureReason: code === 0 ? 'empty-output' : `nonzero-exit:${code ?? 'null'}`,
+            stderrTail: tail(),
+          });
+        }
+      });
       // The stdin socket emits its own async 'error' (e.g. EPIPE if the child
       // exits before we finish writing). `child.on('error')` does NOT cover the
       // stream, so without this handler that event is unhandled and can crash
@@ -116,7 +163,7 @@ export function makeClaudeSpawn(reviewModel: string): ClaudeSpawnFn {
         child.stdin?.write(stdin);
         child.stdin?.end();
       } catch {
-        finish({ stdout: '', timedOut: true });
+        finish({ stdout: '', timedOut: true, failureReason: 'stdin-error', stderrTail: tail() });
       }
     });
   };

--- a/tests/unit/dream-reviewer-diagnostics.test.ts
+++ b/tests/unit/dream-reviewer-diagnostics.test.ts
@@ -1,0 +1,198 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { DreamingManager } from '../../src/agent/dreaming';
+import { makeClaudeSpawn, type ClaudeSpawnFn } from '../../src/agent/skill-learning/reviewer';
+import { gatherTranscript, type DreamHistoryDb } from '../../src/agent/dreaming/gather';
+
+// Regression suite for #353 — the dream reviewer's failures used to be
+// undebuggable: makeClaudeSpawn discarded stderr and collapsed every failure into
+// a bare `timedOut`, and the #352 reviewer-catch log was dead code (runDreamReviewer
+// never throws). These tests pin the observable behavior: an error run now logs a
+// distinguishable reason + stderr tail, on the branch that actually fires.
+
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+
+function makeDb(): DreamHistoryDb {
+  return {
+    listSessions: () => [{ sessionId: 's1', lastActivity: NOW - 2 * HOUR }],
+    getSessionTranscript: () => [{ role: 'user', content: 'some durable-looking fact', ts: NOW - 2 * HOUR }],
+  };
+}
+
+function mkWs(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dream-diag-'));
+  fs.writeFileSync(path.join(dir, 'MEMORY.md'), '# Memory\n\n- existing fact\n');
+  fs.writeFileSync(path.join(dir, 'USER.md'), 'u');
+  return dir;
+}
+
+type LogEntry = { msg: string; data?: Record<string, unknown> };
+function mkLogger(sink: LogEntry[]) {
+  return { info: (msg: string, data?: Record<string, unknown>) => sink.push({ msg, data }) };
+}
+
+const NO_OUTPUT_LOG = 'dream: reviewer produced no usable output';
+
+describe('dreaming diagnostics (#353): reviewer failures are observable', () => {
+  it('DR-1: a timed-out reviewer → outcome=error AND a reachable failure log fires', async () => {
+    // PROVEN-RED: on pre-#353 code this log line does not exist — the `review.timedOut`
+    // branch recorded outcome=error but logged nothing (and the #352 catch was dead).
+    const ws = mkWs();
+    try {
+      const logs: LogEntry[] = [];
+      const timedOutSpawn: ClaudeSpawnFn = async () => ({ stdout: '', timedOut: true });
+      const mgr = new DreamingManager({
+        db: makeDb(),
+        agentId: 'founder',
+        workspaceDir: ws,
+        globalCfg: { mode: 'auto' },
+        spawnFn: timedOutSpawn,
+        logger: mkLogger(logs),
+      });
+
+      const res = await mgr.dreamOnce(NOW);
+
+      expect(res.outcome).toBe('error');
+      const failLog = logs.find((l) => l.msg === NO_OUTPUT_LOG);
+      expect(failLog).toBeDefined();
+      expect(failLog!.data?.agentId).toBe('founder');
+      expect(failLog!.data?.outcome).toBe('error');
+    } finally {
+      fs.rmSync(ws, { recursive: true });
+    }
+  });
+
+  it('DR-2: a structured failure reason + stderr tail are surfaced in the log', async () => {
+    const ws = mkWs();
+    try {
+      const logs: LogEntry[] = [];
+      const spawn: ClaudeSpawnFn = async () => ({
+        stdout: '',
+        timedOut: true,
+        failureReason: 'timeout',
+        stderrTail: 'API Error: 429 overloaded_error',
+      });
+      const mgr = new DreamingManager({
+        db: makeDb(),
+        agentId: 'founder',
+        workspaceDir: ws,
+        globalCfg: { mode: 'auto' },
+        spawnFn: spawn,
+        logger: mkLogger(logs),
+      });
+
+      await mgr.dreamOnce(NOW);
+
+      const failLog = logs.find((l) => l.msg === NO_OUTPUT_LOG);
+      expect(failLog).toBeDefined();
+      expect(failLog!.data?.failureReason).toBe('timeout');
+      expect(String(failLog!.data?.stderrTail)).toContain('overloaded_error');
+    } finally {
+      fs.rmSync(ws, { recursive: true });
+    }
+  });
+
+  it('DR-3: a spawn that THROWS is caught, audited as error, and its reason logged (never crashes)', async () => {
+    const ws = mkWs();
+    try {
+      const logs: LogEntry[] = [];
+      const throwingSpawn: ClaudeSpawnFn = async () => {
+        throw new Error('ENOENT: claude binary missing');
+      };
+      const mgr = new DreamingManager({
+        db: makeDb(),
+        agentId: 'founder',
+        workspaceDir: ws,
+        globalCfg: { mode: 'auto' },
+        spawnFn: throwingSpawn,
+        logger: mkLogger(logs),
+      });
+
+      // Must not reject — dreaming must never wedge the daemon.
+      const res = await mgr.dreamOnce(NOW);
+      expect(res.outcome).toBe('error');
+
+      // runDreamReviewer converts the throw into a timedOut result carrying the
+      // reason, so the reachable branch logs it (the defensive contract-violation
+      // catch stays a fallback, not the sole diagnostic).
+      const failLog = logs.find((l) => l.msg === NO_OUTPUT_LOG);
+      expect(failLog).toBeDefined();
+      expect(String(failLog!.data?.failureReason)).toContain('spawn-throw');
+    } finally {
+      fs.rmSync(ws, { recursive: true });
+    }
+  });
+
+  it('DR-4: makeClaudeSpawn captures stderr + a non-zero-exit reason (was discarded before)', async () => {
+    // A fake claude that writes its real error to stderr and exits non-zero with
+    // empty stdout — the exact shape that used to vanish into an opaque timedOut.
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fakebin-'));
+    const binPath = path.join(binDir, 'fake-claude.sh');
+    fs.writeFileSync(binPath, '#!/bin/sh\ncat >/dev/null\necho "API Error: 429 overloaded_error" >&2\nexit 1\n');
+    fs.chmodSync(binPath, 0o755);
+    const prevBin = process.env.CLAUDE_BIN;
+    process.env.CLAUDE_BIN = binPath;
+    try {
+      const spawn = makeClaudeSpawn('claude-haiku-4-5-20251001');
+      const r = await spawn([], 'a prompt');
+      expect(r.stdout).toBe('');
+      expect(r.failureReason).toMatch(/^nonzero-exit:1$/);
+      expect(String(r.stderrTail)).toContain('overloaded_error');
+    } finally {
+      if (prevBin === undefined) delete process.env.CLAUDE_BIN;
+      else process.env.CLAUDE_BIN = prevBin;
+      fs.rmSync(binDir, { recursive: true });
+    }
+  });
+
+  it('DR-5: makeClaudeSpawn success path is unchanged (stdout returned, no failure reason)', async () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fakebin-'));
+    const binPath = path.join(binDir, 'fake-claude.sh');
+    const envelope = JSON.stringify({ result: '{"summary":"ok","proposals":[]}', usage: {} });
+    fs.writeFileSync(binPath, `#!/bin/sh\ncat >/dev/null\ncat <<'JSON'\n${envelope}\nJSON\n`);
+    fs.chmodSync(binPath, 0o755);
+    const prevBin = process.env.CLAUDE_BIN;
+    process.env.CLAUDE_BIN = binPath;
+    try {
+      const spawn = makeClaudeSpawn('claude-haiku-4-5-20251001');
+      const r = await spawn([], 'a prompt');
+      expect(r.stdout).toContain('proposals');
+      expect(r.failureReason).toBeUndefined();
+      expect(r.timedOut).toBeFalsy();
+    } finally {
+      if (prevBin === undefined) delete process.env.CLAUDE_BIN;
+      else process.env.CLAUDE_BIN = prevBin;
+      fs.rmSync(binDir, { recursive: true });
+    }
+  });
+
+  it('DR-6: a healthy reviewer run does NOT emit the failure log (no false positives)', async () => {
+    const ws = mkWs();
+    try {
+      const logs: LogEntry[] = [];
+      const goodSpawn: ClaudeSpawnFn = async () => ({
+        stdout: JSON.stringify({ result: JSON.stringify({ summary: 's', proposals: [] }), usage: {} }),
+      });
+      const mgr = new DreamingManager({
+        db: makeDb(),
+        agentId: 'founder',
+        workspaceDir: ws,
+        globalCfg: { mode: 'auto' },
+        spawnFn: goodSpawn,
+        logger: mkLogger(logs),
+      });
+
+      const res = await mgr.dreamOnce(NOW);
+      expect(res.outcome).toBe('no-changes');
+      expect(logs.find((l) => l.msg === NO_OUTPUT_LOG)).toBeUndefined();
+    } finally {
+      fs.rmSync(ws, { recursive: true });
+    }
+  });
+});
+
+// Keep the shared import referenced so the suite documents the real seam.
+void gatherTranscript;

--- a/tests/unit/dream-reviewer-diagnostics.test.ts
+++ b/tests/unit/dream-reviewer-diagnostics.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { DreamingManager } from '../../src/agent/dreaming';
 import { makeClaudeSpawn, type ClaudeSpawnFn } from '../../src/agent/skill-learning/reviewer';
-import { gatherTranscript, type DreamHistoryDb } from '../../src/agent/dreaming/gather';
+import type { DreamHistoryDb } from '../../src/agent/dreaming/gather';
 
 // Regression suite for #353 — the dream reviewer's failures used to be
 // undebuggable: makeClaudeSpawn discarded stderr and collapsed every failure into
@@ -193,6 +193,3 @@ describe('dreaming diagnostics (#353): reviewer failures are observable', () => 
     }
   });
 });
-
-// Keep the shared import referenced so the suite documents the real seam.
-void gatherTranscript;


### PR DESCRIPTION
Closes #353

## Problem

Nightly dreaming recorded `outcome=error` for an agent whenever the dream **reviewer** spawn failed, but the failure was **undebuggable**:

- `makeClaudeSpawn` set `stdio: ['pipe','pipe','ignore']`, **discarding the child's stderr** — the one place a real cause (e.g. `429 / overloaded_error`) is printed.
- Every failure mode (120s timeout, spawn `error`, stdin EPIPE, non-zero exit) collapsed into a single `timedOut` boolean.
- The reviewer-catch log added in #352 (`src/agent/dreaming/index.ts`) was **dead code**: `runDreamReviewer` is contracted never to throw (it converts spawn failures into a `timedOut` result), so that `catch` never runs. The real error branch logged nothing.

Net effect: the largest-memory agent errored on two consecutive dream nights (`tokens: 0`, audit says only *"Reviewer produced no usable output (timeout or malformed)"*), never ran its net-shrink reviewer, and stayed over budget — with no way to tell **why** the reviewer failed. A live reproduce showed the same model + prompt size succeeds in ~23s in isolation, so the cause is environmental (contention/rate-limit at dream fan-out) — exactly what the discarded stderr would have shown.

## Fix (observability first — no guessed remediation)

- **`makeClaudeSpawn`** (shared spawn): pipe stderr and keep a bounded tail; return a structured `failureReason` (`timeout` / `spawn-error: …` / `nonzero-exit:<code>` / `stdin-error`) plus `stderrTail` alongside `stdout`. Fields are additive/optional — the skill-learning reviewer that reads only `{ stdout, timedOut }` is unaffected, and the success path is byte-for-byte unchanged.
- **`runDreamReviewer`**: thread `failureReason` + `stderrTail` into `DreamReviewResult`, keeping its never-throws contract.
- **`dreamOnce`**: log the distinguishable reason on the **reachable** `review.timedOut` branch (with `agentId` + stderr tail). The #352 catch is reframed as a defensive contract-violation fallback, not the sole diagnostic.

The underlying remediation (bounded retry/backoff, serialized spawns, or a longer timeout) is intentionally **out of scope** — it will be chosen once one dream night logs the actual `failureReason`, rather than guessed now.

## Tests

`tests/unit/dream-reviewer-diagnostics.test.ts` (6 cases):
- DR-1/2/3 — a timed-out / structured-failure / throwing spawn produces `outcome=error` **and** a reachable log carrying `failureReason` (+ stderr tail). **Proven-red**: with the diagnostic log neutralized (pre-fix behavior) DR-1/2/3 fail on exactly the "log fired" assertion, while DR-4/5/6 stay green.
- DR-4 — `makeClaudeSpawn` against a fake claude that writes to stderr and exits 1 surfaces `nonzero-exit:1` + the stderr tail (was silently dropped before).
- DR-5 — success path unchanged (stdout returned, no failure reason).
- DR-6 — a healthy run emits no failure log (no false positives).

## Verification

- `npm run typecheck` clean.
- Full `npm test`: **3382 tests pass**, 0 assertion failures (one integration suite flakes only under parallel worker contention — passes 27/27 run alone; unrelated to this change).
- No change to route-out draining or the reviewer's output classification.
