### PR TITLE
fix: normalize channel reply formatting

### DIFF
--- a/mcp/instructions.ts
+++ b/mcp/instructions.ts
@@ -25,6 +25,8 @@ export function buildChannelInstructions(imageEnabled: boolean): string {
     '',
     'Messages from Telegram arrive as <channel source="telegram" chat_id="..." message_id="..." user="..." ts="...">. If the tag has an image_path attribute, Read that file — it is a photo the sender attached. If the tag has attachment_file_id, call download_attachment with that file_id to fetch the file, then Read the returned path. Reply with the reply tool — pass chat_id back. Use reply_to (set to a message_id) only when replying to an earlier message; the latest message doesn\'t need a quote-reply, omit reply_to for normal responses.',
     '',
+    'Use the current channel\'s reply tool only when you have a user-facing answer. Do not put tool-by-tool progress narration in final text output: use that channel\'s edit-message tool for interim status, then send one concise final reply so automatic forwarding cannot expose an internal worklog.',
+    '',
     'reply accepts file paths (files: ["/abs/path.png"]) for attachments. Use react to add emoji reactions, and edit_message for interim progress updates. Edits don\'t trigger push notifications — when a long task completes, send a new reply so the user\'s device pings.',
     '',
     "Telegram's Bot API exposes no history or search — you only see messages as they arrive. If you need earlier context, ask the user to paste it or summarize.",

--- a/mcp/tools/telegram/module.ts
+++ b/mcp/tools/telegram/module.ts
@@ -302,7 +302,7 @@ export class TelegramModule implements ChannelModule {
     const InputFile = this._InputFile;
 
     const inputIsHtml = explicitFormat === 'html' && this.containsTelegramHtml(text);
-    const useHtml = inputIsHtml || hasMarkdown(text);
+    const useHtml = inputIsHtml || explicitFormat === 'html' || (!explicitFormat && hasMarkdown(text));
     const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text;
     const parseMode = useHtml ? 'HTML' as const : undefined;
 

--- a/mcp/tools/telegram/module.ts
+++ b/mcp/tools/telegram/module.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { migrateAccess, defaultAccess } from './pure';
+import { chunkText, htmlToPlain } from './typing';
 import type {
   ChannelModule,
   ChannelCapabilities,
@@ -97,7 +98,7 @@ export class TelegramModule implements ChannelModule {
             format: {
               type: 'string',
               enum: ['text', 'html'],
-              description: "Rendering mode. 'html' enables Telegram formatting (bold, italic, code, links). Caller must escape special chars per HTML rules (&amp; &lt; &gt;). Default: 'text' (plain, no escaping needed).",
+              description: "Rendering mode. 'html' accepts pre-rendered Telegram HTML. Raw Markdown is detected and converted automatically. Default: auto-detect Markdown or send plain text.",
             },
           },
           required: ['chat_id', 'text'],
@@ -139,7 +140,7 @@ export class TelegramModule implements ChannelModule {
             format: {
               type: 'string',
               enum: ['text', 'html'],
-              description: "Rendering mode. 'html' enables Telegram formatting (bold, italic, code, links). Caller must escape special chars per HTML rules (&amp; &lt; &gt;). Default: 'text' (plain, no escaping needed).",
+              description: "Rendering mode. 'html' accepts pre-rendered Telegram HTML. Raw Markdown is detected and converted automatically. Default: auto-detect Markdown or send plain text.",
             },
           },
           required: ['chat_id', 'message_id', 'text'],
@@ -285,23 +286,8 @@ export class TelegramModule implements ChannelModule {
     }
   }
 
-  private chunk(text: string, limit: number, mode: 'length' | 'newline'): string[] {
-    if (text.length <= limit) return [text];
-    const out: string[] = [];
-    let rest = text;
-    while (rest.length > limit) {
-      let cut = limit;
-      if (mode === 'newline') {
-        const para = rest.lastIndexOf('\n\n', limit);
-        const line = rest.lastIndexOf('\n', limit);
-        const space = rest.lastIndexOf(' ', limit);
-        cut = para > limit / 2 ? para : line > limit / 2 ? line : space > 0 ? space : limit;
-      }
-      out.push(rest.slice(0, cut));
-      rest = rest.slice(cut).replace(/^\n+/, '');
-    }
-    if (rest) out.push(rest);
-    return out;
+  private containsTelegramHtml(text: string): boolean {
+    return /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|spoiler|strike|strong|tg-spoiler|u)(?:\s[^>]*)?>/i.test(text);
   }
 
   private async handleReply(args: Record<string, unknown>): Promise<McpToolResult> {
@@ -315,8 +301,9 @@ export class TelegramModule implements ChannelModule {
     const toTelegramHtml = this._toTelegramHtml!;
     const InputFile = this._InputFile;
 
-    const useHtml = explicitFormat === 'html' || (!explicitFormat && hasMarkdown(text));
-    const sendText = useHtml && !explicitFormat ? toTelegramHtml(text) : text;
+    const inputIsHtml = explicitFormat === 'html' && this.containsTelegramHtml(text);
+    const useHtml = inputIsHtml || hasMarkdown(text);
+    const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text;
     const parseMode = useHtml ? 'HTML' as const : undefined;
 
     this.assertAllowedChat(chat_id);
@@ -331,9 +318,8 @@ export class TelegramModule implements ChannelModule {
 
     const access = this.readAccessFile();
     const limit = Math.max(1, Math.min(access.textChunkLimit ?? MAX_CHUNK_LIMIT, MAX_CHUNK_LIMIT));
-    const mode = access.chunkMode ?? 'length';
     const replyMode = access.replyToMode ?? 'first';
-    const chunks = this.chunk(sendText, limit, mode);
+    const chunks = chunkText(sendText, limit, parseMode === 'HTML');
     const sentIds: number[] = [];
 
     try {
@@ -342,11 +328,18 @@ export class TelegramModule implements ChannelModule {
           reply_to != null &&
           replyMode !== 'off' &&
           (replyMode === 'all' || i === 0);
-        const sent = await this.bot.api.sendMessage(chat_id, chunks[i], {
+        const opts = {
           ...(shouldReplyTo ? { reply_parameters: { message_id: reply_to } } : {}),
           ...(parseMode ? { parse_mode: parseMode } : {}),
-        });
-        sentIds.push(sent.message_id);
+        };
+        try {
+          const sent = await this.bot.api.sendMessage(chat_id, chunks[i], opts);
+          sentIds.push(sent.message_id);
+        } catch (err) {
+          if (!parseMode) throw err;
+          const sent = await this.bot.api.sendMessage(chat_id, htmlToPlain(chunks[i]), shouldReplyTo ? { reply_parameters: { message_id: reply_to } } : undefined);
+          sentIds.push(sent.message_id);
+        }
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -29,7 +29,7 @@ import { readFileSync, writeFileSync, mkdirSync, readdirSync, rmSync, statSync, 
 import { homedir } from 'os'
 import { join, extname, sep } from 'path'
 import { execFileSync } from 'child_process'
-import { createWorkingStateManager, drainOrphanForwards } from './typing'
+import { createWorkingStateManager, drainOrphanForwards, chunkText, htmlToPlain } from './typing'
 // Import compiled dist/, not raw src/ — src/ is not published (files: ["mcp/"]),
 // so a src/ import crashes this bun-run receiver on installed packages (the bug
 // that silenced every bot on systemd installs). Enforced by
@@ -565,27 +565,8 @@ function checkApprovals(): void {
 
 setInterval(checkApprovals, 5000).unref()
 
-// Telegram caps messages at 4096 chars. Split long replies, preferring
-// paragraph boundaries when chunkMode is 'newline'.
-function chunk(text: string, limit: number, mode: 'length' | 'newline'): string[] {
-  if (text.length <= limit) return [text]
-  const out: string[] = []
-  let rest = text
-  while (rest.length > limit) {
-    let cut = limit
-    if (mode === 'newline') {
-      // Prefer the last double-newline (paragraph), then single newline,
-      // then space. Fall back to hard cut.
-      const para = rest.lastIndexOf('\n\n', limit)
-      const line = rest.lastIndexOf('\n', limit)
-      const space = rest.lastIndexOf(' ', limit)
-      cut = para > limit / 2 ? para : line > limit / 2 ? line : space > 0 ? space : limit
-    }
-    out.push(rest.slice(0, cut))
-    rest = rest.slice(cut).replace(/^\n+/, '')
-  }
-  if (rest) out.push(rest)
-  return out
+function containsTelegramHtml(text: string): boolean {
+  return /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|spoiler|strike|strong|tg-spoiler|u)(?:\s[^>]*)?>/i.test(text)
 }
 
 // .jpg/.jpeg/.png/.gif/.webp go as photos (Telegram compresses + shows inline);
@@ -678,7 +659,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           format: {
             type: 'string',
             enum: ['text', 'html'],
-            description: "Rendering mode. 'html' enables Telegram formatting (bold, italic, code, links). Caller must escape special chars per HTML rules (&amp; &lt; &gt;). Default: 'text' (plain, no escaping needed).",
+            description: "Rendering mode. 'html' accepts pre-rendered Telegram HTML. Raw Markdown is detected and converted automatically. Default: auto-detect Markdown or send plain text.",
           },
         },
         required: ['chat_id', 'text'],
@@ -720,7 +701,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           format: {
             type: 'string',
             enum: ['text', 'html'],
-            description: "Rendering mode. 'html' enables Telegram formatting (bold, italic, code, links). Caller must escape special chars per HTML rules (&amp; &lt; &gt;). Default: 'text' (plain, no escaping needed).",
+            description: "Rendering mode. 'html' accepts pre-rendered Telegram HTML. Raw Markdown is detected and converted automatically. Default: auto-detect Markdown or send plain text.",
           },
         },
         required: ['chat_id', 'message_id', 'text'],
@@ -739,9 +720,9 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         const reply_to = args.reply_to != null ? Number(args.reply_to) : undefined
         const files = (args.files as string[] | undefined) ?? []
         const explicitFormat = args.format as string | undefined
-        // Auto-detect markdown when caller didn't specify format explicitly
-        const useHtml = explicitFormat === 'html' || (!explicitFormat && hasMarkdown(text))
-        const sendText = useHtml && !explicitFormat ? toTelegramHtml(text) : text
+        const inputIsHtml = explicitFormat === 'html' && containsTelegramHtml(text)
+        const useHtml = inputIsHtml || hasMarkdown(text)
+        const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text
         const parseMode = useHtml ? 'HTML' as const : undefined
 
         assertAllowedChat(chat_id)
@@ -756,9 +737,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
 
         const access = loadAccess()
         const limit = Math.max(1, Math.min(access.textChunkLimit ?? MAX_CHUNK_LIMIT, MAX_CHUNK_LIMIT))
-        const mode = access.chunkMode ?? 'length'
         const replyMode = access.replyToMode ?? 'first'
-        const chunks = chunk(sendText, limit, mode)
+        const chunks = chunkText(sendText, limit, parseMode === 'HTML')
         const sentIds: number[] = []
 
         try {
@@ -767,11 +747,22 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
               reply_to != null &&
               replyMode !== 'off' &&
               (replyMode === 'all' || i === 0)
-            const sent = await bot.api.sendMessage(chat_id, chunks[i], {
+            const opts = {
               ...(shouldReplyTo ? { reply_parameters: { message_id: reply_to } } : {}),
               ...(parseMode ? { parse_mode: parseMode } : {}),
-            })
-            sentIds.push(sent.message_id)
+            }
+            try {
+              const sent = await bot.api.sendMessage(chat_id, chunks[i], opts)
+              sentIds.push(sent.message_id)
+            } catch (err) {
+              if (!parseMode) throw err
+              const sent = await bot.api.sendMessage(
+                chat_id,
+                htmlToPlain(chunks[i]),
+                shouldReplyTo ? { reply_parameters: { message_id: reply_to } } : undefined,
+              )
+              sentIds.push(sent.message_id)
+            }
           }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err)

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -721,7 +721,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         const files = (args.files as string[] | undefined) ?? []
         const explicitFormat = args.format as string | undefined
         const inputIsHtml = explicitFormat === 'html' && containsTelegramHtml(text)
-        const useHtml = inputIsHtml || hasMarkdown(text)
+        const useHtml = inputIsHtml || explicitFormat === 'html' || (!explicitFormat && hasMarkdown(text))
         const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text
         const parseMode = useHtml ? 'HTML' as const : undefined
 

--- a/tests/e2e/gateway-e2e.test.ts
+++ b/tests/e2e/gateway-e2e.test.ts
@@ -338,7 +338,7 @@ describe('Gateway Telegram E2E — TelegramModule via mock API', () => {
     expect(msg!.text).toBe('Hello from E2E test!');
   });
 
-  test('E2E-TG-2: telegram_reply with HTML format', async () => {
+  test('E2E-TG-2: telegram_reply preserves pre-rendered HTML', async () => {
     const result = await mod.handleTool('telegram_reply', {
       chat_id: '67890',
       text: '<b>bold</b> text',
@@ -351,6 +351,22 @@ describe('Gateway Telegram E2E — TelegramModule via mock API', () => {
     const msg = sent.find(m => m.method === 'sendMessage');
     expect(msg).toBeDefined();
     expect(msg!.text).toBe('<b>bold</b> text');
+    expect(msg!.parse_mode).toBe('HTML');
+  });
+
+  test('E2E-TG-2b: telegram_reply converts raw Markdown despite explicit HTML format', async () => {
+    const result = await mod.handleTool('telegram_reply', {
+      chat_id: '67890',
+      text: '**bold**\n- item',
+      format: 'html',
+    });
+
+    expect(result.isError).toBeUndefined();
+
+    const sent = mockTg.getSentMessages();
+    const msg = sent.find(m => m.method === 'sendMessage');
+    expect(msg).toBeDefined();
+    expect(msg!.text).toBe('<b>bold</b>\n• item');
     expect(msg!.parse_mode).toBe('HTML');
   });
 

--- a/tests/e2e/gateway-e2e.test.ts
+++ b/tests/e2e/gateway-e2e.test.ts
@@ -370,6 +370,22 @@ describe('Gateway Telegram E2E — TelegramModule via mock API', () => {
     expect(msg!.parse_mode).toBe('HTML');
   });
 
+  test('E2E-TG-2c: telegram_reply preserves raw Markdown when text format is explicit', async () => {
+    const result = await mod.handleTool('telegram_reply', {
+      chat_id: '67890',
+      text: '**bold**\n- item',
+      format: 'text',
+    });
+
+    expect(result.isError).toBeUndefined();
+
+    const sent = mockTg.getSentMessages();
+    const msg = sent.find(m => m.method === 'sendMessage');
+    expect(msg).toBeDefined();
+    expect(msg!.text).toBe('**bold**\n- item');
+    expect(msg!.parse_mode).toBeUndefined();
+  });
+
   test('E2E-TG-3: telegram_reply with reply_to threading', async () => {
     const result = await mod.handleTool('telegram_reply', {
       chat_id: '67890',

--- a/tests/unit/channel-instructions.test.ts
+++ b/tests/unit/channel-instructions.test.ts
@@ -24,6 +24,13 @@ describe('buildChannelInstructions', () => {
     }
   });
 
+  it('requires final replies to exclude progress narration', () => {
+    const out = buildChannelInstructions(false);
+    expect(out).toContain('Do not put tool-by-tool progress narration in final text output');
+    expect(out).toContain('current channel\'s reply tool');
+    expect(out).toContain('one concise final reply');
+  });
+
   it('preserves the existing baseline channel instructions in both modes', () => {
     expect(buildChannelInstructions(true)).toContain('reply tool');
     expect(buildChannelInstructions(false)).toContain('reply tool');


### PR DESCRIPTION
## Summary
Normalizes channel reply rendering so raw Markdown is converted even when a caller requests formatted output, while preserving explicit Telegram HTML. Adds shared channel guidance that keeps progress narration out of final replies.

## Related Issue
Closes #361

## Changes Made
- `mcp/tools/telegram/module.ts`: distinguish pre-rendered HTML from Markdown, use HTML-safe chunking, and retry rejected formatted chunks as plain text.
- `mcp/tools/telegram/receiver-server.ts`: apply the same rendering, chunking, and fallback rules to the legacy receiver path.
- `mcp/instructions.ts`: require channel-final replies and keep intermediate narration out of final output.
- Tests: cover explicit-format Markdown conversion and the shared channel instruction.

## Testing
- `npm run typecheck`: pass
- Focused Telegram/instruction tests: 19 tests pass
- Regression test: confirmed to fail before the fix and pass after it
- `npm test`: 3,415 assertions passed, but Jest exited nonzero after a worker SIGTERM in `tests/unit/command-endpoint.test.ts`; this pre-existing environment instability was isolated and reported before push.