### PR TITLE
fix(shell): track every foreground tool call, not just Task, in the fallback idle gate

### DIFF
--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -683,8 +683,9 @@ class Driver {
       { isBusy: this.screen.isBusy(), quietMs: this.screen.quietMs() },
       HEARTBEAT_LIVENESS_QUIET_MS,
     )
-      // A pending Task sub-agent runs invisibly (sidechain records, quiet
-      // screen) — keep writing the heartbeat so the receiver's stalled
+      // A pending tool call (Task's invisible sub-agent, or a quiet
+      // foreground tool like Bash) can leave the screen quiet with no PTY
+      // output — keep writing the heartbeat so the receiver's stalled
       // detector doesn't tear the session down in exactly the window the
       // pendingToolUseIds gate is holding the turn open for.
       || (this.turn ? this.turn.pendingToolUseIds.size > 0 : false);

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -109,17 +109,20 @@ interface ActiveTurn {
    *  menuToolSeen — see maybeProbeAndBridge()/advanceProbe() below and
    *  planning-61. */
   probe: ProbeState | null;
-  /** tool_use ids for **Task** calls from this turn's own (non-sidechain)
-   *  assistant records that have no matching tool_result yet. A Task tool call
-   *  runs an invisible sub-agent whose own work writes only sidechain
-   *  transcript records — the screen can look idle (no busy marker, quiet ≥
-   *  FALLBACK_IDLE_QUIET_MS) for stretches while it's genuinely still running.
-   *  Non-empty blocks the fallback end-of-turn heuristic so it can never end
-   *  the turn out from under a pending sub-agent. Only Task is tracked:
-   *  ordinary foreground tools (Bash/Read/Edit…) keep the TUI busy, so they
-   *  never reach the fallback anyway, and tracking them would let an
-   *  interrupted-mid-tool turn (no tool_result ever lands) block the fallback
-   *  forever. */
+  /** tool_use ids for ANY tool call from this turn's own (non-sidechain)
+   *  assistant records that have no matching tool_result yet. Originally only
+   *  Task calls were tracked here, on the assumption that ordinary foreground
+   *  tools (Bash/Read/Edit…) always keep the TUI busy or the screen changing.
+   *  That assumption is false for a quiet, long-running foreground tool (e.g.
+   *  a git hook running a slow, mostly-silent test suite): the screen can
+   *  look idle (no busy marker, quiet ≥ FALLBACK_IDLE_QUIET_MS) for stretches
+   *  while it's genuinely still running — same shape as a Task sub-agent
+   *  (issue #388). Non-empty blocks the fallback end-of-turn heuristic so it
+   *  can never end the turn out from under any pending tool call. An
+   *  interrupted-mid-tool turn (no tool_result ever lands) is not left stuck
+   *  forever either: the watchdog below (WATCHDOG_MS) ends the turn with an
+   *  error, session preserved, exactly as it already did for an orphaned
+   *  Task. */
   pendingToolUseIds: Set<string>;
 }
 
@@ -445,16 +448,16 @@ class Driver {
     }
   }
 
