### PR TITLE
fix(session): prevent dead sessions from wedging the pool (#371)

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1326,6 +1326,15 @@ export class AgentRunner extends EventEmitter {
    */
   private waitForSessionRestart(proc: SessionProcess): Promise<void> {
     if (proc.isRunning()) return Promise.resolve();
+    // Dead with no respawn in flight → the restarted/restartFailed/failed events
+    // this waits on will never fire, so blocking for the full timeout only to
+    // reject is pointless. Fail fast so the caller recovers immediately. (The
+    // primary caller, getOrSpawnSession, already guards on isRestartScheduled()
+    // and respawns instead of calling here; this is a defence-in-depth backstop
+    // for any other caller.) See #371.
+    if (!proc.isRestartScheduled()) {
+      return Promise.reject(new Error('Session is not running and no restart is scheduled'));
+    }
     return new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
         cleanup();
@@ -1376,7 +1385,34 @@ export class AgentRunner extends EventEmitter {
       // but THIS gap is hit before a turn even starts, so that fix can't see
       // it). Wait for the pending respawn to actually land before handing the
       // session back.
-      if (!existing.isRunning()) await this.waitForSessionRestart(existing);
+      //
+      // But only wait if a respawn is actually in flight. A session can also be
+      // dead with NOTHING coming — permanently failed (max restarts), or stopped
+      // without eviction. Handing that corpse back would wedge the caller:
+      // sendMessage() no-ops on a null child, and waitForSessionRestart would
+      // block for the full timeout waiting on a restarted/failed event that will
+      // never fire. Drop it and spawn a fresh session instead so the message is
+      // served immediately. See #371.
+      if (!existing.isRunning()) {
+        if (existing.isRestartScheduled()) {
+          await this.waitForSessionRestart(existing);
+        } else {
+          this.logger.warn('Mapped session is dead with no restart in flight — respawning fresh', {
+            mapKey, source,
+          });
+          const respawn = (async () => {
+            await existing.stop();          // idempotent on a dead child; closes watchers + signal file
+            this.sessions.delete(mapKey);
+            return this.spawnSession(mapKey, source, sessionId, effectiveOverride);
+          })();
+          this.sessionSpawnLocks.set(mapKey, respawn);
+          try {
+            return await respawn;
+          } finally {
+            this.sessionSpawnLocks.delete(mapKey);
+          }
+        }
+      }
 
       // Restart if model changed (including switching back to the agent default)
       if (existing.modelOverride !== effectiveOverride) {
@@ -1490,6 +1526,18 @@ export class AgentRunner extends EventEmitter {
     // Forward all session output lines so listeners on AgentRunner (GatewayRouter,
     // CronScheduler, tests) receive them without needing individual session references.
     proc.on('output', (line: string) => this.emit('output', line));
+
+    // API sessions get NONE of the channel lifecycle handlers below (the whole
+    // block is gated to source !== 'api'), so a permanent failure would
+    // otherwise leave the dead SessionProcess in the pool: the next
+    // getOrSpawnSession returns it and, finding no auto-restart in flight, would
+    // block on waitForSessionRestart for the full 20s timeout before rejecting —
+    // the "wedge" #371 describes. Remove it from the pool on failure so the next
+    // message spawns a fresh session instead. (Channel sessions already do this
+    // inside the notify handler below.)
+    if (source === 'api') {
+      proc.once('failed', () => this.sessions.delete(mapKey));
+    }
 
     // Notify typing indicator when session permanently fails (max restarts exceeded)
     if (source !== 'api') {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -1097,7 +1097,13 @@ export class SessionProcess extends EventEmitter {
           });
       } else {
         // stop() won the race before the timer fired — no respawn will happen.
+        // Wake any waiter blocked on this restart (waitForSessionRestart) so it
+        // rejects immediately instead of hanging for the full timeout: the
+        // restarted/restartFailed/failed event it waits on would otherwise never
+        // fire. Clearing the flag first also lets a fresh getOrSpawnSession call
+        // take the respawn-fresh path. See #371.
         this._restartScheduled = false;
+        this.emit('restartFailed', new Error('Session restart abandoned: session stopping'));
       }
     }, AUTO_RESTART_DELAY_MS);
   }

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -59,6 +59,14 @@ export function resolveMaxHistoryMessages(
 }
 const AUTO_RESTART_DELAY_MS = 5_000;
 const MAX_RESTARTS = 3;
+// A respawned child that stays alive at least this long counts as a healthy run
+// rather than a member of a crash loop: on its eventual death the crash budget
+// (restartCount) is reset so sporadic crashes spread across a long-lived
+// session don't slowly accumulate toward a false permanent `failed`. Must be
+// comfortably longer than the crash-loop window (AUTO_RESTART_DELAY_MS *
+// MAX_RESTARTS = 15s) so a genuine tight crash loop never survives it and the
+// MAX_RESTARTS backstop still fires. See issue #371.
+const RESTART_COUNT_RESET_MS = 60_000;
 // Bound how many times a single session may auto-respawn to recover from a
 // corrupted thinking block, so a recovery that never helps can't loop forever.
 const MAX_THINKING_RECOVERIES = 2;
@@ -113,6 +121,18 @@ export class SessionProcess extends EventEmitter {
   private process: ChildProcess | null = null;
   private stopping = false;
   private restartCount = 0;
+  // Wall-clock time the current (or most recent) child was spawned. Used by the
+  // exit handler to measure how long that child survived, so a death after
+  // sustained healthy uptime resets the crash budget instead of counting toward
+  // MAX_RESTARTS. See RESTART_COUNT_RESET_MS.
+  private lastSpawnAt = 0;
+  // True while a crash-triggered respawn is in flight — from the moment
+  // scheduleRestart() arms the AUTO_RESTART_DELAY_MS timer until the replacement
+  // child has attached (emit 'restarted') or the respawn failed/was abandoned.
+  // The runner reads this via isRestartScheduled() to distinguish "a restart is
+  // coming, wait for it" from "dead with nothing coming, respawn fresh" — the
+  // latter would otherwise wedge on waitForSessionRestart's full timeout. #371.
+  private _restartScheduled = false;
   private restartRequested = false;
   private _processing = false;
   private _pendingRestart = false;
@@ -716,6 +736,7 @@ export class SessionProcess extends EventEmitter {
     // Fresh child is alive: clear any exit observed for a prior process (e.g.
     // after an auto-restart), so isRunning()/interrupt() see it as live.
     this._exited = false;
+    this.lastSpawnAt = Date.now();
 
     // Send initial prompt only for Telegram/Discord sessions.
     // API sessions receive the first message directly via sendApiMessage(),
@@ -1004,6 +1025,16 @@ export class SessionProcess extends EventEmitter {
       // rmSync(force)), so emitting on every child exit — including auto-restart
       // — is safe.
       this.emit('exit', code, signal);
+      // A child that ran healthily for a sustained period before dying is not
+      // part of a crash loop — reset the crash budget so an occasional crash
+      // over a long-lived session doesn't slowly accumulate toward MAX_RESTARTS
+      // and trip a false permanent `failed` (which would tear down a healthy
+      // session and, for an API session, previously wedge it — see #371). A
+      // rapid crash loop never survives RESTART_COUNT_RESET_MS, so the
+      // MAX_RESTARTS backstop is preserved.
+      if (this.lastSpawnAt && Date.now() - this.lastSpawnAt >= RESTART_COUNT_RESET_MS) {
+        this.restartCount = 0;
+      }
       if (!this.stopping) this.scheduleRestart();
     });
 
@@ -1040,6 +1071,10 @@ export class SessionProcess extends EventEmitter {
       return;
     }
     this.restartCount++;
+    // A crash-triggered respawn is now committed (timer armed below). Mark it in
+    // flight so waitForSessionRestart knows to wait for the replacement child
+    // rather than fail fast. Cleared once the respawn settles (or is skipped).
+    this._restartScheduled = true;
     this.logger.warn(`Scheduling session restart in ${AUTO_RESTART_DELAY_MS}ms`, {
       attempt: this.restartCount,
     });
@@ -1051,11 +1086,18 @@ export class SessionProcess extends EventEmitter {
           // sendMessage() will no longer silently no-op. Emitted on every
           // successful crash-triggered respawn — cheap, and nothing currently
           // listens outside that one call site.
-          .then(() => this.emit('restarted'))
+          .then(() => {
+            this._restartScheduled = false;
+            this.emit('restarted');
+          })
           .catch(err => {
+            this._restartScheduled = false;
             this.logger.error('restart failed', { error: err.message });
             this.emit('restartFailed', err);
           });
+      } else {
+        // stop() won the race before the timer fired — no respawn will happen.
+        this._restartScheduled = false;
       }
     }, AUTO_RESTART_DELAY_MS);
   }
