### PR TITLE
fix(telegram): preserve agent-authored Telegram HTML tags instead of escaping them

### DIFF
--- a/mcp/tools/telegram/lib/markdown.ts
+++ b/mcp/tools/telegram/lib/markdown.ts
@@ -294,3 +294,28 @@ export function toTelegramHtml(text: string): string {
 
   return out.join('')
 }
+
+/**
+ * Resolve how a channel reply should be sent given an optional explicit format.
+ * Mirrors the auto-forward decision in src/agent/runner.ts: agent-authored
+ * Telegram HTML tags must trigger HTML mode even when the text contains no
+ * markdown, otherwise a pure-HTML reply falls through to raw text with no
+ * parse_mode and the tags render literally (e.g. a visible "<b>").
+ * - explicit 'html' + already-valid Telegram HTML -> send verbatim under HTML
+ * - explicit 'html' (not yet valid) -> convert via toTelegramHtml under HTML
+ * - explicit 'text' -> always raw, no parse_mode (caller asked for plain text)
+ * - auto (no format) -> HTML when markdown OR Telegram tags are present
+ */
+export function resolveTelegramReplyFormat(
+  text: string,
+  explicitFormat?: string,
+): { sendText: string; parseMode: 'HTML' | undefined } {
+  const inputIsHtml = explicitFormat === 'html' && containsTelegramHtml(text)
+  const useHtml =
+    inputIsHtml ||
+    explicitFormat === 'html' ||
+    (!explicitFormat && (hasMarkdown(text) || containsTelegramHtml(text)))
+  const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text
+  const parseMode: 'HTML' | undefined = useHtml ? 'HTML' : undefined
+  return { sendText, parseMode }
+}

--- a/mcp/tools/telegram/lib/markdown.ts
+++ b/mcp/tools/telegram/lib/markdown.ts
@@ -8,6 +8,27 @@ export function normalizeTelegramLineBreaks(text: string): string {
   return text.replace(/(?:<|&lt;)br\s*\/?(?:>|&gt;)/gi, '\n')
 }
 
