### PR TITLE
feat(slack): add image attachment support (outbound + inbound)

### DIFF
--- a/mcp/tools/discord/module.ts
+++ b/mcp/tools/discord/module.ts
@@ -30,8 +30,7 @@ import { createMessageHandler } from './inbound';
 // the others see the O_EXCL marker and drop, so a stranger's DM is handled once.
 import { initDedupDir, isDuplicate, pruneDedup } from '../telegram/dedup';
 import type { DiscordMessageContext } from './types';
-
-const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+import { MAX_ATTACHMENT_BYTES } from '../shared/limits';
 
 /** AgentRunner callback base (origin of CLAUDE_CHANNEL_CALLBACK, "" when unset).
  *  Used to mint/approve `/cli` pairings via the runner, the same bridge the

--- a/mcp/tools/shared/limits.ts
+++ b/mcp/tools/shared/limits.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared limits for the channel reply tools (Discord / Telegram / Slack).
+ *
+ * Self-contained on purpose, like share-client.ts: mcp/** ships as source
+ * without src/**, so this module must not import from src/ (see
+ * tests/unit/mcp-no-src-imports.test.ts).
+ */
+
+/**
+ * Cap on a single outbound attachment. 50 MB is the smallest of the three
+ * platforms' own upload ceilings, so one value keeps the tools' behaviour
+ * identical instead of each re-declaring the same literal.
+ */
+export const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;

--- a/mcp/tools/slack/module.ts
+++ b/mcp/tools/slack/module.ts
@@ -21,9 +21,7 @@ import type { ToolModule, McpToolDefinition, McpToolResult, ToolVisibility } fro
 // "Cannot find module" from an installed package). `npm run build` must have
 // run at least once for this import to resolve locally.
 import { SlackClient } from '../../../dist/api/slack-client.js';
-
-// Same cap Discord/Telegram use for outbound attachments.
-const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+import { MAX_ATTACHMENT_BYTES } from '../shared/limits';
 
 export class SlackModule implements ToolModule {
   id = 'slack';

--- a/mcp/tools/slack/module.ts
+++ b/mcp/tools/slack/module.ts
@@ -11,6 +11,7 @@
  * bot token at any time, so this module always sends directly from the
  * subprocess.
  */
+import * as fs from 'fs';
 import type { ToolModule, McpToolDefinition, McpToolResult, ToolVisibility } from '../../types';
 // mcp/ ships as source (package.json `files` lists "mcp/", not "src/") and
 // runs directly under bun — it may only import a compiled dist/ artifact,
@@ -21,9 +22,17 @@ import type { ToolModule, McpToolDefinition, McpToolResult, ToolVisibility } fro
 // run at least once for this import to resolve locally.
 import { SlackClient } from '../../../dist/api/slack-client.js';
 
+// Same cap Discord/Telegram use for outbound attachments.
+const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+
 export class SlackModule implements ToolModule {
   id = 'slack';
   toolVisibility: ToolVisibility = 'current-channel';
+
+  // Files already delivered this session. Small models sometimes retry
+  // slack_reply after a transient send hiccup even though the upload
+  // succeeded, which spams duplicate images. We never re-send the same file.
+  private readonly sentFiles = new Set<string>();
 
   isEnabled(): boolean {
     return process.env.GATEWAY_ORIGIN_CHANNEL === 'slack';
@@ -36,6 +45,7 @@ export class SlackModule implements ToolModule {
         description:
           'Send a reply to the current Slack conversation. ' +
           'Pass chat_id (the Slack channel/DM id shown in the <channel> tag) and text. ' +
+          'Optionally pass files (absolute paths) to attach images or documents. ' +
           'Also pass message_id from the <channel> tag when present — it clears the ' +
           '⏳ "seen" reaction the gateway left on the inbound message. ' +
           'Pass thread_id to reply inside the same thread instead of top-level.',
@@ -50,6 +60,14 @@ export class SlackModule implements ToolModule {
               type: 'string',
               description: 'Message text.',
             },
+            files: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Absolute file paths to attach (e.g. a generate_image result path). ' +
+                'Optional — text can be sent alone, files can be sent alone, or both ' +
+                'together as one message with the text as caption.',
+            },
             message_id: {
               type: 'string',
               description:
@@ -63,7 +81,9 @@ export class SlackModule implements ToolModule {
                 'to a threaded message stays in-thread.',
             },
           },
-          required: ['chat_id', 'text'],
+          // `text` is NOT required: a files-only reply (an image with no caption)
+          // is a legitimate send.
+          required: ['chat_id'],
         },
       },
     ];