@@ -1265,6 +1307,20 @@ export class SessionProcess extends EventEmitter {
    */
   hasPendingRestart(): boolean {
     return this._pendingRestart;
+  }
+
+  /**
+   * True while a crash-triggered auto-restart is in flight — armed by
+   * scheduleRestart() on child death and cleared once the replacement child
+   * attaches ('restarted'), the respawn fails ('restartFailed'), or the restart
+   * is abandoned because stop() raced in. Distinct from hasPendingRestart(),
+   * which tracks a *deferred* (graceful, turn-boundary) restart. The runner
+   * reads this to tell "a restart is coming, wait for it" apart from "dead with
+   * nothing coming, respawn a fresh session" — the latter would otherwise block
+   * on waitForSessionRestart's full timeout and wedge the caller. See #371.
+   */
+  isRestartScheduled(): boolean {
+    return this._restartScheduled;
   }
 
   touch(): void {

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -383,11 +383,13 @@ class Driver {
     });
     // SIGHUP (controlling terminal / OS hangup) has no handler by default, so
     // Node would terminate the pty-shell with the default action (exit 129),
-    // killing the wrapper abruptly WITHOUT running shutdown(). The parent
-    // SessionProcess sees a raw non-zero exit and, on a channel session, may
-    // accumulate it toward MAX_RESTARTS. Treat SIGHUP like SIGTERM: shut down
-    // gracefully (exit 0) so the parent's normal exit→restart path runs instead
-    // of an unexplained hard death. See issue #371.
+    // killing the wrapper abruptly WITHOUT running shutdown() — which means the
+    // underlying claude child is never reaped (host.kill()) and can be orphaned.
+    // Treat SIGHUP like SIGTERM: run the graceful shutdown(0) path so the child
+    // is cleaned up and the parent observes a normal exit. (This does not change
+    // whether the exit counts toward MAX_RESTARTS — every exit routes through
+    // scheduleRestart; the win here is orderly teardown, not restart accounting.)
+    // See issue #371.
     process.on('SIGHUP', () => {
       logDebug('SIGHUP → killing claude');
       this.shutdown(0);

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -381,6 +381,17 @@ class Driver {
       logDebug('SIGTERM → killing claude');
       this.shutdown(0);
     });
+    // SIGHUP (controlling terminal / OS hangup) has no handler by default, so
+    // Node would terminate the pty-shell with the default action (exit 129),
+    // killing the wrapper abruptly WITHOUT running shutdown(). The parent
+    // SessionProcess sees a raw non-zero exit and, on a channel session, may
+    // accumulate it toward MAX_RESTARTS. Treat SIGHUP like SIGTERM: shut down
+    // gracefully (exit 0) so the parent's normal exit→restart path runs instead
+    // of an unexplained hard death. See issue #371.
+    process.on('SIGHUP', () => {
+      logDebug('SIGHUP → killing claude');
+      this.shutdown(0);
+    });
   }
 
   // ---- transcript events: claude → gateway --------------------------------

--- a/tests/unit/api-stream-crash-recovery.test.ts
+++ b/tests/unit/api-stream-crash-recovery.test.ts
@@ -348,4 +348,152 @@ describe('AgentRunner.sendApiMessageStream — subprocess exit mid-turn', () => 
       sendMessageSpy.mockRestore();
     }
   });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // #371 — session wedge: a dead session must never linger in the pool.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it("a permanently-failed API session is evicted from the pool so the next message spawns fresh (not a wedge) — #371", async () => {