-  /** A tool_use block appeared in this turn's transcript. Only **Task** calls
-   *  are tracked (see ActiveTurn.pendingToolUseIds) — they run an invisible
-   *  sub-agent that can leave the screen idle-quiet while still in flight. */
-  private onToolUse(toolUseId: string, toolName: string): void {
-    if (this.turn && toolName === 'Task') {
+  /** A tool_use block appeared in this turn's transcript. Every tool is
+   *  tracked (see ActiveTurn.pendingToolUseIds) — any of them can leave the
+   *  screen idle-quiet for a stretch while still genuinely in flight. */
+  private onToolUse(toolUseId: string, _toolName: string): void {
+    if (this.turn) {
       this.turn.pendingToolUseIds.add(toolUseId);
     }
   }
 
-  /** A non-sidechain tool_result landed — clears the pending Task gate on the
+  /** A non-sidechain tool_result landed — clears the pending-tool gate on the
    *  fallback end-of-turn heuristic (see ActiveTurn.pendingToolUseIds) and
    *  counts as progress so the watchdog's clock resets. */
   private onToolResult(toolUseId: string): void {
@@ -841,10 +844,11 @@ class Driver {
 
     // Fallback end-of-turn (e.g. interrupted turn never writes turn_duration):
     // ran → idle prompt → quiet, and we already streamed assistant output.
-    // pendingToolUseIds must be empty too — a Task tool call's sub-agent runs
-    // invisibly (its own transcript records are sidechain and filtered out),
-    // so the screen can look idle-quiet for stretches while the turn is
-    // genuinely still in flight (see onToolResult()/pendingToolUseIds above).
+    // pendingToolUseIds must be empty too — any tool call (Task's invisible
+    // sub-agent, or an ordinary foreground tool like Bash sitting quiet
+    // through a long hook/build) can leave the screen looking idle-quiet for
+    // stretches while the turn is genuinely still in flight (see
+    // onToolResult()/pendingToolUseIds above; issue #388).
     if (turn.sawBusy && turn.sawAssistant
         && turn.pendingToolUseIds.size === 0
         && this.screen.hasPrompt()
@@ -856,15 +860,16 @@ class Driver {
 
     if (now - turn.lastProgressAt > WATCHDOG_MS) {
       if (turn.pendingToolUseIds.size > 0) {
-        // A pending Task held the turn past the watchdog: either a genuinely
-        // long sub-agent that stayed screen-quiet the whole time, or an
-        // orphaned tool_use whose result never landed. End the turn with an
-        // error but keep the PTY session alive — killing it would drop queued
-        // messages and is unrecoverable, whereas a stuck/slow sub-agent is
-        // turn-local. (Distinct from the no-progress kill below, which means
-        // the whole TUI has wedged.)
-        logWarn(`pending Task exceeded ${WATCHDOG_MS}ms without a result — ending turn, session preserved`);
-        this.finishTurn(true, `sub-agent did not complete within ${WATCHDOG_MS}ms`);
+        // A pending tool call held the turn past the watchdog: either a
+        // genuinely long-running call (sub-agent or foreground tool) that
+        // stayed screen-quiet the whole time, or an orphaned tool_use whose
+        // result never landed. End the turn with an error but keep the PTY
+        // session alive — killing it would drop queued messages and is
+        // unrecoverable, whereas a stuck/slow tool call is turn-local.
+        // (Distinct from the no-progress kill below, which means the whole
+        // TUI has wedged.)
+        logWarn(`pending tool call exceeded ${WATCHDOG_MS}ms without a result — ending turn, session preserved`);
+        this.finishTurn(true, `tool call did not complete within ${WATCHDOG_MS}ms`);
         return;
       }
       this.finishTurn(true, `no progress for ${WATCHDOG_MS}ms — giving up`);

--- a/tests/helpers/mock-claude-tui-menu.js
+++ b/tests/helpers/mock-claude-tui-menu.js
@@ -66,6 +66,10 @@
  *                          detection heuristic would wrongly end the turn at
  *                          ~2s here too, submitting the next queued message
  *                          into a still-busy TUI (issue #388).
+ *   BASH_ORPHAN         — like TASK_ORPHAN, but for an ordinary foreground
+ *                          tool (Bash): its tool_result never arrives. Proves
+ *                          the watchdog's "session preserved" recovery isn't
+ *                          Task-specific either.
  *   …SWALLOW_ONCE…      — (substring anywhere in the text) the first Enter
  *                          is swallowed: the draft stays in the input line
  *                          ("❯ <text>"), never busy, no transcript. The
@@ -290,6 +294,25 @@ function submit(text) {
       });
       writeTranscript('bash-wait-final-result');
     }, 4500);
+    return;
+  }
+  if (trimmed === 'BASH_ORPHAN') {
+    // Like TASK_ORPHAN, but for an ordinary foreground tool (Bash): a
+    // tool_use lands but its tool_result NEVER arrives (the shell command
+    // hung or the process died) and no turn_duration is written. The
+    // fallback stays blocked (pendingToolUseIds never empties); the
+    // watchdog must end the turn with an error WITHOUT killing the PTY
+    // session — the same "session preserved" branch that TASK_ORPHAN
+    // proves, now exercised for a non-Task tool name (issue #388).
+    scenario = null;
+    render('esc to interrupt\r\n❯ ');
+    setTimeout(() => {
+      appendRecord({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'bash-2', name: 'Bash', input: {} }] },
+      });
+      idle(); // then silence — no tool_result, no turn_duration, ever.
+    }, 150);
     return;
   }
 

--- a/tests/helpers/mock-claude-tui-menu.js
+++ b/tests/helpers/mock-claude-tui-menu.js
@@ -57,6 +57,15 @@
  *                          arrives. The watchdog must end the turn with an
  *                          error WITHOUT killing the session (run with a
  *                          shortened PTY_SHELL_WATCHDOG_MS).
+ *   BASH_WAIT           — like TASK_WAIT, but the tool_use is an ORDINARY
+ *                          foreground tool (Bash), simulating a quiet,
+ *                          long-running shell command (e.g. a git hook
+ *                          running a slow test suite) rather than a Task
+ *                          sub-agent. Pre-fix, only Task calls were tracked
+ *                          in pendingToolUseIds, so the fallback idle-
+ *                          detection heuristic would wrongly end the turn at
+ *                          ~2s here too, submitting the next queued message
+ *                          into a still-busy TUI (issue #388).
  *   …SWALLOW_ONCE…      — (substring anywhere in the text) the first Enter
  *                          is swallowed: the draft stays in the input line
  *                          ("❯ <text>"), never busy, no transcript. The
@@ -253,6 +262,34 @@ function submit(text) {
       });
       idle(); // then silence — no tool_result, no turn_duration, ever.
     }, 150);
