### PR TITLE
docs(memory): disclose <agentId>-<reason>.md filename in tool descriptions

### DIFF
--- a/mcp/tools/memory/module.test.ts
+++ b/mcp/tools/memory/module.test.ts
@@ -62,3 +62,20 @@ test('memory_shared_write: succeeds normally when GATEWAY_AGENT_ID is set', asyn
   const body = JSON.parse((result.content[0] as { text: string }).text);
   expect(body.written).toBe(true);
 });
+
+// claude-gateway#381: the tool descriptions must disclose the actual on-disk
+// filename BEFORE a caller writes, not just leave it discoverable from the
+// returned `path` after the fact — the agentId prefix is load-bearing for
+// memory_shared_delete's ownership scoping (see archive-writer.ts's
+// sharedNoteSlug) and was previously undocumented.
+test('memory_shared_write description discloses the <agentId>-<reason>.md filename scheme', () => {
+  const mod = new MemoryModule();
+  const tool = mod.getTools().find((t) => t.name === 'memory_shared_write');
+  expect(tool?.description).toContain('<your-agent-id>-<reason>.md');
+});
+
+test('memory_shared_delete description cross-references the same filename scheme', () => {
+  const mod = new MemoryModule();
+  const tool = mod.getTools().find((t) => t.name === 'memory_shared_delete');
+  expect(tool?.description).toContain('<your-agent-id>-<reason>.md');
+});

--- a/mcp/tools/memory/module.ts
+++ b/mcp/tools/memory/module.ts
@@ -75,14 +75,14 @@ export class MemoryModule implements ToolModule {
       {
         name: 'memory_shared_write',
         description:
-          'Create or update one note in the shared, cross-agent knowledge base RIGHT NOW, instead of waiting for the nightly automatic promotion. This is an explicit, agent-initiated write (works even when shared-KB mode is "propose") — not a bypass of nightly auto-promotion, which is unaffected and unrelated. Notes are identified by "reason" (per-agent, stable): calling again with the same "reason" targets the SAME note. By default this fails if a note for that "reason" already exists — pass force:true to overwrite it (update). The note becomes searchable via memory_search (corpus "shared" or "all") shortly after this call returns.',
+          'Create or update one note in the shared, cross-agent knowledge base RIGHT NOW, instead of waiting for the nightly automatic promotion. This is an explicit, agent-initiated write (works even when shared-KB mode is "propose") — not a bypass of nightly auto-promotion, which is unaffected and unrelated. Notes are identified by "reason" (per-agent, stable): calling again with the same "reason" targets the SAME note. The note is saved as "<your-agent-id>-<reason>.md" in the shared vault — the agent id is always prefixed to the filename and cannot be omitted; this keeps notes from colliding across agents and scopes memory_shared_delete to only the notes you wrote. By default this fails if a note for that "reason" already exists — pass force:true to overwrite it (update). The note becomes searchable via memory_search (corpus "shared" or "all") shortly after this call returns.',
         inputSchema: {
           type: 'object',
           properties: {
             content: { type: 'string', description: 'Full note body to write into the shared KB. Max 100KB.' },
             reason: {
               type: 'string',
-              description: 'Short slug identifying this note, e.g. "deploy-runbook". Stable identity — reuse it to update the same note later.',
+              description: 'Short slug identifying this note, e.g. "deploy-runbook". Stable identity — reuse it to update the same note later. Saved as "<your-agent-id>-<reason>.md", not a literal "<reason>.md".',
             },
             force: {
               type: 'boolean',
@@ -96,7 +96,7 @@ export class MemoryModule implements ToolModule {
       {
         name: 'memory_shared_delete',
         description:
-          'Delete one note this agent previously wrote to the shared knowledge base via memory_shared_write, by its "reason". Only notes this agent itself wrote can be targeted (identity is scoped to the calling agent) — this cannot delete another agent\'s notes or notes the nightly dreaming pipeline promoted.',
+          'Delete one note this agent previously wrote to the shared knowledge base via memory_shared_write, by its "reason". Only notes this agent itself wrote can be targeted — identity is scoped to the calling agent via the same "<your-agent-id>-<reason>.md" filename memory_shared_write uses — so this cannot delete another agent\'s notes or notes the nightly dreaming pipeline promoted.',
         inputSchema: {
           type: 'object',
           properties: {


### PR DESCRIPTION
## Summary
Fixes claude-gateway#381 — `memory_shared_write`'s tool description implied the caller controls the shared-KB note's filename via `reason`, but the actual on-disk filename is always `<agentId>-<reason>.md`. This is only discoverable after the fact from the returned `path`, not before the write, so a calling agent could tell its user the wrong filename.

## Root cause (re-verified against current `main`)
- `mcp/tools/memory/module.ts` (`memory_shared_write`/`memory_shared_delete` tool descriptions) never mentioned the agentId prefix.
- `mcp/tools/memory/archive-writer.ts`'s `sharedNoteSlug(agentId, reason)` deliberately builds `<agentId>-<reason>` — intentional, load-bearing for `memory_shared_delete`'s ownership scoping (a delete can only target notes the calling agent itself wrote). This prefixing must NOT change.
- `API.md`/`README.md` already document the `<agentId>-<reason>` naming scheme correctly — only the MCP tool's own in-session `description` field (what the calling agent reads before acting) was missing it.

## Fix
Description-only change, no behavior change:
- `memory_shared_write`'s description and its `reason` parameter description now state the note is saved as `"<your-agent-id>-<reason>.md"`, not a literal `"<reason>.md"`.
- `memory_shared_delete`'s description cross-references the same filename scheme to explain why ownership scoping works the way it does.

## Regression tests
Added to `mcp/tools/memory/module.test.ts`:
- `memory_shared_write description discloses the <agentId>-<reason>.md filename scheme`
- `memory_shared_delete description cross-references the same filename scheme`

**Proven to fail on the pre-fix code** — reverted the description change, both new tests failed (`toContain` mismatch against the un-updated description text); restored the fix, all 5 tests in the file pass.

## Acceptance criteria (from #381)
- [x] `memory_shared_write` tool description explicitly documents the `<agentId>-<reason>.md` naming scheme
- [x] `memory_shared_delete` tool description cross-references the same naming scheme for clarity
- [x] No behavior/API change — description text only

## Out of scope (per #381)
- No option added to opt out of the agentId prefix — would break `memory_shared_delete`'s ownership-scoping guarantee.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `bun test` (mcp/) — 23/23 passed, including the 2 new tests
- [x] `npm test` (jest) — 3553/3553 passed (187 suites) — unaffected, confirms no behavioral regression
- [x] Proven-red: both new tests fail on the pre-fix description text, pass after restoring the fix
- [x] `API.md`/`README.md` checked — already correct, no update needed (they document the naming scheme; only the in-session tool description was missing it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)