### PR TITLE
fix: Stop-triggered SIGINT edge cases in API sessions + image-gen cancel/model attribution

### DIFF
--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -102,7 +102,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: visibleTools,
 }));
 
-mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+mcp.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
   const toolName = req.params.name;
   const args = (req.params.arguments ?? {}) as Record<string, unknown>;
 
@@ -114,7 +114,11 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     };
   }
 
-  return mod.handleTool(toolName, args);
+  // extra.signal fires on notifications/cancelled for THIS call (the SDK matches
+  // it by requestId) — the CLI sends that when a user Stop/Ctrl-C interrupts an
+  // in-flight tool call. Threaded through so a long-running module (image
+  // generation's poll loop) can react instead of running to its full timeout.
+  return mod.handleTool(toolName, args, extra.signal);
 });
 
 // Connect MCP transport

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -762,10 +762,16 @@ export class ImageModule implements ToolModule {
 
 // Resolves early (without rejecting) on abort — the poll loop re-checks
 // signal.aborted itself right after, so this only needs to shorten the wait.
+// The abort listener is removed when the timer fires normally: sleep() is called
+// once per poll iteration against the SAME long-lived signal (up to ~75 times for
+// the default 150s/2s budget), so leaving { once:true } listeners around on the
+// non-abort path would pile them onto that one signal and trip Node's
+// MaxListenersExceededWarning.
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((r) => {
-    const t = setTimeout(r, ms);
-    signal?.addEventListener('abort', () => { clearTimeout(t); r(); }, { once: true });
+    const onAbort = () => { clearTimeout(t); r(); };
+    const t = setTimeout(() => { signal?.removeEventListener('abort', onAbort); r(); }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -109,14 +109,17 @@ export class ImageModule implements ToolModule {
     return imageToolDefs;
   }
 
-  async handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+  async handleTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<McpToolResult> {
     if (name !== 'generate_image') {
       return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
     }
     const action = typeof args.action === 'string' ? args.action : 'generate';
     switch (action) {
       case 'generate':
-        return this.handleGenerate(args);
+        // Only "generate" gets the signal — it's the one action with a multi-second
+        // poll loop worth reacting to a Stop mid-flight (#2216 follow-up on the
+        // getpod side). status/list/list_refs are single bounded requests already.
+        return this.handleGenerate(args, signal);
       case 'status':
         return this.handleStatus(args);
       case 'list':
@@ -257,7 +260,7 @@ export class ImageModule implements ToolModule {
     };
   }
 
-  private async handleGenerate(args: Record<string, unknown>): Promise<McpToolResult> {
+  private async handleGenerate(args: Record<string, unknown>, signal?: AbortSignal): Promise<McpToolResult> {
     const prompt = typeof args.prompt === 'string' ? args.prompt.trim() : '';
     const model = typeof args.model === 'string' ? args.model.trim() : '';
     if (!prompt) {
@@ -369,11 +372,16 @@ export class ImageModule implements ToolModule {
       return { content: [{ type: 'text', text: 'generate_image: image service did not return a task_id' }], isError: true };
     }
 
-    // Poll (E2) until done/failed or budget exceeded.
+    // Poll (E2) until done/failed, budget exceeded, or the caller cancels this call
+    // (Stop mid-generation — #2216 follow-up). Checked at the top of every
+    // iteration AND inside the sleep itself, so a cancel lands within one wakeup
+    // instead of waiting out the full poll interval.
     const deadline = Date.now() + this.pollTimeoutMs();
     let last: JobResponse = submit;
     while (Date.now() < deadline) {
-      await sleep(DEFAULT_POLL_INTERVAL_MS);
+      if (signal?.aborted) return this.cancelledResult(taskId);
+      await sleep(DEFAULT_POLL_INTERVAL_MS, signal);
+      if (signal?.aborted) return this.cancelledResult(taskId);
       const polled = await this.fetchJob(taskId);
       if (polled.__transportError) {
         // transient transport error — keep polling until deadline
@@ -526,6 +534,36 @@ export class ImageModule implements ToolModule {
   private pollTimeoutMs(): number {
     const raw = Number(process.env.IMAGE_POLL_TIMEOUT_MS);
     return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_POLL_TIMEOUT_MS;
+  }
+
+  /**
+   * Best-effort E3 cancel — fires and never throws, so a failed cancel call can
+   * never break the caller's own (already-cancelled) tool response. The api-side
+   * cancel is itself idempotent/no-op-safe on an already-terminal or unknown task,
+   * so no need to track whether this actually reached a still-running job.
+   */
+  private async cancelJob(taskId: string): Promise<void> {
+    try {
+      await fetch(`${this.baseUrl()}/v1/images/jobs/${encodeURIComponent(taskId)}/cancel`, {
+        method: 'POST',
+        headers: this.headers(),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch {
+      // non-fatal — the local tool call already reports itself cancelled either way
+    }
+  }
+
+  /** Tool result for a Stop-triggered cancellation, firing the E3 cancel first. */
+  private cancelledResult(taskId: string): McpToolResult {
+    void this.cancelJob(taskId);
+    return {
+      content: [{
+        type: 'text',
+        text: `generate_image: cancelled (task_id ${taskId}).`,
+      }],
+      isError: true,
+    };
   }
 
   /** Fetch a job (E2), classifying transport vs HTTP errors so the poller can retry transient ones. */
@@ -720,8 +758,13 @@ export class ImageModule implements ToolModule {
   }
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+// Resolves early (without rejecting) on abort — the poll loop re-checks
+// signal.aborted itself right after, so this only needs to shorten the wait.
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((r) => {
+    const t = setTimeout(r, ms);
+    signal?.addEventListener('abort', () => { clearTimeout(t); r(); }, { once: true });
+  });
 }
 
 function sanitize(s: string): string {

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -692,12 +692,14 @@ export class ImageModule implements ToolModule {
         text: JSON.stringify({
           status: 'done',
           task_id: taskId,
+          ...(model ? { model } : {}),
           byok: job.byok ?? false,
           cost: job.cost ?? 0,
           files,
           ...(artifacts ? { artifacts } : {}),
           ...(droppedImages > 0 ? { dropped_images: droppedImages } : {}),
           note: 'Image saved. Deliver it to the user with your channel delivery tool — api_reply/reply (files: [...]), or line_image on LINE. Do NOT open/Read the file to inspect it first; attach it and answer briefly.'
+            + (model ? ` Mention which model made it (${model}).` : '')
             + (artifacts ? ' To edit this image later, reference it via its artifact_ref (e.g. image: "artifact:...").' : '')
             + (droppedImages > 0 ? ` (${droppedImages} extra image(s) beyond the cap were not saved)` : ''),
         }),

--- a/mcp/types.ts
+++ b/mcp/types.ts
@@ -77,8 +77,13 @@ export interface ChannelModule {
   /** MCP tools exposed by this module */
   getTools(): McpToolDefinition[];
 
-  /** Execute a tool call */
-  handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult>;
+  /**
+   * Execute a tool call. `signal` fires when the MCP client cancels this specific
+   * call (e.g. the CLI sends notifications/cancelled after a user Stop/Ctrl-C
+   * interrupts an in-flight tool call) — optional so existing modules that don't
+   * need it are unaffected.
+   */
+  handleTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<McpToolResult>;
 
   /** Initialize bot client for tool calls (non-blocking) */
   initBot?(): Promise<void>;
@@ -99,7 +104,8 @@ export interface ToolModule {
   toolVisibility: ToolVisibility;
   isEnabled(): boolean;
   getTools(): McpToolDefinition[];
-  handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult>;
+  /** See ChannelModule.handleTool's `signal` doc — same optional-cancellation contract. */
+  handleTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<McpToolResult>;
   skillsDir?: string;
 }
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -6,7 +6,7 @@ import * as net from 'net';
 import * as path from 'path';
 import { AgentConfig, GatewayConfig, Logger, Message, ModelConfig, StreamEvent, ApiAttachment, ImageParams } from '../types';
 import { createLogger } from '../logger';
-import { SessionProcess, MAX_HISTORY_MESSAGES, resolveMaxHistoryMessages } from '../session/process';
+import { SessionProcess, MAX_HISTORY_MESSAGES, resolveMaxHistoryMessages, INTERRUPTED_NO_REPLY_TEXT } from '../session/process';
 import { SessionStore, SessionNotInIndexError } from '../session/store';
 import { SessionCompactor } from '../session/compactor';
 import { TelegramReceiver } from '../telegram/receiver';
@@ -2796,19 +2796,27 @@ export class AgentRunner extends EventEmitter {
       // line that already settled this turn (see onExit below).
       let settled = false;
 
-      const done = (result: string) => {
+      const done = (result: string, interrupted = false) => {
         if (settled) return;
         settled = true;
         cleanup();
         const attachments = this.popApiAttachments(sessionId);
+        const trimmed = result.trim();
+        // A /stop that lands before any text or attachment came out of this turn
+        // would otherwise persist nothing at all — the last committed message
+        // stays the user's forever, and the web sidebar's "typing…" indicator
+        // never clears (it only clears once the last message is from the
+        // assistant). Same wording buildInitialPrompt uses to patch this same
+        // dangling-turn shape for the next spawn's in-memory context.
+        const finalText = !trimmed && !attachments.length && interrupted ? INTERRUPTED_NO_REPLY_TEXT : trimmed;
         // Persist assistant reply. Image-only replies (empty text but attachments
         // present) must also persist — otherwise the screenshot vanishes from history.
-        if (result.trim() || attachments.length) {
+        if (finalText || attachments.length) {
           const apiAssistantTs = Date.now();
           this.sessionStore
             .appendMessage(this.agentConfig.id, sessionId, {
               role: 'assistant',
-              content: result.trim(),
+              content: finalText,
               ts: apiAssistantTs,
             })
             .catch(() => {});
@@ -2817,12 +2825,12 @@ export class AgentRunner extends EventEmitter {
             sessionId,
             source: 'api',
             role: 'assistant',
-            content: result.trim(),
+            content: finalText,
             mediaFiles: attachments.length ? attachments.map((a) => `media/${a.relPath}`) : undefined,
             ts: apiAssistantTs,
           });
         }
-        resolve({ text: result.trim(), attachments });
+        resolve({ text: finalText, attachments });
       };
 
       const fail = (err: Error) => {
@@ -2849,8 +2857,9 @@ export class AgentRunner extends EventEmitter {
       // successful stop, not a crash — resolve like the graceful path instead
       // of surfacing "process exited unexpectedly" for a stop the user asked for.
       const onExit = () => {
-        if (session.consumeInterruptFlag()) {
-          done(buffer.join(''));
+        const interrupted = session.consumeInterruptFlag();
+        if (interrupted) {
+          done(buffer.join(''), true);
           return;
         }
         fail(Object.assign(new Error('Session process exited unexpectedly before responding.'), { code: 'PROCESS_EXITED' }));
@@ -2867,7 +2876,7 @@ export class AgentRunner extends EventEmitter {
 
       const resetQuiet = () => {
         if (quietTimer) clearTimeout(quietTimer);
-        quietTimer = setTimeout(() => done(buffer.join('')), 2000);
+        quietTimer = setTimeout(() => done(buffer.join(''), session.consumeInterruptFlag()), 2000);
       };
 
       const onOutput = (line: string) => {
@@ -2906,7 +2915,12 @@ export class AgentRunner extends EventEmitter {
             // accumulated buffer (needed for non-Anthropic models e.g. OpenRouter,
             // which emit result:"" even though the text arrived via stream_event chunks).
             const resultText = (obj['result'] as string | undefined) || buffer.join('');
-            done(resultText);
+            // Consumed here (rather than left for onExit) so the graceful path — a
+            // result line flushed before the subprocess exits — still gets credit
+            // for the interrupt; onExit's own consumeInterruptFlag() call would
+            // otherwise see it already cleared and take the (harmless, settled-
+            // guarded) fail() branch instead.
+            done(resultText, session.consumeInterruptFlag());
           }
         } catch {
           /* non-JSON stdout line */
@@ -3029,20 +3043,28 @@ export class AgentRunner extends EventEmitter {
     // Accumulate tool_use blocks from stream_event (content_block_start → delta → stop)
     const toolBlocks = new Map<number, { id: string; name: string; chunks: string[] }>();
 
-    const done = (result: string) => {
+    const done = (result: string, interrupted = false) => {
       if (settled) return;
       settled = true;
       cleanup();
       const attachments = this.popApiAttachments(sessionId);
+      const trimmed = result.trim();
+      // A /stop that lands before any text or attachment came out of this turn
+      // would otherwise persist nothing at all — the last committed message
+      // stays the user's forever, and the web sidebar's "typing…" indicator
+      // never clears (it only clears once the last message is from the
+      // assistant). Same wording buildInitialPrompt uses to patch this same
+      // dangling-turn shape for the next spawn's in-memory context.
+      const finalText = !trimmed && !attachments.length && interrupted ? INTERRUPTED_NO_REPLY_TEXT : trimmed;
       // Persist assistant reply regardless of whether the SSE client is still connected.
       // Image-only replies (empty text but attachments present) must also persist —
       // otherwise the screenshot vanishes from history once the stream ends.
-      if (result.trim() || attachments.length) {
+      if (finalText || attachments.length) {
         const streamAssistantTs = Date.now();
         this.sessionStore
           .appendMessage(this.agentConfig.id, sessionId, {
             role: 'assistant',
-            content: result.trim(),
+            content: finalText,
             ts: streamAssistantTs,
           })
           .catch(() => {});
@@ -3051,12 +3073,12 @@ export class AgentRunner extends EventEmitter {
           sessionId,
           source: 'api',
           role: 'assistant',
-          content: result.trim(),
+          content: finalText,
           mediaFiles: attachments.length ? attachments.map((a) => `media/${a.relPath}`) : undefined,
           ts: streamAssistantTs,
         });
       }
-      callbacks.onDone(result.trim(), attachments);
+      callbacks.onDone(finalText, attachments);
     };
 
     const fail = (err: Error) => {
@@ -3084,8 +3106,9 @@ export class AgentRunner extends EventEmitter {
     // successful stop, not a crash — resolve like the graceful path instead
     // of surfacing "process exited unexpectedly" for a stop the user asked for.
     const onExit = () => {
-      if (session.consumeInterruptFlag()) {
-        done(buffer.join(''));
+      const interrupted = session.consumeInterruptFlag();
+      if (interrupted) {
+        done(buffer.join(''), true);
         return;
       }
       fail(Object.assign(new Error('Session process exited unexpectedly before responding.'), { code: 'PROCESS_EXITED' }));
@@ -3169,7 +3192,12 @@ export class AgentRunner extends EventEmitter {
           lastPartialText = ''; // reset for next turn
           // Use || so empty-string result falls back to buffer (OpenRouter emits result:"").
           const resultText = (obj['result'] as string | undefined) || buffer.join('');
-          done(resultText);
+          // Consumed here (rather than left for onExit) so the graceful path — a
+          // result line flushed before the subprocess exits — still gets credit
+          // for the interrupt; onExit's own consumeInterruptFlag() call would
+          // otherwise see it already cleared and take the (harmless, settled-
+          // guarded) fail() branch instead.
+          done(resultText, session.consumeInterruptFlag());
         }
       } catch {
         /* non-JSON stdout line */

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2843,7 +2843,16 @@ export class AgentRunner extends EventEmitter {
       // pendingApiSessions — and the caller's pending-response spinner — stuck
       // until the up-to-15-minute opts.timeoutMs + API_TIMEOUT_HARD_CAP_EXTRA_MS
       // safety net finally fired.
+      //
+      // If the exit followed a /stop (the CLI's SIGINT handler fell through to
+      // default termination instead of flushing a result line), that's a
+      // successful stop, not a crash — resolve like the graceful path instead
+      // of surfacing "process exited unexpectedly" for a stop the user asked for.
       const onExit = () => {
+        if (session.consumeInterruptFlag()) {
+          done(buffer.join(''));
+          return;
+        }
         fail(Object.assign(new Error('Session process exited unexpectedly before responding.'), { code: 'PROCESS_EXITED' }));
       };
 
@@ -3069,7 +3078,16 @@ export class AgentRunner extends EventEmitter {
     // Without this, a mid-turn crash left pendingApiSessions — and the web's
     // pending-response spinner — stuck until the up-to-15-minute
     // opts.timeoutMs + API_TIMEOUT_HARD_CAP_EXTRA_MS safety net finally fired.
+    //
+    // If the exit followed a /stop (the CLI's SIGINT handler fell through to
+    // default termination instead of flushing a result line), that's a
+    // successful stop, not a crash — resolve like the graceful path instead
+    // of surfacing "process exited unexpectedly" for a stop the user asked for.
     const onExit = () => {
+      if (session.consumeInterruptFlag()) {
+        done(buffer.join(''));
+        return;
+      }
       fail(Object.assign(new Error('Session process exited unexpectedly before responding.'), { code: 'PROCESS_EXITED' }));
     };
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -73,6 +73,11 @@ const MAX_API_IMAGES = 5;
  *  CLI turn is still producing a result that must reach history, exactly like
  *  the client-disconnect path. This cap bounds a genuinely hung turn. */
 const API_TIMEOUT_HARD_CAP_EXTRA_MS = 600_000;
+// Bound on getOrSpawnSession's wait for a crash-triggered auto-restart to land
+// (session/process.ts's AUTO_RESTART_DELAY_MS is 5s, plus real CLI spawn time
+// observed up to a few seconds more) — generous, but must not be the long
+// API_TIMEOUT_HARD_CAP_EXTRA_MS chain: this is a pre-turn gap, not a turn.
+const SESSION_RESTART_WAIT_TIMEOUT_MS = 20_000;
 // Hard timeout for the one-shot local `claude -p` triage during recovery
 // (Epic #195, Phase 3b). A slow/hung triage collapses to a safe notify-only.
 const RECOVERY_TRIAGE_TIMEOUT_MS = 15_000;
@@ -1277,6 +1282,37 @@ export class AgentRunner extends EventEmitter {
     );
   }
 
+  /**
+   * Await a SessionProcess's in-flight crash-triggered auto-restart
+   * (scheduleRestart's setTimeout → spawnProcess) instead of handing back a
+   * process whose sendMessage() will silently no-op. Resolves once the new
+   * child is attached ('restarted'); rejects on a definitive restart failure
+   * ('restartFailed', or 'failed' once MAX_RESTARTS is exhausted) or, as a
+   * last resort, on SESSION_RESTART_WAIT_TIMEOUT_MS so a caller is never left
+   * hanging past that bound.
+   */
+  private waitForSessionRestart(proc: SessionProcess): Promise<void> {
+    if (proc.isRunning()) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error('Session restart did not complete in time'));
+      }, SESSION_RESTART_WAIT_TIMEOUT_MS);
+      const onRestarted = () => { cleanup(); resolve(); };
+      const onRestartFailed = (err: Error) => { cleanup(); reject(err); };
+      const onFailed = () => { cleanup(); reject(new Error('Session failed permanently (max restarts exceeded)')); };
+      const cleanup = () => {
+        clearTimeout(timer);
+        proc.off('restarted', onRestarted);
+        proc.off('restartFailed', onRestartFailed);
+        proc.off('failed', onFailed);
+      };
+      proc.once('restarted', onRestarted);
+      proc.once('restartFailed', onRestartFailed);
+      proc.once('failed', onFailed);
+    });
+  }
+
   private async getOrSpawnSession(
     mapKey: string,              // Map lookup key (chatId for telegram/discord, sessionId for API)
     source: 'telegram' | 'discord' | 'line' | 'api',
@@ -1296,6 +1332,19 @@ export class AgentRunner extends EventEmitter {
 
     const existing = this.sessions.get(mapKey);
     if (existing) {
+      // The mapped SessionProcess can be mid auto-restart (its child crashed —
+      // see the 'exit'/scheduleRestart cycle in session/process.ts — and the
+      // AUTO_RESTART_DELAY_MS timer hasn't fired the replacement child yet).
+      // existing.sendMessage() silently no-ops while .process is null (only a
+      // warning log, no error, no event), which previously left the caller's
+      // pendingApiSessions entry stuck until the long timeout chain (the same
+      // failure mode this whole area was already patched for — see the
+      // session.on('exit', onExit) fix in sendApiMessage/sendApiMessageStream —
+      // but THIS gap is hit before a turn even starts, so that fix can't see
+      // it). Wait for the pending respawn to actually land before handing the
+      // session back.
+      if (!existing.isRunning()) await this.waitForSessionRestart(existing);
+
       // Restart if model changed (including switching back to the agent default)
       if (existing.modelOverride !== effectiveOverride) {
         this.logger.info('Model changed, restarting session', { mapKey, oldModel: existing.modelOverride, newModel: effectiveOverride ?? agentDefaultModel });

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2743,8 +2743,13 @@ export class AgentRunner extends EventEmitter {
       let quietTimer: ReturnType<typeof setTimeout> | undefined;
       // Track partial message text for delta computation (--include-partial-messages)
       let lastPartialText = '';
+      // Guards done/fail against a double-fire — e.g. onExit racing a 'result'
+      // line that already settled this turn (see onExit below).
+      let settled = false;
 
       const done = (result: string) => {
+        if (settled) return;
+        settled = true;
         cleanup();
         const attachments = this.popApiAttachments(sessionId);
         // Persist assistant reply. Image-only replies (empty text but attachments
@@ -2772,6 +2777,8 @@ export class AgentRunner extends EventEmitter {
       };
 
       const fail = (err: Error) => {
+        if (settled) return;
+        settled = true;
         // Terminal close for a turn that produced no result (#75): record it so
         // history does not end on a dangling user message, and drain the
         // attachment buffer so nothing leaks into the next turn.
@@ -2780,11 +2787,23 @@ export class AgentRunner extends EventEmitter {
         reject(err); // no-op when the soft timeout already rejected
       };
 
+      // The subprocess died without ever emitting a final `result` line (crash,
+      // an unexpected signal — distinct from a graceful /stop, whose SIGINT
+      // handler still emits a terminal result before exiting, so `done()` wins
+      // that race and this is a no-op). Without this, a mid-turn crash left
+      // pendingApiSessions — and the caller's pending-response spinner — stuck
+      // until the up-to-15-minute opts.timeoutMs + API_TIMEOUT_HARD_CAP_EXTRA_MS
+      // safety net finally fired.
+      const onExit = () => {
+        fail(Object.assign(new Error('Session process exited unexpectedly before responding.'), { code: 'PROCESS_EXITED' }));
+      };
+
       const cleanup = () => {
         clearTimeout(globalTimer);
         if (hardCapTimer) clearTimeout(hardCapTimer);
         if (quietTimer) clearTimeout(quietTimer);
         session.off('output', onOutput);
+        session.off('exit', onExit);
         this.pendingApiSessions.delete(sessionId);
       };
 
@@ -2850,6 +2869,7 @@ export class AgentRunner extends EventEmitter {
       }, opts.timeoutMs);
 
       session.on('output', onOutput);
+      session.on('exit', onExit);
       session.setProcessing(true);
       session.sendMessage(channelXml);
       // Do NOT call resetQuiet() here — the quiet timer should only start
@@ -2993,10 +3013,22 @@ export class AgentRunner extends EventEmitter {
       notifyError(err);
     };
 
+    // The subprocess died without ever emitting a final `result` line (crash,
+    // an unexpected signal — distinct from a graceful /stop, whose SIGINT
+    // handler still emits a terminal result before exiting, so `done()` wins
+    // that race and this is a no-op via the `settled` guard in fail()).
+    // Without this, a mid-turn crash left pendingApiSessions — and the web's
+    // pending-response spinner — stuck until the up-to-15-minute
+    // opts.timeoutMs + API_TIMEOUT_HARD_CAP_EXTRA_MS safety net finally fired.
+    const onExit = () => {
+      fail(Object.assign(new Error('Session process exited unexpectedly before responding.'), { code: 'PROCESS_EXITED' }));
+    };
+
     const cleanup = () => {
       clearTimeout(globalTimer);
       if (hardCapTimer) clearTimeout(hardCapTimer);
       session.off('output', onOutput);
+      session.off('exit', onExit);
       this.pendingApiSessions.delete(sessionId);
     };
 
@@ -3099,6 +3131,7 @@ export class AgentRunner extends EventEmitter {
     }, opts.timeoutMs);
 
     session.on('output', onOutput);
+    session.on('exit', onExit);
 
     // Image paths only work when allowTools:true — Claude needs the Read tool to access them
     const allowToolsStream = opts.allowTools ?? false;

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -1005,9 +1005,17 @@ export class SessionProcess extends EventEmitter {
     });
     setTimeout(() => {
       if (!this.stopping) {
-        this.spawnProcess().catch(err =>
-          this.logger.error('restart failed', { error: err.message }),
-        );
+        this.spawnProcess()
+          // Tell anyone waiting on this SessionProcess (getOrSpawnSession's
+          // !isRunning() gap, below) that a new child is attached and
+          // sendMessage() will no longer silently no-op. Emitted on every
+          // successful crash-triggered respawn — cheap, and nothing currently
+          // listens outside that one call site.
+          .then(() => this.emit('restarted'))
+          .catch(err => {
+            this.logger.error('restart failed', { error: err.message });
+            this.emit('restartFailed', err);
+          });
       }
     }, AUTO_RESTART_DELAY_MS);
   }

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -98,6 +98,12 @@ export class SessionProcess extends EventEmitter {
   private restartRequested = false;
   private _processing = false;
   private _pendingRestart = false;
+  // Set by interrupt() right before SIGINT, cleared at the start of the next
+  // sendMessage(). Lets a caller's process-exit handler tell a /stop-triggered
+  // exit (CLI's SIGINT handler fell through to default termination instead of
+  // flushing a terminal `result` line) apart from a genuine crash — see
+  // consumeInterruptFlag().
+  private interruptRequested = false;
   private restartWatcher: chokidar.FSWatcher | null = null;
   private readonly sessionStore: SessionStore;
   private readonly agentConfig: AgentConfig;
@@ -1062,6 +1068,9 @@ export class SessionProcess extends EventEmitter {
       });
       return;
     }
+    // A new turn starting means any prior interrupt() is no longer "the last
+    // thing that happened" — don't let it misattribute a future crash.
+    this.interruptRequested = false;
     // Signal queued state + ensure typing signal file exists for this turn.
     // If the previous turn already called stop() and cleared the typing loop,
     // re-creating the signal file here lets stop() restart the loop for queued turns.
@@ -1184,8 +1193,22 @@ export class SessionProcess extends EventEmitter {
   interrupt(): boolean {
     if (!this.process || this.process.killed) return false;
     if (!this._processing) return false;
+    this.interruptRequested = true;
     this.process.kill('SIGINT');
     return true;
+  }
+
+  /**
+   * Reads and clears the interrupt() flag. True means the process exit a
+   * caller is currently handling followed a /stop SIGINT rather than an
+   * unrelated crash — e.g. so the exit can resolve the turn the same way a
+   * gracefully-flushed interrupted `result` line would, instead of surfacing
+   * a "process exited unexpectedly" error for something the user asked for.
+   */
+  consumeInterruptFlag(): boolean {
+    const requested = this.interruptRequested;
+    this.interruptRequested = false;
+    return requested;
   }
 
   markPendingRestart(): void {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -31,6 +31,14 @@ const CHANNEL_REPLY_TOOLS = new Set([
   'mcp__gateway__line_reply',
 ]);
 
+// Shared wording for a turn that ended (gracefully or via a mid-turn exit) with no
+// assistant text at all — used both to patch the in-memory prompt fed to the next
+// spawn (buildInitialPrompt below) and, in AgentRunner, to persist a real assistant
+// message to durable history so a dangling last-message-from-user turn doesn't leave
+// the web sidebar's "typing…" indicator stuck (isSessionPending only clears once the
+// last committed message is from the assistant).
+export const INTERRUPTED_NO_REPLY_TEXT = '[Session was interrupted before I could respond.]';
+
 /**
  * Resolve the per-spawn history re-injection cap with precedence
  * per-agent → global → MAX_HISTORY_MESSAGES. Non-finite or negative values are
@@ -290,7 +298,7 @@ export class SessionProcess extends EventEmitter {
     // If the last message is a dangling user turn (session was interrupted before Claude responded),
     // inject a synthetic assistant acknowledgement so the conversation structure stays valid.
     if (recent[recent.length - 1]?.role === 'user') {
-      recent.push({ role: 'assistant', content: '[Session was interrupted before I could respond.]', ts: Date.now() });
+      recent.push({ role: 'assistant', content: INTERRUPTED_NO_REPLY_TEXT, ts: Date.now() });
     }
 
     const historyText = recent

--- a/tests/unit/api-stream-crash-recovery.test.ts
+++ b/tests/unit/api-stream-crash-recovery.test.ts
@@ -69,6 +69,7 @@ jest.mock('child_process', () => ({
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import { AgentRunner } from '../../src/agent/runner';
+import { SessionProcess } from '../../src/session/process';
 import { AgentConfig, GatewayConfig } from '../../src/types';
 
 function makeAgentConfig(workspace: string): AgentConfig {
@@ -162,4 +163,81 @@ describe('AgentRunner.sendApiMessageStream — subprocess exit mid-turn', () => 
     expect(onError).not.toHaveBeenCalled();
     expect(runner.hasActiveApiSession(sessionId)).toBe(false);
   });
+
+  it('a send during the ~5s auto-restart window waits for the respawn instead of silently no-op-ing (getOrSpawnSession)', async () => {
+    // Real timers throughout (accepts the real ~5s AUTO_RESTART_DELAY_MS
+    // cost) — deliberately NOT jest.useFakeTimers(). An earlier version tried
+    // controlling this with fake timers + counted microtask drains and it
+    // passed identically with the fix present AND reverted: this call chain
+    // also does real, unmocked SessionStore filesystem I/O (ensureApiSession)
+    // ahead of getOrSpawnSession, whose completion isn't ordered by fake
+    // timers or by counting Promise.resolve() ticks — only genuine wall-clock
+    // waiting reproduces the actual race deterministically. Verified this
+    // version DOES discriminate: reverting the runner.ts/process.ts fix while
+    // keeping this test makes it fail exactly as expected below.
+    //
+    // Also spies on SessionProcess.prototype.sendMessage to record
+    // isRunning() at the INSTANT each call happens, rather than inferring
+    // correctness from stdin content after the fact — content-based checks
+    // were fooled by a stale onOutput listener surviving the restart (see the
+    // git history of this test for that dead end too).
+    const sendMessageRunningStates: boolean[] = [];
+    const originalSendMessage = SessionProcess.prototype.sendMessage;
+    const sendMessageSpy = jest
+      .spyOn(SessionProcess.prototype, 'sendMessage')
+      .mockImplementation(function (this: SessionProcess, text: string) {
+        sendMessageRunningStates.push(this.isRunning());
+        return originalSendMessage.call(this, text);
+      });
+
+    try {
+      // Turn 1: gets a process, then crashes with no result line (same shape
+      // as the first test above — this also exercises the onExit fix,
+      // confirming turn 1 fails promptly rather than hanging).
+      const turn1Error = jest.fn();
+      await runner.sendApiMessageStream(
+        sessionId, chatId, 'turn 1',
+        { onChunk: jest.fn(), onDone: jest.fn(), onError: turn1Error },
+        { timeoutMs: 60_000 },
+      );
+      const proc1 = lastProcess!;
+      expect(proc1).not.toBeNull();
+
+      proc1.emit('exit', null, 'SIGKILL'); // crash — no result line, triggers scheduleRestart
+      await Promise.resolve();
+      expect(turn1Error).toHaveBeenCalledTimes(1);
+      expect(runner.hasActiveApiSession(sessionId)).toBe(false); // the earlier fix already covers this
+
+      // Turn 2 fires IMMEDIATELY — well inside the real ~5s auto-restart
+      // window, since sendApiMessageStream's own pre-getOrSpawnSession work
+      // (ensureApiSession etc.) takes milliseconds, not seconds.
+      const turn2Done = jest.fn();
+      const turn2Error = jest.fn();
+      await runner.sendApiMessageStream(
+        sessionId, chatId, 'turn 2',
+        { onChunk: jest.fn(), onDone: turn2Done, onError: turn2Error },
+        { timeoutMs: 60_000 },
+      );
+
+      // The whole point: sendMessage is NEVER called while the process is
+      // down. Turn 1's own call (index 0) was on a live process too — the
+      // second entry is turn 2's, and it must be true, not false.
+      expect(sendMessageSpy).toHaveBeenCalledTimes(2);
+      expect(sendMessageRunningStates).toEqual([true, true]);
+
+      const proc2 = lastProcess!;
+      expect(proc2).not.toBe(proc1);
+
+      // Let turn 2 complete normally to confirm the session is fully healthy again.
+      proc2.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', result: 'turn 2 reply' }) + '\n'));
+      proc2.emit('exit', 0, null);
+      await new Promise((r) => setImmediate(r));
+
+      expect(turn2Done).toHaveBeenCalledTimes(1);
+      expect(turn2Done.mock.calls[0][0]).toBe('turn 2 reply');
+      expect(turn2Error).not.toHaveBeenCalled();
+    } finally {
+      sendMessageSpy.mockRestore();
+    }
+  }, 15_000);
 });

--- a/tests/unit/api-stream-crash-recovery.test.ts
+++ b/tests/unit/api-stream-crash-recovery.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression for the pendingApiSessions stuck-forever bug: a session's CLI
+ * subprocess dying mid-turn (crash, or a Stop whose SIGINT handler didn't get
+ * a chance to flush a final `result` line) previously left
+ * AgentRunner.sendApiMessageStream's promise unsettled until the up-to-15-
+ * minute opts.timeoutMs + API_TIMEOUT_HARD_CAP_EXTRA_MS safety net — during
+ * which `hasActiveApiSession` stayed true and every retry on the same
+ * session_id got a 409 CONFLICT ("Session already has a pending request"),
+ * with the web's UI stuck on "typing..." indefinitely.
+ *
+ * Reproduced live against a real deployment before this fix (see commit
+ * message) — this test drives the same subprocess-exit-without-a-result
+ * scenario through a mocked child_process so it's exercised on every run.
+ *
+ * HistoryDB is mocked because this Node build's node:sqlite lacks the fts5
+ * extension HistoryDB._initSchema() requires — unrelated to the change under
+ * test; every AgentRunner-constructing test in this repo hits the same wall
+ * in this environment.
+ */
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── HistoryDB mock (sidesteps the local node:sqlite/fts5 gap) ────────────────
+jest.mock('../../src/history/db', () => ({
+  HistoryDB: {
+    forDir: jest.fn(() => ({ insertMessage: jest.fn() })),
+    forAgent: jest.fn(() => ({ insertMessage: jest.fn() })),
+  },
+}));
+
+// ── child_process mock (capture the spawned mock process for output/exit) ────
+interface MockStdin { writable: boolean; write: jest.Mock }
+interface MockChildProcess extends EventEmitter {
+  stdin: MockStdin | null;
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+}
+
+let lastProcess: MockChildProcess | null = null;
+
+function makeMockProcess(): MockChildProcess {
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdin = { writable: true, write: jest.fn() };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.killed = false;
+  proc.pid = Math.floor(Math.random() * 90000) + 10000;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = true;
+    process.nextTick(() => proc.emit('exit', null, signal ?? 'SIGTERM'));
+    return true;
+  });
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(() => {
+    lastProcess = makeMockProcess();
+    return lastProcess;
+  }),
+  spawnSync: jest.fn(() => ({ status: 0, stdout: '', stderr: '', error: undefined })),
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import { AgentRunner } from '../../src/agent/runner';
+import { AgentConfig, GatewayConfig } from '../../src/types';
+
+function makeAgentConfig(workspace: string): AgentConfig {
+  return {
+    id: 'alfred',
+    description: 'test agent',
+    workspace,
+    env: '',
+    telegram: { botToken: 'test-token' },
+    claude: { model: 'claude-opus-4-6', dangerouslySkipPermissions: false, extraFlags: [] },
+  };
+}
+
+function makeGatewayConfig(): GatewayConfig {
+  return { gateway: { logDir: '/tmp/test-api-crash-logs', timezone: 'UTC' }, agents: [] };
+}
+
+describe('AgentRunner.sendApiMessageStream — subprocess exit mid-turn', () => {
+  let tmpDir: string;
+  let runner: AgentRunner;
+  const chatId = 'web-1';
+  const sessionId = 'sess-crash-1';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'api-crash-test-'));
+    const workspaceDir = path.join(tmpDir, 'agents', 'alfred', 'workspace');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    runner = new AgentRunner(makeAgentConfig(workspaceDir), makeGatewayConfig());
+    lastProcess = null;
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('a subprocess exit with NO prior result line fails the turn immediately (not after the timeout chain)', async () => {
+    const onDone = jest.fn();
+    const onError = jest.fn();
+
+    await runner.sendApiMessageStream(
+      sessionId,
+      chatId,
+      'hello',
+      { onChunk: jest.fn(), onDone, onError },
+      { timeoutMs: 60_000 }, // deliberately long — must NOT be what unblocks this
+    );
+
+    expect(runner.hasActiveApiSession(sessionId)).toBe(true);
+    expect(lastProcess).not.toBeNull();
+
+    // The subprocess dies (crash, or a Stop whose SIGINT handler didn't flush
+    // a final result) WITHOUT ever emitting a `result` stdout line.
+    lastProcess!.emit('exit', null, 'SIGINT');
+    // Let the 'exit' handler's microtask/listener chain settle.
+    await new Promise((r) => setImmediate(r));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toMatchObject({ code: 'PROCESS_EXITED' });
+    expect(onDone).not.toHaveBeenCalled();
+    // The whole point of the fix: cleared immediately, not stuck until the
+    // 60s timeoutMs (let alone the 10-minute hard-cap extra) elapses.
+    expect(runner.hasActiveApiSession(sessionId)).toBe(false);
+  });
+
+  it('a subprocess exit AFTER a result line is a no-op (the graceful-stop / normal-completion path is unaffected)', async () => {
+    const onDone = jest.fn();
+    const onError = jest.fn();
+
+    await runner.sendApiMessageStream(
+      sessionId,
+      chatId,
+      'hello',
+      { onChunk: jest.fn(), onDone, onError },
+      { timeoutMs: 60_000 },
+    );
+
+    expect(lastProcess).not.toBeNull();
+
+    // Normal completion: the CLI emits its terminal `result` line before exiting
+    // (this is also what a graceful /stop looks like when the CLI's own SIGINT
+    // handler gets a chance to flush one).
+    lastProcess!.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', result: 'hi there' }) + '\n'));
+    lastProcess!.emit('exit', 0, null);
+    await new Promise((r) => setImmediate(r));
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onDone.mock.calls[0][0]).toBe('hi there');
+    // The exit-triggered fail() must be a no-op once done() already settled —
+    // no spurious error surfaced alongside a real, successful reply.
+    expect(onError).not.toHaveBeenCalled();
+    expect(runner.hasActiveApiSession(sessionId)).toBe(false);
+  });
+});

--- a/tests/unit/api-stream-crash-recovery.test.ts
+++ b/tests/unit/api-stream-crash-recovery.test.ts
@@ -69,7 +69,7 @@ jest.mock('child_process', () => ({
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import { AgentRunner } from '../../src/agent/runner';
-import { SessionProcess } from '../../src/session/process';
+import { SessionProcess, INTERRUPTED_NO_REPLY_TEXT } from '../../src/session/process';
 import { AgentConfig, GatewayConfig } from '../../src/types';
 
 function makeAgentConfig(workspace: string): AgentConfig {
@@ -287,6 +287,51 @@ describe('AgentRunner.sendApiMessageStream — subprocess exit mid-turn', () => 
 
       expect(onDone).toHaveBeenCalledTimes(1);
       expect(onDone.mock.calls[0][0]).toBe('partial reply');
+      expect(onError).not.toHaveBeenCalled();
+      expect(runner.hasActiveApiSession(sessionId)).toBe(false);
+    } finally {
+      sendMessageSpy.mockRestore();
+    }
+  });
+
+  it('/stop with NOTHING streamed yet persists an interrupted placeholder, not a silent empty turn', async () => {
+    // Regression: a /stop landing before any text/tool output (e.g. the user
+    // asked for something that would call a tool, and hit Stop before the
+    // model produced a single token) left `done('')` persisting nothing at
+    // all — the last committed message stayed the user's forever, so the web
+    // sidebar's "typing…" indicator (computePendingConversationIds, which
+    // only clears once the last message is from the assistant) never
+    // cleared. Confirmed live: a real session's history DB showed the user's
+    // message as the newest row with no assistant reply after it.
+    let liveSession: SessionProcess | undefined;
+    const originalSendMessage = SessionProcess.prototype.sendMessage;
+    const sendMessageSpy = jest
+      .spyOn(SessionProcess.prototype, 'sendMessage')
+      .mockImplementation(function (this: SessionProcess, text: string) {
+        liveSession = this;
+        return originalSendMessage.call(this, text);
+      });
+
+    try {
+      const onDone = jest.fn();
+      const onError = jest.fn();
+
+      await runner.sendApiMessageStream(
+        sessionId,
+        chatId,
+        'generate me a picture',
+        { onChunk: jest.fn(), onDone, onError },
+        { timeoutMs: 60_000 },
+      );
+
+      expect(liveSession).toBeDefined();
+
+      // Stop before a single token of output arrived — buffer is still empty.
+      expect(liveSession!.interrupt()).toBe(true);
+      await new Promise((r) => setImmediate(r));
+
+      expect(onDone).toHaveBeenCalledTimes(1);
+      expect(onDone.mock.calls[0][0]).toBe(INTERRUPTED_NO_REPLY_TEXT);
       expect(onError).not.toHaveBeenCalled();
       expect(runner.hasActiveApiSession(sessionId)).toBe(false);
     } finally {

--- a/tests/unit/api-stream-crash-recovery.test.ts
+++ b/tests/unit/api-stream-crash-recovery.test.ts
@@ -30,6 +30,16 @@ jest.mock('../../src/history/db', () => ({
   },
 }));
 
+// ── knowledge/archive-db mock (same node:sqlite gap, pulled in transitively via
+// process.ts's resolveSharedConfig/sharedVaultDir import and runner.ts's
+// fire-and-forget spawnArchiveReindex on session spawn) — shared knowledge is
+// disabled, so nothing here needs to do anything.
+jest.mock('../../src/agent/knowledge', () => ({
+  resolveSharedConfig: jest.fn(() => ({ enabled: false })),
+  sharedVaultDir: jest.fn(() => '/tmp'),
+  spawnArchiveReindex: jest.fn(),
+}));
+
 // ── child_process mock (capture the spawned mock process for output/exit) ────
 interface MockStdin { writable: boolean; write: jest.Mock }
 interface MockChildProcess extends EventEmitter {

--- a/tests/unit/api-stream-crash-recovery.test.ts
+++ b/tests/unit/api-stream-crash-recovery.test.ts
@@ -240,4 +240,57 @@ describe('AgentRunner.sendApiMessageStream — subprocess exit mid-turn', () => 
       sendMessageSpy.mockRestore();
     }
   }, 15_000);
+
+  it('a subprocess exit caused by /stop (interrupt()) resolves gracefully, not as a PROCESS_EXITED error', async () => {
+    // Same subprocess-exit-without-a-result shape as the first test, but this
+    // time the exit is the direct, expected result of the user pressing Stop
+    // (SessionProcess.interrupt() sending SIGINT) rather than an unrelated
+    // crash. Regression: before consumeInterruptFlag(), onExit couldn't tell
+    // the difference and surfaced "Session process exited unexpectedly before
+    // responding." to the chat UI for a stop the user asked for.
+    let liveSession: SessionProcess | undefined;
+    const originalSendMessage = SessionProcess.prototype.sendMessage;
+    const sendMessageSpy = jest
+      .spyOn(SessionProcess.prototype, 'sendMessage')
+      .mockImplementation(function (this: SessionProcess, text: string) {
+        liveSession = this;
+        return originalSendMessage.call(this, text);
+      });
+
+    try {
+      const onDone = jest.fn();
+      const onError = jest.fn();
+
+      await runner.sendApiMessageStream(
+        sessionId,
+        chatId,
+        'hello',
+        { onChunk: jest.fn(), onDone, onError },
+        { timeoutMs: 60_000 },
+      );
+
+      expect(liveSession).toBeDefined();
+      expect(lastProcess).not.toBeNull();
+
+      // Some partial text streamed in before the user hit Stop.
+      lastProcess!.stdout!.emit(
+        'data',
+        Buffer.from(JSON.stringify({ type: 'text', text: 'partial reply' }) + '\n'),
+      );
+
+      // The user presses Stop. The CLI's SIGINT handler, in this scenario,
+      // falls through to default termination instead of flushing a result
+      // line — exactly the case that previously had no way to distinguish
+      // itself from a crash.
+      expect(liveSession!.interrupt()).toBe(true);
+      await new Promise((r) => setImmediate(r));
+
+      expect(onDone).toHaveBeenCalledTimes(1);
+      expect(onDone.mock.calls[0][0]).toBe('partial reply');
+      expect(onError).not.toHaveBeenCalled();
+      expect(runner.hasActiveApiSession(sessionId)).toBe(false);
+    } finally {
+      sendMessageSpy.mockRestore();
+    }
+  });
 });

--- a/tests/unit/image-generate-cancel.test.ts
+++ b/tests/unit/image-generate-cancel.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for generate_image's Stop-mid-generation cancellation (getpod #2216
+ * follow-up) — mcp/tools/image/module.ts's handleGenerate poll loop + the new E3
+ * cancel call.
+ *
+ * mcp/server.ts threads the MCP SDK's per-call AbortSignal (fired by the SDK when
+ * the client sends notifications/cancelled for this tool call — the mechanism the
+ * CLI uses to propagate a user Stop/Ctrl-C into an in-flight tool call) into
+ * ImageModule.handleTool. Locked in here, entirely at the module level (no real
+ * CLI/MCP transport involved — fetch is mocked):
+ *
+ *  1. An aborted signal stops the poll loop promptly (does not run to
+ *     IMAGE_POLL_TIMEOUT_MS) and fires POST /v1/images/jobs/:id/cancel for the
+ *     submitted task_id.
+ *  2. The tool result reports the cancellation (isError, mentions the task_id) —
+ *     not a generic timeout/error.
+ *  3. A cancel-call failure (network error) never throws out of handleTool — the
+ *     caller's own (already-cancelled) result still returns cleanly.
+ *  4. status/list/list_refs do NOT receive the signal at all (only "generate" has
+ *     a poll loop worth reacting to) — handleTool's dispatch, not re-tested per
+ *     action here since it's a single `case 'generate':` line change.
+ */
+import { ImageModule } from '../../mcp/tools/image/module';
+
+const BASE = 'https://image.example.com';
+
+const ENV_KEYS = ['IMAGE_BASE_URL', 'ANTHROPIC_BASE_URL', 'IMAGE_API_KEY', 'ANTHROPIC_AUTH_TOKEN'] as const;
+
+type Captured = { url: string; method: string };
+
+describe('generate_image action="generate" — Stop mid-poll cancels the job', () => {
+  const saved: Record<string, string | undefined> = {};
+  const realFetch = global.fetch;
+  let calls: Captured[];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.ANTHROPIC_BASE_URL = BASE;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+    calls = [];
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test('aborting mid-poll cancels the job and returns promptly, not after the full poll timeout', async () => {
+    const controller = new AbortController();
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method });
+      if (url.endsWith('/v1/images/generations') && method === 'POST') {
+        // Abort right after submit — the poll loop's very first check (before its
+        // first sleep) must catch this, so the test never waits out a real
+        // DEFAULT_POLL_INTERVAL_MS.
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-1', status: 'queued' }), { status: 202 });
+      }
+      if (url.includes('/v1/images/jobs/tid-1/cancel') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-1', cancelled: true, status: 'cancelling' }), { status: 200 });
+      }
+      // The poll loop must never reach GET .../jobs/tid-1 once aborted.
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new ImageModule().handleTool(
+      'generate_image',
+      { action: 'generate', model: 'gemini/gemini-2.5-flash-image', prompt: 'a red apple' },
+      controller.signal
+    );
+
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain('cancelled');
+    expect((res.content[0] as { text: string }).text).toContain('tid-1');
+
+    const cancelCalls = calls.filter((c) => c.url.includes('/cancel'));
+    expect(cancelCalls).toHaveLength(1);
+    expect(cancelCalls[0]!.method).toBe('POST');
+
+    // The poll loop bailed BEFORE ever GETting the job status.
+    expect(calls.some((c) => c.url.endsWith('/v1/images/jobs/tid-1'))).toBe(false);
+  });
+
+  test('a failed cancel call does not throw — the tool call still resolves cleanly', async () => {
+    const controller = new AbortController();
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/images/generations') && method === 'POST') {
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-2', status: 'queued' }), { status: 202 });
+      }
+      if (url.includes('/v1/images/jobs/tid-2/cancel')) {
+        throw new TypeError('network error');
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new ImageModule().handleTool(
+      'generate_image',
+      { action: 'generate', model: 'gemini/gemini-2.5-flash-image', prompt: 'a red apple' },
+      controller.signal
+    );
+
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain('cancelled');
+  });
+
+  test('an already-aborted signal short-circuits before even submitting is NOT assumed — generate still submits once', async () => {
+    // handleGenerate only starts checking the signal once it reaches the poll loop
+    // (after submit) — the initial POST always fires. This locks in that the
+    // signal is a poll-loop concern, not a submit-time short-circuit, since the
+    // job must exist server-side before there is anything to cancel.
+    const controller = new AbortController();
+    controller.abort();
+    let submitCount = 0;
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/images/generations') && method === 'POST') {
+        submitCount++;
+        return new Response(JSON.stringify({ task_id: 'tid-3', status: 'queued' }), { status: 202 });
+      }
+      if (url.includes('/v1/images/jobs/tid-3/cancel')) {
+        return new Response(JSON.stringify({ task_id: 'tid-3', cancelled: true, status: 'cancelling' }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new ImageModule().handleTool(
+      'generate_image',
+      { action: 'generate', model: 'gemini/gemini-2.5-flash-image', prompt: 'a red apple' },
+      controller.signal
+    );
+
+    expect(submitCount).toBe(1);
+    expect(res.isError).toBe(true);
+  });
+});

--- a/tests/unit/image-generate-cancel.test.ts
+++ b/tests/unit/image-generate-cancel.test.ts
@@ -20,11 +20,12 @@
  *     a poll loop worth reacting to) — handleTool's dispatch, not re-tested per
  *     action here since it's a single `case 'generate':` line change.
  */
+import { getEventListeners } from 'events';
 import { ImageModule } from '../../mcp/tools/image/module';
 
 const BASE = 'https://image.example.com';
 
-const ENV_KEYS = ['IMAGE_BASE_URL', 'ANTHROPIC_BASE_URL', 'IMAGE_API_KEY', 'ANTHROPIC_AUTH_TOKEN'] as const;
+const ENV_KEYS = ['IMAGE_BASE_URL', 'ANTHROPIC_BASE_URL', 'IMAGE_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'IMAGE_POLL_TIMEOUT_MS'] as const;
 
 type Captured = { url: string; method: string };
 
@@ -144,4 +145,44 @@ describe('generate_image action="generate" — Stop mid-poll cancels the job', (
     expect(submitCount).toBe(1);
     expect(res.isError).toBe(true);
   });
+
+  test('the poll loop does not leak an abort listener per iteration on the normal (non-aborted) path', async () => {
+    // Regression: sleep() adds an { once:true } abort listener each poll iteration
+    // against the SAME long-lived per-call signal. { once:true } only removes it
+    // when abort actually fires — so on the normal path (timer fires, never
+    // aborted) an un-removed listener piles up every iteration (up to ~75 for the
+    // default 150s/2s budget), tripping Node's MaxListenersExceededWarning. Here
+    // the signal is NEVER aborted and the job stays 'processing' until the poll
+    // budget runs out, so after handleTool returns the signal must hold ZERO abort
+    // listeners. Before the fix this was one-per-iteration.
+    process.env.IMAGE_POLL_TIMEOUT_MS = '6000'; // ~3 real 2s sleeps, then deadline exit
+    const controller = new AbortController();
+    let polls = 0;
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/images/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-leak', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/images/jobs/tid-leak') && method === 'GET') {
+        polls++;
+        return new Response(JSON.stringify({ task_id: 'tid-leak', status: 'processing' }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new ImageModule().handleTool(
+      'generate_image',
+      { action: 'generate', model: 'gemini/gemini-2.5-flash-image', prompt: 'a red apple' },
+      controller.signal
+    );
+
+    // Loop ran several iterations (proving multiple sleeps happened) and exited via
+    // the poll-budget deadline, not via abort.
+    expect(polls).toBeGreaterThanOrEqual(2);
+    expect(controller.signal.aborted).toBe(false);
+    expect((res.content[0] as { text: string }).text).toContain('still generating');
+    // The invariant: no abort listeners left dangling on the signal.
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary

A handful of edge cases around `/stop` (SIGINT) on API sessions, found while hardening a chat client's Stop button against this gateway. All reproduced live before the fix and covered by regression tests.

## What's fixed

**1. A crashed subprocess left `pendingApiSessions` stuck (up to ~15 min)**
If a session's CLI subprocess died mid-turn without ever emitting a terminal `result` line, `sendApiMessage`/`sendApiMessageStream`'s promise never settled. The caller-visible symptom: every retry on that `session_id` got a `409` ("Session already has a pending request") until `opts.timeoutMs` + the hard-cap safety net finally fired. Fix: both methods now listen for the subprocess `exit` event and fail the turn immediately if no result ever arrived — a `settled` guard makes this a no-op on the normal path where a result line does arrive just before exit.

**2. A message sent during the ~5s auto-restart window silently no-op'd**
After a crash, `SessionProcess` schedules a respawn ~5s later. A turn submitted into that window called `sendMessage()` on a subprocess that wasn't running yet, which just logs a warning and drops the message — the caller waits with nothing ever coming back. `getOrSpawnSession` now waits for the pending restart (via a `restarted`/`restartFailed` event) before handing back a session to send into.

**3. A `/stop`-triggered SIGINT was indistinguishable from a real crash**
`SessionProcess.interrupt()` sends SIGINT to ask the CLI to stop the current turn. Normally the CLI's own SIGINT handler flushes a terminal `result` line before the process exits (or stays alive) — but sometimes it exits without ever flushing one, which (after fix #1) surfaced "Session process exited unexpectedly before responding." to the end user for a Stop *they themselves* just pressed. `interrupt()` now sets a flag consumed by the exit handler, so this specific shape resolves like a graceful stop instead of erroring.

**4. A `/stop` before any output streamed left a dangling user turn**
If Stop landed before the model produced any text or tool output, the turn resolved with nothing to persist — the caller's history ends on the user's own message with no reply, which breaks any UI that infers "still pending" from `last message role == user`. Now persists the same placeholder `buildInitialPrompt` already uses for this exact shape when patching the next spawn's context: `[Session was interrupted before I could respond.]`.

**5. `generate_image`'s poll loop now reacts to Stop, and reports which model it used**
- `handleTool`/`handleGenerate` take an optional `AbortSignal` (threaded from the MCP SDK's own `notifications/cancelled`, via `extra.signal` in `mcp/server.ts`) so a Stop mid-generation lands within one poll wakeup instead of running to the full timeout, and fires a best-effort cancel call to the image endpoint (`POST /v1/images/jobs/:id/cancel` if your deployment implements it — silently ignored otherwise).
- The delivered result now includes the `model` that was requested for the image, so an agent can tell the user "made with X" instead of staying silent about it.

## How this was tested

- Unit tests added/updated: `tests/unit/api-stream-crash-recovery.test.ts` (crash-mid-turn, restart-window race, /stop-vs-crash disambiguation, dangling-turn placeholder — 5 tests), `tests/unit/image-generate-cancel.test.ts` (abort-mid-poll, cancel-call-never-throws, submit-always-fires-once, no-abort-listener-leak on the normal poll path — 4 tests).
- Each fix was verified live before being written: reverting the corresponding code change and re-running its test reproduces the original failure.
- Rebased onto current `main` (v1.7.0) from where this branch originated (v1.6.6) — one small conflict in `src/session/process.ts` (both branches added a top-level const in the same spot), resolved by keeping both. Full `tsc --noEmit` clean; full unit suite passes except pre-existing environment-only failures already present on bare `main` (this sandbox is missing `node:sqlite`, plus a few filesystem/symlink-timing tests unrelated to this change — confirmed identical failures on `main` before this branch's commits).

## Checklist

- [x] Reviewed my own code
- [x] Tests added and passing (`npx jest tests/unit/api-stream-crash-recovery.test.ts tests/unit/image-generate-cancel.test.ts`)
- [x] `tsc --noEmit` clean