+    return;
+  }
+  if (trimmed === 'BASH_WAIT') {
+    // Simulates an ordinary foreground tool (Bash) staying quiet for LONGER
+    // than FALLBACK_IDLE_QUIET_MS (2000ms) — e.g. a git hook running a slow,
+    // mostly-silent test suite. Same shape as TASK_WAIT, but the tool_use
+    // name is a foreground tool, not Task. Pre-fix, onToolUse() only tracked
+    // 'Task' calls into pendingToolUseIds, so this scenario's tool_use would
+    // be ignored and the fallback would end the turn at ~2s, submitting the
+    // next queued message into a still-busy TUI (issue #388).
+    scenario = null;
+    render('esc to interrupt\r\n❯ ');
+    setTimeout(() => {
+      appendRecord({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'bash-1', name: 'Bash', input: {} }] },
+      });
+      idle(); // busy marker gone — screen looks done, but the tool_use is still pending
+    }, 150);
+    // Same wide margin as TASK_WAIT (4500ms vs. the test's 2600ms assertion
+    // window) so the two-process wall-clock race doesn't flake under CI load.
+    setTimeout(() => {
+      appendRecord({
+        type: 'user',
+        message: { content: [{ type: 'tool_result', tool_use_id: 'bash-1', content: 'exit 0' }] },
+      });
+      writeTranscript('bash-wait-final-result');
+    }, 4500);
     return;
   }
 

--- a/tests/integration/pty-menu-probe.test.ts
+++ b/tests/integration/pty-menu-probe.test.ts
@@ -403,4 +403,37 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     );
     expect(second).toBe(true);
   }, 25000);
+
+  /**
+   * I-PTY-MENU-14: an ordinary foreground tool (Bash), not Task, staying
+   * screen-quiet for longer than FALLBACK_IDLE_QUIET_MS while genuinely still
+   * running (e.g. a git hook running a slow, silent test suite). Pre-fix,
+   * only Task tool_use blocks were tracked in pendingToolUseIds, so this
+   * shape reached the fallback exactly like TASK_WAIT's sub-agent gap and
+   * the turn ended early (issue #388). Mirrors I-PTY-MENU-11 but with a
+   * non-Task tool name, proving the fix isn't Task-specific.
+   */
+  it('I-PTY-MENU-14: a pending non-Task tool_use (Bash) blocks the fallback idle finish until its tool_result lands', async () => {
+    start();
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('BASH_WAIT'));
+
+    // The Bash call is still "running" (screen quiet, no busy marker, no
+    // tool_result yet) — the pre-fix fallback would already have ended the
+    // turn by ~2s. It must still be open.
+    await waitMs(2600);
+    expect(collector.find((e) => e.type === 'result')).toBeUndefined();
+
+    // Once the tool_result + final answer land, the turn completes with the
+    // real text — not an early, truncated one.
+    const completed = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      5000,
+    );
+    expect(completed).toBe(true);
+    const result = collector.find((e) => e.type === 'result') as ProtocolEvent & { subtype: string; result?: string };
+    expect(result.subtype).toBe('success');
+    expect(result.result).toContain('bash-wait-final-result');
+  }, 20000);
 });

