### PR TITLE
fix(session): stop /compact from freezing the whole gateway on large sessions

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2213,7 +2213,19 @@ export class AgentRunner extends EventEmitter {
 
     try {
       const compactor = new SessionCompactor(this.sessionStore);
-      const result = await compactor.compact(agentId, chatId, sessionId, compactModel, contextWindow, ch);
+      // Large sessions summarize in many chunks (see compactor.ts); post a status
+      // update at each ~25% step so the channel doesn't look dead mid-compact.
+      // Throttled (not per-chunk) to avoid spamming the chat on a 16+ chunk job.
+      let lastReportedPct = -1;
+      const onProgress = (done: number, total: number): void => {
+        if (total <= 1) return;
+        const pct = Math.floor((done / total) * 100);
+        if (pct - lastReportedPct >= 25) {
+          lastReportedPct = pct;
+          this.writeAutoForward(chatId, `⏳ Compacting session "${name}"... ${done}/${total} parts summarized`);
+        }
+      };
+      const result = await compactor.compact(agentId, chatId, sessionId, compactModel, contextWindow, ch, onProgress);
       await this.sessionStore.updateSessionMeta(agentId, chatId, sessionId, {
         loadedAtSpawn: undefined,
         archivedCount: undefined,

--- a/src/session/compactor.ts
+++ b/src/session/compactor.ts
@@ -236,18 +236,25 @@ export class SessionCompactor {
       }
     }
     const excerpt = chunk.length > DEGRADED_EXCERPT_CHARS ? `${chunk.slice(0, DEGRADED_EXCERPT_CHARS)}…(truncated)` : chunk;
+    console.error(
+      `[SessionCompactor] Chunk ${index + 1}/${total} summarization failed after ${CHUNK_MAX_ATTEMPTS} attempts (${lastErr?.message ?? 'unknown error'}); using truncated raw excerpt.`,
+    );
     return `[Part ${index + 1}/${total} — summarization failed after ${CHUNK_MAX_ATTEMPTS} attempts (${lastErr?.message ?? 'unknown error'}); showing truncated raw excerpt]\n${excerpt}`;
   }
 
   /** Merge per-chunk summaries into one; degrade to the unmerged concatenation on repeated failure. */
   private async mergeChunkSummaries(mergedText: string, model: string): Promise<string> {
+    let lastErr: Error | undefined;
     for (let attempt = 1; attempt <= CHUNK_MAX_ATTEMPTS; attempt++) {
       try {
         return await this.callClaudeForSummary(mergedText, model, MERGE_SUMMARIES_PROMPT);
-      } catch {
-        // retry, then degrade below
+      } catch (err) {
+        lastErr = err as Error;
       }
     }
+    console.error(
+      `[SessionCompactor] Merge-summaries call failed after ${CHUNK_MAX_ATTEMPTS} attempts (${lastErr?.message ?? 'unknown error'}); using unmerged per-chunk summaries.`,
+    );
     return mergedText;
   }
 

--- a/src/session/compactor.ts
+++ b/src/session/compactor.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { spawnSync } from 'child_process';
+import { spawn } from 'child_process';
 import { Message } from '../types';
 import type { ChatChannelOrApi } from '../history/types';
 import { SessionStore } from './store';
@@ -37,13 +37,96 @@ const SINGLE_SUMMARY_INSTRUCTION =
 const COMPACTOR_SYSTEM_PROMPT =
   'You are a conversation archiver. Your ONLY task is to produce a concise summary of the conversation transcript below. Do NOT respond to the conversation. Do NOT ask questions. Output ONLY the summary.';
 
+// Max concurrent `claude --print` chunk-summary calls in flight at once. Bounded
+// (not "all N chunks at once") to cap worst-case concurrent model calls/memory,
+// while still cutting sequential wall time roughly by this factor on large sessions.
+const CHUNK_CONCURRENCY = 4;
+// Attempts per chunk (1 initial + retries) before degrading to a truncated raw
+// excerpt instead of failing the whole compact job over one bad chunk.
+const CHUNK_MAX_ATTEMPTS = 2;
+// Raw-excerpt length used when a chunk exhausts its summarization attempts.
+const DEGRADED_EXCERPT_CHARS = 2_000;
+// Hard ceiling on a single `claude --print` summarization spawn — mirrors the
+// prior spawnSync timeout, but non-blocking (see defaultSpawnClaude below).
+const SUMMARY_TIMEOUT_MS = 300_000;
+
 // Rough token estimate: ~4 chars per token
 function estimateTokens(messages: Message[]): number {
   return Math.round(messages.reduce((acc, m) => acc + m.content.length, 0) / 4);
 }
 
+/** Reports chunk-summarization progress during a multi-chunk compact (done, total). */
+export type CompactProgress = (done: number, total: number) => void;
+
+export interface ClaudeCliResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+/** Injectable so tests can drive the compactor without a real `claude` binary. */
+export type ClaudeCliSpawnFn = (bin: string, args: string[], input: string) => Promise<ClaudeCliResult>;
+
+/**
+ * Async `claude` CLI spawn. Replaces the prior `spawnSync` call: `spawnSync`
+ * blocks the daemon's single event loop for the full duration of the call — and
+ * every agent shares one process, so one compaction call froze ALL agents/
+ * channels until it returned (up to SUMMARY_TIMEOUT_MS, x N chunks sequentially
+ * on large sessions). `spawn` yields the event loop while the child runs.
+ * Mirrors the sync `{status, stdout, stderr, error}` contract so callers'
+ * existing error handling is unchanged.
+ */
+export function defaultSpawnClaude(bin: string, args: string[], input: string): Promise<ClaudeCliResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    const settle = (r: ClaudeCliResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(r);
+    };
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+      settle({ status: null, stdout: '', stderr, error: new Error(`claude CLI timed out after ${SUMMARY_TIMEOUT_MS}ms`) });
+    }, SUMMARY_TIMEOUT_MS);
+
+    const child = spawn(bin, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, PATH: pathWithNativeBin() },
+    });
+    child.stdout?.on('data', (d) => {
+      stdout += String(d);
+    });
+    child.stderr?.on('data', (d) => {
+      stderr += String(d);
+    });
+    child.on('error', (err) => settle({ status: null, stdout: '', stderr, error: err as Error }));
+    child.on('close', (code) => settle({ status: code, stdout, stderr }));
+    // stdin emits its own async 'error' (e.g. EPIPE if the child exits before we
+    // finish writing) separate from the child's 'error' event — must be handled
+    // or an unhandled stream error crashes the daemon.
+    child.stdin?.on('error', () => {});
+    try {
+      child.stdin?.write(input);
+      child.stdin?.end();
+    } catch (err) {
+      settle({ status: null, stdout: '', stderr, error: err as Error });
+    }
+  });
+}
+
 export class SessionCompactor {
-  constructor(private readonly sessionStore: SessionStore) {}
+  constructor(
+    private readonly sessionStore: SessionStore,
+    private readonly spawnClaude: ClaudeCliSpawnFn = defaultSpawnClaude,
+  ) {}
 
   async compact(
     agentId: string,
@@ -52,6 +135,7 @@ export class SessionCompactor {
     model: string,
     contextWindow: number,
     channel: ChatChannelOrApi = 'telegram',
+    onProgress?: CompactProgress,
   ): Promise<CompactionResult> {
     // Load current history
     const messages = await this.sessionStore.loadTelegramSession(agentId, chatId, sessionId, channel);
@@ -77,7 +161,7 @@ export class SessionCompactor {
       .map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
       .join('\n\n');
 
-    const summaryText = await this.summarizeWithChunking(historyText, model);
+    const summaryText = await this.summarizeWithChunking(historyText, model, onProgress);
     const compacted: Message[] = [
       { role: 'system', content: `[Conversation Summary]\n${summaryText}`, ts: Date.now() },
       ...tail,
@@ -95,32 +179,76 @@ export class SessionCompactor {
     return { beforeMessages, afterMessages, beforeTokens, afterTokens, reductionPct, contextPctBefore, contextPctAfter };
   }
 
-  private async summarizeWithChunking(historyText: string, model: string): Promise<string> {
-    // If small enough, summarize directly
+  private async summarizeWithChunking(historyText: string, model: string, onProgress?: CompactProgress): Promise<string> {
+    // If small enough, summarize directly. No chunking → no chunk to retry/degrade
+    // against, so a failure here still fails the compact job (original behavior).
     if (historyText.length <= CHUNK_CHARS) {
       return this.callClaudeForSummary(historyText, model);
     }
 
-    // Split into chunks and summarize each
+    // Split into chunks and summarize with bounded concurrency; a single bad
+    // chunk degrades to a raw excerpt instead of failing the whole job.
     const chunks = this.splitIntoChunks(historyText, CHUNK_CHARS);
-    const chunkSummaries: string[] = [];
+    const chunkSummaries = await this.summarizeChunksConcurrently(chunks, model, onProgress);
 
-    for (let i = 0; i < chunks.length; i++) {
-      const summary = await this.callClaudeForSummary(
-        chunks[i],
-        model,
-        `This is part ${i + 1} of ${chunks.length} of a longer conversation. Summarize this segment concisely.`,
-      );
-      chunkSummaries.push(`[Part ${i + 1}/${chunks.length}]\n${summary}`);
-    }
-
-    // Merge chunk summaries into final summary
+    // Merge chunk summaries into final summary. If the merge call itself can't
+    // be completed, fall back to the concatenated per-part summaries rather than
+    // losing the whole compaction — still far smaller than the raw history.
     const mergedText = chunkSummaries.join('\n\n');
-    return this.callClaudeForSummary(
-      mergedText,
-      model,
-      MERGE_SUMMARIES_PROMPT,
-    );
+    return this.mergeChunkSummaries(mergedText, model);
+  }
+
+  /** Bounded worker pool (mirrors the pattern in apps/installer.ts restoreRunningApps): at
+   *  most CHUNK_CONCURRENCY `claude --print` calls in flight; results land by index so
+   *  output order matches chunk order regardless of completion order. */
+  private async summarizeChunksConcurrently(
+    chunks: string[],
+    model: string,
+    onProgress?: CompactProgress,
+  ): Promise<string[]> {
+    const results: string[] = new Array(chunks.length);
+    let completed = 0;
+    let cursor = 0;
+    const worker = async (): Promise<void> => {
+      while (cursor < chunks.length) {
+        const i = cursor++;
+        results[i] = await this.summarizeChunkWithFallback(chunks[i], model, i, chunks.length);
+        completed++;
+        onProgress?.(completed, chunks.length);
+      }
+    };
+    const poolSize = Math.min(CHUNK_CONCURRENCY, chunks.length);
+    await Promise.all(Array.from({ length: poolSize }, () => worker()));
+    return results;
+  }
+
+  /** Summarize one chunk; after CHUNK_MAX_ATTEMPTS failures, degrade to a truncated raw
+   *  excerpt instead of throwing, so one bad chunk can't fail the whole compact job. */
+  private async summarizeChunkWithFallback(chunk: string, model: string, index: number, total: number): Promise<string> {
+    const instruction = `This is part ${index + 1} of ${total} of a longer conversation. Summarize this segment concisely.`;
+    let lastErr: Error | undefined;
+    for (let attempt = 1; attempt <= CHUNK_MAX_ATTEMPTS; attempt++) {
+      try {
+        const summary = await this.callClaudeForSummary(chunk, model, instruction);
+        return `[Part ${index + 1}/${total}]\n${summary}`;
+      } catch (err) {
+        lastErr = err as Error;
+      }
+    }
+    const excerpt = chunk.length > DEGRADED_EXCERPT_CHARS ? `${chunk.slice(0, DEGRADED_EXCERPT_CHARS)}…(truncated)` : chunk;
+    return `[Part ${index + 1}/${total} — summarization failed after ${CHUNK_MAX_ATTEMPTS} attempts (${lastErr?.message ?? 'unknown error'}); showing truncated raw excerpt]\n${excerpt}`;
+  }
+
+  /** Merge per-chunk summaries into one; degrade to the unmerged concatenation on repeated failure. */
+  private async mergeChunkSummaries(mergedText: string, model: string): Promise<string> {
+    for (let attempt = 1; attempt <= CHUNK_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await this.callClaudeForSummary(mergedText, model, MERGE_SUMMARIES_PROMPT);
+      } catch {
+        // retry, then degrade below
+      }
+    }
+    return mergedText;
   }
 
   private splitIntoChunks(text: string, maxChars: number): string[] {
@@ -157,12 +285,7 @@ export class SessionCompactor {
     const claudeBinRaw = process.env.CLAUDE_BIN ?? resolveClaudeBin().bin;
     const [claudeBin, ...claudeBinArgs] = claudeBinRaw.split(' ');
 
-    const result = spawnSync(claudeBin, [...claudeBinArgs, '--print', '--model', model], {
-      input: prompt,
-      encoding: 'utf-8',
-      timeout: 300_000,
-      env: { ...process.env, PATH: pathWithNativeBin() },
-    });
+    const result = await this.spawnClaude(claudeBin, [...claudeBinArgs, '--print', '--model', model], prompt);
 
     if (result.error) {
       throw new Error(`claude CLI error: ${result.error.message}`);

--- a/tests/unit/api-session-commands.test.ts
+++ b/tests/unit/api-session-commands.test.ts
@@ -12,10 +12,12 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-// ── Mock child_process (restartProcess on /clear spawns a child) ──────────────
+// ── Mock child_process (restartProcess on /clear spawns a child; SessionCompactor's
+//    async `claude --print` spawn (#376) also goes through this same `spawn` mock —
+//    distinguished by the `--print` flag, since compactor calls no longer use spawnSync) ──
 
 interface MockChildProcess extends EventEmitter {
-  stdin: { writable: boolean; write: jest.Mock } | null;
+  stdin: { writable: boolean; write: jest.Mock; end: jest.Mock; on: jest.Mock } | null;
   stdout: EventEmitter | null;
   stderr: EventEmitter | null;
   killed: boolean;
@@ -25,7 +27,7 @@ interface MockChildProcess extends EventEmitter {
 
 function makeMockProcess(): MockChildProcess {
   const proc = new EventEmitter() as MockChildProcess;
-  proc.stdin = { writable: true, write: jest.fn() };
+  proc.stdin = { writable: true, write: jest.fn(), end: jest.fn(), on: jest.fn() };
   proc.stdout = new EventEmitter();
   proc.stderr = new EventEmitter();
   proc.killed = false;
@@ -38,11 +40,28 @@ function makeMockProcess(): MockChildProcess {
   return proc;
 }
 
-const mockSpawnSync = jest.fn();
+/** Queued result for the compactor's `claude --print` spawn — set via mockCompactorCli.mockReturnValueOnce(...). */
+const mockCompactorCli = jest.fn(() => ({ status: 0, stdout: '', stderr: '', error: undefined as Error | undefined }));
 
 jest.mock('child_process', () => ({
-  spawn: jest.fn(() => makeMockProcess()),
-  spawnSync: (...args: unknown[]) => mockSpawnSync(...args),
+  spawn: jest.fn((_bin: string, args: string[]) => {
+    const proc = makeMockProcess();
+    if (args.includes('--print')) {
+      // SessionCompactor's defaultSpawnClaude: resolve async (next tick, like a real
+      // child exiting) via the queued result instead of the old sync spawnSync return.
+      const r = mockCompactorCli();
+      process.nextTick(() => {
+        if (r.error) {
+          proc.emit('error', r.error);
+          return;
+        }
+        if (r.stdout) proc.stdout!.emit('data', r.stdout);
+        if (r.stderr) proc.stderr!.emit('data', r.stderr);
+        proc.emit('close', r.status);
+      });
+    }
+    return proc;
+  }),
 }));
 
 // ── Imports ───────────────────────────────────────────────────────────────────
@@ -94,7 +113,8 @@ describe('executeApiCommand session counting (#160)', () => {
       JSON.stringify({ agents: [{ id: 'alfred', claude: { model: 'claude-opus-4-6' } }] }, null, 2) + '\n',
     );
     runner = new AgentRunner(makeAgentConfig(workspaceDir), makeGatewayConfig());
-    mockSpawnSync.mockReset();
+    mockCompactorCli.mockReset();
+    mockCompactorCli.mockReturnValue({ status: 0, stdout: '', stderr: '', error: undefined });
   });
 
   afterEach(async () => {
@@ -158,7 +178,7 @@ describe('executeApiCommand session counting (#160)', () => {
 
   it('U-RUN-05: /compact end-to-end — compacts the flat store and returns keptMessages count', async () => {
     await seedFlatStore(sessionId, 6);
-    mockSpawnSync.mockReturnValueOnce({ status: 0, stdout: 'Compact summary.', stderr: '', error: undefined });
+    mockCompactorCli.mockReturnValueOnce({ status: 0, stdout: 'Compact summary.', stderr: '', error: undefined });
 
     const { result, responseText } = await runner.executeApiCommand(sessionId, chatId, '/compact', { skipPersist: true });
 

--- a/tests/unit/session-compactor.test.ts
+++ b/tests/unit/session-compactor.test.ts
@@ -2,15 +2,32 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { SessionStore } from '../../src/session/store';
-import { SessionCompactor, NotEnoughMessagesError } from '../../src/session/compactor';
+import { SessionCompactor, NotEnoughMessagesError, type ClaudeCliSpawnFn, type ClaudeCliResult } from '../../src/session/compactor';
 import { Message } from '../../src/types';
 
-// ── Mock child_process.spawnSync ─────────────────────────────────────────────
+// ── Fake `claude` CLI spawn (injected — see reviewer.ts's ClaudeSpawnFn for the
+//    same convention) ──────────────────────────────────────────────────────────
 
-const mockSpawnSync = jest.fn();
-jest.mock('child_process', () => ({
-  spawnSync: (...args: unknown[]) => mockSpawnSync(...args),
-}));
+function makeSpawnSuccess(stdout: string): ClaudeCliResult {
+  return { status: 0, stdout, stderr: '' };
+}
+
+function makeSpawnError(status: number, stderr = 'CLI Error'): ClaudeCliResult {
+  return { status, stdout: '', stderr };
+}
+
+/** Records every call and returns queued results in order; extra calls repeat the last result. */
+function queueSpawn(...results: ClaudeCliResult[]): { spawn: ClaudeCliSpawnFn; calls: Array<{ bin: string; args: string[]; input: string }> } {
+  const calls: Array<{ bin: string; args: string[]; input: string }> = [];
+  let i = 0;
+  const spawn: ClaudeCliSpawnFn = async (bin, args, input) => {
+    calls.push({ bin, args, input });
+    const r = results[Math.min(i, results.length - 1)];
+    i++;
+    return r;
+  };
+  return { spawn, calls };
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -18,20 +35,11 @@ function makeMsg(role: 'user' | 'assistant', content: string, ts = Date.now()): 
   return { role, content, ts };
 }
 
-function makeSpawnSuccess(summaryText: string) {
-  return { status: 0, stdout: summaryText, stderr: '', error: undefined };
-}
-
-function makeSpawnError(status: number, stderr = 'CLI Error') {
-  return { status, stdout: '', stderr, error: undefined };
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('SessionCompactor', () => {
   let tmpDir: string;
   let sessionStore: SessionStore;
-  let compactor: SessionCompactor;
 
   const agentId = 'test-agent';
   const chatId = '123456';
@@ -39,19 +47,18 @@ describe('SessionCompactor', () => {
   beforeEach(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compactor-test-'));
     sessionStore = new SessionStore(tmpDir);
-    compactor = new SessionCompactor(sessionStore);
-    mockSpawnSync.mockReset();
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    jest.clearAllMocks();
   });
 
   // -------------------------------------------------------------------------
   // U18: compact with < 5 messages → throws NotEnoughMessagesError
   // -------------------------------------------------------------------------
   it('U18: compact with fewer than 5 messages throws NotEnoughMessagesError', async () => {
+    const { spawn } = queueSpawn(makeSpawnSuccess('unused'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
 
@@ -69,6 +76,8 @@ describe('SessionCompactor', () => {
   });
 
   it('U18b: compact with exactly 4 messages throws NotEnoughMessagesError', async () => {
+    const { spawn, calls } = queueSpawn(makeSpawnSuccess('unused'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
 
@@ -81,13 +90,15 @@ describe('SessionCompactor', () => {
     ).rejects.toBeInstanceOf(NotEnoughMessagesError);
 
     // claude CLI should NOT have been called (error thrown before CLI call)
-    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------
   // U19: successful compact → archive saved at {sessionId}.pre-compact-{ts}.json
   // -------------------------------------------------------------------------
   it('U19: successful compact saves archive file named {sessionId}.pre-compact-{ts}.json', async () => {
+    const { spawn } = queueSpawn(makeSpawnSuccess('This is a concise summary of the conversation.'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
 
@@ -95,8 +106,6 @@ describe('SessionCompactor', () => {
       const role = i % 2 === 0 ? 'user' : 'assistant';
       await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `message ${i}`));
     }
-
-    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('This is a concise summary of the conversation.'));
 
     const tsBefore = Date.now();
     await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
@@ -124,13 +133,14 @@ describe('SessionCompactor', () => {
   // the CLI default model or a hardcoded bare `claude` binary.
   // -------------------------------------------------------------------------
   it('U-CB1: honors CLAUDE_BIN (with args) and passes --print with the selected model', async () => {
+    const { spawn, calls } = queueSpawn(makeSpawnSuccess('summary'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
     for (let i = 0; i < 6; i++) {
       const role = i % 2 === 0 ? 'user' : 'assistant';
       await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `m${i}`));
     }
-    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('summary'));
 
     const prev = process.env.CLAUDE_BIN;
     process.env.CLAUDE_BIN = 'node /opt/claude/cli.js';
@@ -141,9 +151,8 @@ describe('SessionCompactor', () => {
       else process.env.CLAUDE_BIN = prev;
     }
 
-    const [bin, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
-    expect(bin).toBe('node');
-    expect(args).toEqual(['/opt/claude/cli.js', '--print', '--model', 'claude-sonnet-4-6']);
+    expect(calls[0].bin).toBe('node');
+    expect(calls[0].args).toEqual(['/opt/claude/cli.js', '--print', '--model', 'claude-sonnet-4-6']);
   });
 
   // -------------------------------------------------------------------------
@@ -151,13 +160,14 @@ describe('SessionCompactor', () => {
   // selected model is still passed to the CLI.
   // -------------------------------------------------------------------------
   it('U-CB2: resolves a binary and passes --print when CLAUDE_BIN is unset', async () => {
+    const { spawn, calls } = queueSpawn(makeSpawnSuccess('summary'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
     for (let i = 0; i < 6; i++) {
       const role = i % 2 === 0 ? 'user' : 'assistant';
       await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `m${i}`));
     }
-    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('summary'));
 
     const prev = process.env.CLAUDE_BIN;
     delete process.env.CLAUDE_BIN;
@@ -167,16 +177,17 @@ describe('SessionCompactor', () => {
       if (prev !== undefined) process.env.CLAUDE_BIN = prev;
     }
 
-    const [bin, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
-    expect(typeof bin).toBe('string');
-    expect(bin.length).toBeGreaterThan(0);
-    expect(args).toEqual(['--print', '--model', 'claude-sonnet-4-6']);
+    expect(typeof calls[0].bin).toBe('string');
+    expect(calls[0].bin.length).toBeGreaterThan(0);
+    expect(calls[0].args).toEqual(['--print', '--model', 'claude-sonnet-4-6']);
   });
 
   // -------------------------------------------------------------------------
   // U20: compacted history has summary system message + last 40 verbatim
   // -------------------------------------------------------------------------
   it('U20: compacted history has summary system message as first entry plus last 40 verbatim messages', async () => {
+    const { spawn } = queueSpawn(makeSpawnSuccess('Summary: user asked about 7 things, assistant answered.'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
 
@@ -190,7 +201,6 @@ describe('SessionCompactor', () => {
     }
 
     const summaryText = 'Summary: user asked about 7 things, assistant answered.';
-    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess(summaryText));
 
     await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
 
@@ -211,6 +221,8 @@ describe('SessionCompactor', () => {
   });
 
   it('U20b: compact returns correct CompactionResult metadata', async () => {
+    const { spawn } = queueSpawn(makeSpawnSuccess('brief summary'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
 
@@ -219,8 +231,6 @@ describe('SessionCompactor', () => {
       const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
       await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, '1234567890'));
     }
-
-    mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('brief summary'));
 
     const result = await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
 
@@ -235,8 +245,12 @@ describe('SessionCompactor', () => {
 
   // -------------------------------------------------------------------------
   // U21: CLI failure mid-compact → original history unchanged
+  // (single-chunk / non-chunked path: a failure is NOT retried/degraded — there is
+  // nothing to fall back to, so the compact job still fails as before)
   // -------------------------------------------------------------------------
   it('U21: CLI failure mid-compact leaves original history unchanged', async () => {
+    const { spawn } = queueSpawn(makeSpawnError(1, 'Internal error'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
 
@@ -247,9 +261,6 @@ describe('SessionCompactor', () => {
       originalMessages.push(msg);
       await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, msg);
     }
-
-    // Mock claude CLI returning non-zero exit
-    mockSpawnSync.mockReturnValueOnce(makeSpawnError(1, 'Internal error'));
 
     await expect(
       compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
@@ -264,6 +275,9 @@ describe('SessionCompactor', () => {
   });
 
   it('U21b: CLI process error mid-compact leaves original history unchanged', async () => {
+    // Simulate process spawn error (e.g., claude not found)
+    const { spawn } = queueSpawn({ status: null, stdout: '', stderr: '', error: new Error('spawn ENOENT') });
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
 
@@ -274,9 +288,6 @@ describe('SessionCompactor', () => {
       originalMessages.push(msg);
       await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, msg);
     }
-
-    // Simulate process spawn error (e.g., claude not found)
-    mockSpawnSync.mockReturnValueOnce({ status: null, stdout: '', stderr: '', error: new Error('spawn ENOENT') });
 
     await expect(
       compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
@@ -291,6 +302,8 @@ describe('SessionCompactor', () => {
 
   it('U21c: CLI failure still saves the archive file before failing', async () => {
     // Archive write happens BEFORE the CLI call, so it should survive the failure
+    const { spawn } = queueSpawn(makeSpawnError(1, 'Rate limited'));
+    const compactor = new SessionCompactor(sessionStore, spawn);
     const index = await sessionStore.getOrCreateIndex(agentId, chatId);
     const sessionId = index.activeSessionId;
 
@@ -298,8 +311,6 @@ describe('SessionCompactor', () => {
       const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
       await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `msg ${i}`));
     }
-
-    mockSpawnSync.mockReturnValueOnce(makeSpawnError(1, 'Rate limited'));
 
     await expect(
       compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000),
@@ -340,6 +351,9 @@ describe('SessionCompactor', () => {
     });
 
     it('U-CMP-API-2: compact(api) succeeds on a flat-store conversation and writes the result back to the flat store', async () => {
+      const { spawn } = queueSpawn(makeSpawnSuccess('Concise api summary.'));
+      const compactor = new SessionCompactor(sessionStore, spawn);
+
       const messages: Message[] = [];
       for (let i = 0; i < 6; i++) {
         const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
@@ -347,8 +361,6 @@ describe('SessionCompactor', () => {
         messages.push(msg);
         await sessionStore.appendMessage(agentId, apiSessionId, msg);
       }
-
-      mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('Concise api summary.'));
 
       const result = await compactor.compact(agentId, apiStoreChatId, apiSessionId, 'claude-sonnet-4-6', 200000, 'api');
 
@@ -365,12 +377,14 @@ describe('SessionCompactor', () => {
     });
 
     it('U-CMP-API-3: compact(api) archives the original under the structured api-{chatId} dir', async () => {
+      const { spawn } = queueSpawn(makeSpawnSuccess('summary'));
+      const compactor = new SessionCompactor(sessionStore, spawn);
+
       for (let i = 0; i < 6; i++) {
         const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
         await sessionStore.appendMessage(agentId, apiSessionId, makeMsg(role, `api message ${i}`));
       }
 
-      mockSpawnSync.mockReturnValueOnce(makeSpawnSuccess('summary'));
       await compactor.compact(agentId, apiStoreChatId, apiSessionId, 'claude-sonnet-4-6', 200000, 'api');
 
       const apiDir = path.join(tmpDir, agentId, 'sessions', `api-${apiStoreChatId}`); // → sessions/api-777000
@@ -381,6 +395,9 @@ describe('SessionCompactor', () => {
     });
 
     it('U-CMP-API-4: compact(api) with fewer than 5 flat-store messages still throws NotEnoughMessagesError', async () => {
+      const { spawn, calls } = queueSpawn(makeSpawnSuccess('unused'));
+      const compactor = new SessionCompactor(sessionStore, spawn);
+
       await sessionStore.appendMessage(agentId, apiSessionId, makeMsg('user', 'one'));
       await sessionStore.appendMessage(agentId, apiSessionId, makeMsg('assistant', 'two'));
 
@@ -389,7 +406,143 @@ describe('SessionCompactor', () => {
       ).rejects.toThrow(NotEnoughMessagesError);
 
       // CLI must never be invoked when there's nothing to compact.
-      expect(mockSpawnSync).not.toHaveBeenCalled();
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  // ─── Large-session chunked compaction (#376) — the async spawn + concurrency +
+  //     per-chunk retry/degrade + progress-callback behavior this issue fixes ───
+  describe('large-session chunking (#376)', () => {
+    /** Build enough messages to exceed CHUNK_CHARS (100_000) after joining. */
+    function seedLargeSession(sessionId: string, chunkCount: number): Promise<void> {
+      // Each message ~30K chars of content → ~4 msgs ≈ 1 chunk boundary crossed;
+      // use a generous multiplier so `chunkCount` chunks are produced reliably.
+      const bigContent = 'x'.repeat(30_000);
+      const totalMsgs = chunkCount * 4 + 2; // +2 margin beyond KEEP_LAST_MESSAGES tail exclusion isn't needed here since these are all "toSummarize"
+      const writes: Promise<void>[] = [];
+      for (let i = 0; i < totalMsgs; i++) {
+        const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+        writes.push(sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, bigContent, Date.now() + i)));
+      }
+      return Promise.all(writes).then(() => undefined);
+    }
+
+    it('U-CMP-LG-1: chunked compact makes multiple CLI calls (one per chunk + one merge)', async () => {
+      const { spawn, calls } = queueSpawn(makeSpawnSuccess('chunk or merge summary'));
+      const compactor = new SessionCompactor(sessionStore, spawn);
+      const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+      const sessionId = index.activeSessionId;
+      await seedLargeSession(sessionId, 3);
+
+      await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+
+      // Must be more than one call (chunked), and the last call is the merge.
+      expect(calls.length).toBeGreaterThan(1);
+    });
+
+    it('U-CMP-LG-2: never runs more than CHUNK_CONCURRENCY (4) chunk-summary calls at once', async () => {
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const spawn: ClaudeCliSpawnFn = async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 10));
+        inFlight--;
+        return makeSpawnSuccess('summary');
+      };
+      const compactor = new SessionCompactor(sessionStore, spawn);
+      const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+      const sessionId = index.activeSessionId;
+      await seedLargeSession(sessionId, 12); // well beyond the concurrency cap
+
+      await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+
+      expect(maxInFlight).toBeLessThanOrEqual(4);
+      expect(maxInFlight).toBeGreaterThan(1); // proves it actually parallelizes, not sequential
+    });
+
+    it('U-CMP-LG-3: one failing chunk degrades to a raw excerpt instead of failing the whole compact', async () => {
+      let call = 0;
+      const mergeInputs: string[] = [];
+      const spawn: ClaudeCliSpawnFn = async (_bin, _args, input) => {
+        call++;
+        // Fail every call whose prompt is for "part 2" (both attempts), succeed on everything else.
+        if (input.includes('part 2 of')) return makeSpawnError(1, 'model overloaded');
+        if (input.includes('Merge them into a single concise summary')) mergeInputs.push(input);
+        return makeSpawnSuccess(`ok-summary-${call}`);
+      };
+      const compactor = new SessionCompactor(sessionStore, spawn);
+      const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+      const sessionId = index.activeSessionId;
+      await seedLargeSession(sessionId, 3);
+
+      // Must NOT throw — the whole job completes despite the one dead chunk.
+      const result = await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+      expect(result.afterMessages).toBeGreaterThan(0);
+
+      // The degraded excerpt (not a thrown error) is what reached the merge step —
+      // proves the bad chunk was carried forward as data, not allowed to kill the job.
+      expect(mergeInputs).toHaveLength(1);
+      expect(mergeInputs[0]).toContain('summarization failed after 2 attempts');
+    });
+
+    it('U-CMP-LG-4: merge-call failure degrades to the concatenated chunk summaries instead of throwing', async () => {
+      const spawn: ClaudeCliSpawnFn = async (_bin, _args, input) => {
+        // The merge call carries the "Merge them into a single concise summary" instruction.
+        if (input.includes('Merge them into a single concise summary')) return makeSpawnError(1, 'merge model down');
+        return makeSpawnSuccess('chunk-ok');
+      };
+      const compactor = new SessionCompactor(sessionStore, spawn);
+      const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+      const sessionId = index.activeSessionId;
+      await seedLargeSession(sessionId, 3);
+
+      const result = await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+      expect(result.afterMessages).toBeGreaterThan(0);
+
+      const compacted = await sessionStore.loadTelegramSession(agentId, chatId, sessionId);
+      const summaryMsg = compacted.find((m) => m.role === 'system');
+      // Degraded output is the concatenated per-part summaries (still contains the per-part markers).
+      expect(summaryMsg?.content).toContain('[Part 1/');
+      expect(summaryMsg?.content).toContain('chunk-ok');
+    });
+
+    it('U-CMP-LG-5: onProgress is called once per completed chunk, ending at (total, total)', async () => {
+      const { spawn } = queueSpawn(makeSpawnSuccess('summary'));
+      const compactor = new SessionCompactor(sessionStore, spawn);
+      const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+      const sessionId = index.activeSessionId;
+      await seedLargeSession(sessionId, 3);
+
+      const progressCalls: Array<[number, number]> = [];
+      await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000, 'telegram', (done, total) => {
+        progressCalls.push([done, total]);
+      });
+
+      expect(progressCalls.length).toBeGreaterThan(0);
+      const total = progressCalls[0][1];
+      expect(progressCalls.every(([, t]) => t === total)).toBe(true);
+      expect(progressCalls[progressCalls.length - 1]).toEqual([total, total]);
+      // done values must be exactly 1..total, one call each (no skips, no dupes).
+      expect(progressCalls.map(([d]) => d)).toEqual(Array.from({ length: total }, (_, i) => i + 1));
+    });
+
+    it('U-CMP-LG-6: onProgress is never called for a non-chunked (single-call) compact', async () => {
+      const { spawn } = queueSpawn(makeSpawnSuccess('summary'));
+      const compactor = new SessionCompactor(sessionStore, spawn);
+      const index = await sessionStore.getOrCreateIndex(agentId, chatId);
+      const sessionId = index.activeSessionId;
+      for (let i = 0; i < 6; i++) {
+        const role: 'user' | 'assistant' = i % 2 === 0 ? 'user' : 'assistant';
+        await sessionStore.appendTelegramMessage(agentId, chatId, sessionId, makeMsg(role, `small ${i}`));
+      }
+
+      const progressCalls: Array<[number, number]> = [];
+      await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000, 'telegram', (done, total) => {
+        progressCalls.push([done, total]);
+      });
+
+      expect(progressCalls).toHaveLength(0);
     });
   });
 });

--- a/tests/unit/session-compactor.test.ts
+++ b/tests/unit/session-compactor.test.ts
@@ -476,14 +476,23 @@ describe('SessionCompactor', () => {
       const sessionId = index.activeSessionId;
       await seedLargeSession(sessionId, 3);
 
-      // Must NOT throw — the whole job completes despite the one dead chunk.
-      const result = await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
-      expect(result.afterMessages).toBeGreaterThan(0);
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        // Must NOT throw — the whole job completes despite the one dead chunk.
+        const result = await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+        expect(result.afterMessages).toBeGreaterThan(0);
 
-      // The degraded excerpt (not a thrown error) is what reached the merge step —
-      // proves the bad chunk was carried forward as data, not allowed to kill the job.
-      expect(mergeInputs).toHaveLength(1);
-      expect(mergeInputs[0]).toContain('summarization failed after 2 attempts');
+        // The degraded excerpt (not a thrown error) is what reached the merge step —
+        // proves the bad chunk was carried forward as data, not allowed to kill the job.
+        expect(mergeInputs).toHaveLength(1);
+        expect(mergeInputs[0]).toContain('summarization failed after 2 attempts');
+
+        // Degradation is logged server-side, not silent.
+        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Chunk 2/'));
+        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('summarization failed after 2 attempts'));
+      } finally {
+        errSpy.mockRestore();
+      }
     });
 
     it('U-CMP-LG-4: merge-call failure degrades to the concatenated chunk summaries instead of throwing', async () => {
@@ -497,7 +506,14 @@ describe('SessionCompactor', () => {
       const sessionId = index.activeSessionId;
       await seedLargeSession(sessionId, 3);
 
-      const result = await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      let result: Awaited<ReturnType<typeof compactor.compact>>;
+      try {
+        result = await compactor.compact(agentId, chatId, sessionId, 'claude-sonnet-4-6', 200000);
+        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Merge-summaries call failed after 2 attempts'));
+      } finally {
+        errSpy.mockRestore();
+      }
       expect(result.afterMessages).toBeGreaterThan(0);
 
       const compacted = await sessionStore.loadTelegramSession(agentId, chatId, sessionId);


### PR DESCRIPTION
## Summary
Fixes #376 — `/compact` on a large session freezes the entire gateway (all agents/channels) and can lose all progress to a single transient failure.

Root cause: `SessionCompactor.callClaudeForSummary` called `spawnSync` to invoke `claude --print` once per ~100K-char chunk of history, sequentially. `spawnSync` blocks the daemon's single Node.js event loop; every agent in this gateway shares one process, so one compaction call froze all of them until it returned. Measured against a real 2,153-message session: 16 chunks → 17 sequential blocking model calls → up to ~15 minutes of total gateway freeze per `/compact`, and any single chunk failure aborted the whole job.

## Changes (`src/session/compactor.ts`, `src/agent/runner.ts`)
1. **Async spawn** — replaced `spawnSync` with an async `child_process.spawn`-based call (`defaultSpawnClaude`), mirroring the existing `ClaudeSpawnFn` seam pattern already used in `agent/skill-learning/reviewer.ts`. The event loop is never blocked while a compaction chunk call is in flight. The spawn is injectable (`ClaudeCliSpawnFn`) via the `SessionCompactor` constructor, matching the codebase's existing testability convention — no real `claude` binary needed in tests.
2. **Bounded-concurrency chunk summarization** — chunks now summarize through a small worker pool (cap 4 in flight), mirroring the pattern already used in `apps/installer.ts`'s `restoreRunningApps`. Results are written by index so output order matches chunk order regardless of completion order. Cuts wall time roughly by the concurrency factor on large sessions.
3. **Per-chunk retry + graceful degrade** — a chunk gets one retry; if it still fails, it degrades to a truncated raw excerpt (clearly labeled) instead of throwing and killing the whole compact job. Same treatment for the final merge-summaries call: retry once, then fall back to the concatenated per-chunk summaries rather than losing the whole compaction.
4. **Progress reporting** — the channel `/compact` handler now posts throttled status updates (~25% steps) during a multi-chunk compact, so a large session doesn't look dead mid-compact. (Scoped as periodic status messages via the existing `writeAutoForward` path rather than true message-editing — the gateway has no per-channel message-ID/edit plumbing for this call site today, and adding one would expand this fix into channel-adapter territory across Telegram/Discord/Slack/LINE. Periodic status updates satisfy the same goal — visible progress, no "is this dead?" — without that scope creep.)

Scoping note: retry/degrade only applies to the **chunked** path (session large enough to need >1 chunk). The non-chunked (small session, single call) path is intentionally left throwing on failure as before — there's nothing to degrade against for a single call, and this keeps the existing small-session test contract unchanged.

## How to test
- `/compact` a small session (<5 messages) → still throws `NotEnoughMessagesError` as before.
- `/compact` a normal session (fits in one chunk) → unchanged behavior; a CLI failure still aborts with the original error message.
- `/compact` a very large session (>100K chars of history to summarize) → multiple chunk calls run concurrently (cap 4), progress messages appear every ~25%, and a single bad chunk/merge call no longer aborts the whole compaction.

## Regression tests (all proven-red against the pre-fix code before verifying green)
Added to `tests/unit/session-compactor.test.ts` under `large-session chunking (#376)`:
- `U-CMP-LG-2`: max concurrent chunk-summary calls is bounded by `CHUNK_CONCURRENCY` but > 1 (proves it's not sequential). **Proven red**: forcing `CHUNK_CONCURRENCY = 1` fails the `> 1` assertion.
- `U-CMP-LG-3`: a failing chunk degrades instead of failing the whole job. **Proven red**: removing the retry/degrade loop makes the whole compact throw.
- `U-CMP-LG-4`: a failing merge call degrades to the concatenated chunk summaries. **Proven red**: removing the merge retry/degrade makes the whole compact throw.
- `U-CMP-LG-5`/`U-CMP-LG-6`: `onProgress` fires once per completed chunk (and never for a non-chunked compact). **Proven red**: removing the `onProgress` call leaves the callback uninvoked.

Also rewrote the existing `spawnSync`-mocking tests to use the new injectable `ClaudeCliSpawnFn` (same behavior/assertions preserved, `U18`–`U21c`, `U-CB1/2`, `U-CMP-API-1..4` all still pass), and updated `tests/unit/api-session-commands.test.ts`'s `child_process` mock (its `spawn` mock now also resolves the compactor's `--print` calls, since compactor no longer uses `spawnSync`).

## Gates
- `tsc --noEmit`: clean
- `tsc` full build: clean
- Full suite: **3549/3549 passed**, 187 suites (`jest --runInBand`)
- Proven-red verified for all 4 fixes individually (see above), then restored + re-verified green

Closes #376
