### PR TITLE
fix: cancel an in-flight image generation even when the CLI never sends notifications/cancelled

### DIFF
--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -118,19 +118,37 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
   // it by requestId) — the CLI sends that when a user Stop/Ctrl-C interrupts an
   // in-flight tool call. Threaded through so a long-running module (image
   // generation's poll loop) can react instead of running to its full timeout.
-  return mod.handleTool(toolName, args, extra.signal);
+  // Also combine with shutdownController.signal: the CLI sending that
+  // notification is only a "SHOULD" in the MCP spec, not a "MUST", and in
+  // practice a Stop that lets the CLI process exit cleanly (rather than
+  // staying alive to keep chatting) closes this server's stdin without ever
+  // sending notifications/cancelled — extra.signal would then never fire, and
+  // an in-flight image generation would poll to its full timeout instead of
+  // cancelling. stdin closing is a reliable, protocol-independent signal that
+  // the turn is over either way, so it backstops the notification.
+  const combinedSignal = AbortSignal.any([extra.signal, shutdownController.signal]);
+  return mod.handleTool(toolName, args, combinedSignal);
 });
 
 // Connect MCP transport
 await mcp.connect(new StdioServerTransport());
 
-// Graceful shutdown
+// Graceful shutdown — used by stdin-close, SIGINT, and SIGTERM paths.
+// Awaits any in-flight image cancel (E3) before exiting so the provider
+// actually stops generating when the user presses Stop, rather than the
+// process dying mid-request and the cancel call never reaching the server.
+const imageModuleRef = modules.find((m) => m.id === 'image') as { drainCancel?: () => Promise<void> } | undefined;
 let shuttingDown = false;
 function shutdown(): void {
   if (shuttingDown) return;
   shuttingDown = true;
   shutdownController.abort();
-  setTimeout(() => process.exit(0), 2000);
+  // Give the event loop one tick so the poll loop's sleep() onAbort listener
+  // fires and cancelledResult() sets activeCancelPromise before we try to drain it.
+  setImmediate(async () => {
+    try { await imageModuleRef?.drainCancel?.(); } catch { /* non-fatal */ }
+    process.exit(0);
+  });
 }
 process.stdin.on('end', shutdown);
 process.stdin.on('close', shutdown);

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -143,10 +143,19 @@ function shutdown(): void {
   if (shuttingDown) return;
   shuttingDown = true;
   shutdownController.abort();
+  // Hard cap: never let shutdown block on the drain. cancelJob() is bounded by
+  // its own AbortSignal.timeout (up to 30s), which is far longer than a
+  // supervisor's SIGTERM→SIGKILL grace period. Force-exit after a short window
+  // so a slow/hung provider cancel can't keep the process alive and risk SIGKILL
+  // mid-drain. Whichever fires first wins; unref() so the timer itself never
+  // holds the loop open.
+  const forceExit = setTimeout(() => process.exit(0), 2000);
+  forceExit.unref();
   // Give the event loop one tick so the poll loop's sleep() onAbort listener
   // fires and cancelledResult() sets activeCancelPromise before we try to drain it.
   setImmediate(async () => {
     try { await imageModuleRef?.drainCancel?.(); } catch { /* non-fatal */ }
+    clearTimeout(forceExit);
     process.exit(0);
   });
 }

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -382,9 +382,12 @@ export class ImageModule implements ToolModule {
       if (signal?.aborted) return this.cancelledResult(taskId);
       await sleep(DEFAULT_POLL_INTERVAL_MS, signal);
       if (signal?.aborted) return this.cancelledResult(taskId);
-      const polled = await this.fetchJob(taskId);
+      const polled = await this.fetchJob(taskId, signal);
       if (polled.__transportError) {
-        // transient transport error — keep polling until deadline
+        // transient transport error (or abort signal fired mid-fetch) — check
+        // signal before continuing so a Stop-triggered abort isn't swallowed
+        // as a retryable error and the cancel fires on the next loop iteration.
+        if (signal?.aborted) return this.cancelledResult(taskId);
         continue;
       }
       if (polled.httpError) return this.mapHttpError(polled.httpError.status, polled.httpError.body);
@@ -539,8 +542,9 @@ export class ImageModule implements ToolModule {
   /**
    * Best-effort E3 cancel — fires and never throws, so a failed cancel call can
    * never break the caller's own (already-cancelled) tool response. The api-side
-   * cancel is itself idempotent/no-op-safe on an already-terminal or unknown task,
-   * so no need to track whether this actually reached a still-running job.
+   * cancel is itself idempotent/no-op-safe on an already-terminal or unknown task.
+   * cancelledResult() tracks the returned promise (activeCancelPromise) so a
+   * process-exiting shutdown can await it via drainCancel() instead of racing it.
    */
   private async cancelJob(taskId: string): Promise<void> {
     try {
@@ -554,9 +558,23 @@ export class ImageModule implements ToolModule {
     }
   }
 
+  // Tracks the in-flight cancel call so drainCancel() can await it before the
+  // server process exits — a Stop that lets the CLI process die cleanly closes
+  // this server's stdin, which fires process.exit() shortly after; without
+  // this, that exit can race the fire-and-forget cancelJob() fetch and kill it
+  // before the request ever reaches the provider.
+  private activeCancelPromise: Promise<void> | null = null;
+
+  /** Wait for any in-flight E3 cancel to complete. Called by the shutdown handler. */
+  async drainCancel(): Promise<void> {
+    if (this.activeCancelPromise) await this.activeCancelPromise;
+  }
+
   /** Tool result for a Stop-triggered cancellation, firing the E3 cancel first. */
   private cancelledResult(taskId: string): McpToolResult {
-    void this.cancelJob(taskId);
+    this.activeCancelPromise = this.cancelJob(taskId).finally(() => {
+      this.activeCancelPromise = null;
+    });
     return {
       content: [{
         type: 'text',
@@ -567,13 +585,19 @@ export class ImageModule implements ToolModule {
   }
 
   /** Fetch a job (E2), classifying transport vs HTTP errors so the poller can retry transient ones. */
-  private async fetchJob(taskId: string): Promise<{ job?: JobResponse; httpError?: { status: number; body: string }; __transportError?: unknown }> {
+  private async fetchJob(taskId: string, signal?: AbortSignal): Promise<{ job?: JobResponse; httpError?: { status: number; body: string }; __transportError?: unknown }> {
     let res: Response;
     try {
+      // Combine with the caller's cancel signal (not just the request timeout) so
+      // a Stop that lands mid-fetch aborts the request immediately instead of
+      // waiting out REQUEST_TIMEOUT_MS before the poll loop even gets to check.
+      const fetchSignal = signal
+        ? AbortSignal.any([AbortSignal.timeout(REQUEST_TIMEOUT_MS), signal])
+        : AbortSignal.timeout(REQUEST_TIMEOUT_MS);
       res = await fetch(`${this.baseUrl()}/v1/images/jobs/${encodeURIComponent(taskId)}`, {
         method: 'GET',
         headers: this.headers(),
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        signal: fetchSignal,
       });
     } catch (err) {
       return { __transportError: err };
@@ -764,7 +788,7 @@ export class ImageModule implements ToolModule {
 // signal.aborted itself right after, so this only needs to shorten the wait.
 // The abort listener is removed when the timer fires normally: sleep() is called
 // once per poll iteration against the SAME long-lived signal (up to ~75 times for
-// the default 150s/2s budget), so leaving { once:true } listeners around on the
+// the default 150s/2s budget), so leaving { once: true } listeners around on the
 // non-abort path would pile them onto that one signal and trip Node's
 // MaxListenersExceededWarning.
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -3409,9 +3409,8 @@ export class AgentRunner extends EventEmitter {
     //
     // skipPersist (wire param store_user_message=false) suppresses BOTH the user command and
     // the assistant reply: programmatic REST callers leave no trace in chat history at all.
-    // `force` overrides that for notes that must stay visible regardless (see /stop below).
-    const persist = (role: 'user' | 'assistant', content: string, force = false) => {
-      if ((skipPersist && !force) || !content) return;
+    const persist = (role: 'user' | 'assistant', content: string) => {
+      if (skipPersist || !content) return;
       this.historyDb.insertMessage({ chatId: dbChatId, sessionId, source: 'api', role, content, ts: Date.now() });
     };
 
@@ -3423,7 +3422,6 @@ export class AgentRunner extends EventEmitter {
 
     let result: Record<string, unknown>;
     let responseText: string;
-    let forcePersist = false;
     try {
       if (cmd === '/model') {
         const model = this.agentConfig.claude.model;
@@ -3436,14 +3434,7 @@ export class AgentRunner extends EventEmitter {
         const session = this.sessions.get(sessionId);
         const stopped = session ? session.interrupt() : false;
         result = { stopped };
-        responseText = stopped
-          ? 'Session was interrupted before I could respond.'
-          : 'No active session to stop.';
-        // A turn was actually cut off — always leave a visible note in history so the
-        // web Stop button (skipPersist:true, to suppress the "/stop" command echo) and
-        // a typed /stop command show the same outcome instead of the button leaving a
-        // silently-dangling user turn.
-        forcePersist = stopped;
+        responseText = stopped ? 'Session interrupted.' : 'No active session to stop.';
       } else if (cmd === '/restart') {
         this.restartProcess(sessionId).catch(() => {});
         result = { restarting: true };
@@ -3546,8 +3537,7 @@ export class AgentRunner extends EventEmitter {
 
     // Persist the human-readable response as an assistant turn so the conversation ends with
     // an assistant message (the web's computeIsPendingResponse needs last.role !== 'user').
-    // forcePersist writes it even under skipPersist (set only when /stop cut a turn off).
-    persist('assistant', responseText, forcePersist);
+    persist('assistant', responseText);
 
     return { result, responseText };
   }

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -3409,8 +3409,9 @@ export class AgentRunner extends EventEmitter {
     //
     // skipPersist (wire param store_user_message=false) suppresses BOTH the user command and
     // the assistant reply: programmatic REST callers leave no trace in chat history at all.
-    const persist = (role: 'user' | 'assistant', content: string) => {
-      if (skipPersist || !content) return;
+    // `force` overrides that for notes that must stay visible regardless (see /stop below).
+    const persist = (role: 'user' | 'assistant', content: string, force = false) => {
+      if ((skipPersist && !force) || !content) return;
       this.historyDb.insertMessage({ chatId: dbChatId, sessionId, source: 'api', role, content, ts: Date.now() });
     };
 
@@ -3422,6 +3423,7 @@ export class AgentRunner extends EventEmitter {
 
     let result: Record<string, unknown>;
     let responseText: string;
+    let forcePersist = false;
     try {
       if (cmd === '/model') {
         const model = this.agentConfig.claude.model;
@@ -3434,7 +3436,14 @@ export class AgentRunner extends EventEmitter {
         const session = this.sessions.get(sessionId);
         const stopped = session ? session.interrupt() : false;
         result = { stopped };
-        responseText = stopped ? 'Session interrupted.' : 'No active session to stop.';
+        responseText = stopped
+          ? 'Session was interrupted before I could respond.'
+          : 'No active session to stop.';
+        // A turn was actually cut off — always leave a visible note in history so the
+        // web Stop button (skipPersist:true, to suppress the "/stop" command echo) and
+        // a typed /stop command show the same outcome instead of the button leaving a
+        // silently-dangling user turn.
+        forcePersist = stopped;
       } else if (cmd === '/restart') {
         this.restartProcess(sessionId).catch(() => {});
         result = { restarting: true };
@@ -3537,7 +3546,8 @@ export class AgentRunner extends EventEmitter {
 
     // Persist the human-readable response as an assistant turn so the conversation ends with
     // an assistant message (the web's computeIsPendingResponse needs last.role !== 'user').
-    persist('assistant', responseText);
+    // forcePersist writes it even under skipPersist (set only when /stop cut a turn off).
+    persist('assistant', responseText, forcePersist);
 
     return { result, responseText };
   }

--- a/tests/unit/image-generate-cancel.test.ts
+++ b/tests/unit/image-generate-cancel.test.ts
@@ -186,3 +186,83 @@ describe('generate_image action="generate" — Stop mid-poll cancels the job', (
     expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
   }, 20_000);
 });
+
+describe('drainCancel() — lets a process-exiting shutdown wait for the E3 call', () => {
+  const saved: Record<string, string | undefined> = {};
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.ANTHROPIC_BASE_URL = BASE;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test('resolves immediately when nothing is in flight', async () => {
+    const mod = new ImageModule();
+    // No cancelledResult() ever ran — activeCancelPromise is still null.
+    await expect(mod.drainCancel()).resolves.toBeUndefined();
+  });
+
+  test('waits for an in-flight cancel call to actually finish before resolving', async () => {
+    const controller = new AbortController();
+    let resolveCancelFetch!: (res: Response) => void;
+    const cancelFetchGate = new Promise<Response>((resolve) => { resolveCancelFetch = resolve; });
+    let cancelFetchSettled = false;
+
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/images/generations') && method === 'POST') {
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-drain', status: 'queued' }), { status: 202 });
+      }
+      if (url.includes('/v1/images/jobs/tid-drain/cancel') && method === 'POST') {
+        // Held open deliberately — drainCancel() must not resolve before this does.
+        const res = await cancelFetchGate;
+        cancelFetchSettled = true;
+        return res;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const mod = new ImageModule();
+    // Don't await yet — the cancel HTTP call is parked on cancelFetchGate.
+    const genPromise = mod.handleTool(
+      'generate_image',
+      { action: 'generate', model: 'gemini/gemini-2.5-flash-image', prompt: 'a red apple' },
+      controller.signal
+    );
+
+    // Give handleGenerate's poll loop a tick to reach cancelledResult() and set
+    // activeCancelPromise before we start racing drainCancel() against it.
+    await new Promise((r) => setImmediate(r));
+
+    let drainSettled = false;
+    const drainPromise = mod.drainCancel().then(() => { drainSettled = true; });
+
+    // The cancel fetch is still parked — neither the tool call nor drainCancel
+    // should have settled yet.
+    await new Promise((r) => setImmediate(r));
+    expect(cancelFetchSettled).toBe(false);
+    expect(drainSettled).toBe(false);
+
+    resolveCancelFetch(new Response(JSON.stringify({ task_id: 'tid-drain', cancelled: true, status: 'cancelling' }), { status: 200 }));
+
+    await drainPromise;
+    expect(drainSettled).toBe(true);
+    expect(cancelFetchSettled).toBe(true);
+
+    await genPromise;
+  });
+});

--- a/tests/unit/image-generate-cancel.test.ts
+++ b/tests/unit/image-generate-cancel.test.ts
@@ -185,6 +185,88 @@ describe('generate_image action="generate" — Stop mid-poll cancels the job', (
     // The invariant: no abort listeners left dangling on the signal.
     expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
   }, 20_000);
+
+  test('the caller cancel signal is threaded into the fetchJob GET, so a Stop mid-fetch aborts the request', async () => {
+    // Mechanism: fetchJob builds AbortSignal.any([timeout, callerSignal]) and passes it
+    // as the GET's signal. Without threading, a Stop landing mid-poll would wait out
+    // REQUEST_TIMEOUT_MS on the in-flight GET before the loop could react. Capture the
+    // signal actually handed to fetch and prove that aborting the caller aborts it.
+    const controller = new AbortController();
+    let capturedGetSignal: AbortSignal | undefined;
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method });
+      if (url.endsWith('/v1/images/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-sig', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/images/jobs/tid-sig') && method === 'GET') {
+        capturedGetSignal = init?.signal ?? undefined;
+        // Simulate the Stop landing while this GET is in flight.
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-sig', status: 'processing' }), { status: 200 });
+      }
+      if (url.includes('/v1/images/jobs/tid-sig/cancel') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-sig', cancelled: true, status: 'cancelling' }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new ImageModule().handleTool(
+      'generate_image',
+      { action: 'generate', model: 'gemini/gemini-2.5-flash-image', prompt: 'a red apple' },
+      controller.signal
+    );
+
+    // The GET actually received a signal, and it is the combined one that reflects the
+    // caller's abort (not a bare per-request timeout signal).
+    expect(capturedGetSignal).toBeInstanceOf(AbortSignal);
+    expect(capturedGetSignal!.aborted).toBe(true);
+    // The loop then bailed to a cancel, not a timeout/error.
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain('cancelled');
+    expect(calls.filter((c) => c.url.includes('/cancel'))).toHaveLength(1);
+  });
+
+  test('a transport error that coincides with an abort is not swallowed as retryable — it cancels', async () => {
+    // fetchJob maps a thrown fetch (network error / abort) to { __transportError }. The
+    // poll loop treats that as transient and would `continue` to retry — but it first
+    // checks signal.aborted so a Stop-triggered abort mid-fetch resolves to a cancel
+    // instead of silently looping. Prove that branch: throw on the GET AND abort in the
+    // same turn, and assert the loop cancels rather than issuing a second GET.
+    const controller = new AbortController();
+    let getCount = 0;
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method });
+      if (url.endsWith('/v1/images/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-terr', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/images/jobs/tid-terr') && method === 'GET') {
+        getCount++;
+        controller.abort();
+        throw new TypeError('network error'); // → fetchJob returns { __transportError }
+      }
+      if (url.includes('/v1/images/jobs/tid-terr/cancel') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-terr', cancelled: true, status: 'cancelling' }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new ImageModule().handleTool(
+      'generate_image',
+      { action: 'generate', model: 'gemini/gemini-2.5-flash-image', prompt: 'a red apple' },
+      controller.signal
+    );
+
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain('cancelled');
+    expect((res.content[0] as { text: string }).text).toContain('tid-terr');
+    // The abort was honored immediately: exactly one GET (no retry), and a cancel fired.
+    expect(getCount).toBe(1);
+    expect(calls.filter((c) => c.url.includes('/cancel'))).toHaveLength(1);
+  });
 });
 
 describe('drainCancel() — lets a process-exiting shutdown wait for the E3 call', () => {


### PR DESCRIPTION
## Summary

Follow-up to #356 (thanks for merging that, and for the abort-listener-leak fix you pushed onto that branch directly — it's included here as a matter of course since this branches off current `main`).

While verifying #356's fix end-to-end against a real deployment, found that `generate_image`'s cancellation still doesn't reliably reach the provider for what turns out to be the *majority* of real Stop presses.

## The gap

`mcp/server.ts` threads the MCP SDK's per-call `extra.signal` into `handleTool` — that signal fires when the CLI sends `notifications/cancelled` for the in-flight call. But per the MCP spec, a client sending that notification is a "SHOULD", not a "MUST". In practice: a Stop that lets the CLI process exit cleanly (rather than staying alive to keep chatting) closes this server's stdin *without* ever sending that notification. `extra.signal` then never fires, and an in-flight `generate_image` poll loop runs to its full timeout instead of cancelling — confirmed live: the job's terminal state showed no cancellation ever reached the provider, credit already spent.

## The fix

stdin closing already drives this server's own shutdown (`shutdownController`) regardless of whether the CLI sent the notification — it's a reliable, protocol-independent "the turn is over" signal. Combining it with `extra.signal` via `AbortSignal.any()` means either one cancels an in-flight tool call.

Getting that to actually reach the provider needed a few follow-on pieces:
- `fetchJob()` now takes the same combined signal, so a Stop landing mid-poll aborts that GET immediately instead of waiting up to `REQUEST_TIMEOUT_MS`.
- The poll loop's transport-error branch now checks `signal.aborted` before retrying, so an abort during a failed fetch isn't swallowed as "transient, keep polling" for one extra iteration.
- The cancel HTTP call (`cancelJob`) is fire-and-forget from `cancelledResult()`'s point of view — but the whole point of stdin-close driving cancellation is that the process is about to exit. A bare `process.exit()` shortly after could kill that fetch before it ever reaches the provider. `cancelledResult()` now tracks the promise (`activeCancelPromise`), and the shutdown handler awaits it via a new `drainCancel()` before exiting.

## How this was tested

- Two new tests in `tests/unit/image-generate-cancel.test.ts` covering `drainCancel()`: resolves immediately with nothing in flight, and genuinely waits for an in-flight cancel fetch to settle before resolving (using a gated mock fetch to prove the ordering, not just that both eventually happen).
- Reproduced live against a real deployment before writing the fix (Stop during image generation → job kept polling server-side, credit spent, no cancellation reached the provider) and confirmed after (job terminates with a `context canceled`-style error from the provider's own polling loop, credit refunded).
- `tsc --noEmit` clean, full `npx jest --testPathPattern=unit` — no regressions versus current `main` (same pre-existing environment-only failures on both sides: this sandbox is missing `node:sqlite`, plus a few filesystem/symlink-timing tests unrelated to this change).

## Checklist

- [x] Reviewed my own code
- [x] Tests added and passing
- [x] `tsc --noEmit` clean