### PR TITLE
fix: synchronize GPT model registry and dismiss picker

### DIFF
--- a/API.md
+++ b/API.md
@@ -74,7 +74,7 @@ browser to open a link owns it (a link opened in a second browser is rejected), 
 | `DELETE` | `/api/v1/agents/:agentId` | Admin | Delete an agent |
 | `POST` | `/api/v1/agents/:agentId/messages` | Key | Send a message — sync JSON or SSE stream; supports slash commands |
 | `POST` | `/api/v1/agents/:agentId/greeting` | Write | Stream a proactive welcome from `GREETING.md` into an existing session (SSE); returns 204 if file absent |
-| `GET` | `/api/v1/models` | Key | List all supported Claude models |
+| `GET` | `/api/v1/models` | Key | List all supported models (Claude and GPT) |
 | `PUT` | `/api/v1/agents/:agentId/model` | Admin | Set the active model for an agent |
 
 ### Session Management API
@@ -1438,7 +1438,7 @@ The stream ends with `data: [DONE]`.
 
 ### GET /api/v1/models
 
-List all supported Claude models from gateway config.
+List all supported models (Claude and GPT) from gateway config.
 
 ```bash
 curl -H "X-Api-Key: my-secret-key-123" \
@@ -1451,7 +1451,8 @@ curl -H "X-Api-Key: my-secret-key-123" \
     { "id": "claude-opus-5",     "name": "Opus 5",     "alias": "opus",     "contextWindow": 200000,  "multiplier": 1 },
     { "id": "claude-opus-5[1m]", "name": "Opus 5 (1M)", "alias": "opus[1m]", "contextWindow": 1000000, "multiplier": 1 },
     { "id": "claude-opus-4-8",   "name": "Opus 4.8",   "alias": "opus48",   "contextWindow": 200000,  "multiplier": 1 },
-    { "id": "claude-sonnet-5",   "name": "Sonnet 5",   "alias": "sonnet",   "contextWindow": 200000,  "multiplier": 1 }
+    { "id": "claude-sonnet-5",   "name": "Sonnet 5",   "alias": "sonnet",   "contextWindow": 200000,  "multiplier": 1 },
+    { "id": "gpt-5.6-sol[1m]",   "name": "GPT 5.6 Sol", "alias": "gpt56sol", "contextWindow": 1050000, "multiplier": 1 }
   ]
 }
 ```
@@ -1720,7 +1721,7 @@ curl -X POST \
 ```
 
 ```json
-{ "compacted": true, "keptMessages": 10, "sessionId": "da19d84a-6a36-4f57-b419-d322d82c4db8" }
+{ "success": true, "keptMessages": 10, "archivedMessages": 42 }
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1151,7 +1151,7 @@ paired, the following commands are available in a private chat:
 | Command | Description |
 |---------|-------------|
 | `/model` | Show the current AI model |
-| `/models` | Switch AI model — shows an inline keyboard; selecting a model triggers a graceful restart and notifies when back online |
+| `/models` | Switch AI model — shows an inline keyboard; selecting a model triggers a graceful restart and notifies when back online; **Dismiss** closes the picker without changing the model |
 
 **Account**
 

--- a/config.template.json
+++ b/config.template.json
@@ -10,7 +10,7 @@
       "claude.dangerouslySkipPermissions"
     ]
   },
-  "configVersion": "1.0.29",
+  "configVersion": "1.0.30",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
@@ -26,7 +26,11 @@
       { "id": "claude-opus-4-6",           "label": "Opus 4.6",         "alias": "opus46",      "contextWindow": 200000 },
       { "id": "claude-sonnet-5",           "label": "Sonnet 5",         "alias": "sonnet",      "contextWindow": 200000 },
       { "id": "claude-sonnet-4-6",         "label": "Sonnet 4.6",       "alias": "sonnet46",    "contextWindow": 200000 },