+    // Before the fix, the `failed` (max-restarts) handler that removes the dead
+    // SessionProcess from the pool was gated to `source !== 'api'`, so an API
+    // session that permanently failed stayed mapped. The next getOrSpawnSession
+    // returned that corpse and blocked on waitForSessionRestart for the full 20s
+    // timeout before rejecting — the wedge.
+    let liveSession: SessionProcess | undefined;
+    const originalSendMessage = SessionProcess.prototype.sendMessage;
+    const sendMessageSpy = jest
+      .spyOn(SessionProcess.prototype, 'sendMessage')
+      .mockImplementation(function (this: SessionProcess, text: string) {
+        liveSession = this;
+        return originalSendMessage.call(this, text);
+      });
+
+    try {
+      // Turn 1 completes normally → the session is live and mapped.
+      await runner.sendApiMessageStream(
+        sessionId, chatId, 'hello',
+        { onChunk: jest.fn(), onDone: jest.fn(), onError: jest.fn() },
+        { timeoutMs: 60_000 },
+      );
+      lastProcess!.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', result: 'hi' }) + '\n'));
+      await new Promise((r) => setImmediate(r));
+
+      expect(liveSession).toBeDefined();
+      const sessions = (runner as unknown as { sessions: Map<string, SessionProcess> }).sessions;
+      // For API sessions the pool is keyed by the session id.
+      expect(sessions.get(sessionId)).toBe(liveSession);
+
+      // The session hits the permanent-failure ceiling (max auto-restarts).
+      liveSession!.emit('failed');
+      await new Promise((r) => setImmediate(r));
+
+      // Fix: an API session must be dropped from the pool on `failed`, exactly
+      // like a channel session — so the next message spawns a fresh session
+      // instead of being handed the dead one.
+      expect(sessions.has(sessionId)).toBe(false);
+    } finally {
+      sendMessageSpy.mockRestore();
+    }
+  });
+
+  it("a message to a dead, non-restarting mapped API session respawns fresh instead of wedging — #371", async () => {
+    // A session can be dead with NO auto-restart in flight (stopped without
+    // eviction, or permanently failed). getOrSpawnSession used to unconditionally
+    // await waitForSessionRestart on it, blocking for the full 20s timeout on a
+    // restarted/failed event that never comes. The fix: detect "dead + no restart
+    // scheduled" and respawn a fresh session immediately.
+    let liveSession: SessionProcess | undefined;
+    const originalSendMessage = SessionProcess.prototype.sendMessage;
+    const sendMessageSpy = jest
+      .spyOn(SessionProcess.prototype, 'sendMessage')
+      .mockImplementation(function (this: SessionProcess, text: string) {
+        liveSession = this;
+        return originalSendMessage.call(this, text);
+      });
+
+    try {
+      // Turn 1 → proc1, complete normally.
+      await runner.sendApiMessageStream(
+        sessionId, chatId, 'turn 1',
+        { onChunk: jest.fn(), onDone: jest.fn(), onError: jest.fn() },
+        { timeoutMs: 60_000 },
+      );
+      const proc1 = lastProcess!;
+      proc1.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', result: 'r1' }) + '\n'));
+      await new Promise((r) => setImmediate(r));
+
+      const session1 = liveSession!;
+      const sessions = (runner as unknown as { sessions: Map<string, SessionProcess> }).sessions;
+      expect(sessions.get(sessionId)).toBe(session1);
+
+      // Kill the session WITHOUT evicting it from the pool → dead, stopping=true,
+      // no auto-restart scheduled: the exact "corpse left in the map" state.
+      await session1.stop();
+      expect(session1.isRunning()).toBe(false);
+      expect(session1.isRestartScheduled()).toBe(false);
+      expect(sessions.get(sessionId)).toBe(session1); // still mapped
+
+      // Turn 2 must be served by a fresh session, promptly — not blocked on the
+      // 20s restart-wait timeout.
+      const turn2Done = jest.fn();
+      const turn2Error = jest.fn();
+      await runner.sendApiMessageStream(
+        sessionId, chatId, 'turn 2',
+        { onChunk: jest.fn(), onDone: turn2Done, onError: turn2Error },
+        { timeoutMs: 60_000 },
+      );
+      const proc2 = lastProcess!;
+      expect(proc2).not.toBe(proc1);
+
+      proc2.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', result: 'r2' }) + '\n'));
+      await new Promise((r) => setImmediate(r));
+
+      expect(turn2Done).toHaveBeenCalledTimes(1);
+      expect(turn2Done.mock.calls[0][0]).toBe('r2');
+      expect(turn2Error).not.toHaveBeenCalled();
+      // The corpse was replaced by the fresh session in the pool.
+      expect(sessions.get(sessionId)).not.toBe(session1);
+    } finally {
+      sendMessageSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('waitForSessionRestart rejects immediately for a dead session with no restart scheduled (no 20s hang) — #371', async () => {
+    // Defence-in-depth backstop: even a caller that reaches waitForSessionRestart
+    // directly on a dead, non-restarting session must not block for the full
+    // timeout. It should reject at once so the caller can recover.
+    let liveSession: SessionProcess | undefined;
+    const originalSendMessage = SessionProcess.prototype.sendMessage;
+    const sendMessageSpy = jest
+      .spyOn(SessionProcess.prototype, 'sendMessage')
+      .mockImplementation(function (this: SessionProcess, text: string) {
+        liveSession = this;
+        return originalSendMessage.call(this, text);
+      });
+
+    try {
+      await runner.sendApiMessageStream(
+        sessionId, chatId, 'hello',
+        { onChunk: jest.fn(), onDone: jest.fn(), onError: jest.fn() },
+        { timeoutMs: 60_000 },
+      );
+      lastProcess!.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', result: 'r' }) + '\n'));
+      await new Promise((r) => setImmediate(r));
+
+      const session1 = liveSession!;
+      await session1.stop();
+      expect(session1.isRunning()).toBe(false);
+      expect(session1.isRestartScheduled()).toBe(false);
+
+      const started = Date.now();
+      await expect(
+        (runner as unknown as { waitForSessionRestart(p: SessionProcess): Promise<void> })
+          .waitForSessionRestart(session1),
+      ).rejects.toThrow(/no restart is scheduled/);
+      // Rejected essentially instantly — nowhere near the 20s wait timeout.
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      sendMessageSpy.mockRestore();
+    }
+  });
 });

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -2597,6 +2597,40 @@ describe('SessionProcess — crash-budget reset on healthy uptime (#371)', () =>
 
     await sp.stop();
   });
