### PR TITLE
fix(telegram): turn-scope auto-forward dedup and queue .forward writes

### DIFF
--- a/mcp/tools/discord/module.ts
+++ b/mcp/tools/discord/module.ts
@@ -586,29 +586,37 @@ export class DiscordModule implements ChannelModule {
       if (!file.endsWith('.forward')) continue;
       const filePath = path.join(typingDir, file);
       const channelId = file.slice(0, -'.forward'.length);
-      let text: string;
-      let parseMode: undefined | 'html';
+      // AgentRunner.writeAutoForward() appends to a queue rather than
+      // overwriting (claude-gateway#380), so this file is a JSON array of
+      // { text, format, turnId } entries — but tolerate the pre-queue
+      // single-object form and the original plain-text form too, since a
+      // file in flight during a rolling deploy can be in either shape.
+      let entries: Array<{ text?: unknown; format?: unknown }>;
       try {
         const raw = fs.readFileSync(filePath, 'utf8').trim();
         try {
-          const parsed = JSON.parse(raw) as { text: string; format: string };
-          text = parsed.text;
-          parseMode = parsed.format === 'html' ? 'html' : undefined;
+          const parsed: unknown = JSON.parse(raw);
+          entries = Array.isArray(parsed) ? parsed : [parsed as { text?: unknown; format?: unknown }];
         } catch {
-          text = raw;
+          entries = [{ text: raw }];
         }
         fs.rmSync(filePath, { force: true });
       } catch { continue; }
 
-      if (!text) continue;
-      try {
-        const channel = await this.client.channels.fetch(channelId);
-        if (parseMode === 'html') {
-          // Discord doesn't support HTML — strip tags and send plain text
-          text = text.replace(/<[^>]*>/g, '');
-        }
-        await sendMessage(channel, text, {});
-      } catch { /* non-fatal */ }
+      // Discord has no `.replied` dedup mechanism (unlike Telegram) — every
+      // queued entry is delivered, in order.
+      for (const entry of entries) {
+        let text = typeof entry.text === 'string' ? entry.text : '';
+        if (!text) continue;
+        try {
+          const channel = await this.client.channels.fetch(channelId);
+          if (entry.format === 'html') {
+            // Discord doesn't support HTML — strip tags and send plain text
+            text = text.replace(/<[^>]*>/g, '');
+          }
+          await sendMessage(channel, text, {});
+        } catch { /* non-fatal */ }
+      }
     }
   }
 

--- a/mcp/tools/telegram/module.ts
+++ b/mcp/tools/telegram/module.ts
@@ -363,10 +363,18 @@ export class TelegramModule implements ChannelModule {
       }
     }
 
-    // Write .replied marker
+    // Write .replied marker, tagged with the live typing-signal timestamp as
+    // this turn's id — the receiver (typing.ts) only treats a queued
+    // auto-forward as "already replied" when its own turnId matches this one,
+    // so a marker left over from an earlier turn can never suppress a later
+    // turn's forward (see typing.ts's isEntryAlreadyReplied()).
     try {
       fs.mkdirSync(this.typingDir, { recursive: true });
-      fs.writeFileSync(path.join(this.typingDir, `${chat_id}.replied`), sendText);
+      let turnId: string | null = null;
+      try {
+        turnId = fs.readFileSync(path.join(this.typingDir, chat_id), 'utf8').trim() || null;
+      } catch {}
+      fs.writeFileSync(path.join(this.typingDir, `${chat_id}.replied`), JSON.stringify({ text: sendText, turnId }));
     } catch {}
 
     const result = sentIds.length === 1

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -783,10 +783,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
 
         // Typing persists until agent-runner sees result event + delay.
         // Removed signalReplyDone() — reply does not mean done, agent may continue working.