-      { "id": "claude-haiku-4-5-20251001", "label": "Haiku 4.5",        "alias": "haiku",       "contextWindow": 200000 }
+      { "id": "claude-haiku-4-5-20251001", "label": "Haiku 4.5",        "alias": "haiku",       "contextWindow": 200000 },
+      { "id": "gpt-5.6-sol[1m]",           "label": "GPT 5.6 Sol",      "alias": "gpt56sol",    "contextWindow": 1050000 },
+      { "id": "gpt-5.6-terra[1m]",         "label": "GPT 5.6 Terra",    "alias": "gpt56terra",  "contextWindow": 1050000 },
+      { "id": "gpt-5.6-luna[1m]",          "label": "GPT 5.6 Luna",     "alias": "gpt56luna",   "contextWindow": 1050000 },
+      { "id": "gpt-5.5[1m]",               "label": "GPT 5.5",          "alias": "gpt55",       "contextWindow": 1050000 }
     ],
     "api": {
       "keys": [

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -903,6 +903,10 @@ const AVAILABLE_MODELS = [
   { id: 'claude-sonnet-5',           label: 'Sonnet 5',         alias: 'sonnet' },
   { id: 'claude-sonnet-4-6',         label: 'Sonnet 4.6',       alias: 'sonnet46' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5',        alias: 'haiku' },
+  { id: 'gpt-5.6-sol[1m]',           label: 'GPT 5.6 Sol',      alias: 'gpt56sol' },
+  { id: 'gpt-5.6-terra[1m]',         label: 'GPT 5.6 Terra',    alias: 'gpt56terra' },
+  { id: 'gpt-5.6-luna[1m]',          label: 'GPT 5.6 Luna',     alias: 'gpt56luna' },
+  { id: 'gpt-5.5[1m]',               label: 'GPT 5.5',          alias: 'gpt55' },
 ]
 
 // Base URL for command API calls to the AgentRunner callback server.
@@ -1231,6 +1235,7 @@ bot.command('models', async ctx => {
       const prefix = m.id === currentModel ? '\u2705 ' : ''
       keyboard.text(`${prefix}${m.label}`, `model:${m.id}`).row()
     }
+    keyboard.text('Dismiss', 'models:dismiss')
 
     await ctx.reply(`Current model: ${currentModel}\nSelect a model:`, {
       reply_markup: keyboard,
@@ -1478,6 +1483,16 @@ bot.on('callback_query:data', async ctx => {
         process.stderr.write(`telegram channel: menu cancel callback POST failed: ${err}\n`)
       })
     }
+    return
+  }
+
+  if (data === 'models:dismiss') {
+    if (!isCallbackAuthorized(ctx)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    await ctx.answerCallbackQuery({ text: 'Dismissed' }).catch(() => {})
+    await ctx.deleteMessage().catch(() => {})
     return
   }
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -60,6 +60,10 @@ export const DEFAULT_MODELS: ModelConfig[] = [
   { id: 'claude-sonnet-5',           label: 'Sonnet 5',         alias: 'sonnet',      contextWindow: 200000 },
   { id: 'claude-sonnet-4-6',         label: 'Sonnet 4.6',       alias: 'sonnet46',    contextWindow: 200000 },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5',        alias: 'haiku',       contextWindow: 200000 },
+  { id: 'gpt-5.6-sol[1m]',           label: 'GPT 5.6 Sol',      alias: 'gpt56sol',    contextWindow: 1050000 },
+  { id: 'gpt-5.6-terra[1m]',         label: 'GPT 5.6 Terra',    alias: 'gpt56terra',  contextWindow: 1050000 },
+  { id: 'gpt-5.6-luna[1m]',          label: 'GPT 5.6 Luna',     alias: 'gpt56luna',   contextWindow: 1050000 },
+  { id: 'gpt-5.5[1m]',               label: 'GPT 5.5',          alias: 'gpt55',       contextWindow: 1050000 },
 ];
 
 const PROTECTED_WORKSPACE_FILES = [
@@ -3385,7 +3389,7 @@ export class AgentRunner extends EventEmitter {
     sessionId: string,
     chatId: string,
     command: string,
-    opts?: { skipPersist?: boolean },
+    opts?: { skipPersist?: boolean; model?: string },
   ): Promise<{ result: Record<string, unknown>; responseText: string }> {
     const agentId = this.agentConfig.id;
     const storeChatId = chatId;           // sessionStore adds channel prefix internally
@@ -3515,7 +3519,8 @@ export class AgentRunner extends EventEmitter {
         responseText = 'Session cleared.';
       } else if (cmd === '/compact') {
         const ch = 'api' as const;
-        const compactEffectiveModel = this.agentConfig.claude.model;
+        const activeSession = this.sessions.get(sessionId);
+        const compactEffectiveModel = opts?.model ?? activeSession?.modelOverride ?? this.agentConfig.claude.model;
         const availableModels = this.gatewayConfig.gateway.models ?? DEFAULT_MODELS;
         const modelConfig = availableModels.find((m) => m.id === compactEffectiveModel);
         const contextWindow = modelConfig?.contextWindow ?? 200000;

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -435,7 +435,7 @@ export function createApiRouter(
           res.socket?.setNoDelay(true);
           try {
             const { responseText } = await runner.executeApiCommand(
-              sessionId, chatIdStr, trimmedMessage, { skipPersist: skipUserMessage },
+              sessionId, chatIdStr, trimmedMessage, { skipPersist: skipUserMessage, model: modelStr },
             );
             sseCallbacks.onChunk({ type: 'text_delta', text: responseText } as import('../types').StreamEvent);
             sseCallbacks.onDone(responseText, []);

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -650,10 +650,17 @@ export function migrateConfig(
   );
 }
 
+const LEGACY_MODEL_ID_RENAMES: Readonly<Record<string, string>> = {
+  'gpt-5.6-sol': 'gpt-5.6-sol[1m]',
+  'gpt-5.6-terra': 'gpt-5.6-terra[1m]',
+  'gpt-5.6-luna': 'gpt-5.6-luna[1m]',
+  'gpt-5.5': 'gpt-5.5[1m]',
+};
+
 /**
  * Merge models from template into user config by ID.
  * Adds new models, updates alias/label/contextWindow of existing ones.
- * Preserves user models not in template.
+ * Renames retired built-in IDs and preserves unrelated user models.
  */
 function migrateModels(
   config: Record<string, unknown>,
@@ -668,6 +675,10 @@ function migrateModels(
   if (!templateModels || templateModels.length === 0) return;
 
   const userModels = (gw.models ?? []) as Array<Record<string, unknown>>;
+  for (const model of userModels) {
+    const renamedId = LEGACY_MODEL_ID_RENAMES[String(model.id)];
+    if (renamedId) model.id = renamedId;
+  }
   const userMap = new Map(userModels.map((m) => [m.id as string, m]));
   const merged: Array<Record<string, unknown>> = [];
 
@@ -691,6 +702,16 @@ function migrateModels(
   }
 
   gw.models = merged;
+
+  if (Array.isArray(config.agents)) {
+    for (const agent of config.agents as Array<Record<string, unknown>>) {
+      const claude = agent.claude;
+      if (!claude || typeof claude !== 'object' || Array.isArray(claude)) continue;
+      const model = (claude as Record<string, unknown>).model;
+      const renamedId = LEGACY_MODEL_ID_RENAMES[String(model)];
+      if (renamedId) (claude as Record<string, unknown>).model = renamedId;
+    }
+  }
 }
 
 // Exported for testing

--- a/src/session/compactor.ts
+++ b/src/session/compactor.ts
@@ -76,7 +76,7 @@ export class SessionCompactor {
       .map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
       .join('\n\n');
 
-    const summaryText = await this.summarizeWithChunking(historyText);
+    const summaryText = await this.summarizeWithChunking(historyText, model);
     const compacted: Message[] = [
       { role: 'system', content: `[Conversation Summary]\n${summaryText}`, ts: Date.now() },
       ...tail,
@@ -94,10 +94,10 @@ export class SessionCompactor {
     return { beforeMessages, afterMessages, beforeTokens, afterTokens, reductionPct, contextPctBefore, contextPctAfter };
   }
 
-  private async summarizeWithChunking(historyText: string): Promise<string> {
+  private async summarizeWithChunking(historyText: string, model: string): Promise<string> {
     // If small enough, summarize directly
     if (historyText.length <= CHUNK_CHARS) {
-      return this.callClaudeForSummary(historyText);
+      return this.callClaudeForSummary(historyText, model);
     }
 
     // Split into chunks and summarize each
@@ -107,6 +107,7 @@ export class SessionCompactor {
     for (let i = 0; i < chunks.length; i++) {
       const summary = await this.callClaudeForSummary(
         chunks[i],
+        model,
         `This is part ${i + 1} of ${chunks.length} of a longer conversation. Summarize this segment concisely.`,
       );
       chunkSummaries.push(`[Part ${i + 1}/${chunks.length}]\n${summary}`);
@@ -116,6 +117,7 @@ export class SessionCompactor {
     const mergedText = chunkSummaries.join('\n\n');
     return this.callClaudeForSummary(
       mergedText,
+      model,
       MERGE_SUMMARIES_PROMPT,
     );
   }
@@ -140,6 +142,7 @@ export class SessionCompactor {
 
   private async callClaudeForSummary(
     text: string,
+    model: string,
     instruction = SINGLE_SUMMARY_INSTRUCTION,
   ): Promise<string> {
     // Wrap content in XML tags so claude treats it as data to analyze, not an active conversation
@@ -153,7 +156,7 @@ export class SessionCompactor {
     const claudeBinRaw = process.env.CLAUDE_BIN ?? resolveClaudeBin().bin;
     const [claudeBin, ...claudeBinArgs] = claudeBinRaw.split(' ');
 
-    const result = spawnSync(claudeBin, [...claudeBinArgs, '--print'], {
+    const result = spawnSync(claudeBin, [...claudeBinArgs, '--print', '--model', model], {
       input: prompt,
       encoding: 'utf-8',
       timeout: 300_000,

--- a/tests/integration/telegram-plugin-process.test.ts
+++ b/tests/integration/telegram-plugin-process.test.ts
@@ -223,6 +223,13 @@ function startMockCallbackServer(port: number) {
       res.writeHead(200, { 'Content-Type': 'application/json' })
       if (body['command'] === 'cli_pair') {
         res.end(JSON.stringify({ success: true, pairingId: 'a'.repeat(36), code: '1234', url: 'https://host.example/cli/' + 'a'.repeat(36) }))
+      } else if (body['command'] === 'get_model') {
+        res.end(JSON.stringify({ model: 'claude-opus-5' }))
+      } else if (body['command'] === 'get_models') {
+        res.end(JSON.stringify({ models: [
+          { id: 'claude-opus-5', label: 'Opus 5' },
+          { id: 'claude-sonnet-5', label: 'Sonnet 5' },
+        ] }))
       } else {
         res.end(JSON.stringify({ success: true }))
       }
@@ -489,5 +496,78 @@ describe('Telegram plugin E2E (process + mock Telegram API)', () => {
     expect(pair).toBeTruthy()
     expect((pair!['payload'] as { channel: string; user_id: string }).channel).toBe('telegram')
     expect((pair!['payload'] as { channel: string; user_id: string }).user_id).toBe(USER_ID)
+  }, 30000)
+
+  // ── test 7: /models picker can be dismissed without changing the model ─────
+
+  test('/models Dismiss acknowledges and deletes the picker without setting a model', async () => {
+    const t0 = Date.now()
+    const now = Math.floor(t0 / 1000)
+    const callbackStart = mockCb.commands.length
+
+    mock.queueUpdate({
+      message: {
+        message_id: 78,
+        from: { id: Number(USER_ID), username: 'tester', is_bot: false, first_name: 'Tester' },
+        chat: { id: Number(USER_ID), type: 'private' },
+        date: now,
+        text: '/models',
+        entities: [{ type: 'bot_command', offset: 0, length: 7 }],
+      },
+    })
+
+    const picker = await mock.waitForCall('sendMessage', t0, 20000)
+    let markup = picker.body['reply_markup'] as unknown
+    if (typeof markup === 'string') markup = JSON.parse(markup)
+    const rows = (markup as { inline_keyboard: Array<Array<Record<string, unknown>>> }).inline_keyboard
+    expect(rows[rows.length - 1]).toEqual([{ text: 'Dismiss', callback_data: 'models:dismiss' }])
+    expect(rows.flat().filter(b => /^model:/.test(String(b['callback_data'])))).toHaveLength(2)
+
+    const authorizedAt = Date.now()
+    mock.queueUpdate({
+      callback_query: {
+        id: 'dismiss-authorized',
+        chat_instance: 'instance-authorized',
+        data: 'models:dismiss',
+        from: { id: Number(USER_ID), username: 'tester', is_bot: false, first_name: 'Tester' },
+        message: {
+          message_id: 500,
+          date: now,
+          chat: { id: Number(USER_ID), type: 'private' },
+          from: { id: 99999, is_bot: true, username: 'testbot', first_name: 'TestBot' },
+          text: 'Current model: claude-opus-5\nSelect a model:',
+        },
+      },
+    })
+
+    const acknowledgement = await mock.waitForCall('answerCallbackQuery', authorizedAt, 20000)
+    expect(acknowledgement.body['text']).toBe('Dismissed')
+    const deleted = await mock.waitForCall('deleteMessage', authorizedAt, 20000)
+    expect(String(deleted.body['chat_id'])).toBe(USER_ID)
+    expect(String(deleted.body['message_id'])).toBe('500')
+    await sleep(300)
+    expect(mockCb.commands.slice(callbackStart).find(c => c['command'] === 'set_model')).toBeUndefined()
+
+    const unauthorizedAt = Date.now()
+    mock.queueUpdate({
+      callback_query: {
+        id: 'dismiss-unauthorized',
+        chat_instance: 'instance-unauthorized',
+        data: 'models:dismiss',
+        from: { id: 888777666, username: 'stranger', is_bot: false, first_name: 'Stranger' },
+        message: {
+          message_id: 501,
+          date: now,
+          chat: { id: Number(USER_ID), type: 'private' },
+          from: { id: 99999, is_bot: true, username: 'testbot', first_name: 'TestBot' },
+        },
+      },
+    })
+
+    const rejection = await mock.waitForCall('answerCallbackQuery', unauthorizedAt, 20000)
+    expect(rejection.body['text']).toBe('Not authorized.')
+    await sleep(300)
+    expect(mock.calls.find(c => c.method === 'deleteMessage' && c.ts >= unauthorizedAt)).toBeUndefined()
+    expect(mockCb.commands.slice(callbackStart).find(c => c['command'] === 'set_model')).toBeUndefined()
   }, 30000)
 })

--- a/tests/unit/config-migration-real-upgrade.test.ts
+++ b/tests/unit/config-migration-real-upgrade.test.ts
@@ -7,6 +7,7 @@ import {
   loadCleanTemplate,
   stripIgnoredPaths,
   BIND_PRESERVED_WARNING,
+  compareSemver,
 } from '../../src/config/migrator';
 
 /**
@@ -327,5 +328,90 @@ describe('config migration — Opus 5 support reaches existing installs', () => 
     );
     expect(custom).toBeDefined();
     expect(custom.alias).toBe('mine');
+  });
+});
+
+/**
+ * Existing installs persist their own gateway.models list. The version bump is
+ * therefore part of the feature: without it, migrateModels() is never reached.
+ */
+describe('config migration — GPT models reach existing installs', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gpt-model-upgrade-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writePreGptConfig(): string {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          configVersion: '1.0.29',
+          gateway: {
+            bind: '0.0.0.0',
+            models: [
+              { id: 'gpt-5.6-terra', label: 'Old GPT Terra', alias: 'oldterra', contextWindow: 1000000 },
+              { id: 'openrouter/custom-model', label: 'My BYOK', alias: 'mine', contextWindow: 128000 },
+            ],
+          },
+          agents: [
+            {
+              id: 'legacy-gpt-agent',
+              claude: { model: 'gpt-5.6-terra', extraFlags: [] },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+    return configPath;
+  }
+
+  it('uses a template version newer than the pre-GPT registry', () => {
+    expect(compareSemver(templateVersion(), '1.0.29')).toBeGreaterThan(0);
+  });
+
+  it('adds missing GPT models and corrects metadata for an existing GPT entry', () => {
+    const configPath = writePreGptConfig();
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.needed).toBe(true);
+    expect(result.addedFields).toContain('gateway.models[gpt-5.6-sol[1m]]');
+    expect(result.addedFields).not.toContain('gateway.models[gpt-5.6-terra[1m]]');
+    expect(result.addedFields).toContain('gateway.models[gpt-5.6-luna[1m]]');
+    expect(result.addedFields).toContain('gateway.models[gpt-5.5[1m]]');
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(migrated.configVersion).toBe(templateVersion());
+    expect(migrated.gateway.models).toContainEqual({
+      id: 'gpt-5.6-terra[1m]',
+      label: 'GPT 5.6 Terra',
+      alias: 'gpt56terra',
+      contextWindow: 1050000,
+    });
+    expect(migrated.gateway.models.some((model: { id: string }) => model.id === 'gpt-5.6-terra')).toBe(false);
+    expect(migrated.agents[0].claude.model).toBe('gpt-5.6-terra[1m]');
+  });
+
+  it('preserves a user-owned model that is not in the template', () => {
+    const configPath = writePreGptConfig();
+    runRealUpgrade(configPath);
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(migrated.gateway.models).toContainEqual({
+      id: 'openrouter/custom-model',
+      label: 'My BYOK',
+      alias: 'mine',
+      contextWindow: 128000,
+    });
   });
 });

--- a/tests/unit/models-registry.test.ts
+++ b/tests/unit/models-registry.test.ts
@@ -57,6 +57,14 @@ describe('model registry — Opus 5 is a first-class model', () => {
 });
 
 describe('model registry — DEFAULT_MODELS and template stay in sync', () => {
+  it('uses OpenAI-documented 1,050,000-token windows for all GPT models', () => {
+    const gptIds = ['gpt-5.6-sol[1m]', 'gpt-5.6-terra[1m]', 'gpt-5.6-luna[1m]', 'gpt-5.5[1m]'];
+    for (const id of gptIds) {
+      expect(byId(DEFAULT_MODELS, id)?.contextWindow).toBe(1050000);
+      expect(byId(templateModels(), id)?.contextWindow).toBe(1050000);
+    }
+  });
+
   it('both registries contain exactly the same set of model ids', () => {
     const codeIds = DEFAULT_MODELS.map((m) => m.id).sort();
     const templateIds = templateModels().map((m) => m.id).sort();

--- a/tests/unit/session-compactor.test.ts
+++ b/tests/unit/session-compactor.test.ts
@@ -119,11 +119,11 @@ describe('SessionCompactor', () => {
   });
 
   // -------------------------------------------------------------------------
-  // U-CB1: the summary call honors CLAUDE_BIN (which may carry args) and always
-  // appends --print. Prevents the `claude --print` site from regressing to a
-  // hardcoded bare `claude` that a native-installer migration would break.
+  // U-CB1: the summary call honors CLAUDE_BIN (which may carry args), passes the
+  // selected model, and includes --print. Prevents compaction from silently using
+  // the CLI default model or a hardcoded bare `claude` binary.
   // -------------------------------------------------------------------------
-  it('U-CB1: honors CLAUDE_BIN (with args) and passes --print', async () => {
+  it('U-CB1: honors CLAUDE_BIN (with args) and passes --print with the selected model', async () => {
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
     for (let i = 0; i < 6; i++) {
@@ -143,12 +143,12 @@ describe('SessionCompactor', () => {
 
     const [bin, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
     expect(bin).toBe('node');
-    expect(args).toEqual(['/opt/claude/cli.js', '--print']);
+    expect(args).toEqual(['/opt/claude/cli.js', '--print', '--model', 'claude-sonnet-4-6']);
   });
 
   // -------------------------------------------------------------------------
-  // U-CB2: with CLAUDE_BIN unset the binary is resolved (non-empty) and --print
-  // is still the final arg.
+  // U-CB2: with CLAUDE_BIN unset the binary is resolved (non-empty), and the
+  // selected model is still passed to the CLI.
   // -------------------------------------------------------------------------
   it('U-CB2: resolves a binary and passes --print when CLAUDE_BIN is unset', async () => {
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
@@ -170,7 +170,7 @@ describe('SessionCompactor', () => {
     const [bin, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
     expect(typeof bin).toBe('string');
     expect(bin.length).toBeGreaterThan(0);
-    expect(args[args.length - 1]).toBe('--print');
+    expect(args).toEqual(['--print', '--model', 'claude-sonnet-4-6']);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add the documented 1,050,000-token context window metadata for the GPT model entries
- migrate existing configurations to the updated model registry while preserving custom models
- add an authorized Dismiss button to the Telegram `/models` picker

## Validation
- `npm run typecheck`
- `npm test` — 182 suites / 3427 tests passed
- regression coverage was verified to fail before the implementation was restored

Closes #359