+
+  it("emits 'restartFailed' when stop() races the auto-restart window, so waiters don't hang — #371", async () => {
+    const sp = makeSp('sess:budget-race', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start(); // real timers for the spawn + fs I/O
+
+    // Switch to fake timers only for the restart-delay window. The timer's
+    // stop-race branch does NOT call spawnProcess (stopping===true), so no fs
+    // I/O runs under fake timers.
+    jest.useFakeTimers();
+    try {
+      const restartFailedSpy = jest.fn();
+      sp.on('restartFailed', restartFailedSpy);
+
+      // Crash → scheduleRestart arms the 5s timer and marks a restart in flight.
+      lastProcess!.emit('exit', 1, null);
+      await Promise.resolve();
+      expect(sp.isRestartScheduled()).toBe(true);
+
+      // stop() races in before the timer fires (the child is already gone, so
+      // stop() just sets stopping=true and returns).
+      await sp.stop();
+
+      // Timer fires into the stop-race branch: it must wake waiters, not clear
+      // the flag silently (which previously left waitForSessionRestart to hang
+      // for the full 20s timeout before rejecting).
+      jest.advanceTimersByTime(5_000); // AUTO_RESTART_DELAY_MS
+      await Promise.resolve();
+
+      expect(restartFailedSpy).toHaveBeenCalledTimes(1);
+      expect(sp.isRestartScheduled()).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });
 
 // ── resolveMaxHistoryMessages ────────────────────────────────────────────────

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -2515,6 +2515,90 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
   });
 });
 
