### PR TITLE
fix(session): don't wedge a session when /stop's SIGINT is survived

### DIFF
--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -116,6 +116,16 @@ export class SessionProcess extends EventEmitter {
   private restartRequested = false;
   private _processing = false;
   private _pendingRestart = false;
+  // True once we have OBSERVED the child actually exit (the 'exit' handler
+  // fired). Distinct from Node's ChildProcess.killed, which flips true the
+  // instant ANY signal is delivered — including a graceful /stop SIGINT that
+  // the pty-shell traps and SURVIVES (it forwards ESC to interrupt the TUI turn
+  // and keeps running). Liveness checks must use _exited, never .killed: a
+  // survived-SIGINT child is still alive, and treating it as dead wedges the
+  // session forever (isRunning() → false → the next turn waits on a restart
+  // that never comes; see runner.ts waitForSessionRestart). Reset to false on
+  // every fresh spawn.
+  private _exited = false;
   // Set by interrupt() right before SIGINT, cleared at the start of the next
   // sendMessage(). Lets a caller's process-exit handler tell a /stop-triggered
   // exit (CLI's SIGINT handler fell through to default termination instead of
@@ -703,6 +713,9 @@ export class SessionProcess extends EventEmitter {
     });
 
     this.process = proc;
+    // Fresh child is alive: clear any exit observed for a prior process (e.g.
+    // after an auto-restart), so isRunning()/interrupt() see it as live.
+    this._exited = false;
 
     // Send initial prompt only for Telegram/Discord sessions.
     // API sessions receive the first message directly via sendApiMessage(),
@@ -982,6 +995,7 @@ export class SessionProcess extends EventEmitter {
       });
       if (ptyStreamSocketPath) ptyStreamRegistry.close(ptyStreamSocketPath);
       this.process = null;
+      this._exited = true;
       // Notify listeners that the underlying subprocess died. The runner relies
       // on this to tear down per-chat typing/processing state when a session is
       // stopped or restarted mid-turn (without a final result/session_idle).