@@ -79,12 +99,26 @@ export class SlackModule implements ToolModule {
     const text = typeof args.text === 'string' ? args.text : '';
     const messageId = typeof args.message_id === 'string' ? args.message_id : '';
     const threadId = typeof args.thread_id === 'string' ? args.thread_id : '';
+    const requested = Array.isArray(args.files) ? (args.files as unknown[]) : [];
     const token = process.env.SLACK_BOT_TOKEN ?? '';
 
     if (!chatId) {
       return { content: [{ type: 'text', text: 'slack_reply: missing chat_id' }], isError: true };
     }
-    if (!text) {
+
+    // Drop files already delivered successfully this session (retry-dedup): a
+    // small model sometimes retries slack_reply after a transient hiccup even
+    // though the upload landed, which would spam duplicate images.
+    const files = requested.filter(
+      (f): f is string => typeof f === 'string' && !this.sentFiles.has(f),
+    );
+
+    // Nothing new to say or send — the whole reply is a duplicate retry. No-op
+    // success so the agent treats it as delivered and stops retrying.
+    if (!text && files.length === 0 && requested.length > 0) {
+      return { content: [{ type: 'text', text: 'already sent (duplicate suppressed)' }] };
+    }
+    if (!text && files.length === 0) {
       return { content: [{ type: 'text', text: 'slack_reply: text cannot be empty' }], isError: true };
     }
     if (!token) {
@@ -93,16 +127,46 @@ export class SlackModule implements ToolModule {
 
     const client = new SlackClient({ botToken: token, logDir: process.env.GATEWAY_WORKSPACE_DIR ?? '/tmp' });
     try {
-      const sent = await client.postMessage(chatId, text, threadId || undefined);
+      // Size-check before any upload starts, so an oversized file fails fast
+      // instead of half-way through a multi-file batch.
+      for (const f of files) {
+        const st = fs.statSync(f);
+        if (st.size > MAX_ATTACHMENT_BYTES) {
+          throw new Error(`file too large: ${f} (${(st.size / 1024 / 1024).toFixed(1)}MB, max 50MB)`);
+        }
+      }
+
+      // With files, ONE uploadFiles call carries both the attachments and the
+      // text (as Slack's initial_comment) — never also postMessage, which would
+      // split one reply into two Slack messages.
+      const sent =
+        files.length > 0
+          ? await client.uploadFiles(chatId, files, {
+              threadTs: threadId || undefined,
+              initialComment: text || undefined,
+            })
+          : await client.postMessage(chatId, text, threadId || undefined);
       if (!sent.ok) {
         return { content: [{ type: 'text', text: `slack_reply failed: ${sent.error}` }], isError: true };
       }
+      // Mark as sent only AFTER the send succeeds — a genuine failure leaves
+      // them eligible for a retry rather than silently dropped.
+      for (const f of files) this.sentFiles.add(f);
       // Best-effort: clear the ack-reaction the webhook left on the inbound
       // message. Never blocks or fails the reply itself on a reaction error.
       if (messageId) {
         void client.removeReaction(chatId, messageId).catch(() => {});
       }
-      return { content: [{ type: 'text', text: 'Sent message to Slack.' }] };
+      return {
+        content: [
+          {
+            type: 'text',
+            text: files.length > 0
+              ? `Sent message to Slack (${files.length} file(s)).`
+              : 'Sent message to Slack.',
+          },
+        ],
+      };
     } catch (err) {
       return {
         content: [{ type: 'text', text: `slack_reply failed: ${(err as Error).message}` }],

--- a/mcp/tools/telegram/module.ts
+++ b/mcp/tools/telegram/module.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { migrateAccess, defaultAccess } from './pure';
 import { chunkText, htmlToPlain } from './typing';
+import { MAX_ATTACHMENT_BYTES } from '../shared/limits';
 import type {
   ChannelModule,
   ChannelCapabilities,
@@ -20,7 +21,6 @@ import type {
 } from '../../types';
 
 const PHOTO_EXTS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
-const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 const MAX_CHUNK_LIMIT = 4096;
 
 export class TelegramModule implements ChannelModule {

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -39,6 +39,7 @@ import { createIncidentStore } from '../../../dist/agent/incident-store.js'
 import type { RecoveryOutcome } from '../../../dist/agent/incident.js'
 import { initDedupDir, isDuplicate as _isDuplicate, pruneDedup as _pruneDedup } from './dedup'
 import { normalizeTelegramLineBreaks, resolveTelegramReplyFormat, migrateAccess, telegramDisplayName } from './pure'
+import { MAX_ATTACHMENT_BYTES } from '../shared/limits'
 
 // Standalone fallback: default state dir to ~/.claude/channels/telegram
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
@@ -336,7 +337,6 @@ function defaultAccess(): Access {
 }
 
 const MAX_CHUNK_LIMIT = 4096
-const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024
 
 // reply's files param takes any path. Claude can already Read+paste file
 // contents, so this isn't a new exfil channel for arbitrary paths — but the

--- a/src/api/line-webhook-router.ts
+++ b/src/api/line-webhook-router.ts
@@ -30,10 +30,15 @@ import {
   generatePairingCode,
 } from './pending-senders';
 import { wasBotMentioned, type LineMessageLike } from './line-mention';
+import { MediaStore } from '../history/media-store';
+import { sniffImageExt } from '../shared/image-sniff';
 import type { WebhookAppHandler } from './webhooks-router';
 
 const LOADING_SECONDS = 20; // 5..60, multiple of 5; 1:1 chats only
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024; // matches MediaStore.maxUploadBytes
+// Inbound image cap. Sourced from MediaStore, which is where the downloaded
+// bytes end up — a router-local literal could drift into accepting an image the
+// store then rejects.
+const MAX_IMAGE_BYTES = MediaStore.maxUploadBytes;
 
 /** A sane public hostname: letters, digits, dot, hyphen, optional :port. */
 const HOST_RE = /^[A-Za-z0-9.\-:]+$/;
@@ -91,18 +96,6 @@ function persistPublicBase(
   } catch (err) {
     logger.debug('LINE webhook: .public-base write failed', { error: (err as Error).message });
   }
-}
-
-/** Pick a file extension from an image's magic bytes; default jpg (LINE photos). */
-function sniffImageExt(buf: Buffer): string {
-  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpg';
-  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png';
-  if (buf.length >= 3 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return 'gif';
-  if (
-    buf.length >= 12 &&
-    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
-  ) return 'webp';
-  return 'jpg';
 }
 
 /**

--- a/src/api/slack-client.ts
+++ b/src/api/slack-client.ts
@@ -8,6 +8,8 @@
  * needed here — this is a plain fetch wrapper around the handful of Web API
  * methods the channel actually uses.
  */
+import * as fs from 'fs';
+import * as path from 'path';
 import { createLogger } from '../logger';
 
 const SLACK_API_BASE = 'https://slack.com/api';
@@ -19,7 +21,7 @@ export interface SlackClientOptions {
   apiBase?: string;
 }
 
-interface SlackApiResponse {
+export interface SlackApiResponse {
   ok: boolean;
   error?: string;
   [key: string]: unknown;
@@ -88,6 +90,81 @@ export class SlackClient {
       unfurl_media: false,
       ...(threadTs ? { thread_ts: threadTs } : {}),
     });
+  }
+
+  /**
+   * Send one or more local files to a conversation.
+   *
+   * Slack's old one-shot `files.upload` is deprecated (retired for new apps), so
+   * this uses the documented 3-step external-upload flow:
+   *
+   *   1. `files.getUploadURLExternal` (per file) → a one-shot `upload_url` + `file_id`
+   *   2. POST the raw bytes to that URL as multipart/form-data, field name `file`
+   *      (Slack documents it as `curl -F file=@image.jpg <upload_url>`) — this step
+   *      does NOT go through `call()`: different content-type, different host.
+   *   3. ONE `files.completeUploadExternal` for the whole batch, which is what
+   *      actually shares them into the channel.
+   *
+   * Step 3 must be JSON, not form-urlencoded (unlike every other method here —
+   * see `call()`'s doc comment): `files` is a nested array, which
+   * form-encoding cannot express.
+   *
+   * `initialComment` rides along on step 3, so text + images arrive as ONE Slack
+   * message rather than a separate `chat.postMessage` plus a bare file drop.
+   */
+  async uploadFiles(
+    channel: string,
+    filePaths: string[],
+    opts?: { threadTs?: string; initialComment?: string },
+  ): Promise<SlackApiResponse> {
+    if (filePaths.length === 0) return { ok: false, error: 'no_files' };
+
+    const uploaded: Array<{ id: string; title: string }> = [];
+    for (const filePath of filePaths) {
+      const filename = path.basename(filePath);
+      const length = fs.statSync(filePath).size;
+
+      // Step 1 — reserve an upload slot. `call()` already logs on !ok.
+      const reserved = await this.call('files.getUploadURLExternal', { filename, length });
+      if (!reserved.ok) return reserved;
+      const uploadUrl = typeof reserved.upload_url === 'string' ? reserved.upload_url : '';
+      const fileId = typeof reserved.file_id === 'string' ? reserved.file_id : '';
+      if (!uploadUrl || !fileId) {
+        this.logger.warn('Slack files.getUploadURLExternal returned no upload_url/file_id', { filename });
+        return { ok: false, error: 'upload_url_missing' };
+      }
+
+      // Step 2 — the bytes themselves.
+      const form = new FormData();
+      form.append('file', new Blob([new Uint8Array(fs.readFileSync(filePath))]), filename);
+      const put = await fetch(uploadUrl, { method: 'POST', body: form });
+      if (!put.ok) {
+        this.logger.warn('Slack file byte upload failed', { filename, status: put.status });
+        return { ok: false, error: `upload_failed_${put.status}` };
+      }
+
+      uploaded.push({ id: fileId, title: filename });
+    }
+
+    // Step 3 — share the batch into the conversation.
+    const res = await fetch(`${this.apiBase}/files.completeUploadExternal`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.botToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        files: uploaded,
+        channel_id: channel,
+        ...(opts?.threadTs ? { thread_ts: opts.threadTs } : {}),
+        ...(opts?.initialComment ? { initial_comment: opts.initialComment } : {}),
+      }),
+    });
+    const json = (await res.json()) as SlackApiResponse;
+    if (!json.ok) {
+      this.logger.warn('Slack API files.completeUploadExternal failed', { error: json.error });
+    }
+    return json;
   }
 
   /**

--- a/src/api/slack-webhook-router.ts
+++ b/src/api/slack-webhook-router.ts
@@ -33,31 +33,18 @@ import {
   generatePairingCode,
 } from './pending-senders';
 import { SlackClient } from './slack-client';
+import { MediaStore } from '../history/media-store';
+import { sniffImageExt } from '../shared/image-sniff';
 import type { WebhookAppHandler } from './webhooks-router';
 
 // Requests older than this are rejected outright (Slack's own replay-protection
 // guidance: reject if the timestamp is more than 5 minutes from "now").
 const MAX_REQUEST_AGE_SECONDS = 60 * 5;
 
-// Inbound image cap — same value LINE uses (matches MediaStore.maxUploadBytes).
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
-
-/**
- * Pick a file extension from an image's magic bytes; default jpg. Same sniffer
- * LINE's inbound path uses (line-webhook-router.ts) — deliberately duplicated
- * rather than shared: each channel router keeps its own media helpers local,
- * and Slack's `mimetype` field is untrusted enough that we sniff anyway.
- */
-function sniffImageExt(buf: Buffer): string {
-  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpg';
-  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png';
-  if (buf.length >= 3 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return 'gif';
-  if (
-    buf.length >= 12 &&
-    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
-  ) return 'webp';
-  return 'jpg';
-}
+// Inbound image cap. Sourced from MediaStore, which is where the downloaded
+// bytes end up — a router-local literal could drift into accepting an image the
+// store then rejects.
+const MAX_IMAGE_BYTES = MediaStore.maxUploadBytes;
 
 /**
  * Fetch an inbound Slack image's bytes and write them to a temp file, returning

--- a/src/api/slack-webhook-router.ts
+++ b/src/api/slack-webhook-router.ts
@@ -56,7 +56,26 @@ const MAX_IMAGE_BYTES = MediaStore.maxUploadBytes;
  * Returns null on an empty body; throws on HTTP failure or over-cap size — the
  * caller logs and forwards the turn regardless.
  */
-async function downloadSlackImage(botToken: string, fileUrl: string): Promise<string | null> {
+async function downloadSlackImage(
+  botToken: string,
+  fileUrl: string,
+  fileId?: string,
+): Promise<string | null> {
+  // Defence in depth: the signature check upstream already guarantees the event
+  // (and thus `url_private`) is authentic Slack data, but never send the bot
+  // token anywhere other than Slack's own file host. If a future refactor ever
+  // moves the download ahead of verification, or Slack changes the payload
+  // shape, this stops the token from leaking to an attacker-chosen host.
+  let host: string;
+  try {
+    host = new URL(fileUrl).hostname;
+  } catch {
+    throw new Error('invalid file url');
+  }
+  if (host !== 'slack.com' && !host.endsWith('.slack.com')) {
+    throw new Error(`refusing to send bot token to non-Slack host: ${host}`);
+  }
+
   const res = await fetch(fileUrl, { headers: { Authorization: `Bearer ${botToken}` } });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
@@ -84,7 +103,10 @@ async function downloadSlackImage(botToken: string, fileUrl: string): Promise<st
   }
 
   if (buf.length === 0) return null;
-  const dest = path.join(os.tmpdir(), `slack-img-${Date.now()}.${sniffImageExt(buf)}`);
+  // Include the Slack file id (like LINE's `line-img-${messageId}-…`) so two
+  // events landing in the same millisecond on a shared tmpdir can't collide.
+  const suffix = fileId ? `${fileId}-${Date.now()}` : `${Date.now()}`;
+  const dest = path.join(os.tmpdir(), `slack-img-${suffix}.${sniffImageExt(buf)}`);
   fs.writeFileSync(dest, buf);
   return dest;
 }
@@ -420,7 +442,7 @@ export function createSlackWebhookHandler(
     );
     if (token && imageFile?.url_private) {
       try {
-        const imgPath = await downloadSlackImage(token, imageFile.url_private);
+        const imgPath = await downloadSlackImage(token, imageFile.url_private, imageFile.id);
         if (imgPath) norm.meta.image_path = imgPath;
       } catch (err) {
         logger.warn('Slack webhook: image download failed', {

--- a/src/api/slack-webhook-router.ts
+++ b/src/api/slack-webhook-router.ts
@@ -15,6 +15,9 @@
  */
 import { type Request, type Response } from 'express';
 import { createHmac, timingSafeEqual } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import type { AgentRunner } from '../agent/runner';
 import { createLogger } from '../logger';
 import {
@@ -35,6 +38,69 @@ import type { WebhookAppHandler } from './webhooks-router';
 // Requests older than this are rejected outright (Slack's own replay-protection
 // guidance: reject if the timestamp is more than 5 minutes from "now").
 const MAX_REQUEST_AGE_SECONDS = 60 * 5;
+
+// Inbound image cap — same value LINE uses (matches MediaStore.maxUploadBytes).
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
+/**
+ * Pick a file extension from an image's magic bytes; default jpg. Same sniffer
+ * LINE's inbound path uses (line-webhook-router.ts) — deliberately duplicated
+ * rather than shared: each channel router keeps its own media helpers local,
+ * and Slack's `mimetype` field is untrusted enough that we sniff anyway.
+ */
+function sniffImageExt(buf: Buffer): string {
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpg';
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png';
+  if (buf.length >= 3 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return 'gif';
+  if (
+    buf.length >= 12 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return 'webp';
+  return 'jpg';
+}
+
+/**
+ * Fetch an inbound Slack image's bytes and write them to a temp file, returning
+ * its absolute path. `url_private` is NOT public — it requires the bot token as
+ * a bearer, the same auth requirement LINE's blob API has.
+ *
+ * The runner copies the returned path into the agent's permanent MediaStore and
+ * tells the agent to Read it (meta.image_path), exactly as for LINE/Telegram.
+ * Returns null on an empty body; throws on HTTP failure or over-cap size — the
+ * caller logs and forwards the turn regardless.
+ */
+async function downloadSlackImage(botToken: string, fileUrl: string): Promise<string | null> {
+  const res = await fetch(fileUrl, { headers: { Authorization: `Bearer ${botToken}` } });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  // Cheap early reject on the declared length, then enforce the cap again while
+  // reading — a response that omits or lies about content-length must not be
+  // able to blow past it.
+  const declared = Number(res.headers.get('content-length') ?? '');
+  if (Number.isFinite(declared) && declared > MAX_IMAGE_BYTES) {
+    throw new Error(`image exceeds ${MAX_IMAGE_BYTES} byte cap`);
+  }
+
+  let buf: Buffer;
+  if (res.body) {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+      total += chunk.byteLength;
+      if (total > MAX_IMAGE_BYTES) throw new Error(`image exceeds ${MAX_IMAGE_BYTES} byte cap`);
+      chunks.push(Buffer.from(chunk));
+    }
+    buf = Buffer.concat(chunks);
+  } else {
+    buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length > MAX_IMAGE_BYTES) throw new Error(`image exceeds ${MAX_IMAGE_BYTES} byte cap`);
+  }
+
+  if (buf.length === 0) return null;
+  const dest = path.join(os.tmpdir(), `slack-img-${Date.now()}.${sniffImageExt(buf)}`);
+  fs.writeFileSync(dest, buf);
+  return dest;
+}
 
 /**
  * One-time pairing-code message — same visual-match-code contract as LINE's
@@ -59,8 +125,18 @@ export type NormalizedSlackMessage = {
   meta: Record<string, string>;
 };
 
+/** A file attached to an inbound event (message with subtype `file_share`, or an app_mention). */
+interface SlackEventFile {
+  id?: string;
+  name?: string;
+  mimetype?: string;
+  /** Private download URL — needs the bot token as a bearer, not publicly fetchable. */
+  url_private?: string;
+}
+
 interface SlackEvent {
   type: string;
+  subtype?: string;
   channel?: string;
   channel_type?: string;
   user?: string;
@@ -69,6 +145,7 @@ interface SlackEvent {
   ts?: string;
   thread_ts?: string;
   event_ts?: string;
+  files?: SlackEventFile[];
 }
 
 /**
@@ -89,7 +166,11 @@ function stripBotMention(text: string, botUserId: string | undefined): string {
  * Normalize a Slack Events API `event` into the gateway's {content, meta}
  * intake shape. Returns null for anything not handled in v1 (bot-authored
  * events, missing channel/user, non message/app_mention types — see 2c for
- * what's deliberately deferred: files, edits, reactions, etc.).
+ * what's deliberately deferred: edits, reactions, etc.).
+ *
+ * Stays synchronous and pure: an attached image's bytes are fetched by the
+ * async handler AFTER this returns (see downloadSlackImage's call site), which
+ * sets `meta.image_path` on the object built here.
  */
 export function normalizeSlackEvent(
   event: SlackEvent,
@@ -339,6 +420,26 @@ export function createSlackWebhookHandler(
       const client = new SlackClient({ botToken: token, logDir, apiBase: opts.apiBase });
       if (event.ts) {
         void client.addReaction(resolved.conversationId, event.ts).catch(() => {});
+      }
+    }
+
+    // Inbound image: fetch the first image attachment's bytes with the bot token
+    // and hand the agent an absolute path (meta.image_path) — the same contract
+    // LINE uses, so the runner persists it to MediaStore and tells the agent to
+    // Read it. Best-effort: a failure only logs, the text turn still forwards.
+    // Scope is images only; other file types are left alone for now.
+    const imageFile = event.files?.find(
+      (f) => typeof f.mimetype === 'string' && f.mimetype.startsWith('image/') && f.url_private,
+    );
+    if (token && imageFile?.url_private) {
+      try {
+        const imgPath = await downloadSlackImage(token, imageFile.url_private);
+        if (imgPath) norm.meta.image_path = imgPath;
+      } catch (err) {
+        logger.warn('Slack webhook: image download failed', {
+          fileId: imageFile.id,
+          error: (err as Error).message,
+        });
       }
     }
 

--- a/src/shared/image-sniff.ts
+++ b/src/shared/image-sniff.ts
@@ -1,0 +1,24 @@
+/**
+ * Cross-channel inbound media helpers.
+ *
+ * Shared by the channel webhook routers (LINE, Slack) so each one does not
+ * carry its own copy of the same magic-byte table.
+ */
+
+/**
+ * Pick a file extension from an image's magic bytes; default jpg.
+ *
+ * Sniffing (rather than trusting a platform-supplied `mimetype`/filename) is
+ * deliberate: the field is attacker-controlled on every channel, and LINE does
+ * not send one at all.
+ */
+export function sniffImageExt(buf: Buffer): string {
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpg';
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png';
+  if (buf.length >= 3 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return 'gif';
+  if (
+    buf.length >= 12 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return 'webp';
+  return 'jpg';
+}

--- a/tests/unit/slack-mcp.test.ts
+++ b/tests/unit/slack-mcp.test.ts
@@ -8,6 +8,9 @@
  * tests/unit/cron-client-update.test.ts's pattern) rather than hitting a real
  * Slack API.
  */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { normalizeSlackEvent } from '../../src/api/slack-webhook-router';
 import { SlackModule } from '../../mcp/tools/slack/module';
 
@@ -103,10 +106,14 @@ describe('SlackModule', () => {
     expect(new SlackModule().isEnabled()).toBe(false);
   });
 
-  test('getTools() exposes exactly slack_reply, requiring chat_id + text', () => {
+  test('getTools() exposes exactly slack_reply, requiring only chat_id', () => {
     const tools = new SlackModule().getTools();
     expect(tools.map((t) => t.name)).toEqual(['slack_reply']);
-    expect((tools[0].inputSchema as { required: string[] }).required).toEqual(['chat_id', 'text']);
+    // `text` is optional — a files-only reply (image, no caption) is valid.
+    expect((tools[0].inputSchema as { required: string[] }).required).toEqual(['chat_id']);
+    const props = (tools[0].inputSchema as { properties: Record<string, { type: string; items?: { type: string } }> })
+      .properties;
+    expect(props.files).toMatchObject({ type: 'array', items: { type: 'string' } });
   });
 
   test('missing chat_id → error, no network attempted', async () => {
@@ -116,7 +123,7 @@ describe('SlackModule', () => {
     expect(res.content[0].text).toMatch(/missing chat_id/i);
   });
 
-  test('empty text → error', async () => {
+  test('empty text and no files → error', async () => {
     const mod = new SlackModule();
     const res = await mod.handleTool('slack_reply', { chat_id: 'D1', text: '' });
     expect(res.isError).toBe(true);
@@ -189,6 +196,181 @@ describe('SlackModule', () => {
       const mod = new SlackModule();
       await mod.handleTool('slack_reply', { chat_id: 'D1', text: 'hi' });
       expect(calls.some((c) => c.url.endsWith('/reactions.remove'))).toBe(false);
+    });
+  });
+
+  /**
+   * `files` on slack_reply drives Slack's 3-step external-upload flow
+   * (files.getUploadURLExternal → raw multipart POST to the returned upload_url
+   * → one files.completeUploadExternal). The old files.upload is deprecated, so
+   * the sequence itself is the contract worth pinning.
+   */
+  describe('file attachments (mocked 3-step upload)', () => {
+    const realFetch = global.fetch;
+    let calls: { url: string; init?: RequestInit }[];
+    let tmpDir: string;
+    let imgPath: string;
+
+    const bodyOf = (url: string) => calls.find((c) => c.url.endsWith(url));
+    const jsonBody = (init?: RequestInit) => JSON.parse(String(init?.body)) as Record<string, unknown>;
+
+    beforeEach(() => {
+      process.env.SLACK_BOT_TOKEN = 'xoxb-test';
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-slack-upload-'));
+      imgPath = path.join(tmpDir, 'pic.png');
+      fs.writeFileSync(imgPath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02]));
+      calls = [];
+      global.fetch = (async (input: string, init?: RequestInit) => {
+        const url = String(input);
+        calls.push({ url, init });
+        if (url.endsWith('/files.getUploadURLExternal')) {
+          const q = Object.fromEntries(new URLSearchParams(String(init?.body)));
+          return {
+            ok: true,
+            json: async () => ({
+              ok: true,
+              upload_url: `https://files.slack.test/upload/${q.filename}`,
+              file_id: `F-${q.filename}`,
+            }),
+          } as Response;
+        }
+        if (url.startsWith('https://files.slack.test/upload/')) {
+          return { ok: true, status: 200, json: async () => ({ ok: true }) } as Response;
+        }
+        return { ok: true, json: async () => ({ ok: true }) } as Response;
+      }) as typeof fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = realFetch;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('text + files → getUploadURL, byte POST, then ONE completeUpload (no chat.postMessage)', async () => {
+      const other = path.join(tmpDir, 'chart.png');
+      fs.writeFileSync(other, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+      const mod = new SlackModule();
+      const res = await mod.handleTool('slack_reply', {
+        chat_id: 'D1',
+        text: 'here you go',
+        thread_id: '1699999999.000000',
+        files: [imgPath, other],
+      });
+      expect(res.isError).toBeFalsy();
+      expect(res.content[0].text).toMatch(/2 file\(s\)/);
+
+      // Exact call order: reserve+upload per file, then one shared complete.
+      expect(calls.map((c) => c.url)).toEqual([
+        'https://slack.com/api/files.getUploadURLExternal',
+        'https://files.slack.test/upload/pic.png',
+        'https://slack.com/api/files.getUploadURLExternal',
+        'https://files.slack.test/upload/chart.png',
+        'https://slack.com/api/files.completeUploadExternal',
+      ]);
+      // Text rides along as initial_comment — never a second postMessage.
+      expect(calls.some((c) => c.url.endsWith('/chat.postMessage'))).toBe(false);
+
+      const reserve = Object.fromEntries(
+        new URLSearchParams(String(calls[0].init?.body)),
+      );
+      expect(reserve).toMatchObject({ filename: 'pic.png', length: '6' });
+
+      // Step 2 is multipart with the bytes under field name `file`.
+      const upload = calls[1].init?.body;
+      expect(upload).toBeInstanceOf(FormData);
+      expect((upload as FormData).get('file')).toBeTruthy();
+
+      // Step 3 is JSON (a nested `files` array can't be form-encoded).
+      const complete = bodyOf('/files.completeUploadExternal');
+      expect(
+        (complete?.init?.headers as Record<string, string>)['Content-Type'],
+      ).toMatch(/application\/json/);
+      expect(jsonBody(complete?.init)).toEqual({
+        files: [
+          { id: 'F-pic.png', title: 'pic.png' },
+          { id: 'F-chart.png', title: 'chart.png' },
+        ],
+        channel_id: 'D1',
+        thread_ts: '1699999999.000000',
+        initial_comment: 'here you go',
+      });
+    });
+
+    test('files without text → sends, no "text cannot be empty" error, no initial_comment', async () => {
+      const mod = new SlackModule();
+      const res = await mod.handleTool('slack_reply', { chat_id: 'D1', files: [imgPath] });
+      expect(res.isError).toBeFalsy();
+      expect(res.content[0].text).not.toMatch(/text cannot be empty/i);
+      const complete = jsonBody(bodyOf('/files.completeUploadExternal')?.init);
+      expect(complete.initial_comment).toBeUndefined();
+      expect(complete.channel_id).toBe('D1');
+    });
+
+    test('oversized file → error before any upload call is made', async () => {
+      const big = path.join(tmpDir, 'huge.png');
+      fs.writeFileSync(big, '');
+      fs.truncateSync(big, 51 * 1024 * 1024); // sparse — instant, statSync still reports 51MB
+
+      const mod = new SlackModule();
+      const res = await mod.handleTool('slack_reply', { chat_id: 'D1', text: 'big', files: [big] });
+      expect(res.isError).toBe(true);
+      expect(res.content[0].text).toMatch(/file too large.*max 50MB/i);
+      expect(calls).toHaveLength(0);
+    });
+
+    test('retrying the same file path uploads it only once (retry-dedup)', async () => {
+      const mod = new SlackModule();
+      await mod.handleTool('slack_reply', { chat_id: 'D1', text: 'first', files: [imgPath] });
+      const uploadsAfterFirst = calls.filter((c) => c.url.endsWith('/files.getUploadURLExternal')).length;
+      expect(uploadsAfterFirst).toBe(1);
+
+      // Same file again with new text: the file is suppressed, the text still posts.
+      const res = await mod.handleTool('slack_reply', { chat_id: 'D1', text: 'retry', files: [imgPath] });
+      expect(res.isError).toBeFalsy();
+      expect(calls.filter((c) => c.url.endsWith('/files.getUploadURLExternal'))).toHaveLength(1);
+      expect(bodyOf('/chat.postMessage')).toBeTruthy();
+
+      // Same file, no text at all: whole reply is a duplicate → no-op success.
+      const dup = await mod.handleTool('slack_reply', { chat_id: 'D1', files: [imgPath] });
+      expect(dup.isError).toBeFalsy();
+      expect(dup.content[0].text).toMatch(/duplicate suppressed/i);
+      expect(calls.filter((c) => c.url.endsWith('/files.getUploadURLExternal'))).toHaveLength(1);
+    });
+
+    test('a failed upload leaves the file eligible for retry (not marked as sent)', async () => {
+      global.fetch = (async (input: string, init?: RequestInit) => {
+        const url = String(input);
+        calls.push({ url, init });
+        if (url.endsWith('/files.getUploadURLExternal')) {
+          return { ok: true, json: async () => ({ ok: false, error: 'rate_limited' }) } as Response;
+        }
+        return { ok: true, json: async () => ({ ok: true }) } as Response;
+      }) as typeof fetch;
+
+      const mod = new SlackModule();
+      const first = await mod.handleTool('slack_reply', { chat_id: 'D1', files: [imgPath] });
+      expect(first.isError).toBe(true);
+      expect(first.content[0].text).toMatch(/rate_limited/);
+
+      // Second attempt must actually try again, not report a phantom duplicate.
+      const second = await mod.handleTool('slack_reply', { chat_id: 'D1', files: [imgPath] });
+      expect(second.content[0].text).not.toMatch(/duplicate suppressed/i);
+      expect(calls.filter((c) => c.url.endsWith('/files.getUploadURLExternal'))).toHaveLength(2);
+    });
+
+    test('message_id still clears the ack-reaction after a file send', async () => {
+      const mod = new SlackModule();
+      await mod.handleTool('slack_reply', {
+        chat_id: 'D1',
+        files: [imgPath],
+        message_id: '1700000000.000100',
+      });
+      const reaction = bodyOf('/reactions.remove');
+      expect(Object.fromEntries(new URLSearchParams(String(reaction?.init?.body)))).toMatchObject({
+        channel: 'D1',
+        timestamp: '1700000000.000100',
+      });
     });
   });
 });

--- a/tests/unit/slack-normalize.test.ts
+++ b/tests/unit/slack-normalize.test.ts
@@ -1,10 +1,21 @@
 /**
- * Unit tests for normalizeSlackEvent (src/api/slack-webhook-router.ts) —
- * the Slack Events API → {content, meta} intake shape, with focus on the
- * bot self-mention stripping added for app_mention text (an app_mention is
- * delivered with the raw `<@Ubot>` markup inline, which is noise to the agent).
+ * Unit tests for the Slack inbound normalization path
+ * (src/api/slack-webhook-router.ts):
+ *
+ *  - normalizeSlackEvent — the Slack Events API → {content, meta} intake shape,
+ *    with focus on the bot self-mention stripping added for app_mention text
+ *    (an app_mention is delivered with the raw `<@Ubot>` markup inline, which is
+ *    noise to the agent).
+ *  - inbound image download — `meta.image_path`. normalizeSlackEvent stays pure
+ *    and synchronous, so the download happens in the async handler right after
+ *    it; the only way to exercise it is to drive the REAL handler with a signed
+ *    request (mirrors tests/unit/cli-line-e2e.test.ts's approach) and inspect
+ *    what gets forwarded to the agent's /channel callback.
  */
-import { normalizeSlackEvent } from '../../src/api/slack-webhook-router';
+import { createHmac } from 'crypto';
+import * as fs from 'fs';
+import { createSlackWebhookHandler, normalizeSlackEvent } from '../../src/api/slack-webhook-router';
+import type { AgentRunner } from '../../src/agent/runner';
 
 const BOT = 'U0BOT';
 
@@ -71,5 +82,198 @@ describe('normalizeSlackEvent() — bot mention stripping', () => {
       BOT,
     );
     expect(norm).toBeNull();
+  });
+});
+
+describe('inbound image download → meta.image_path', () => {
+  const AGENT = 'slack-agent';
+  const SECRET = 'test-signing-secret';
+  const TOKEN = 'xoxb-inbound-test';
+  const DM = 'D999';
+  const USER = 'U456';
+  const PRIVATE_URL = 'https://files.slack.com/files-pri/T1-F1/pic.png';
+  const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x11, 0x22]);
+
+  const realFetch = global.fetch;
+  let handler: ReturnType<typeof createSlackWebhookHandler>;
+  let forwarded: Array<{ content: string; meta: Record<string, string> }>;
+  let downloadInits: RequestInit[];
+  let downloadResponse: () => Response | Promise<Response>;
+  const written: string[] = [];
+
+  function fakeRunner(): AgentRunner {
+    return {
+      getAgentConfig: () => ({
+        id: AGENT,
+        slack: { botToken: TOKEN, signingSecret: SECRET, dmPolicy: 'open' },
+      }),
+      getCallbackPort: () => 0,
+    } as unknown as AgentRunner;
+  }
+
+  function makeRes() {
+    const res = { status: jest.fn(), json: jest.fn() };
+    res.status.mockReturnValue(res as never);
+    res.json.mockReturnValue(res as never);
+    return res;
+  }
+
+  /** Drive the real handler with a correctly signed event_callback. */
+  function post(event: Record<string, unknown>, eventId = `Ev${Math.random()}`) {
+    const buf = Buffer.from(
+      JSON.stringify({
+        type: 'event_callback',
+        event_id: eventId,
+        event,
+        authorizations: [{ user_id: BOT }],
+      }),
+    );
+    const ts = String(Math.floor(Date.now() / 1000));
+    const sig = `v0=${createHmac('sha256', SECRET).update(`v0:${ts}:${buf.toString('utf8')}`).digest('hex')}`;
+    const req = {
+      params: { agentId: AGENT },
+      header: (h: string) => {
+        const k = h.toLowerCase();
+        if (k === 'x-slack-signature') return sig;
+        if (k === 'x-slack-request-timestamp') return ts;
+        return undefined;
+      },
+      headers: {},
+      body: buf,
+    };
+    return handler.handlePost(req as never, makeRes() as never);
+  }
+
+  const imageEvent = (files: unknown[]) => ({
+    type: 'message',
+    subtype: 'file_share',
+    channel: DM,
+    channel_type: 'im',
+    user: USER,
+    text: 'look at this',
+    ts: '1700000000.000100',
+    event_ts: '1700000000.000100',
+    files,
+  });
+
+  beforeEach(() => {
+    forwarded = [];
+    downloadInits = [];
+    // Default: a real Response, so the streaming read path is genuinely exercised.
+    downloadResponse = () => new Response(PNG);
+    handler = createSlackWebhookHandler(new Map([[AGENT, fakeRunner()]]), '/tmp');
+
+    global.fetch = (async (input: string, init?: RequestInit) => {
+      const url = String(input);
+      if (url === PRIVATE_URL) {
+        downloadInits.push(init ?? {});
+        return downloadResponse();
+      }
+      if (url.endsWith('/channel')) {
+        forwarded.push(JSON.parse(String(init?.body)));
+        return { ok: true, json: async () => ({}) } as Response;
+      }
+      // Slack Web API (the ack reaction) — always fine.
+      return { ok: true, json: async () => ({ ok: true }) } as Response;
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    for (const f of written) fs.rmSync(f, { force: true });
+    written.length = 0;
+  });
+
+  test('image attachment → bytes fetched with the bot token, meta.image_path written to disk', async () => {
+    await post(imageEvent([{ id: 'F1', name: 'pic.png', mimetype: 'image/png', url_private: PRIVATE_URL }]));
+
+    expect(forwarded).toHaveLength(1);
+    const imgPath = forwarded[0].meta.image_path;
+    expect(imgPath).toBeTruthy();
+    written.push(imgPath);
+    // Extension comes from the magic bytes, not the (untrusted) mimetype field.
+    expect(imgPath).toMatch(/slack-img-\d+\.png$/);
+    expect(fs.readFileSync(imgPath)).toEqual(PNG);
+
+    // url_private is NOT public — it must be fetched with the bot token.
+    expect(downloadInits).toHaveLength(1);
+    expect((downloadInits[0].headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+
+    // The text turn is unaffected by the attachment.
+    expect(forwarded[0].content).toBe('look at this');
+    expect(forwarded[0].meta.chat_id).toBe(DM);
+  });
+
+  test('non-image attachment → skipped entirely, no download, no image_path', async () => {
+    await post(imageEvent([{ id: 'F2', name: 'notes.pdf', mimetype: 'application/pdf', url_private: PRIVATE_URL }]));
+
+    expect(downloadInits).toHaveLength(0);
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0].meta.image_path).toBeUndefined();
+    expect(forwarded[0].content).toBe('look at this');
+  });
+
+  test('picks the first image when a non-image file precedes it', async () => {
+    await post(
+      imageEvent([
+        { id: 'F2', name: 'notes.pdf', mimetype: 'application/pdf', url_private: 'https://files.slack.com/other' },
+        { id: 'F1', name: 'pic.png', mimetype: 'image/png', url_private: PRIVATE_URL },
+      ]),
+    );
+    expect(downloadInits).toHaveLength(1);
+    written.push(forwarded[0].meta.image_path);
+    expect(forwarded[0].meta.image_path).toBeTruthy();
+  });
+
+  test('over-cap image → no image_path, but the text turn still forwards', async () => {
+    downloadResponse = () =>
+      ({
+        ok: true,
+        status: 200,
+        headers: { get: (h: string) => (h.toLowerCase() === 'content-length' ? String(21 * 1024 * 1024) : null) },
+        body: null,
+        arrayBuffer: async () => new ArrayBuffer(0),
+      }) as unknown as Response;
+
+    await post(imageEvent([{ id: 'F1', name: 'huge.png', mimetype: 'image/png', url_private: PRIVATE_URL }]));
+
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0].meta.image_path).toBeUndefined();
+    expect(forwarded[0].content).toBe('look at this');
+  });
+
+  test('download failure → message is never dropped, just forwarded without image_path', async () => {
+    downloadResponse = () => ({ ok: false, status: 403 }) as unknown as Response;
+
+    await post(imageEvent([{ id: 'F1', name: 'pic.png', mimetype: 'image/png', url_private: PRIVATE_URL }]));
+
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0].meta.image_path).toBeUndefined();
+    expect(forwarded[0].content).toBe('look at this');
+  });
+
+  test('a thrown fetch (network error) also forwards the turn', async () => {
+    downloadResponse = () => {
+      throw new Error('ECONNRESET');
+    };
+
+    await post(imageEvent([{ id: 'F1', name: 'pic.png', mimetype: 'image/png', url_private: PRIVATE_URL }]));
+
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0].meta.image_path).toBeUndefined();
+  });
+
+  test('an event with no files at all is unchanged', async () => {
+    await post({
+      type: 'message',
+      channel: DM,
+      channel_type: 'im',
+      user: USER,
+      text: 'plain text',
+      ts: '1700000000.000200',
+    });
+    expect(downloadInits).toHaveLength(0);
+    expect(forwarded[0].meta.image_path).toBeUndefined();
+    expect(forwarded[0].content).toBe('plain text');
   });
 });

--- a/tests/unit/slack-normalize.test.ts
+++ b/tests/unit/slack-normalize.test.ts
@@ -98,6 +98,7 @@ describe('inbound image download → meta.image_path', () => {
   let handler: ReturnType<typeof createSlackWebhookHandler>;
   let forwarded: Array<{ content: string; meta: Record<string, string> }>;
   let downloadInits: RequestInit[];
+  let fetchedUrls: string[];
   let downloadResponse: () => Response | Promise<Response>;
   const written: string[] = [];
 
@@ -159,12 +160,14 @@ describe('inbound image download → meta.image_path', () => {
   beforeEach(() => {
     forwarded = [];
     downloadInits = [];
+    fetchedUrls = [];
     // Default: a real Response, so the streaming read path is genuinely exercised.
     downloadResponse = () => new Response(PNG);
     handler = createSlackWebhookHandler(new Map([[AGENT, fakeRunner()]]), '/tmp');
 
     global.fetch = (async (input: string, init?: RequestInit) => {
       const url = String(input);
+      fetchedUrls.push(url);
       if (url === PRIVATE_URL) {
         downloadInits.push(init ?? {});
         return downloadResponse();
@@ -191,8 +194,9 @@ describe('inbound image download → meta.image_path', () => {
     const imgPath = forwarded[0].meta.image_path;
     expect(imgPath).toBeTruthy();
     written.push(imgPath);
-    // Extension comes from the magic bytes, not the (untrusted) mimetype field.
-    expect(imgPath).toMatch(/slack-img-\d+\.png$/);
+    // Extension comes from the magic bytes, not the (untrusted) mimetype field;
+    // the Slack file id is embedded so same-millisecond events can't collide.
+    expect(imgPath).toMatch(/slack-img-F1-\d+\.png$/);
     expect(fs.readFileSync(imgPath)).toEqual(PNG);
 
     // url_private is NOT public — it must be fetched with the bot token.
@@ -261,6 +265,21 @@ describe('inbound image download → meta.image_path', () => {
 
     expect(forwarded).toHaveLength(1);
     expect(forwarded[0].meta.image_path).toBeUndefined();
+  });
+
+  test('url_private on a non-Slack host → bot token never sent, no image_path, turn still forwards', async () => {
+    // A url_private pointing anywhere other than *.slack.com must be refused
+    // BEFORE the fetch, so the bot token can never leak to an attacker host.
+    const EVIL = 'https://evil.example.com/files-pri/T1-F1/pic.png';
+    await post(imageEvent([{ id: 'F1', name: 'pic.png', mimetype: 'image/png', url_private: EVIL }]));
+
+    // No request was ever made to the evil host (guard runs before fetch).
+    expect(downloadInits).toHaveLength(0);
+    expect(fetchedUrls).not.toContain(EVIL);
+    // The turn is never dropped — it just forwards without an image.
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0].meta.image_path).toBeUndefined();
+    expect(forwarded[0].content).toBe('look at this');
   });
 
   test('an event with no files at all is unchanged', async () => {


### PR DESCRIPTION
## Summary

Adds image attachment support to the Slack channel (#367), in both directions:

- **Outbound**: `slack_reply` can now attach files. `SlackClient.uploadFiles()`
  implements Slack's current 3-step external-upload flow
  (`files.getUploadURLExternal` → raw multipart upload → one
  `files.completeUploadExternal` call for the whole batch — the old
  `files.upload` is deprecated). `text` is no longer required, so an
  image-only reply is valid.
- **Inbound**: the webhook handler now downloads the first `image/*` entry in
  an event's `files[]` via `url_private` (bot-token bearer — it's not a
  public URL) and surfaces it to the agent as `meta.image_path`, the same
  contract LINE's inbound image path already uses. Capped at 20MB.
  `normalizeSlackEvent` stays synchronous/pure; the download runs after it in
  the async handler and is best-effort — a failed download only logs, the
  text turn still forwards.

Tested end-to-end against a real Slack workspace: image generation replies
arrive as real attachments, and images sent into a DM/channel are picked up
by the agent on its next turn. Requires the `files:write` (outbound) and
`files:read` (inbound) bot scopes, reinstalled to the workspace.

## Design note: `files` on `slack_reply`, not a separate `slack_image` tool

LINE needed a dedicated `line_image` tool because LINE's API can only fetch
images from a public HTTPS URL, so that tool mints a short-lived share-bridge
URL — a mechanic specific to LINE's constraint. Slack (like Telegram and
Discord) has bot-token-authenticated direct upload instead, so it follows
their existing pattern: `files: string[]` directly on the one reply tool,
with the same retry-dedup (`sentFiles`) and 50MB cap Discord's reply tool
already uses. This also means `slack_reply` now honors the channel-agnostic
image instructions every channel already receives ("...deliver that single
file with your reply tool ... files: [...]"), which it silently didn't
before.

Slack's `completeUploadExternal` accepts an `initial_comment`, so text +
images land as one message rather than two.

## What's in each commit

**`feat(slack): add image attachment support (outbound + inbound)`** — the
core change described above, plus 13 new tests covering the 3-step upload
sequence (call order, payload shape, thread_ts/initial_comment passthrough,
oversize rejection, retry-dedup, text-optional-when-files-present) and
inbound download (meta.image_path set on success, non-image files skipped,
oversize capped, a failed download still forwards the text turn).

**`refactor(slack): reuse existing MediaStore cap + shared image-sniff/attachment-cap helpers`**
— found three things duplicated across files instead of reused: a 20MB image
cap independently hardcoded in both LINE's and Slack's inbound routers when
`MediaStore.maxUploadBytes` already defines it; the same magic-byte
extension-sniffing function copy-pasted between the two routers; and a 50MB
attachment cap separately declared in Discord's and Telegram's reply tools
(now Slack's too). Consolidated into `src/shared/image-sniff.ts` and
`mcp/tools/shared/limits.ts`.

**`refactor(telegram): reuse the shared MAX_ATTACHMENT_BYTES instead of a 4th local copy`**
— the same 50MB cap had a second, separate local declaration in Telegram's
`module.ts` (distinct from `receiver-server.ts`, which the prior commit
already fixed) — same duplication class, one file short of complete.

## How to test

1. Configure `slack.botToken` + `slack.signingSecret` on an agent, with the
   `files:write` and `files:read` Bot Token Scopes added and the app
   reinstalled to the workspace.
2. Ask the agent to generate an image → confirm it arrives as a real Slack
   attachment, not a text description of a missing capability.
3. Send an image into the DM/channel → confirm the agent's next turn can
   `Read` it via the `image_path` it receives.
4. `npm test` — full suite unchanged from this repo's known baseline (37
   failed suites / 461 failed tests, pre-existing `fts5`/PTY environment
   gaps unrelated to this change); all Slack suites plus the new tests pass.
   `npm run typecheck` and `npm run build` both clean.
