### PR TITLE
fix(session): skill-learning restart no longer SIGKILLs sessions with in-flight background sub-agents

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2421,6 +2421,21 @@ export class AgentRunner extends EventEmitter {
         }
         proc.markPendingRestart();
         deferred++;
+      } else if (proc.hasLikelyOutstandingBackgroundWork() && proc.source !== 'api') {
+        // A session that dispatched a background Agent/Workflow tool_use and then
+        // ended its OWN turn looks idle here, but a sub-agent it launched may
+        // still be doing real work — SIGKILLing it now would silently destroy
+        // that in-flight work with no notification or recovery (the incident
+        // this guards against: a CLAUDE.md-triggered restart killed a session
+        // mid-way through 3 dispatched code-review sub-agents). Treat it like
+        // deferIdle below regardless of which tier called restartOrDefer —
+        // lossless respawn on its next message, never an immediate stop.
+        //
+        // Same `source !== 'api'` guard as deferIdle below, for the same reason:
+        // `pendingRestarts` is only ever consumed by the channel-turn path
+        // (injectTurn), so arming it for an api-sourced session would leak.
+        this.pendingRestarts.add(id);
+        deferred++;
       } else if (deferIdle && proc.source !== 'api') {
         // Lossless deferral for CHANNEL sessions only: leave the idle process
         // running and arm a restart on its next message (mirrors the

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2421,27 +2421,25 @@ export class AgentRunner extends EventEmitter {
         }
         proc.markPendingRestart();
         deferred++;
-      } else if (proc.hasLikelyOutstandingBackgroundWork() && proc.source !== 'api') {
-        // A session that dispatched a background Agent/Workflow tool_use and then
-        // ended its OWN turn looks idle here, but a sub-agent it launched may
-        // still be doing real work — SIGKILLing it now would silently destroy
-        // that in-flight work with no notification or recovery (the incident
-        // this guards against: a CLAUDE.md-triggered restart killed a session
-        // mid-way through 3 dispatched code-review sub-agents). Treat it like
-        // deferIdle below regardless of which tier called restartOrDefer —
-        // lossless respawn on its next message, never an immediate stop.
-        //
-        // Same `source !== 'api'` guard as deferIdle below, for the same reason:
-        // `pendingRestarts` is only ever consumed by the channel-turn path
-        // (injectTurn), so arming it for an api-sourced session would leak.
-        this.pendingRestarts.add(id);
-        deferred++;
-      } else if (deferIdle && proc.source !== 'api') {
-        // Lossless deferral for CHANNEL sessions only: leave the idle process
-        // running and arm a restart on its next message (mirrors the
-        // image-size-threshold path). Do NOT call proc.markPendingRestart() here
-        // — on an idle process it fires deferredRestartReady immediately and
-        // stops the session.
+      } else if ((proc.hasLikelyOutstandingBackgroundWork() || deferIdle) && proc.source !== 'api') {
+        // Lossless deferral for CHANNEL sessions: leave the idle process running
+        // and arm a restart on its next message instead of an immediate stop.
+        // Two independent reasons land here, neither gated by skipBusy (which
+        // only governs the isProcessing branch above — a session that's already
+        // idle isn't the self-restart-footgun case skipBusy exists for):
+        //   - deferIdle: the caller explicitly asked never to SIGKILL an idle
+        //     bystander (mirrors the image-size-threshold path).
+        //   - hasLikelyOutstandingBackgroundWork(): regardless of which tier
+        //     called restartOrDefer — even today's aggressive default — a
+        //     session that dispatched a background Agent/Workflow tool_use and
+        //     then ended its OWN turn looks idle here, but a sub-agent it
+        //     launched may still be doing real work. SIGKILLing it now would
+        //     silently destroy that in-flight work with no notification or
+        //     recovery (the incident this guards against: a CLAUDE.md-triggered
+        //     restart killed a session mid-way through 3 dispatched code-review
+        //     sub-agents).
+        // Do NOT call proc.markPendingRestart() here — on an idle process it
+        // fires deferredRestartReady immediately and stops the session.
         //
         // Guard on source: `pendingRestarts` is consumed ONLY in injectTurn (the
         // channel turn path, keyed by chatId). api / __heartbeat__ sessions are

--- a/src/agent/workspace-loader.ts
+++ b/src/agent/workspace-loader.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { WorkspaceFiles, LoadedWorkspace, WatchHandle } from '../types';
 import { createWatcher } from '../watch/factory';
 import { loadSkills, renderSkillsSection } from '../skills';
+import { DIARY_FILENAME } from './skill-learning/notifier';
 
 export class MissingRequiredFileError extends Error {
   constructor(fileName: string) {
@@ -407,9 +408,23 @@ const WATCH_DEBOUNCE_MS = 300;
  *   composed into CLAUDE.md exactly like SOUL/AGENTS, so it belongs in this tier
  *   for the same reason — omitting it would SIGKILL idle sessions on an
  *   IDENTITY.md write while deferring the semantically identical SOUL write.
+ *
+ * SKILL_LEARNING_FILES — the skill-learning diary (SKILLS_LEARNED.md, written by
+ *   the auto skill-create/update pipeline, not the live conversation). Unlike
+ *   MEMORY_FILES, the session whose transcript was reviewed is very often NOT
+ *   the one that needs restarting — other idle sessions on the same agent don't
+ *   already hold the new skill, so `none` would be wrong. It gets the same
+ *   `defer-idle` treatment as IDENTITY_FILES instead: reach sessions on their
+ *   next message, never SIGKILL one that's idle only because it dispatched a
+ *   background Agent/Workflow sub-agent and is waiting on it (see
+ *   hasLikelyOutstandingBackgroundWork() in session/process.ts — that guard
+ *   covers every restart tier, but keeping this file out of the aggressive
+ *   `restart` tier in the first place is the direct fix for the incident that
+ *   surfaced it).
  */
 export const MEMORY_FILES = new Set<string>(['MEMORY.md', 'USER.md']);
 export const IDENTITY_FILES = new Set<string>(['SOUL.md', 'AGENTS.md', 'IDENTITY.md']);
+export const SKILL_LEARNING_FILES = new Set<string>([DIARY_FILENAME]);
 
 /**
  * Union of the two tiers — kept for callers that only need "did the agent write
@@ -418,6 +433,7 @@ export const IDENTITY_FILES = new Set<string>(['SOUL.md', 'AGENTS.md', 'IDENTITY
 export const AGENT_WRITABLE_FILES = new Set<string>([
   ...MEMORY_FILES,
   ...IDENTITY_FILES,
+  ...SKILL_LEARNING_FILES,
 ]);
 
 /**
@@ -428,8 +444,9 @@ export const AGENT_WRITABLE_FILES = new Set<string>([
  *                  the writing session already holds the change and every future
  *                  spawn reads the recomposed CLAUDE.md, so a restart is pure
  *                  downside. A memory write can never drop a live session.
- *  - `defer-idle`  Operator identity (SOUL.md/AGENTS.md/IDENTITY.md), possibly
- *                  mixed with memory files: skip busy sessions (self-restart footgun) and
+ *  - `defer-idle`  Operator identity (SOUL.md/AGENTS.md/IDENTITY.md) or the
+ *                  skill-learning diary (SKILLS_LEARNED.md), possibly mixed with
+ *                  memory files: skip busy sessions (self-restart footgun) and
  *                  defer idle ones (lossless respawn on next message) — never
  *                  SIGKILL an idle bystander.
  *  - `restart`     Any non-agent-writable change (HEARTBEAT.md, operator config,

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -32,6 +32,23 @@ const CHANNEL_REPLY_TOOLS = new Set([
   'mcp__gateway__line_reply',
 ]);
 
+// Tool names whose tool_use dispatches genuinely background work: the call
+// itself returns immediately (a task/agent id), and completion is delivered
+// later as a separate, asynchronously-injected turn (a task-notification) —
+// never as this tool_use's own tool_result. A session that ends its own turn
+// right after dispatching one of these is legitimately idle *from the CLI's
+// perspective* while real work is still in flight elsewhere. See
+// BACKGROUND_AGENT_GRACE_MS and hasLikelyOutstandingBackgroundWork() below.
+const BACKGROUND_DISPATCH_TOOLS = new Set(['Agent', 'Workflow']);
+// How long a session is treated as "may still have outstanding background
+// work" after dispatching one of BACKGROUND_DISPATCH_TOOLS, once its own turn
+// has ended. Generous enough to cover a multi-agent review of a large diff
+// (the incident that motivated this — a config-driven restart SIGHUP'd a
+// session mid-review, killing 3 in-flight review sub-agents with it, see
+// issue referenced in restartOrDefer below); bounded so a dispatch that never
+// reports back (crashed, errored) can't block a config rollout forever.
+const BACKGROUND_AGENT_GRACE_MS = 15 * 60 * 1000;
+
 // Shared wording for a turn that ended (gracefully or via a mid-turn exit) with no
 // assistant text at all — used both to patch the in-memory prompt fed to the next
 // spawn (buildInitialPrompt below) and, in AgentRunner, to persist a real assistant
@@ -101,6 +118,14 @@ export class SessionProcess extends EventEmitter {
   readonly source: ChatChannelOrApi;
   private readonly sessionChannel: ChatChannel;
   lastActivityAt = Date.now(); // accessible by AgentRunner for eviction sort
+  // Wall-clock time of the most recent BACKGROUND_DISPATCH_TOOLS tool_use seen
+  // in this session's own turn, while no NEWER turn has started since. Cleared
+  // whenever a fresh turn begins (setProcessing(true)) since by then the
+  // dispatch either reported back (the notification woke this turn) or has
+  // been superseded by unrelated new work — either way the idle-window concern
+  // this field exists for no longer applies. Read via
+  // hasLikelyOutstandingBackgroundWork().
+  private lastBackgroundAgentDispatchAt: number | null = null;
   readonly spawnedAt = Date.now();
   /** Backend used to run the subprocess. Set during start(); 'headless' until then. */
   backend: 'pty-shell' | 'headless' = 'headless';
@@ -850,6 +875,20 @@ export class SessionProcess extends EventEmitter {
               lastPartialText = '';
             }
 
+            // Record a background-dispatch tool_use (see BACKGROUND_DISPATCH_TOOLS)
+            // so restartOrDefer can tell "genuinely idle" apart from "idle because
+            // it just fired off async work and is waiting on a task-notification".
+            // Only the final (non-partial) message carries a fully materialised
+            // tool_use block, same as the reply-mirror check above.
+            if (!isPartial && !this.queryMode) {
+              for (const block of obj.message.content) {
+                if (block.type === 'tool_use' && BACKGROUND_DISPATCH_TOOLS.has(block.name)) {
+                  this.lastBackgroundAgentDispatchAt = Date.now();
+                  break;
+                }
+              }
+            }
+
             // Mirror channel replies (telegram_reply/discord_reply/line_reply) into
             // the resumable session store at delivery time. The user-facing text is
             // carried in the tool_use input, not a text block, so assistantBuffer
@@ -1259,6 +1298,13 @@ export class SessionProcess extends EventEmitter {
   setProcessing(active: boolean): void {
     if (this._processing !== active) {
       this._processing = active;
+      if (active) {
+        // A fresh turn is starting — either the notification this dispatch was
+        // waiting on just woke it (resolved), or unrelated new work superseded
+        // it (moot either way). isProcessing now covers this session correctly
+        // on its own, so the idle-window concern this field exists for is over.
+        this.lastBackgroundAgentDispatchAt = null;
+      }
       this.emit('processingChange', active);
       if (this.source === 'telegram') {
         const processingPath = path.join(this.typingDir, `${this.chatId}.processing`);
@@ -1342,6 +1388,20 @@ export class SessionProcess extends EventEmitter {
 
   isIdle(idleMs: number): boolean {
     return Date.now() - this.lastActivityAt > idleMs;
+  }
+
+  /**
+   * True when this session's own turn has ended (not `isProcessing`) but it
+   * recently dispatched a BACKGROUND_DISPATCH_TOOLS tool_use — i.e. it looks
+   * idle from the outside while a sub-agent it launched may still be doing
+   * real work. `restartOrDefer` treats this the same as `isProcessing` so a
+   * config-driven restart never SIGKILLs a session mid-dispatch, regardless of
+   * which restart tier triggered it.
+   */
+  hasLikelyOutstandingBackgroundWork(): boolean {
+    if (this._processing) return false;
+    if (this.lastBackgroundAgentDispatchAt === null) return false;
+    return Date.now() - this.lastBackgroundAgentDispatchAt < BACKGROUND_AGENT_GRACE_MS;
   }
 
   isRunning(): boolean {

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -871,6 +871,89 @@ describe('AgentRunner — restartOrDefer', () => {
     expect(getSessions(runner).has('chat:web')).toBe(true);
     expect(pending.has('chat:web')).toBe(true);
   }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS12: REGRESSION — the incident this guards against. A session dispatches a
+  //       background Agent tool_use, ends its OWN turn (idle from the outside),
+  //       and THEN an aggressive restart tier (skipBusy:false, deferIdle:false —
+  //       exactly what a non-agent-writable CLAUDE.md change uses) must NOT
+  //       SIGKILL it. Before this fix it fell straight to toStopNow: isProcessing
+  //       was false and deferIdle was false, so it was stopped immediately,
+  //       destroying whatever the dispatched sub-agent was still doing.
+  // --------------------------------------------------------------------------
+  it('RS12: a session with a dispatched-but-unresolved background Agent call is deferred, not SIGKILLed, even under the aggressive default tier', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:review', 'review this PR');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:review')!;
+    const rawProc = allProcesses[allProcesses.length - 1];
+    // The session dispatches a background sub-agent mid-turn…
+    const dispatchLine = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_1', name: 'Agent', input: {} }] },
+      stop_reason: 'tool_use',
+    });
+    rawProc.stdout!.emit('data', Buffer.from(dispatchLine + '\n'));
+    // …then its OWN turn ends right after (matches the observed session_idle
+    // pattern: "I'll wait for the sub-agents" → turn over, nothing more to do
+    // right now from the CLI's own perspective).
+    sess.setProcessing(false);
+
+    const stopSpy = jest.spyOn(sess, 'stop');
+    const pending = (runner as unknown as { pendingRestarts: Set<string> }).pendingRestarts;
+
+    // The exact call the CLAUDE.md-change ("restart" tier) path makes — no
+    // deferIdle, no skipBusy. This is what SIGKILLed the session in the incident.
+    const counts = await runner.restartOrDefer({ skipBusy: false });
+
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:review')).toBe(true);
+    expect(pending.has('chat:review')).toBe(true);
+    expect(counts).toEqual({ immediate: 0, deferred: 1, skipped: 0 });
+  }, 15000);
+
+  // --------------------------------------------------------------------------
+  // RS13: once the dispatch resolves (a fresh turn starts, e.g. the woken
+  //       notification) and ends without a new dispatch, the SAME aggressive
+  //       tier stops it immediately again — the protection is not permanent or
+  //       accidentally sticky.
+  // --------------------------------------------------------------------------
+  it('RS13: after the background dispatch resolves, the next idle window restarts normally again', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    const port = getCallbackPort(runner);
+    await sendChannelPost(port, 'chat:resolved', 'review this PR');
+    await new Promise(r => setTimeout(r, 100));
+
+    const sess = getSessions(runner).get('chat:resolved')!;
+    const rawProc = allProcesses[allProcesses.length - 1];
+    const dispatchLine = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_2', name: 'Agent', input: {} }] },
+      stop_reason: 'tool_use',
+    });
+    rawProc.stdout!.emit('data', Buffer.from(dispatchLine + '\n'));
+    sess.setProcessing(false);
+    expect(sess.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    // The task-notification wakes the session (a fresh turn) and it ends
+    // normally with no further background dispatch.
+    sess.setProcessing(true);
+    sess.setProcessing(false);
+    expect(sess.hasLikelyOutstandingBackgroundWork()).toBe(false);
+
+    const stopSpy = jest.spyOn(sess, 'stop');
+    const counts = await runner.restartOrDefer({ skipBusy: false });
+
+    expect(stopSpy).toHaveBeenCalled();
+    expect(getSessions(runner).has('chat:resolved')).toBe(false);
+    expect(counts).toEqual({ immediate: 1, deferred: 0, skipped: 0 });
+  }, 15000);
 });
 
 // ── Typing error notification tests ───────────────────────────────────────────

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1091,6 +1091,111 @@ describe('SessionProcess', () => {
   });
 
   // --------------------------------------------------------------------------
+  // hasLikelyOutstandingBackgroundWork() — a session that dispatches a
+  // background Agent/Workflow tool_use and then ends its own turn looks idle
+  // from the outside, but a sub-agent it launched may still be doing real
+  // work. This is the signal restartOrDefer consults so a config-driven
+  // restart never SIGKILLs a session mid-dispatch (the incident: 3 in-flight
+  // code-review sub-agents were destroyed when a skill-learning write
+  // triggered an immediate restart of their idle-but-waiting parent).
+  // --------------------------------------------------------------------------
+
+  function agentDispatchLine(toolName: string): string {
+    return JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'toolu_bg_1', name: toolName, input: {} }],
+      },
+      stop_reason: 'tool_use',
+    });
+  }
+
+  it('BG1: false before any Agent/Workflow dispatch is seen', async () => {
+    const sp = makeSp('chat:bg-none', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(false);
+
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+  });
+
+  it('BG2: true after a final-message Agent tool_use, while idle', async () => {
+    const sp = makeSp('chat:bg-agent', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true); // dispatch happens mid-turn
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Agent') + '\n'));
+    sp.setProcessing(false); // turn ends right after — this is the observed incident shape
+
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+  });
+
+  it('BG3: true after a Workflow dispatch too (same background-task contract as Agent)', async () => {
+    const sp = makeSp('chat:bg-workflow', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Workflow') + '\n'));
+    sp.setProcessing(false);
+
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+  });
+
+  it('BG4: an ordinary tool_use (e.g. Bash) never arms it — no false positive', async () => {
+    const sp = makeSp('chat:bg-bash', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Bash') + '\n'));
+    sp.setProcessing(false);
+
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+  });
+
+  it('BG5: false while the session is actively processing (isProcessing takes precedence)', async () => {
+    const sp = makeSp('chat:bg-processing', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Agent') + '\n'));
+    // Still processing — isProcessing's own branch in restartOrDefer already
+    // covers this session correctly, so this getter defers to it (false here).
+
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+  });
+
+  it('BG6: clears when a fresh turn starts, and does not silently re-arm on that turn ending', async () => {
+    const sp = makeSp('chat:bg-clear', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Agent') + '\n'));
+    sp.setProcessing(false);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    // A fresh turn begins — e.g. the notification this dispatch was waiting on
+    // woke the session, or unrelated new work superseded it.
+    sp.setProcessing(true);
+    // Turn ends with NO new Agent/Workflow dispatch this time.
+    sp.setProcessing(false);
+
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+  });
+
+  it('BG7: expires after BACKGROUND_AGENT_GRACE_MS — a dispatch that never reports back cannot block a restart forever', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-ttl', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Agent') + '\n'));
+    sp.setProcessing(false);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    nowSpy.mockReturnValue(T0 + 16 * 60 * 1000); // +16 min, past the 15-min grace window
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
+  // --------------------------------------------------------------------------
   // U-SP-17: --include-partial-messages flag is in spawn args
   // --------------------------------------------------------------------------
   it('U-SP-17: --include-partial-messages flag is in spawn args', async () => {

--- a/tests/unit/workspace-loader.test.ts
+++ b/tests/unit/workspace-loader.test.ts
@@ -8,6 +8,7 @@ import {
   AGENT_WRITABLE_FILES,
   MEMORY_FILES,
   IDENTITY_FILES,
+  SKILL_LEARNING_FILES,
   classifyWorkspaceRestart,
   resolveMemoryBudget,
   DEFAULT_MEMORY_BUDGET,
@@ -15,6 +16,7 @@ import {
   MissingRequiredFileError,
   buildMemoryIndex,
 } from '../../src/agent/workspace-loader';
+import { DIARY_FILENAME } from '../../src/agent/skill-learning/notifier';
 import { waitFor } from '../helpers/wait-for';
 
 const FIXTURES = path.join(__dirname, '../fixtures/workspaces');
@@ -537,7 +539,7 @@ describe('workspace-loader', () => {
   // -------------------------------------------------------------------------
   // Self-restart footgun guard: agent-writable files skip busy-session restart
   // -------------------------------------------------------------------------
-  it('AGENT_WRITABLE_FILES: contains the memory + identity tiers (incl. IDENTITY.md), not HEARTBEAT/CLAUDE', () => {
+  it('AGENT_WRITABLE_FILES: contains the memory + identity + skill-learning tiers (incl. IDENTITY.md, SKILLS_LEARNED.md), not HEARTBEAT/CLAUDE', () => {
     // Memory-rule files the agent writes about itself/the user
     expect(AGENT_WRITABLE_FILES.has('MEMORY.md')).toBe(true);
     expect(AGENT_WRITABLE_FILES.has('USER.md')).toBe(true);
@@ -545,21 +547,32 @@ describe('workspace-loader', () => {
     expect(AGENT_WRITABLE_FILES.has('SOUL.md')).toBe(true);
     expect(AGENT_WRITABLE_FILES.has('AGENTS.md')).toBe(true);
     expect(AGENT_WRITABLE_FILES.has('IDENTITY.md')).toBe(true);
-    // Files outside both tiers → still trigger a normal restart-or-defer
+    // Skill-learning diary — also agent-self-authored, also deferred, never
+    // SIGKILLed idle (issue that motivated this: a skill-learning auto-edit
+    // triggered a `restart` tier that immediately killed an idle session, taking
+    // its in-flight background sub-agents down with it).
+    expect(AGENT_WRITABLE_FILES.has(DIARY_FILENAME)).toBe(true);
+    expect(AGENT_WRITABLE_FILES.has('SKILLS_LEARNED.md')).toBe(true);
+    // Files outside all tiers → still trigger a normal restart-or-defer
     expect(AGENT_WRITABLE_FILES.has('HEARTBEAT.md')).toBe(false);
     expect(AGENT_WRITABLE_FILES.has('CLAUDE.md')).toBe(false);
   });
 
   // -------------------------------------------------------------------------
-  // Tiered writable sets: memory vs identity (issue #321)
+  // Tiered writable sets: memory vs identity vs skill-learning (issue #321,
+  // extended for the skill-learning tier)
   // -------------------------------------------------------------------------
-  it('MEMORY_FILES/IDENTITY_FILES: partition the writable set correctly', () => {
+  it('MEMORY_FILES/IDENTITY_FILES/SKILL_LEARNING_FILES: partition the writable set correctly', () => {
     expect([...MEMORY_FILES].sort()).toEqual(['MEMORY.md', 'USER.md']);
     expect([...IDENTITY_FILES].sort()).toEqual(['AGENTS.md', 'IDENTITY.md', 'SOUL.md']);
-    // The two tiers are disjoint and their union is exactly AGENT_WRITABLE_FILES.
+    expect([...SKILL_LEARNING_FILES]).toEqual([DIARY_FILENAME]);
+    // The three tiers are pairwise disjoint and their union is exactly
+    // AGENT_WRITABLE_FILES.
     for (const f of MEMORY_FILES) expect(IDENTITY_FILES.has(f)).toBe(false);
+    for (const f of MEMORY_FILES) expect(SKILL_LEARNING_FILES.has(f)).toBe(false);
+    for (const f of IDENTITY_FILES) expect(SKILL_LEARNING_FILES.has(f)).toBe(false);
     expect([...AGENT_WRITABLE_FILES].sort()).toEqual(
-      [...MEMORY_FILES, ...IDENTITY_FILES].sort(),
+      [...MEMORY_FILES, ...IDENTITY_FILES, ...SKILL_LEARNING_FILES].sort(),
     );
   });
 
@@ -584,6 +597,18 @@ describe('workspace-loader', () => {
     // A mix of memory + identity is NOT memory-only → must not restart nothing;
     // identity presence pulls it into the deferred tier.
     expect(classifyWorkspaceRestart(['MEMORY.md', 'SOUL.md'])).toBe('defer-idle');
+  });
+
+  it('classifyWorkspaceRestart: REGRESSION — a skill-learning diary change (or mixed with memory/identity) defers idle, never restarts immediately', () => {
+    // Before this fix, SKILLS_LEARNED.md was outside every safe tier, so an
+    // auto skill-create/update write fell through to the aggressive `restart`
+    // action — which SIGKILLs any session that isn't mid-turn right now,
+    // including one that's idle only because it just dispatched a background
+    // Agent/Workflow sub-agent and is waiting on it.
+    expect(classifyWorkspaceRestart([DIARY_FILENAME])).toBe('defer-idle');
+    expect(classifyWorkspaceRestart(['SKILLS_LEARNED.md'])).toBe('defer-idle');
+    expect(classifyWorkspaceRestart(['SKILLS_LEARNED.md', 'MEMORY.md'])).toBe('defer-idle');
+    expect(classifyWorkspaceRestart(['SKILLS_LEARNED.md', 'SOUL.md'])).toBe('defer-idle');
   });
 
   it('classifyWorkspaceRestart: non-writable or empty change → normal restart', () => {


### PR DESCRIPTION
## Summary
- A skill-learning auto-edit writes `SKILLS_LEARNED.md`, which recomposes `CLAUDE.md` and triggers a workspace-change restart. `classifyWorkspaceRestart` had no safe tier for this file, so it fell to the aggressive default (`'restart'`), which SIGKILLs any session that isn't mid-turn right now
- A session that had just dispatched background `Agent`/`Workflow` sub-agents and ended its own turn (the expected async pattern) looked like an ordinary idle bystander to that check, so it got killed along with whatever its sub-agents were still doing — no notification, no recovery
- This is round A+B of the fix, per the linked issue: (A) the direct trigger, (B) the structural gap that let it be destructive

## Changes

**(A) `src/agent/workspace-loader.ts`** — `SKILLS_LEARNED.md` (`DIARY_FILENAME`) is now classified into the existing `defer-idle` tier (same as `SOUL.md`/`AGENTS.md`/`IDENTITY.md`), not the aggressive default. It's agent-self-authored like `MEMORY_FILES`, but unlike a live session curating its own memory, the session whose transcript was reviewed is often not the one that needs the new skill — other idle sessions don't already hold it, so `'none'` would be wrong; `'defer-idle'` matches.

**(B) `src/session/process.ts`** — `SessionProcess` now records the timestamp of the last `Agent`/`Workflow` tool_use seen in its own stdout stream (the two dispatch-and-notify-later tools in this codebase), and exposes `hasLikelyOutstandingBackgroundWork()`: true while the session is idle, within a bounded 15-minute grace window, cleared as soon as a fresh turn starts (the notification woke it, or unrelated new work superseded it — either way the concern is moot).

**`src/agent/runner.ts`** — `restartOrDefer` now treats `hasLikelyOutstandingBackgroundWork()` the same as `isProcessing`: deferred (lossless, armed for the next message), never immediate-stopped — regardless of which restart tier is calling it. This protects against any other future `'restart'`-tier trigger doing the same destructive thing, not just skill-learning.

## Test plan
- [x] `tests/unit/workspace-loader.test.ts` — extended the tier-partition tests + new `classifyWorkspaceRestart` regression test for `SKILLS_LEARNED.md`. Proven-red: reverted the tier addition, confirmed both tests fail against the pre-fix classification, then restored.
- [x] `tests/unit/session-process.test.ts` — 7 new tests (BG1–BG7) covering `hasLikelyOutstandingBackgroundWork()`: arms on `Agent`/`Workflow` dispatch, no false positive on ordinary tools, `isProcessing` takes precedence, clears on the next turn (and doesn't silently re-arm), and expires past the grace window.
- [x] `tests/unit/agent-runner.test.ts` — 2 new tests (RS12, RS13) at the `restartOrDefer` integration level. RS12 reproduces the exact incident shape (dispatch → own turn ends → the exact `{skipBusy: false}` call the `'restart'` tier makes) and proves the session is deferred, not stopped. RS13 proves the protection isn't permanently sticky — once the dispatch resolves, the next idle window restarts normally again. Proven-red: disabled the new `restartOrDefer` branch, confirmed RS12 fails (stop() gets called), then restored.
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Full jest suite: 3563/3563 pass (187/187 suites)

Docs checked (`API.md`/`README.md`): neither documents `classifyWorkspaceRestart`'s tiers or `restartOrDefer` — this is internal session-lifecycle plumbing, not a documented public behavior, so no doc update needed.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)