+// ── crash-budget reset on healthy uptime (#371) ──────────────────────────────
+// restartCount only ever reset in start()/graceful-restart, never after a
+// crash-triggered respawn succeeded. A long-lived session that crashed a few
+// times over its whole life (each recovering fine) would slowly accumulate
+// toward MAX_RESTARTS and then permanently `failed` on the next crash — tearing
+// down a healthy session (and, for API, wedging it). The fix resets the budget
+// when a child dies after sustained healthy uptime, while a tight crash loop
+// (no uptime gap) still trips MAX_RESTARTS so the backstop is preserved.
+describe('SessionProcess — crash-budget reset on healthy uptime (#371)', () => {
+  let tmpDir: string;
+  let sessionStore: SessionStore;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-budget-'));
+    agentConfig = makeAgentConfig({ workspace: path.join(tmpDir, 'workspace') });
+    fs.mkdirSync(agentConfig.workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions'));
+    lastProcess = null;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  const getRestartCount = (sp: SessionProcess) =>
+    (sp as unknown as { restartCount: number }).restartCount;
+
+  it("resets the crash budget after sustained uptime — no false 'failed' over many lifetime crashes", async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 1_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('sess:budget-1', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start(); // lastSpawnAt = T0
+
+    const failedSpy = jest.fn();
+    sp.on('failed', failedSpy);
+
+    // Crash the child far more times than MAX_RESTARTS, but each death comes
+    // after a long healthy uptime gap (well past RESTART_COUNT_RESET_MS = 60s).
+    // No live respawn happens (the 5s timers never fire in the test), so
+    // lastSpawnAt stays at T0 and each advanced clock reads as a huge uptime →
+    // the budget resets every time and 'failed' is never emitted.
+    for (let i = 1; i <= 8; i++) {
+      nowSpy.mockReturnValue(T0 + i * 120_000); // +2min each crash
+      lastProcess!.emit('exit', 1, null);
+      await Promise.resolve();
+      // Budget resets to 0 then increments to 1 on each healthy-uptime crash.
+      expect(getRestartCount(sp)).toBeLessThanOrEqual(1);
+    }
+    expect(failedSpy).not.toHaveBeenCalled();
+
+    await sp.stop();
+  });
+
+  it("still trips 'failed' at MAX_RESTARTS for a tight crash loop (backstop preserved)", async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 2_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('sess:budget-2', 'api', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const failedSpy = jest.fn();
+    sp.on('failed', failedSpy);
+
+    // Rapid crashes with NO uptime gap (clock barely advances) → uptime stays
+    // under RESTART_COUNT_RESET_MS → budget never resets → after MAX_RESTARTS
+    // the next crash emits the permanent 'failed'.
+    for (let i = 1; i <= 5; i++) {
+      nowSpy.mockReturnValue(T0 + i * 100); // +100ms each — a tight loop
+      lastProcess!.emit('exit', 1, null);
+      await Promise.resolve();
+    }
+    expect(failedSpy).toHaveBeenCalled();
+
+    await sp.stop();
+  });
+});
+
 // ── resolveMaxHistoryMessages ────────────────────────────────────────────────
 
 describe('resolveMaxHistoryMessages', () => {


### PR DESCRIPTION
## Summary

Fixes the `failed to submit turn to the TUI input` / stuck-session **wedge** described in #371.

A session whose subprocess died could linger in the pool as a dead **corpse**: the next message was handed a `SessionProcess` with no child, `sendMessage()` silently no-op'd, and `getOrSpawnSession` blocked on `waitForSessionRestart` for the full 20s timeout before rejecting.

During investigation the issue's original mechanism proved **half-right**: SIGHUP is indeed unhandled (confirmed), but `process.ts` *does* `scheduleRestart()` on a normal exit — so a single SIGHUP recovers on its own. The persistent wedge comes from dead sessions that are left mapped with **no restart coming**. This PR fixes that at the source and defends at the boundary.

## Root-cause fixes (four, interlocking)

1. **SIGHUP handler** (`src/shell/claude-pty-shell.ts`) — a terminal/OS hangup had no handler, so Node killed the wrapper with the default action (exit 129) **without** running `shutdown()`. Now handled like SIGTERM → graceful exit(0) so the parent's normal exit→restart path runs.

2. **Reset the crash budget after sustained healthy uptime** (`src/session/process.ts`) — `restartCount` was only reset in `start()`/graceful-restart, never after a crash-triggered respawn succeeded. A long-lived session that crashed a handful of times across its whole life would accumulate toward `MAX_RESTARTS` and then permanently `failed`. A child that survives past `RESTART_COUNT_RESET_MS` (60s) now resets the budget on its next death; a tight crash loop never survives the window, so the `MAX_RESTARTS` backstop is preserved.

3. **Evict a permanently-failed API session from the pool** (`src/agent/runner.ts`) — the `failed` handler that removes the dead `SessionProcess` was gated to `source !== 'api'`, so a failed **API** session stayed mapped and wedged the next turn. API sessions now drop from the pool on `failed` too.

4. **Recover in `getOrSpawnSession`** (`src/agent/runner.ts`) — when the mapped session is dead with **no restart in flight** (permanently failed, or stopped without eviction), drop the corpse and spawn a fresh session instead of awaiting a restart event that will never fire. `waitForSessionRestart` also fail-fasts in that state as a defence-in-depth backstop. A new `SessionProcess.isRestartScheduled()` accessor distinguishes "a restart is coming, wait" from "dead, nothing coming, respawn fresh".

## Tests

All new tests were **proven to fail on the pre-fix code** (verified by reverting each fix):

- `tests/unit/session-process.test.ts` — crash budget resets on healthy uptime (no false `failed`); a tight crash loop still trips `failed` (backstop intact).
- `tests/unit/api-stream-crash-recovery.test.ts` — a failed API session is evicted from the pool; a message to a dead, non-restarting session respawns fresh instead of wedging; `waitForSessionRestart` rejects immediately instead of hanging for the timeout.

## Gates

- `npm run typecheck` — clean.
- Full suite: **3527 passed**. The one flaky failure (`phase-manual P4-09`, a chokidar 600ms FS-watch timing test) is unrelated to this change and passes in isolation.

Note: fix #1 (SIGHUP) mirrors the established SIGTERM handler exactly and has no isolated unit test — the pty-shell `Driver` is a module-load singleton that spawns a real PTY, so its signal wiring isn't unit-testable here.

Closes #371