+// Opening (with optional attributes) or closing form of every tag Telegram's
+// HTML parse mode honours. Sticky so it can be tested at a given offset without
+// slicing. `[^<>]*` keeps an attribute run from swallowing past the tag.
+const TELEGRAM_HTML_TAG = /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|span|strike|strong|tg-spoiler|u)(?:\s[^<>]*)?>/iy
+
+/** Length of a valid Telegram HTML tag starting at `i` (where text[i] === '<'), or 0 if none. */
+function matchTelegramTag(text: string, i: number): number {
+  if (text[i] !== '<') return 0
+  TELEGRAM_HTML_TAG.lastIndex = i
+  const m = TELEGRAM_HTML_TAG.exec(text)
+  return m ? m[0].length : 0
+}
+
+/** Whether text already contains at least one Telegram-whitelist HTML tag written directly. */
+export function containsTelegramHtml(text: string): boolean {
+  for (let i = text.indexOf('<'); i !== -1; i = text.indexOf('<', i + 1)) {
+    if (matchTelegramTag(text, i) > 0) return true
+  }
+  return false
+}
+
 /**
  * Detects whether text contains markdown formatting patterns
  * that warrant HTML rendering in Telegram.
@@ -238,6 +259,18 @@ export function toTelegramHtml(text: string): string {
       }
     }
 
+    // Pass through a valid Telegram HTML tag the agent wrote directly, verbatim.
+    // Non-whitelist tags (e.g. <script>) fail the match and are escaped as plain
+    // text below, so this is a controlled pass-through, not raw HTML injection.
+    if (text[i] === '<') {
+      const tagLen = matchTelegramTag(text, i)
+      if (tagLen > 0) {
+        out.push(text.slice(i, i + tagLen))
+        i += tagLen
+        continue
+      }
+    }
+
     // Accumulate plain text until next markdown token
     let j = i + 1
     while (j < len) {
@@ -249,6 +282,7 @@ export function toTelegramHtml(text: string): string {
         (c === '*' && text[j + 1] !== '*' && text[j + 1] !== ' ') ||
         (c === '_' && text[j + 1] !== '_' && text[j + 1] !== ' ') ||
         c === '[' ||
+        (c === '<' && matchTelegramTag(text, j) > 0) ||
         (c === '#' && (j === 0 || text[j - 1] === '\n')) ||
         (c === '|' && (j === 0 || text[j - 1] === '\n'))
       ) break

--- a/mcp/tools/telegram/lib/markdown.ts
+++ b/mcp/tools/telegram/lib/markdown.ts
@@ -10,8 +10,11 @@ export function normalizeTelegramLineBreaks(text: string): string {
 
 // Opening (with optional attributes) or closing form of every tag Telegram's
 // HTML parse mode honours. Sticky so it can be tested at a given offset without
-// slicing. `[^<>]*` keeps an attribute run from swallowing past the tag.
-const TELEGRAM_HTML_TAG = /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|span|strike|strong|tg-spoiler|u)(?:\s[^<>]*)?>/iy
+// slicing. `[^<>]*` keeps an attribute run from swallowing past the tag. `span`
+// is intentionally excluded: only `<span class="tg-spoiler">` is valid Telegram
+// HTML and pairing a class-bearing open with a bare `</span>` close is
+// error-prone — agents should use the canonical `<tg-spoiler>` element instead.
+const TELEGRAM_HTML_TAG = /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|strike|strong|tg-spoiler|u)(?:\s[^<>]*)?>/iy
 
 /** Length of a valid Telegram HTML tag starting at `i` (where text[i] === '<'), or 0 if none. */
 function matchTelegramTag(text: string, i: number): number {
@@ -52,6 +55,16 @@ export function hasMarkdown(text: string): boolean {
  */
 function escapeHtml(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/**
+ * Escapes a bare `&` (one not already opening a character entity) inside a
+ * passed-through Telegram HTML tag — Telegram rejects a raw `&` in e.g. an
+ * <a href> query string ("...?a=1&b=2"). `<`/`>` cannot occur here because the
+ * tag matcher forbids them in the attribute run, so only `&` needs escaping.
+ */
+function escapeTagAmp(tag: string): string {
+  return tag.replace(/&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);)/g, '&amp;')
 }
 
 /**
@@ -265,7 +278,7 @@ export function toTelegramHtml(text: string): string {
     if (text[i] === '<') {
       const tagLen = matchTelegramTag(text, i)
       if (tagLen > 0) {
-        out.push(text.slice(i, i + tagLen))
+        out.push(escapeTagAmp(text.slice(i, i + tagLen)))
         i += tagLen
         continue
       }

--- a/mcp/tools/telegram/module.ts
+++ b/mcp/tools/telegram/module.ts
@@ -50,6 +50,10 @@ export class TelegramModule implements ChannelModule {
   private _toTelegramHtml?: (text: string) => string;
   private _normalizeTelegramLineBreaks?: (text: string) => string;
   private _containsTelegramHtml?: (text: string) => boolean;
+  private _resolveTelegramReplyFormat?: (
+    text: string,
+    explicitFormat?: string,
+  ) => { sendText: string; parseMode: 'HTML' | undefined };
   private _InputFile?: any;
   private _typingManager?: any;
 
@@ -191,7 +195,7 @@ export class TelegramModule implements ChannelModule {
     });
 
     // Import pure functions and typing manager
-    const { hasMarkdown, toTelegramHtml, normalizeTelegramLineBreaks, containsTelegramHtml } = await import('./pure');
+    const { hasMarkdown, toTelegramHtml, normalizeTelegramLineBreaks, containsTelegramHtml, resolveTelegramReplyFormat } = await import('./pure');
     const { createWorkingStateManager } = await import('./typing');
 
     const typingManager = createWorkingStateManager(
@@ -213,6 +217,7 @@ export class TelegramModule implements ChannelModule {
     this._toTelegramHtml = toTelegramHtml;
     this._normalizeTelegramLineBreaks = normalizeTelegramLineBreaks;
     this._containsTelegramHtml = containsTelegramHtml;
+    this._resolveTelegramReplyFormat = resolveTelegramReplyFormat;
     this._InputFile = InputFile;
     this._typingManager = typingManager;
 
@@ -296,15 +301,12 @@ export class TelegramModule implements ChannelModule {
     const reply_to = args.reply_to != null ? Number(args.reply_to) : undefined;
     const files = (args.files as string[] | undefined) ?? [];
     const explicitFormat = args.format as string | undefined;
-
-    const hasMarkdown = this._hasMarkdown!;
-    const toTelegramHtml = this._toTelegramHtml!;
     const InputFile = this._InputFile;
 
-    const inputIsHtml = explicitFormat === 'html' && this._containsTelegramHtml!(text);
-    const useHtml = inputIsHtml || explicitFormat === 'html' || (!explicitFormat && hasMarkdown(text));
-    const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text;
-    const parseMode = useHtml ? 'HTML' as const : undefined;
+    // Single source of truth for reply format detection (shared with receiver-server).
+    // Auto mode uses HTML when the text has markdown OR agent-authored Telegram HTML
+    // tags — the latter fixes HTML-only replies being sent raw (no parse_mode).
+    const { sendText, parseMode } = this._resolveTelegramReplyFormat!(text, explicitFormat);
 
     this.assertAllowedChat(chat_id);
 

--- a/mcp/tools/telegram/module.ts
+++ b/mcp/tools/telegram/module.ts
@@ -49,6 +49,7 @@ export class TelegramModule implements ChannelModule {
   private _hasMarkdown?: (text: string) => boolean;
   private _toTelegramHtml?: (text: string) => string;
   private _normalizeTelegramLineBreaks?: (text: string) => string;
+  private _containsTelegramHtml?: (text: string) => boolean;
   private _InputFile?: any;
   private _typingManager?: any;
 
@@ -190,7 +191,7 @@ export class TelegramModule implements ChannelModule {
     });
 
     // Import pure functions and typing manager
-    const { hasMarkdown, toTelegramHtml, normalizeTelegramLineBreaks } = await import('./pure');
+    const { hasMarkdown, toTelegramHtml, normalizeTelegramLineBreaks, containsTelegramHtml } = await import('./pure');
     const { createWorkingStateManager } = await import('./typing');
 
     const typingManager = createWorkingStateManager(
@@ -211,6 +212,7 @@ export class TelegramModule implements ChannelModule {
     this._hasMarkdown = hasMarkdown;
     this._toTelegramHtml = toTelegramHtml;
     this._normalizeTelegramLineBreaks = normalizeTelegramLineBreaks;
+    this._containsTelegramHtml = containsTelegramHtml;
     this._InputFile = InputFile;
     this._typingManager = typingManager;
 
@@ -288,10 +290,6 @@ export class TelegramModule implements ChannelModule {
     }
   }
 
-  private containsTelegramHtml(text: string): boolean {
-    return /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|spoiler|strike|strong|tg-spoiler|u)(?:\s[^>]*)?>/i.test(text);
-  }
-
   private async handleReply(args: Record<string, unknown>): Promise<McpToolResult> {
     const chat_id = args.chat_id as string;
     const text = this._normalizeTelegramLineBreaks!(args.text as string);
@@ -303,7 +301,7 @@ export class TelegramModule implements ChannelModule {
     const toTelegramHtml = this._toTelegramHtml!;
     const InputFile = this._InputFile;
 
-    const inputIsHtml = explicitFormat === 'html' && this.containsTelegramHtml(text);
+    const inputIsHtml = explicitFormat === 'html' && this._containsTelegramHtml!(text);
     const useHtml = inputIsHtml || explicitFormat === 'html' || (!explicitFormat && hasMarkdown(text));
     const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text;
     const parseMode = useHtml ? 'HTML' as const : undefined;

--- a/mcp/tools/telegram/pure.ts
+++ b/mcp/tools/telegram/pure.ts
@@ -332,7 +332,7 @@ function countPending(access: Access, kind: 'dm' | 'group'): number {
   return n
 }
 
-export { hasMarkdown, toTelegramHtml } from './lib/markdown'
+export { hasMarkdown, toTelegramHtml, containsTelegramHtml } from './lib/markdown'
 
 /** Telegram does not support HTML <br> tags; normalize raw and escaped variants to line breaks. */
 export function normalizeTelegramLineBreaks(text: string): string {

--- a/mcp/tools/telegram/pure.ts
+++ b/mcp/tools/telegram/pure.ts
@@ -332,7 +332,7 @@ function countPending(access: Access, kind: 'dm' | 'group'): number {
   return n
 }
 
-export { hasMarkdown, toTelegramHtml, containsTelegramHtml } from './lib/markdown'
+export { hasMarkdown, toTelegramHtml, containsTelegramHtml, resolveTelegramReplyFormat } from './lib/markdown'
 
 /** Telegram does not support HTML <br> tags; normalize raw and escaped variants to line breaks. */
 export function normalizeTelegramLineBreaks(text: string): string {

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -38,7 +38,7 @@ import { formatTurnIncident, type TurnIncident } from '../../../dist/agent/turn-
 import { createIncidentStore } from '../../../dist/agent/incident-store.js'
 import type { RecoveryOutcome } from '../../../dist/agent/incident.js'
 import { initDedupDir, isDuplicate as _isDuplicate, pruneDedup as _pruneDedup } from './dedup'
-import { hasMarkdown, normalizeTelegramLineBreaks, toTelegramHtml, migrateAccess, telegramDisplayName } from './pure'
+import { hasMarkdown, normalizeTelegramLineBreaks, toTelegramHtml, containsTelegramHtml, migrateAccess, telegramDisplayName } from './pure'
 
 // Standalone fallback: default state dir to ~/.claude/channels/telegram
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
@@ -716,7 +716,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         const reply_to = args.reply_to != null ? Number(args.reply_to) : undefined
         const files = (args.files as string[] | undefined) ?? []
         const explicitFormat = args.format as string | undefined
-        const inputIsHtml = explicitFormat === 'html' && /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|spoiler|strike|strong|tg-spoiler|u)(?:\s[^>]*)?>/i.test(text)
+        const inputIsHtml = explicitFormat === 'html' && containsTelegramHtml(text)
         const useHtml = inputIsHtml || explicitFormat === 'html' || (!explicitFormat && hasMarkdown(text))
         const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text
         const parseMode = useHtml ? 'HTML' as const : undefined

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -38,7 +38,7 @@ import { formatTurnIncident, type TurnIncident } from '../../../dist/agent/turn-
 import { createIncidentStore } from '../../../dist/agent/incident-store.js'
 import type { RecoveryOutcome } from '../../../dist/agent/incident.js'
 import { initDedupDir, isDuplicate as _isDuplicate, pruneDedup as _pruneDedup } from './dedup'
-import { hasMarkdown, normalizeTelegramLineBreaks, toTelegramHtml, containsTelegramHtml, migrateAccess, telegramDisplayName } from './pure'
+import { normalizeTelegramLineBreaks, resolveTelegramReplyFormat, migrateAccess, telegramDisplayName } from './pure'
 
 // Standalone fallback: default state dir to ~/.claude/channels/telegram
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
@@ -716,10 +716,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         const reply_to = args.reply_to != null ? Number(args.reply_to) : undefined
         const files = (args.files as string[] | undefined) ?? []
         const explicitFormat = args.format as string | undefined
-        const inputIsHtml = explicitFormat === 'html' && containsTelegramHtml(text)
-        const useHtml = inputIsHtml || explicitFormat === 'html' || (!explicitFormat && hasMarkdown(text))
-        const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text
-        const parseMode = useHtml ? 'HTML' as const : undefined
+        const { sendText, parseMode } = resolveTelegramReplyFormat(text, explicitFormat)
 
         assertAllowedChat(chat_id)
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -12,7 +12,7 @@ import { SessionCompactor } from '../session/compactor';
 import { TelegramReceiver } from '../telegram/receiver';
 import { DiscordReceiver } from '../discord/receiver';
 import { LineReplyManager } from './line-reply-manager';
-import { hasMarkdown, normalizeTelegramLineBreaks, toTelegramHtml } from '../telegram/markdown';
+import { hasMarkdown, normalizeTelegramLineBreaks, toTelegramHtml, containsTelegramHtml } from '../telegram/markdown';
 import { detectSkillCommand, formatSkillContext, type SkillRegistry } from '../skills';
 import { isBuiltinCommand } from './builtin-commands';
 import { SafeModeManager } from './safe-mode';
@@ -1776,7 +1776,7 @@ export class AgentRunner extends EventEmitter {
               const channelText = normalizeTelegramLineBreaks(text)
               if (channelSrcForResult === 'line' && this.lineReply) {
                 void this.lineReply.onAnswer(mapKey, channelText)
-              } else if (channelSrcForResult !== 'discord' && hasMarkdown(channelText)) {
+              } else if (channelSrcForResult !== 'discord' && (hasMarkdown(channelText) || containsTelegramHtml(channelText))) {
                 this.writeAutoForward(mapKey, toTelegramHtml(channelText), 'html');
               } else {
                 this.writeAutoForward(mapKey, channelText);

--- a/src/telegram/markdown.ts
+++ b/src/telegram/markdown.ts
@@ -294,3 +294,28 @@ export function toTelegramHtml(text: string): string {
 
   return out.join('')
 }
+
+/**
+ * Resolve how a channel reply should be sent given an optional explicit format.
+ * Mirrors the auto-forward decision in src/agent/runner.ts: agent-authored
+ * Telegram HTML tags must trigger HTML mode even when the text contains no
+ * markdown, otherwise a pure-HTML reply falls through to raw text with no
+ * parse_mode and the tags render literally (e.g. a visible "<b>").
+ * - explicit 'html' + already-valid Telegram HTML -> send verbatim under HTML
+ * - explicit 'html' (not yet valid) -> convert via toTelegramHtml under HTML
+ * - explicit 'text' -> always raw, no parse_mode (caller asked for plain text)
+ * - auto (no format) -> HTML when markdown OR Telegram tags are present
+ */
+export function resolveTelegramReplyFormat(
+  text: string,
+  explicitFormat?: string,
+): { sendText: string; parseMode: 'HTML' | undefined } {
+  const inputIsHtml = explicitFormat === 'html' && containsTelegramHtml(text)
+  const useHtml =
+    inputIsHtml ||
+    explicitFormat === 'html' ||
+    (!explicitFormat && (hasMarkdown(text) || containsTelegramHtml(text)))
+  const sendText = useHtml && !inputIsHtml ? toTelegramHtml(text) : text
+  const parseMode: 'HTML' | undefined = useHtml ? 'HTML' : undefined
+  return { sendText, parseMode }
+}

--- a/src/telegram/markdown.ts
+++ b/src/telegram/markdown.ts
@@ -8,6 +8,27 @@ export function normalizeTelegramLineBreaks(text: string): string {
   return text.replace(/(?:<|&lt;)br\s*\/?(?:>|&gt;)/gi, '\n')
 }
 
+// Opening (with optional attributes) or closing form of every tag Telegram's
+// HTML parse mode honours. Sticky so it can be tested at a given offset without
+// slicing. `[^<>]*` keeps an attribute run from swallowing past the tag.
+const TELEGRAM_HTML_TAG = /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|span|strike|strong|tg-spoiler|u)(?:\s[^<>]*)?>/iy
+
+/** Length of a valid Telegram HTML tag starting at `i` (where text[i] === '<'), or 0 if none. */
+function matchTelegramTag(text: string, i: number): number {
+  if (text[i] !== '<') return 0
+  TELEGRAM_HTML_TAG.lastIndex = i
+  const m = TELEGRAM_HTML_TAG.exec(text)
+  return m ? m[0].length : 0
+}
+
+/** Whether text already contains at least one Telegram-whitelist HTML tag written directly. */
+export function containsTelegramHtml(text: string): boolean {
+  for (let i = text.indexOf('<'); i !== -1; i = text.indexOf('<', i + 1)) {
+    if (matchTelegramTag(text, i) > 0) return true
+  }
+  return false
+}
+
 /**
  * Detects whether text contains markdown formatting patterns
  * that warrant HTML rendering in Telegram.
@@ -238,6 +259,18 @@ export function toTelegramHtml(text: string): string {
       }
     }
 
+    // Pass through a valid Telegram HTML tag the agent wrote directly, verbatim.
+    // Non-whitelist tags (e.g. <script>) fail the match and are escaped as plain
+    // text below, so this is a controlled pass-through, not raw HTML injection.
+    if (text[i] === '<') {
+      const tagLen = matchTelegramTag(text, i)
+      if (tagLen > 0) {
+        out.push(text.slice(i, i + tagLen))
+        i += tagLen
+        continue
+      }
+    }
+
     // Accumulate plain text until next markdown token
     let j = i + 1
     while (j < len) {
@@ -249,6 +282,7 @@ export function toTelegramHtml(text: string): string {
         (c === '*' && text[j + 1] !== '*' && text[j + 1] !== ' ') ||
         (c === '_' && text[j + 1] !== '_' && text[j + 1] !== ' ') ||
         c === '[' ||
+        (c === '<' && matchTelegramTag(text, j) > 0) ||
         (c === '#' && (j === 0 || text[j - 1] === '\n')) ||
         (c === '|' && (j === 0 || text[j - 1] === '\n'))
       ) break

--- a/src/telegram/markdown.ts
+++ b/src/telegram/markdown.ts
@@ -10,8 +10,11 @@ export function normalizeTelegramLineBreaks(text: string): string {
 
 // Opening (with optional attributes) or closing form of every tag Telegram's
 // HTML parse mode honours. Sticky so it can be tested at a given offset without
-// slicing. `[^<>]*` keeps an attribute run from swallowing past the tag.
-const TELEGRAM_HTML_TAG = /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|span|strike|strong|tg-spoiler|u)(?:\s[^<>]*)?>/iy
+// slicing. `[^<>]*` keeps an attribute run from swallowing past the tag. `span`
+// is intentionally excluded: only `<span class="tg-spoiler">` is valid Telegram
+// HTML and pairing a class-bearing open with a bare `</span>` close is
+// error-prone — agents should use the canonical `<tg-spoiler>` element instead.
+const TELEGRAM_HTML_TAG = /<\/?(?:a|b|blockquote|code|del|em|i|ins|pre|s|strike|strong|tg-spoiler|u)(?:\s[^<>]*)?>/iy
 
 /** Length of a valid Telegram HTML tag starting at `i` (where text[i] === '<'), or 0 if none. */
 function matchTelegramTag(text: string, i: number): number {
@@ -52,6 +55,16 @@ export function hasMarkdown(text: string): boolean {
  */
 function escapeHtml(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/**
+ * Escapes a bare `&` (one not already opening a character entity) inside a
+ * passed-through Telegram HTML tag — Telegram rejects a raw `&` in e.g. an
+ * <a href> query string ("...?a=1&b=2"). `<`/`>` cannot occur here because the
+ * tag matcher forbids them in the attribute run, so only `&` needs escaping.
+ */
+function escapeTagAmp(tag: string): string {
+  return tag.replace(/&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);)/g, '&amp;')
 }
 
 /**
@@ -265,7 +278,7 @@ export function toTelegramHtml(text: string): string {
     if (text[i] === '<') {
       const tagLen = matchTelegramTag(text, i)
       if (tagLen > 0) {
-        out.push(text.slice(i, i + tagLen))
+        out.push(escapeTagAmp(text.slice(i, i + tagLen)))
         i += tagLen
         continue
       }

--- a/tests/unit/telegram-plugin/markdown.test.ts
+++ b/tests/unit/telegram-plugin/markdown.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for hasMarkdown() and toTelegramHtml() from src/telegram/markdown.ts
  */
-import { hasMarkdown, normalizeTelegramLineBreaks, toTelegramHtml } from '../../../src/telegram/markdown'
+import { containsTelegramHtml, hasMarkdown, normalizeTelegramLineBreaks, toTelegramHtml } from '../../../src/telegram/markdown'
 
 describe('hasMarkdown()', () => {
   test('detects **bold**', () => {
@@ -60,6 +60,61 @@ describe('hasMarkdown()', () => {
 describe('normalizeTelegramLineBreaks()', () => {
   test.each(['&lt;br&gt;', '&lt;br/&gt;', '&lt;br /&gt;', '&lt;BR&gt;'])('converts %s to a newline', tag => {
     expect(normalizeTelegramLineBreaks(`first${tag}second`)).toBe('first\nsecond')
+  })
+})
+
+describe('containsTelegramHtml()', () => {
+  test.each([
+    ['<b>x</b>', 'bold'],
+    ['<code>y</code>', 'code'],
+    ['<a href="https://e.com">l</a>', 'link'],
+    ['<pre>block</pre>', 'pre'],
+    ['<tg-spoiler>s</tg-spoiler>', 'spoiler'],
+  ])('detects %s (%s)', input => {
+    expect(containsTelegramHtml(input)).toBe(true)
+  })
+
+  test.each([
+    ['plain text with no tags', 'plain'],
+    ['5 < 6 and 7 > 3', 'bare comparisons'],
+    ['<script>alert(1)</script>', 'non-whitelist tag'],
+    ['<div>x</div>', 'non-whitelist div'],
+  ])('returns false for %s (%s)', input => {
+    expect(containsTelegramHtml(input)).toBe(false)
+  })
+})
+
+describe('toTelegramHtml() preserves agent-authored Telegram HTML tags', () => {
+  // Regression for #365: a directly-written <b>/<code>/etc. mixed with markdown
+  // was escaped to literal &lt;b&gt; while markdown-derived tags rendered.
+  test('mixed markdown and literal HTML tags both render', () => {
+    expect(toTelegramHtml('**bold** <b>x</b> [l](https://e.com)')).toBe(
+      '<b>bold</b> <b>x</b> <a href="https://e.com">l</a>',
+    )
+  })
+
+  test('preserves a lone <code> tag with no markdown', () => {
+    expect(toTelegramHtml('<code>/update-agent</code> route')).toBe('<code>/update-agent</code> route')
+  })
+
+  test('preserves <b>, <i> and <a> together', () => {
+    expect(toTelegramHtml('<b>h</b>\n<i>note</i> and <a href="https://e.com">link</a>')).toBe(
+      '<b>h</b>\n<i>note</i> and <a href="https://e.com">link</a>',
+    )
+  })
+
+  test('escapes non-whitelist tags instead of passing them through', () => {
+    expect(toTelegramHtml('danger <script>alert(1)</script> end')).toBe(
+      'danger &lt;script&gt;alert(1)&lt;/script&gt; end',
+    )
+  })
+
+  test('a tag inside inline code stays literal (escaped within <code>)', () => {
+    expect(toTelegramHtml('talk about `<b>` here')).toBe('talk about <code>&lt;b&gt;</code> here')
+  })
+
+  test('bare < with a space is still escaped, not treated as a tag', () => {
+    expect(toTelegramHtml('a < c > d')).toBe('a &lt; c &gt; d')
   })
 })
 

--- a/tests/unit/telegram-plugin/markdown.test.ts
+++ b/tests/unit/telegram-plugin/markdown.test.ts
@@ -79,8 +79,14 @@ describe('containsTelegramHtml()', () => {
     ['5 < 6 and 7 > 3', 'bare comparisons'],
     ['<script>alert(1)</script>', 'non-whitelist tag'],
     ['<div>x</div>', 'non-whitelist div'],
+    ['<span>x</span>', 'bare span without tg-spoiler class'],
+    ['<span class="tg-spoiler">x</span>', 'span spoiler (use <tg-spoiler> instead)'],
   ])('returns false for %s (%s)', input => {
     expect(containsTelegramHtml(input)).toBe(false)
+  })
+
+  test('detects the canonical <tg-spoiler> element', () => {
+    expect(containsTelegramHtml('<tg-spoiler>hidden</tg-spoiler>')).toBe(true)
   })
 })
 
@@ -115,6 +121,29 @@ describe('toTelegramHtml() preserves agent-authored Telegram HTML tags', () => {
 
   test('bare < with a space is still escaped, not treated as a tag', () => {
     expect(toTelegramHtml('a < c > d')).toBe('a &lt; c &gt; d')
+  })
+
+  // Hardening (PR #366 review): a bare <span> is not valid Telegram HTML, and a
+  // raw & inside a hand-written <a href> query string must be escaped so
+  // Telegram does not reject the message.
+  test('escapes a bare <span> (use <tg-spoiler> for spoilers)', () => {
+    expect(toTelegramHtml('<span>x</span>')).toBe('&lt;span&gt;x&lt;/span&gt;')
+  })
+
+  test('preserves the canonical <tg-spoiler> element verbatim', () => {
+    expect(toTelegramHtml('<tg-spoiler>shh</tg-spoiler>')).toBe('<tg-spoiler>shh</tg-spoiler>')
+  })
+
+  test('escapes a raw & in a passed-through <a href> query string', () => {
+    expect(toTelegramHtml('<a href="https://x.com?a=1&b=2">link</a>')).toBe(
+      '<a href="https://x.com?a=1&amp;b=2">link</a>',
+    )
+  })
+
+  test('leaves an already-encoded &amp; in a passed-through tag untouched', () => {
+    expect(toTelegramHtml('<a href="https://x.com?a=1&amp;b=2">link</a>')).toBe(
+      '<a href="https://x.com?a=1&amp;b=2">link</a>',
+    )
   })
 })
 

--- a/tests/unit/telegram-plugin/markdown.test.ts
+++ b/tests/unit/telegram-plugin/markdown.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for hasMarkdown() and toTelegramHtml() from src/telegram/markdown.ts
  */
-import { containsTelegramHtml, hasMarkdown, normalizeTelegramLineBreaks, toTelegramHtml } from '../../../src/telegram/markdown'
+import { containsTelegramHtml, hasMarkdown, normalizeTelegramLineBreaks, resolveTelegramReplyFormat, toTelegramHtml } from '../../../src/telegram/markdown'
 
 describe('hasMarkdown()', () => {
   test('detects **bold**', () => {
@@ -297,5 +297,50 @@ describe('toTelegramHtml()', () => {
       expect(result).toContain('<code>lastRecalledAt</code>')
       expect(result).toContain('• Point one')
     })
+  })
+})
+
+describe('resolveTelegramReplyFormat() — agent-authored HTML must not render literally', () => {
+  // Real payload shape from the reported bug: agent writes Telegram HTML tags
+  // (<b>, <code>) with NO markdown tokens. Before the fix, auto-detect only
+  // checked hasMarkdown() -> useHtml=false -> raw text, no parse_mode -> the
+  // tags showed up literally in the chat.
+  const htmlOnlyReport =
+    '<b>Code review PR #2294 → commit <code>48060b3c</code></b>\n' +
+    '12 files · <b>+52 / −196</b>\n' +
+    '• verb <code>update</code> in <code>archive-backup-control.sh</code>'
+
+  test('auto format: pure-HTML report is sent as HTML, tags preserved (regression)', () => {
+    const { sendText, parseMode } = resolveTelegramReplyFormat(htmlOnlyReport)
+    // Old behaviour returned parseMode=undefined here — this is the fail-on-old assertion.
+    expect(parseMode).toBe('HTML')
+    expect(sendText).toContain('<b>Code review PR #2294')
+    expect(sendText).toContain('<code>48060b3c</code>')
+    // never escaped into a literal tag
+    expect(sendText).not.toContain('&lt;b&gt;')
+  })
+
+  test('auto format: markdown-only still routes to HTML', () => {
+    const { parseMode } = resolveTelegramReplyFormat('This is **bold** and `code`')
+    expect(parseMode).toBe('HTML')
+  })
+
+  test("explicit 'html' with already-valid tags is sent verbatim under HTML", () => {
+    const { sendText, parseMode } = resolveTelegramReplyFormat('<b>hi</b>', 'html')
+    expect(parseMode).toBe('HTML')
+    expect(sendText).toBe('<b>hi</b>')
+  })
+
+  test("explicit 'text' is always raw with no parse_mode", () => {
+    const { sendText, parseMode } = resolveTelegramReplyFormat(htmlOnlyReport, 'text')
+    expect(parseMode).toBeUndefined()
+    expect(sendText).toBe(htmlOnlyReport)
+  })
+
+  test('non-whitelist tags stay escaped even in auto HTML mode (safety)', () => {
+    const { sendText, parseMode } = resolveTelegramReplyFormat('<b>ok</b> <script>alert(1)</script>')
+    expect(parseMode).toBe('HTML')
+    expect(sendText).toContain('<b>ok</b>')
+    expect(sendText).toContain('&lt;script&gt;')
   })
 })


### PR DESCRIPTION
## Summary
Agent output that mixes markdown with **directly-written Telegram HTML tags** (`<b>`, `<code>`, `<i>`, `<a>`, …) rendered the HTML tags as literal `<b>` text, while markdown-derived formatting/links rendered correctly. Root cause and fix are distinct from #363 (which only normalized `<br>`).

## Root cause (proven on v1.7.5)
`toTelegramHtml()` (`src/telegram/markdown.ts`, duplicated in `mcp/tools/telegram/lib/markdown.ts`) is a hand-written tokenizer. Any non-markdown run is accumulated as plain text and `escapeHtml()`-escaped (`markdown.ts:257`), so an agent-authored `<b>` becomes `&lt;b&gt;` and, under `parse_mode=HTML`, shows as literal `<b>`.

Two paths were affected:
- **Auto-forward** (`src/agent/runner.ts`) only routed to `toTelegramHtml()` when `hasMarkdown()` was true. Pure-HTML output (no markdown) was sent as plain text → literal tags. Mixed output was escaped → literal tags.
- The **reply** path already had an `inputIsHtml` guard, but via a divergent inlined regex.

### Live repro (pre-fix)
```
node -e 'const {toTelegramHtml}=require("./dist/telegram/markdown.js");
console.log(toTelegramHtml("**bold** <b>x</b> [l](https://e.com)"))'
# => <b>bold</b> &lt;b&gt;x&lt;/b&gt; <a href="https://e.com">l</a>
```

## Fix
- **Preserve whitelist tags**: `toTelegramHtml()` passes valid Telegram tags (`a, b, blockquote, code, del, em, i, ins, pre, s, span, strike, strong, tg-spoiler, u`) through verbatim and escapes only the `<`/`>` that are *not* part of such a tag. Non-whitelist tags (`<script>`, `<div>`) are still escaped — a controlled pass-through, not raw HTML injection.
- **Auto-forward** now routes to `toTelegramHtml()` when the text has markdown **or** `containsTelegramHtml()` — so pure-HTML agent output renders too.
- **Consolidation**: `module.ts` and `receiver-server.ts` previously each carried their own inlined tag regex that listed a non-existent `<spoiler>` tag and omitted `<span>`. Both now use the shared `containsTelegramHtml()`. Applied to both `markdown.ts` copies.

## Tests
- New unit tests for `containsTelegramHtml()` and tag preservation in `toTelegramHtml()`, **proven to fail on the pre-fix code** (they produce the escaped `&lt;b&gt;` output).
- Covers: mixed markdown+HTML renders both, lone `<code>` with no markdown, `<b>/<i>/<a>` together, non-whitelist tags stay escaped, a tag inside inline code stays literal, and `a < c > d` stays escaped.
- `npm run typecheck` clean; `mcp` `tsc --noEmit` clean; full `npm test` green: **182 suites, 3448 tests, exit 0**.

## Tradeoff
After this change, prose that literally writes a tag name **outside** code (e.g. `<b>` in plain text) is interpreted as formatting. Tags inside inline/`code` blocks are still escaped and remain safe.

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)