-        // Write .replied marker so auto-forward in typing.ts skips duplicate send.
+        // Write .replied marker so auto-forward in typing.ts skips duplicate send —
+        // tagged with the live typing-signal timestamp as this turn's id, so a
+        // marker left over from an earlier turn can never suppress a later
+        // turn's forward (see typing.ts's isEntryAlreadyReplied()).
         try {
           mkdirSync(TYPING_DIR, { recursive: true })
-          writeFileSync(join(TYPING_DIR, `${chat_id}.replied`), sendText)
+          let turnId: string | null = null
+          try {
+            turnId = readFileSync(join(TYPING_DIR, chat_id), 'utf8').trim() || null
+          } catch {}
+          writeFileSync(join(TYPING_DIR, `${chat_id}.replied`), JSON.stringify({ text: sendText, turnId }))
         } catch { /* non-fatal */ }
 
         const result =

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -547,17 +547,22 @@ export function createWorkingStateManager(
     const forwardPath = forwardFilePath(chatId)
     const repliedPath = repliedFilePath(chatId)
     if (fsApi.existsSync(forwardPath)) {
+      let entries: ForwardEntry[] = []
       try {
-        const raw = fsApi.readFileSync(forwardPath, 'utf8')
-        const repliedTurnId = fsApi.existsSync(repliedPath)
-          ? parseRepliedTurnId(fsApi.readFileSync(repliedPath, 'utf8'))
-          : null
-        for (const entry of parseForwardQueue(raw)) {
-          if (!entry.text || isEntryAlreadyReplied(entry, repliedTurnId)) continue
-          await deliverForwardText(botApi, chatId, entry.text, entry.format === 'html' ? 'HTML' : undefined)
-        }
+        entries = parseForwardQueue(fsApi.readFileSync(forwardPath, 'utf8'))
       } catch {}
+      // Remove BEFORE delivering (mirrors drainOrphanForwards' same comment):
+      // delivery can take a while (multiple chunks, retries), and a
+      // writeAutoForward() append landing mid-delivery must start a fresh
+      // file rather than have this call's cleanup silently discard it.
       fsApi.rmSync(forwardPath, { force: true })
+      const repliedTurnId = fsApi.existsSync(repliedPath)
+        ? parseRepliedTurnId(fsApi.readFileSync(repliedPath, 'utf8'))
+        : null
+      for (const entry of entries) {
+        if (!entry.text || isEntryAlreadyReplied(entry, repliedTurnId)) continue
+        await deliverForwardText(botApi, chatId, entry.text, entry.format === 'html' ? 'HTML' : undefined)
+      }
     }
     // NOTE: interactive-menu (.menu) delivery is handled by an independent poller
     // in receiver-server.ts (drainMenuFiles), NOT here. A menu can be emitted

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -217,6 +217,78 @@ export interface FsApi {
 }
 
 /**
+ * A single queued auto-forward. `turnId` identifies the turn that produced it
+ * (the live typing-signal timestamp read at write time) — `null` when no
+ * signal file existed yet (e.g. an orphan forward from an autonomous wake
+ * with no inbound message). Writers: `AgentRunner.writeAutoForward()`.
+ */
+export interface ForwardEntry {
+  text: string
+  format: 'text' | 'html'
+  turnId: string | null
+}
+
+function normalizeForwardEntry(raw: unknown): ForwardEntry | null {
+  if (raw && typeof raw === 'object' && typeof (raw as { text?: unknown }).text === 'string') {
+    const o = raw as { text: string; format?: unknown; turnId?: unknown }
+    return {
+      text: o.text,
+      format: o.format === 'html' ? 'html' : 'text',
+      turnId: typeof o.turnId === 'string' ? o.turnId : null,
+    }
+  }
+  return null
+}
+
+/**
+ * Parse `.forward` file content into an ordered queue of entries. Accepts the
+ * current queue format (a JSON array), the pre-queue single-object format,
+ * and the original plain-text format — so an in-flight file survives a
+ * rolling deploy in either direction instead of losing its content.
+ */
+export function parseForwardQueue(raw: string): ForwardEntry[] {
+  const trimmed = raw.trim()
+  if (!trimmed) return []
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (Array.isArray(parsed)) {
+      return parsed.map(normalizeForwardEntry).filter((e): e is ForwardEntry => e !== null)
+    }
+    const single = normalizeForwardEntry(parsed)
+    return single ? [single] : []
+  } catch {
+    return [{ text: trimmed, format: 'text', turnId: null }]
+  }
+}
+
+/**
+ * Parse `.replied` marker content. Current format is `{ text, turnId }`; a
+ * legacy marker (plain text, or JSON without a `turnId`) parses to
+ * `turnId: null`, which — per `resolveForwardDelivery` below — never
+ * satisfies dedup, so a marker from a version predating this format degrades
+ * to "deliver" rather than risking a silent drop.
+ */
+function parseRepliedTurnId(raw: string): string | null {
+  try {
+    const parsed = JSON.parse(raw.trim()) as { turnId?: unknown }
+    if (parsed && typeof parsed === 'object' && typeof parsed.turnId === 'string') {
+      return parsed.turnId
+    }
+  } catch {}
+  return null
+}
+
+/**
+ * Turn-scoped dedup: an entry is already covered by the reply tool only when
+ * both sides captured the SAME live turn id at write time. A `null` turnId on
+ * either side never matches — favors an extra/duplicate delivery over a
+ * silently dropped one.
+ */
+function isEntryAlreadyReplied(entry: ForwardEntry, repliedTurnId: string | null): boolean {
+  return repliedTurnId !== null && entry.turnId !== null && entry.turnId === repliedTurnId
+}
+
+/**
  * Deliver auto-forwarded turn text to a chat, never silently dropping content.
  * Each chunk that fails as HTML (e.g. Telegram rejects an entity the balancer
  * didn't anticipate) is retried as plain text — the user always gets the words,
@@ -292,22 +364,18 @@ export function drainOrphanForwards(
     // Remove BEFORE sending so a slow/failing send can't double-deliver.
     fsApi.rmSync(forwardPath, { force: true })
     // Mirror stop()'s dedup: a lingering .replied with no typing state means
-    // the agent already sent this turn's text via the reply tool.
+    // the agent already sent SOME turn's text via the reply tool — but only
+    // entries whose turnId matches that marker's turn are actually covered.
     const repliedPath = `${typingDir}/${chatId}.replied`
+    let repliedTurnId: string | null = null
     if (fsApi.existsSync(repliedPath)) {
+      try { repliedTurnId = parseRepliedTurnId(fsApi.readFileSync(repliedPath, 'utf8')) } catch {}
       fsApi.rmSync(repliedPath, { force: true })
-      continue
     }
-    let text = raw
-    let parseMode: 'HTML' | undefined
-    try {
-      const parsed = JSON.parse(raw) as { text: string; format: string }
-      text = parsed.text
-      parseMode = parsed.format === 'html' ? 'HTML' : undefined
-    } catch {
-      // Old format: plain text
+    for (const entry of parseForwardQueue(raw)) {
+      if (!entry.text || isEntryAlreadyReplied(entry, repliedTurnId)) continue
+      void deliverForwardText(botApi, chatId, entry.text, entry.format === 'html' ? 'HTML' : undefined)
     }
-    if (text) void deliverForwardText(botApi, chatId, text, parseMode)
   }
 }
 
@@ -472,27 +540,21 @@ export function createWorkingStateManager(
         }
       } catch {}
     }
-    // Auto-forward result text to Telegram if the agent did not already reply with the same text.
+    // Auto-forward queued turn text to Telegram, skipping only the entries the
+    // reply tool already sent (same turnId as the .replied marker) — turn A's
+    // leftover marker must never suppress turn B's forward. See
+    // isEntryAlreadyReplied() / the module docstring for the race this guards.
     const forwardPath = forwardFilePath(chatId)
     const repliedPath = repliedFilePath(chatId)
     if (fsApi.existsSync(forwardPath)) {
       try {
-        const raw = fsApi.readFileSync(forwardPath, 'utf8').trim()
-        let forwardText: string
-        let parseMode: 'HTML' | undefined
-        try {
-          const parsed = JSON.parse(raw) as { text: string; format: string }
-          forwardText = parsed.text
-          parseMode = parsed.format === 'html' ? 'HTML' : undefined
-        } catch {
-          // Fallback: treat as plain text (old format compatibility)
-          forwardText = raw
-          parseMode = undefined
-        }
-        // Skip if the reply tool already sent a message (agent already replied)
-        const alreadyReplied = fsApi.existsSync(repliedPath)
-        if (!alreadyReplied && forwardText) {
-          await deliverForwardText(botApi, chatId, forwardText, parseMode)
+        const raw = fsApi.readFileSync(forwardPath, 'utf8')
+        const repliedTurnId = fsApi.existsSync(repliedPath)
+          ? parseRepliedTurnId(fsApi.readFileSync(repliedPath, 'utf8'))
+          : null
+        for (const entry of parseForwardQueue(raw)) {
+          if (!entry.text || isEntryAlreadyReplied(entry, repliedTurnId)) continue
+          await deliverForwardText(botApi, chatId, entry.text, entry.format === 'html' ? 'HTML' : undefined)
         }
       } catch {}
       fsApi.rmSync(forwardPath, { force: true })

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2476,6 +2476,22 @@ export class AgentRunner extends EventEmitter {
     return path.join(this.agentConfig.workspace, stateDir, 'typing');
   }
 
+  /**
+   * Read the live typing-signal file's timestamp as this turn's id. Shared
+   * with the `telegram_reply` MCP tool (a separate process) purely via this
+   * file, so `.forward`/`.replied` markers written around the same turn carry
+   * a matching id — see writeAutoForward()'s dedup comment.
+   */
+  private readCurrentTurnId(chatId: string): string | null {
+    const typingDir = this.getTypingDir(chatId);
+    try {
+      const raw = fs.readFileSync(path.join(typingDir, chatId), 'utf8').trim();
+      return raw || null;
+    } catch {
+      return null;
+    }
+  }
+
   private writeTypingError(chatId: string, code: string): void {
     const typingDir = this.getTypingDir(chatId);
     try {
@@ -2548,9 +2564,37 @@ export class AgentRunner extends EventEmitter {
       return;
     }
     const typingDir = this.getTypingDir(chatId);
+    const forwardPath = path.join(typingDir, `${chatId}.forward`);
     try {
       fs.mkdirSync(typingDir, { recursive: true });
-      fs.writeFileSync(path.join(typingDir, `${chatId}.forward`), JSON.stringify({ text, format }));
+      // Append rather than overwrite: two forward-worthy events for the same
+      // chat before the typing loop drains (e.g. two command replies, or the
+      // race where a queued turn's stop() call drains a prior turn's leftover
+      // state) must both reach the user, not have the second clobber the
+      // first. turnId is the live typing-signal timestamp — the receiver uses
+      // it to scope the `.replied` dedup marker to the turn that wrote it.
+      let entries: Array<{ text: string; format: string; turnId: string | null }> = [];
+      try {
+        const raw = fs.readFileSync(forwardPath, 'utf8').trim();
+        if (raw) {
+          try {
+            const parsed: unknown = JSON.parse(raw);
+            entries = Array.isArray(parsed)
+              ? (parsed as typeof entries)
+              : [parsed as (typeof entries)[number]];
+          } catch {
+            entries = [{ text: raw, format: 'text', turnId: null }];
+          }
+        }
+      } catch {
+        // No existing file — fresh queue.
+      }
+      entries.push({ text, format, turnId: this.readCurrentTurnId(chatId) });
+      // Atomic write (tmp + rename): the receiver polls this directory on
+      // every typing tick, so a non-atomic write could be read mid-flush.
+      const tmpPath = `${forwardPath}.tmp`;
+      fs.writeFileSync(tmpPath, JSON.stringify(entries));
+      fs.renameSync(tmpPath, forwardPath);
     } catch {
       // Non-fatal
     }

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -941,8 +941,10 @@ describe('AgentRunner — typing error notification', () => {
 
     const forwardFile = path.join(getTypingDir(), '123456789.forward');
     expect(fs.existsSync(forwardFile)).toBe(true);
+    // Queue format (claude-gateway#380): an array of entries, each tagged
+    // with the turn that wrote it (null here — no live typing-signal file).
     const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
-    expect(content).toEqual({ text: 'Hello from agent', format: 'text' });
+    expect(content).toEqual([{ text: 'Hello from agent', format: 'text', turnId: null }]);
   });
 
   // --------------------------------------------------------------------------
@@ -957,7 +959,7 @@ describe('AgentRunner — typing error notification', () => {
     const forwardFile = path.join(getTypingDir(), '123456789.forward');
     expect(fs.existsSync(forwardFile)).toBe(true);
     const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
-    expect(content).toEqual({ text: 'Hello <code>code</code>', format: 'html' });
+    expect(content).toEqual([{ text: 'Hello <code>code</code>', format: 'html', turnId: null }]);
   });
 
   // --------------------------------------------------------------------------
@@ -977,7 +979,12 @@ describe('AgentRunner — typing error notification', () => {
     const restartSpy = jest.spyOn(r, 'restartProcess').mockResolvedValue(undefined);
     const proc = { setProcessing: jest.fn() };
     const forwardFile = path.join(getTypingDir(), 'chat:big.forward');
-    const readForward = () => JSON.parse(fs.readFileSync(forwardFile, 'utf8')).text as string;
+    // Queue format (claude-gateway#380): each call appends rather than
+    // overwrites, so read the most recently queued entry's text.
+    const readForward = () => {
+      const entries = JSON.parse(fs.readFileSync(forwardFile, 'utf8')) as Array<{ text: string }>;
+      return entries[entries.length - 1]!.text;
+    };
 
     // Rungs 1..5 → counter climbs, each emits the "Restarting" resend notice + restarts.
     for (let i = 1; i <= 5; i++) {
@@ -1053,7 +1060,12 @@ describe('AgentRunner — typing error notification', () => {
     const restartSpy = jest.spyOn(r, 'restartProcess').mockResolvedValue(undefined);
     const proc = { setProcessing: jest.fn() };
     const forwardFile = path.join(getTypingDir(), 'chat:low.forward');
-    const readForward = () => JSON.parse(fs.readFileSync(forwardFile, 'utf8')).text as string;
+    // Queue format (claude-gateway#380): each call appends rather than
+    // overwrites, so read the most recently queued entry's text.
+    const readForward = () => {
+      const entries = JSON.parse(fs.readFileSync(forwardFile, 'utf8')) as Array<{ text: string }>;
+      return entries[entries.length - 1]!.text;
+    };
 
     // Rungs [20,10,0] → 3 climbing steps, each restarts.
     for (let i = 1; i <= 3; i++) {
@@ -2572,9 +2584,9 @@ describe('AgentRunner — session command routing', () => {
     // A .forward file should have been written (session list response)
     const forwardFile = path.join(getTypingDir(), 'chat:session-cmd.forward');
     expect(fs.existsSync(forwardFile)).toBe(true);
-    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
-    expect(typeof content.text).toBe('string');
-    expect(content.text).toContain('Session');
+    const entries = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    expect(typeof entries[0].text).toBe('string');
+    expect(entries[0].text).toContain('Session');
   }, 15000);
 
   // -------------------------------------------------------------------------
@@ -2593,9 +2605,9 @@ describe('AgentRunner — session command routing', () => {
     // A .forward file should contain confirmation
     const forwardFile = path.join(getTypingDir(), 'chat:new-cmd.forward');
     expect(fs.existsSync(forwardFile)).toBe(true);
-    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
-    expect(content.text).toContain('my session');
-    expect(content.text).toContain('New session created');
+    const entries = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    expect(entries[0].text).toContain('my session');
+    expect(entries[0].text).toContain('New session created');
 
     // The process should NOT be in the session map (new sessions are lazily spawned)
     const sessions = getSessions(runner);
@@ -2613,9 +2625,9 @@ describe('AgentRunner — session command routing', () => {
 
     const forwardFile = path.join(getTypingDir(), 'chat:new-noname.forward');
     expect(fs.existsSync(forwardFile)).toBe(true);
-    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    const entries = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
     // Auto-name should follow "Session N" pattern
-    expect(content.text).toMatch(/Session \d/);
+    expect(entries[0].text).toMatch(/Session \d/);
   }, 15000);
 
   // -------------------------------------------------------------------------
@@ -2699,9 +2711,9 @@ describe('AgentRunner — session command routing', () => {
 
     const forwardFile = path.join(getTypingDir(), `${chatId}.forward`);
     expect(fs.existsSync(forwardFile)).toBe(true);
-    const forward = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
-    expect(forward.text).toContain('Here is the detailed plan.');
-    expect(forward.text).not.toContain('Choose an option');
+    const entries = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
+    expect(entries[0].text).toContain('Here is the detailed plan.');
+    expect(entries[0].text).not.toContain('Choose an option');
   }, 15000);
 
   it('U14b: result that is only the menu text produces no forward (no duplicate)', async () => {

--- a/tests/unit/session-commands.test.ts
+++ b/tests/unit/session-commands.test.ts
@@ -132,8 +132,9 @@ describe('AgentRunner — /session info display (U22, U23)', () => {
   function getForwardText(): string {
     const forwardFile = getForwardFile();
     expect(fs.existsSync(forwardFile)).toBe(true);
-    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
-    return content.text as string;
+    // Queue format (claude-gateway#380): read the most recently queued entry.
+    const entries = JSON.parse(fs.readFileSync(forwardFile, 'utf8')) as Array<{ text: string }>;
+    return entries[entries.length - 1]!.text;
   }
 
   async function waitForForward(): Promise<void> {
@@ -294,8 +295,9 @@ describe('AgentRunner — /stop command', () => {
   function getForwardText(): string {
     const forwardFile = getForwardFile();
     expect(fs.existsSync(forwardFile)).toBe(true);
-    const content = JSON.parse(fs.readFileSync(forwardFile, 'utf8'));
-    return content.text as string;
+    // Queue format (claude-gateway#380): read the most recently queued entry.
+    const entries = JSON.parse(fs.readFileSync(forwardFile, 'utf8')) as Array<{ text: string }>;
+    return entries[entries.length - 1]!.text;
   }
 
   type SessionLike = {

--- a/tests/unit/telegram-plugin/typing.test.ts
+++ b/tests/unit/telegram-plugin/typing.test.ts
@@ -866,15 +866,19 @@ describe('createWorkingStateManager', () => {
       expect(bot.sendMessage).toHaveBeenCalledWith(CHAT_ID, 'Plain text fallback', {})
     })
 
-    it('U-TY-08: skips forward when .replied exists (agent already replied via tool)', async () => {
+    it('U-TY-08: skips forward when .replied exists for the SAME turn (agent already replied via tool)', async () => {
       const bot = makeBotApi()
       const fsApi = makeFsApi()
       const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
 
       mgr.start(CHAT_ID)
-      // Simulate both .forward and .replied exist — agent already sent a reply
-      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'Hello from agent', format: 'text' }))
-      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.replied`, String(Date.now()))
+      // Simulate both .forward and .replied written during the same turn —
+      // both carry the turn's live signal timestamp as turnId.
+      fsApi._files.set(
+        `${TYPING_DIR}/${CHAT_ID}.forward`,
+        JSON.stringify({ text: 'Hello from agent', format: 'text', turnId: 'turn-A' }),
+      )
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.replied`, JSON.stringify({ text: 'Hello from agent', turnId: 'turn-A' }))
 
       // Remove signal file to trigger stop on next tick
       fsApi._files.delete(`${TYPING_DIR}/${CHAT_ID}`)
@@ -883,11 +887,64 @@ describe('createWorkingStateManager', () => {
       await Promise.resolve()
       await Promise.resolve()
 
-      // sendMessage should NOT be called — agent already replied
+      // sendMessage should NOT be called — agent already replied this turn
       const forwardCalls = bot.sendMessage.mock.calls.filter(
         (c: unknown[]) => c[1] === 'Hello from agent'
       )
       expect(forwardCalls).toHaveLength(0)
+    })
+
+    // Regression for claude-gateway#380 — race 1: a `.replied` marker left
+    // over from an earlier turn (turn A) must NEVER suppress a later turn's
+    // (turn B's) auto-forward, even though `stop()` only runs once both
+    // turns have ended. Reproduces the exact race from the issue: turn A
+    // replies via the tool, turn B replies via writeAutoForward (e.g. a
+    // command reply) before stop() ever drains turn A's leftover marker.
+    it('U-TY-08b: turn B forward is delivered despite turn A\'s leftover .replied marker (different turnId)', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+      // Turn A's .replied marker lingers (its own stop() never ran before
+      // turn B's signal-file rewrite made this stop() call the one that
+      // finally observes the missing signal and drains everything).
+      fsApi._files.set(`${TYPING_DIR}/${CHAT_ID}.replied`, JSON.stringify({ text: 'turn A reply', turnId: 'turn-A' }))
+      // Turn B's forward — a different turnId.
+      fsApi._files.set(
+        `${TYPING_DIR}/${CHAT_ID}.forward`,
+        JSON.stringify({ text: 'turn B forward', format: 'text', turnId: 'turn-B' }),
+      )
+
+      await mgr.stop(CHAT_ID)
+
+      expect(bot.sendMessage).toHaveBeenCalledWith(CHAT_ID, 'turn B forward', {})
+    })
+
+    // Regression for claude-gateway#380 — race 2: two forward-worthy events
+    // for the same chat before drain (e.g. two command replies queued back
+    // to back) must both reach the user in order, not have the second
+    // silently clobber the first.
+    it('U-TY-08c: two queued forward entries both deliver in order (no clobber)', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+      fsApi._files.set(
+        `${TYPING_DIR}/${CHAT_ID}.forward`,
+        JSON.stringify([
+          { text: 'first notice', format: 'text', turnId: 'turn-A' },
+          { text: 'second notice', format: 'text', turnId: 'turn-A' },
+        ]),
+      )
+
+      await mgr.stop(CHAT_ID)
+
+      const calls = bot.sendMessage.mock.calls
+        .filter(c => c[0] === CHAT_ID && (c[1] === 'first notice' || c[1] === 'second notice'))
+        .map(c => c[1])
+      expect(calls).toEqual(['first notice', 'second notice'])
     })
 
     it('U-TY-09: cleans up both .forward and .replied files after stop', async () => {
@@ -1272,10 +1329,10 @@ describe('drainOrphanForwards', () => {
     expect(files.has(`${TYPING_DIR}/${CHAT_ID}.forward`)).toBe(true)
   })
 
-  it('U-TY-DR-03: lingering .replied means the reply tool already sent — removes both, no send', () => {
+  it('U-TY-DR-03: lingering .replied for the SAME turn means the reply tool already sent — removes both, no send', () => {
     const files = new Map([
-      [`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'dup', format: 'text' })],
-      [`${TYPING_DIR}/${CHAT_ID}.replied`, '1'],
+      [`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'dup', format: 'text', turnId: 'turn-A' })],
+      [`${TYPING_DIR}/${CHAT_ID}.replied`, JSON.stringify({ text: 'dup', turnId: 'turn-A' })],
     ])
     const fsApi = makeDrainFsApi(files)
     const bot = makeBotApi()
@@ -1283,6 +1340,25 @@ describe('drainOrphanForwards', () => {
     drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)
 
     expect(bot.sendMessage).not.toHaveBeenCalled()
+    expect(files.has(`${TYPING_DIR}/${CHAT_ID}.forward`)).toBe(false)
+    expect(files.has(`${TYPING_DIR}/${CHAT_ID}.replied`)).toBe(false)
+  })
+
+  // Regression for claude-gateway#380 — a `.replied` marker from a DIFFERENT
+  // turn must not suppress this orphan forward, mirroring U-TY-08b for the
+  // drain-poller path.
+  it('U-TY-DR-03b: lingering .replied for a DIFFERENT turn does not suppress the forward', async () => {
+    const files = new Map([
+      [`${TYPING_DIR}/${CHAT_ID}.forward`, JSON.stringify({ text: 'not a dup', format: 'text', turnId: 'turn-B' })],
+      [`${TYPING_DIR}/${CHAT_ID}.replied`, JSON.stringify({ text: 'earlier turn', turnId: 'turn-A' })],
+    ])
+    const fsApi = makeDrainFsApi(files)
+    const bot = makeBotApi()
+
+    drainOrphanForwards(TYPING_DIR, new Set<string>(), bot, fsApi)
+    await Promise.resolve()
+
+    expect(bot.sendMessage).toHaveBeenCalledWith(CHAT_ID, 'not a dup', {})
     expect(files.has(`${TYPING_DIR}/${CHAT_ID}.forward`)).toBe(false)
     expect(files.has(`${TYPING_DIR}/${CHAT_ID}.replied`)).toBe(false)
   })

--- a/tests/unit/telegram-plugin/typing.test.ts
+++ b/tests/unit/telegram-plugin/typing.test.ts
@@ -962,6 +962,33 @@ describe('createWorkingStateManager', () => {
       expect(fsApi._files.has(`${TYPING_DIR}/${CHAT_ID}.replied`)).toBe(false)
     })
 
+    // Self-review follow-up for claude-gateway#380: stop() can take a while to
+    // deliver (multiple chunks, retries over the network). The .forward file
+    // must be removed BEFORE delivery starts — mirroring drainOrphanForwards —
+    // so a writeAutoForward() append landing mid-delivery starts a fresh file
+    // instead of being silently discarded by this call's own cleanup.
+    it('U-TY-09b: .forward is removed BEFORE delivery starts, not after', async () => {
+      const bot = makeBotApi()
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+      fsApi._files.set(
+        `${TYPING_DIR}/${CHAT_ID}.forward`,
+        JSON.stringify({ text: 'hello', format: 'text', turnId: 'turn-A' }),
+      )
+
+      await mgr.stop(CHAT_ID)
+
+      const rmMock = fsApi.rmSync as jest.Mock
+      const forwardRmCallIndex = rmMock.mock.calls.findIndex(
+        (c: unknown[]) => c[0] === `${TYPING_DIR}/${CHAT_ID}.forward`,
+      )
+      const rmOrder = rmMock.mock.invocationCallOrder[forwardRmCallIndex]
+      const sendOrder = bot.sendMessage.mock.invocationCallOrder[0]
+      expect(rmOrder).toBeLessThan(sendOrder)
+    })
+
     it('U-TY-10: splits long auto-forward text into multiple sendMessage calls', async () => {
       const bot = makeBotApi()
       const fsApi = makeFsApi()


### PR DESCRIPTION
## Summary
Fixes claude-gateway#380 — the Telegram auto-forward safety net could silently drop a turn's text when back-to-back turns overlapped the typing loop's 4s poll tick, with no error and no logged incident.

## Root cause (proven in #380, re-verified against current `main` before implementing)
Two independent bugs in `mcp/tools/telegram/typing.ts` / `src/agent/runner.ts`, both live on `main`:

1. **Chat-scoped `.replied` marker.** `createWorkingStateManager().start()` is idempotent — a second inbound message for an already-active chat is a no-op and does not reset `state.startedAt`. `SessionProcess.sendMessage()` unconditionally rewrites the bare typing signal file on every injected turn. Combined, this lets a turn A `.replied` marker (written when the reply tool is called) survive until `stop()` finally runs — coalesced with a later turn B — at which point `stop()`'s dedup check (`fsApi.existsSync(repliedPath)`) sees the leftover marker and deletes turn B's `.forward` text without ever sending it.
2. **Single-slot `.forward` file.** `AgentRunner.writeAutoForward()` wrote via a plain `fs.writeFileSync` overwrite. Two forward-worthy events for the same chat before drain (two command replies, or the same race window) silently clobber each other with no trace.

## Fix
- `.replied` and each queued `.forward` entry now carry a `turnId` — the live typing-signal timestamp read at write time by both writers (`telegram_reply` in `module.ts`/`receiver-server.ts`, and `writeAutoForward` in `runner.ts`). `stop()` and `drainOrphanForwards()` in `typing.ts` only treat a forward entry as already covered by the reply tool when its `turnId` matches the `.replied` marker's `turnId` — a marker from a different turn (or a legacy/orphan entry with no turnId) never suppresses delivery, favoring an extra message over a silently dropped one.
- `writeAutoForward()` now reads the existing `.forward` file (if any), appends the new entry, and writes the array back atomically (tmp + rename) instead of overwriting — so multiple forward-worthy events for the same chat all reach the user, in order.
- `stop()` and `drainOrphanForwards()` drain every entry in the queue, applying the turn-scoped dedup per entry.
- Discord's independent `.forward` poller (`mcp/tools/discord/module.ts`) has no `.replied` dedup and was never subject to this race — but it reads the same shared `.forward` file, so its parser is updated to handle the new array format (with graceful fallback to the legacy single-object and plain-text shapes) so it isn't broken by the format change.
- Backward-compatible parsing throughout: an in-flight `.forward`/`.replied` file from just before this deploy (plain text, or the pre-queue single-object shape) is still read correctly.

## Regression tests
Added to `tests/unit/telegram-plugin/typing.test.ts`:
- `U-TY-08b` — turn B's forward is delivered despite turn A's leftover `.replied` marker (different `turnId`). **Proven to fail on the pre-fix code** (reverted the turn-scoping, test failed with 0 calls; restored, test passes).
- `U-TY-08c` — two queued `.forward` entries both deliver in order, no clobber. **Proven to fail on pre-fix code** (received `[]` instead of both messages).
- `U-TY-DR-03b` — same coverage for the orphan-forward drain path (`drainOrphanForwards`). **Proven to fail on pre-fix code**.
- Existing `U-TY-08` / `U-TY-DR-03` (same-turn dedup) updated to assert on matching `turnId`s, preserving the legitimate same-turn dedup behavior.

`tests/unit/agent-runner.test.ts` and `tests/unit/session-commands.test.ts` updated for the new queue file shape (array of `{text, format, turnId}` instead of a single object).

## Acceptance criteria (from #380)
- [x] A `.replied` marker from turn N is never treated as satisfying dedup for turn N+1's `.forward`.
- [x] Two `writeAutoForward()` calls for the same chat before drain both reach the user (in order), never silently overwriting each other.
- [x] New regression tests fail on the pre-fix code and pass on the post-fix code.
- [x] `drainOrphanForwards()` updated consistently with `stop()`'s new turn-scoped dedup and queue-draining logic.
- [x] Full test suite green; no regression in the existing `.replied`/`.forward` delivery tests.

## Out of scope (per #380, verified)
- LINE/Slack (already special-cased away from the `.forward`/`.replied` mechanism in `writeAutoForward()`).
- Discord's dedup racing — Discord has no `.replied` check at all (`processForwardFiles()` just delivers and deletes), so it was never subject to this race; only its `.forward` parser needed a compatibility update for the new shared file format.
- The turn-trace watchdog (`src/agent/turn-trace.ts`) — read-only observer, only checks `.replied` existence (unaffected by the content-shape change).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 3552/3552 passed (187 suites)
- [x] Proven-red: all 3 new regression tests fail on the pre-fix `typing.ts`, pass after restoring the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)