@@ -1211,7 +1225,10 @@ export class SessionProcess extends EventEmitter {
   }
 
   interrupt(): boolean {
-    if (!this.process || this.process.killed) return false;
+    // .killed is NOT liveness — it flips true on the FIRST SIGINT and stays
+    // true, so a prior /stop would make every later interrupt() no-op even on a
+    // live, actively-processing turn. Gate on _exited (child actually gone).
+    if (!this.process || this._exited) return false;
     if (!this._processing) return false;
     this.interruptRequested = true;
     this.process.kill('SIGINT');
@@ -1259,7 +1276,10 @@ export class SessionProcess extends EventEmitter {
   }
 
   isRunning(): boolean {
-    return this.process !== null && !this.process.killed;
+    // Use _exited (child's 'exit' observed), NOT .killed — .killed is true after
+    // any signal send, including a /stop SIGINT the pty-shell survives, which
+    // would falsely report a healthy interrupted session as not-running.
+    return this.process !== null && !this._exited;
   }
 
   async stop(): Promise<void> {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -225,6 +225,51 @@ describe('SessionProcess', () => {
   });
 
   // --------------------------------------------------------------------------
+  // U-SP-03b: a /stop SIGINT the pty-shell SURVIVES must not wedge the session.
+  // The pty-shell traps SIGINT (forwards ESC to interrupt the TUI turn) and
+  // keeps running, but Node flips ChildProcess.killed=true the instant the
+  // signal is sent. isRunning()/interrupt() must key off the observed 'exit'
+  // (_exited), NOT .killed — otherwise the survived-SIGINT child reads as dead
+  // and the next turn waits forever on a restart that never comes.
+  // Regression for: session stuck "Session restart did not complete in time"
+  // after /stop + resend.
+  // --------------------------------------------------------------------------
+  it('U-SP-03b: a survived /stop SIGINT keeps the session running and interruptible', async () => {
+    const sp = makeSp('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    const child = lastProcess!;
+
+    // Simulate the pty-shell: SIGINT is trapped and survived (no 'exit'); only
+    // SIGTERM/SIGKILL actually kill it. Node still sets killed=true on SIGINT.
+    child.kill = jest.fn((signal?: string) => {
+      child.killed = true;
+      if (signal === 'SIGTERM' || signal === 'SIGKILL') {
+        process.nextTick(() => child.emit('exit', signal === 'SIGKILL' ? 1 : 0, signal));
+      }
+      // SIGINT: the child survives — deliberately emit no 'exit'.
+      return true;
+    });
+
+    // An actively-processing turn, then a /stop interrupt.
+    sp.setProcessing(true);
+    expect(sp.interrupt()).toBe(true);
+    expect(child.kill).toHaveBeenCalledWith('SIGINT');
+    expect(child.killed).toBe(true); // Node flipped it — but the child is alive
+
+    // The child survived, so the session is still running and a follow-up
+    // interrupt on the same live turn must still fire. On the pre-fix code
+    // (isRunning/interrupt gated on child.killed) BOTH of these are false.
+    expect(sp.isRunning()).toBe(true);
+    expect(sp.interrupt()).toBe(true);
+
+    // Sanity (guard against over-correction): a genuine teardown still flips
+    // isRunning() to false.
+    sp.setProcessing(false);
+    await sp.stop();
+    expect(sp.isRunning()).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
   // U-SP-04: isIdle() / touch() behaviour
   // --------------------------------------------------------------------------
   it('U-SP-04: isIdle() returns true after idle window, touch() resets it', async () => {
@@ -1739,16 +1784,21 @@ describe('SessionProcess — isProcessing and deferred restart', () => {
     await sp.stop();
   });
 
-  it('U-SP-INT-03: interrupt() returns false when subprocess is already killed', async () => {
+  it('U-SP-INT-03: interrupt() returns false after the subprocess has actually exited', async () => {
     const sp = makeSp('s1', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
     sp.setProcessing(true);
-    lastProcess!.killed = true;
+
+    // A GENUINE teardown — the child's 'exit' is observed (process gone).
+    // This is distinct from a survived /stop SIGINT, which sets Node's
+    // .killed=true while the child stays alive (see U-SP-03b): that case must
+    // remain interruptible, so interrupt() keys off the observed exit, not
+    // .killed.
+    await sp.stop();
 
     const result = sp.interrupt();
 
     expect(result).toBe(false);
-    expect(lastProcess!.kill).not.toHaveBeenCalled();
   });
 
   it('U-SP-INT-04: interrupt() returns false when subprocess never started', () => {


### PR DESCRIPTION
## What & why

Fixes a session wedge: after a `/stop` interrupts an active turn, the next message failed permanently with `Session restart did not complete in time`, even though the subprocess was alive and idle.

`/stop` → `interrupt()` → `process.kill('SIGINT')`. The pty-shell **traps SIGINT, forwards ESC to interrupt the TUI turn, and keeps running**. But Node sets `ChildProcess.killed = true` on any signal send, and `isRunning()` read `!process.killed` — so it reported the live child as dead forever. The next message hit `getOrSpawnSession`'s `!isRunning()` branch and waited on a restart that never came (`waitForSessionRestart` → 20s timeout → reject), wedging the session on every retry.

## The fix

- New `_exited` flag on `SessionProcess`: cleared on every fresh spawn, set only in the child's `exit` handler.
- `isRunning()` and `interrupt()`'s guard now key off `_exited` (child actually gone), not `ChildProcess.killed` (a signal was sent).

A graceful SIGINT interrupt is expected to leave the process alive, so liveness must key off an observed `exit`, not off signal delivery. This also fixes `interrupt()` silently no-oping on a second `/stop`.

## Tests

- **U-SP-03b (new)** — simulates a pty child that traps-and-survives SIGINT (`killed=true`, no `exit`); asserts `isRunning()` stays `true`, a follow-up `interrupt()` still fires, and a genuine teardown still flips `isRunning()` to `false`. **Proven to fail on the pre-fix code** (`isRunning()` returned `false`).
- **U-SP-INT-03 (updated)** — previously encoded the buggy "`killed` ⇒ treat as dead" premise; now asserts `interrupt()` no-ops only after an observed exit.

## Gates

- `npm run typecheck` clean.
- Full suite green: **187 suites / 3523 tests**.

## Scope notes

- `telegram/receiver.ts` and `discord/receiver.ts` also read `!process.killed` in their `isRunning()`, but those long-lived receiver processes are only ever killed to be torn down (never trapped-and-survived), so `.killed` is correct there. Left unchanged intentionally.

Closes #368