--- a/tests/integration/pty-menu-probe.test.ts
+++ b/tests/integration/pty-menu-probe.test.ts
@@ -436,4 +436,37 @@ describe('I-PTY-MENU-PROBE: behavioral probe confirms/rejects a live overlay', (
     expect(result.subtype).toBe('success');
     expect(result.result).toContain('bash-wait-final-result');
   }, 20000);
+
+  /**
+   * I-PTY-MENU-15: an orphaned non-Task tool_use (Bash) — no tool_result, no
+   * turn_duration ever — must NOT hang forever or kill the session, same as
+   * I-PTY-MENU-13 for Task. Proves the watchdog's "session preserved"
+   * recovery branch isn't Task-specific either (issue #388).
+   */
+  it('I-PTY-MENU-15: an orphaned non-Task tool_use (Bash) ends via the watchdog with an error, session survives', async () => {
+    start({ PTY_SHELL_WATCHDOG_MS: '1500' });
+    await waitMs(2500);
+
+    wrapper.stdin!.write(makeTurnJson('BASH_ORPHAN'));
+
+    // No tool_result ever comes; the shortened watchdog (1500ms after the last
+    // progress) must end the turn with an error rather than hang.
+    const ended = await waitFor(
+      () => !!collector.find((e) => e.type === 'result'),
+      6000,
+    );
+    expect(ended).toBe(true);
+    const result = collector.find((e) => e.type === 'result') as ProtocolEvent & { subtype: string; is_error?: boolean };
+    expect(result.is_error).toBe(true);
+
+    // Session must still be alive (watchdog did NOT shutdown) — a fresh turn
+    // still completes, producing a second result event.
+    expect(wrapper.exitCode).toBeNull();
+    wrapper.stdin!.write(makeTurnJson('hello again'));
+    const second = await waitFor(
+      () => collector.events.filter((e) => e.type === 'result').length >= 2,
+      6000,
+    );
+    expect(second).toBe(true);
+  }, 25000);
 });


### PR DESCRIPTION
## Summary
- Closes #388
- `Driver.onToolUse()` in `src/shell/claude-pty-shell.ts` previously tracked only `Task` tool_use blocks in `pendingToolUseIds`, on the assumption that ordinary foreground tools (Bash/Read/Edit...) always keep the TUI busy or the screen changing.
- A long, screen-quiet foreground tool call (e.g. a `git` pre-push hook running a slow test suite) breaks that assumption: the wrapper's fallback end-of-turn heuristic wrongly concludes the turn ended after `FALLBACK_IDLE_QUIET_MS` (2000ms) of silence, submits the next queued message into a TUI that's still genuinely busy, and the swallowed Enter surfaces as `"failed to submit turn to the TUI input"` after retries are exhausted.
- Fix: `onToolUse()` now tracks every tool_use id regardless of name, using the tool-name-agnostic `onToolUse`/`onToolResult` events `TranscriptTailer` already emits for any (non-sidechain) tool. An interrupted-mid-tool turn whose `tool_result` never lands is still recovered by the existing `WATCHDOG_MS` path (turn ends with an error, session preserved) — exactly as it already handled an orphaned `Task` call.

## Test plan
- [x] Added a `BASH_WAIT` scenario to `tests/helpers/mock-claude-tui-menu.js`, mirroring `TASK_WAIT` but with an ordinary foreground tool name (`Bash`) instead of `Task`.
- [x] Added `I-PTY-MENU-14` to `tests/integration/pty-menu-probe.test.ts`, asserting the fallback idle heuristic does not end the turn while the Bash tool_use is pending, and that the turn completes with the real result once its tool_result lands.
- [x] Verified the new test **fails on the pre-fix code**: temporarily reverted `onToolUse()` to the `toolName === 'Task'` filter, rebuilt, confirmed `I-PTY-MENU-14` fails (empty/early result), then restored the fix.
- [x] Existing Task-specific integration tests (`I-PTY-MENU-11/12/13`) and `pty-stop-stuck-input.test.ts` pass unchanged.
- [x] `npm run typecheck` clean.
- [x] Full suite green: 187 suites / 3554 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>