### PR TITLE
fix: keep the interrupted note visible even after partial output, drop brackets

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2808,7 +2808,12 @@ export class AgentRunner extends EventEmitter {
         // never clears (it only clears once the last message is from the
         // assistant). Same wording buildInitialPrompt uses to patch this same
         // dangling-turn shape for the next spawn's in-memory context.
-        const finalText = !trimmed && !attachments.length && interrupted ? INTERRUPTED_NO_REPLY_TEXT : trimmed;
+        // A /stop that lands AFTER partial text/attachments already streamed out
+        // (e.g. mid tool-use, "กำลังวาด...") must still say so — appended rather
+        // than replacing, so the partial work stays visible alongside the notice.
+        const finalText = interrupted
+          ? [trimmed, INTERRUPTED_NO_REPLY_TEXT].filter(Boolean).join('\n\n')
+          : trimmed;
         // Persist assistant reply. Image-only replies (empty text but attachments
         // present) must also persist — otherwise the screenshot vanishes from history.
         if (finalText || attachments.length) {
@@ -3055,7 +3060,12 @@ export class AgentRunner extends EventEmitter {
       // never clears (it only clears once the last message is from the
       // assistant). Same wording buildInitialPrompt uses to patch this same
       // dangling-turn shape for the next spawn's in-memory context.
-      const finalText = !trimmed && !attachments.length && interrupted ? INTERRUPTED_NO_REPLY_TEXT : trimmed;
+      // A /stop that lands AFTER partial text/attachments already streamed out
+      // (e.g. mid tool-use, "กำลังวาด...") must still say so — appended rather
+      // than replacing, so the partial work stays visible alongside the notice.
+      const finalText = interrupted
+        ? [trimmed, INTERRUPTED_NO_REPLY_TEXT].filter(Boolean).join('\n\n')
+        : trimmed;
       // Persist assistant reply regardless of whether the SSE client is still connected.
       // Image-only replies (empty text but attachments present) must also persist —
       // otherwise the screenshot vanishes from history once the stream ends.

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2809,7 +2809,7 @@ export class AgentRunner extends EventEmitter {
         // assistant). Same wording buildInitialPrompt uses to patch this same
         // dangling-turn shape for the next spawn's in-memory context.
         // A /stop that lands AFTER partial text/attachments already streamed out
-        // (e.g. mid tool-use, "กำลังวาด...") must still say so — appended rather
+        // (e.g. mid tool-use, "Drawing now...") must still say so — appended rather
         // than replacing, so the partial work stays visible alongside the notice.
         const finalText = interrupted
           ? [trimmed, INTERRUPTED_NO_REPLY_TEXT].filter(Boolean).join('\n\n')
@@ -3061,7 +3061,7 @@ export class AgentRunner extends EventEmitter {
       // assistant). Same wording buildInitialPrompt uses to patch this same
       // dangling-turn shape for the next spawn's in-memory context.
       // A /stop that lands AFTER partial text/attachments already streamed out
-      // (e.g. mid tool-use, "กำลังวาด...") must still say so — appended rather
+      // (e.g. mid tool-use, "Drawing now...") must still say so — appended rather
       // than replacing, so the partial work stays visible alongside the notice.
       const finalText = interrupted
         ? [trimmed, INTERRUPTED_NO_REPLY_TEXT].filter(Boolean).join('\n\n')

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -37,7 +37,7 @@ const CHANNEL_REPLY_TOOLS = new Set([
 // message to durable history so a dangling last-message-from-user turn doesn't leave
 // the web sidebar's "typing…" indicator stuck (isSessionPending only clears once the
 // last committed message is from the assistant).
-export const INTERRUPTED_NO_REPLY_TEXT = '[Session was interrupted before I could respond.]';
+export const INTERRUPTED_NO_REPLY_TEXT = 'Session was interrupted before I could respond.';
 
 /**
  * Resolve the per-spawn history re-injection cap with precedence

--- a/tests/unit/api-stream-crash-recovery.test.ts
+++ b/tests/unit/api-stream-crash-recovery.test.ts
@@ -296,7 +296,7 @@ describe('AgentRunner.sendApiMessageStream — subprocess exit mid-turn', () => 
       await new Promise((r) => setImmediate(r));
 
       expect(onDone).toHaveBeenCalledTimes(1);
-      expect(onDone.mock.calls[0][0]).toBe('partial reply');
+      expect(onDone.mock.calls[0][0]).toBe(`partial reply\n\n${INTERRUPTED_NO_REPLY_TEXT}`);
       expect(onError).not.toHaveBeenCalled();
       expect(runner.hasActiveApiSession(sessionId)).toBe(false);
     } finally {


### PR DESCRIPTION
## Summary

Follow-up to #357 — the last commit on that branch (interrupted-note visibility fix) landed 16 minutes after the PR was merged, so it never made it into `main`. Re-opening it here on top of current `main`.

`INTERRUPTED_NO_REPLY_TEXT` only fired when a `/stop` landed **before** any text or attachment came out of the turn. A `/stop` that landed **after** partial text had already streamed (e.g. mid tool-use, "Drawing now...") silently dropped the notice — the turn just looked finished when it wasn't, with no indication anything was interrupted.

## The fix

- `finalText` now **appends** the interrupted note after any partial text/attachments instead of only substituting it when the result was empty. Applied to both `sendApiMessage` and `sendApiMessageStream`'s `done()`.
- Dropped the surrounding brackets from `INTERRUPTED_NO_REPLY_TEXT` per product request — now reads `Session was interrupted before I could respond.` instead of `[Session was interrupted before I could respond.]`.

## Testing

- `tsc --noEmit` clean.
- Verified live against a local deployment: stopping mid tool-use (image generation) now correctly appends the note after the partial assistant text, in both the session JSONL store and the durable history DB that the web client reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)