### PR TITLE
fix(telegram): keep typing while background agents run

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1885,10 +1885,13 @@ export class AgentRunner extends EventEmitter {
             // `session_idle` once it is truly done; headless mode only produces
             // one `result` per message, so the timer pattern still applies there.
             if (proc.backend !== 'pty-shell') {
-              typingDoneTimer = setTimeout(() => {
-                this.writeTypingDone(mapKey);
-                typingDoneTimer = null;
-              }, TYPING_DONE_DELAY_MS);
+              const waitingForBackgroundWork = proc.retainBackgroundWorkingState();
+              if (!waitingForBackgroundWork) {
+                typingDoneTimer = setTimeout(() => {
+                  this.writeTypingDone(mapKey);
+                  typingDoneTimer = null;
+                }, TYPING_DONE_DELAY_MS);
+              }
             }
           }
           // PTY shell signals "truly idle" (no active turn, empty queue) with this
@@ -2649,6 +2652,9 @@ export class AgentRunner extends EventEmitter {
   private startIdleCleaner(): void {
     this.idleCleanerTimer = setInterval(async () => {
       for (const [id, proc] of this.sessions) {
+        // A parent that just dispatched Agent/Workflow work is CLI-idle but its
+        // sub-agent may still need this session to receive the task notification.
+        if (proc.hasLikelyOutstandingBackgroundWork()) continue;
         if (proc.isIdle(this.idleTimeoutMs)) {
           this.logger.info('Stopping idle session', { sessionId: id });
           await proc.stop();

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1895,6 +1895,10 @@ export class AgentRunner extends EventEmitter {
           // event. Start the typing-done timer here so the indicator stays alive
           // through multi-turn tool-call sequences and only stops when all work is done.
           if (obj['type'] === 'session_idle' && proc.backend === 'pty-shell') {
+            // A parent can become idle immediately after dispatching background
+            // Agent/Workflow work. Keep the Telegram typing signal and processing
+            // sentinel alive until the task notification starts its follow-up turn.
+            const waitingForBackgroundWork = proc.retainBackgroundWorkingState();
             // Gateway turn queue: on pty-shell this is the true end of the user's
             // turn (the wrapper only emits it when its own `this.turn` is null, so
             // it never fires between sub-turns) — flush the next queued turn.
@@ -1906,10 +1910,12 @@ export class AgentRunner extends EventEmitter {
             }
             // Skill-learning: pty-shell session_idle is the true end-of-user-turn.
             this.skillLearning?.onTurnEnd(mapKey, actualSessionId);
-            typingDoneTimer = setTimeout(() => {
-              this.writeTypingDone(mapKey);
-              typingDoneTimer = null;
-            }, TYPING_DONE_DELAY_MS);
+            if (!waitingForBackgroundWork) {
+              typingDoneTimer = setTimeout(() => {
+                this.writeTypingDone(mapKey);
+                typingDoneTimer = null;
+              }, TYPING_DONE_DELAY_MS);
+            }
           }
         } catch { /* non-JSON */ }
       });
@@ -1944,6 +1950,12 @@ export class AgentRunner extends EventEmitter {
           messageCountAtSpawn: proc.spawnContext.messageCountAtSpawn,
         }, this.channelFor(mapKey)).catch(() => {});
       }
+
+      proc.on('backgroundWorkExpired', () => {
+        // The child task never notified its parent within the bounded grace
+        // window; release the Telegram typing signal instead of leaving it live.
+        this.writeTypingDone(mapKey);
+      });
 
       // Tear down per-chat typing/processing state whenever the subprocess dies.
       // Uses `on` (not `once`): a single SessionProcess can auto-restart its child

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -126,6 +126,7 @@ export class SessionProcess extends EventEmitter {
   // this field exists for no longer applies. Read via
   // hasLikelyOutstandingBackgroundWork().
   private lastBackgroundAgentDispatchAt: number | null = null;
+  private backgroundWaitTimer: ReturnType<typeof setTimeout> | null = null;
   readonly spawnedAt = Date.now();
   /** Backend used to run the subprocess. Set during start(); 'headless' until then. */
   backend: 'pty-shell' | 'headless' = 'headless';
@@ -1295,6 +1296,40 @@ export class SessionProcess extends EventEmitter {
 
   get isProcessing(): boolean { return this._processing; }
 
+  /**
+   * Extend Telegram's working state only while a parent session is waiting for
+   * background Agent/Workflow work. A bounded expiry releases the state if the
+   * child task never sends its completion notification.
+   */
+  retainBackgroundWorkingState(): boolean {
+    if (this.source !== 'telegram' || !this.hasLikelyOutstandingBackgroundWork()) return false;
+
+    const processingPath = path.join(this.typingDir, `${this.chatId}.processing`);
+    try {
+      fs.mkdirSync(this.typingDir, { recursive: true });
+      fs.writeFileSync(processingPath, String(Date.now()));
+    } catch (err) {
+      this.logger.warn('Failed to retain .processing sentinel for background work', {
+        chatId: this.chatId,
+        error: (err as Error).message,
+      });
+    }
+
+    if (this.backgroundWaitTimer === null) {
+      const elapsed = Date.now() - this.lastBackgroundAgentDispatchAt!;
+      const remaining = Math.max(0, BACKGROUND_AGENT_GRACE_MS - elapsed);
+      this.backgroundWaitTimer = setTimeout(() => {
+        this.backgroundWaitTimer = null;
+        this.lastBackgroundAgentDispatchAt = null;
+        if (!this._processing) {
+          try { fs.rmSync(processingPath, { force: true }); } catch {}
+          this.emit('backgroundWorkExpired');
+        }
+      }, remaining);
+    }
+    return true;
+  }
+
   setProcessing(active: boolean): void {
     if (this._processing !== active) {
       this._processing = active;
@@ -1304,6 +1339,10 @@ export class SessionProcess extends EventEmitter {
         // it (moot either way). isProcessing now covers this session correctly
         // on its own, so the idle-window concern this field exists for is over.
         this.lastBackgroundAgentDispatchAt = null;
+        if (this.backgroundWaitTimer !== null) {
+          clearTimeout(this.backgroundWaitTimer);
+          this.backgroundWaitTimer = null;
+        }
       }
       this.emit('processingChange', active);
       if (this.source === 'telegram') {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -1064,6 +1064,8 @@ export class SessionProcess extends EventEmitter {
       if (ptyStreamSocketPath) ptyStreamRegistry.close(ptyStreamSocketPath);
       this.process = null;
       this._exited = true;
+      this.lastBackgroundAgentDispatchAt = null;
+      this.clearBackgroundWaitTimer();
       // Notify listeners that the underlying subprocess died. The runner relies
       // on this to tear down per-chat typing/processing state when a session is
       // stopped or restarted mid-turn (without a final result/session_idle).
@@ -1296,6 +1298,13 @@ export class SessionProcess extends EventEmitter {
 
   get isProcessing(): boolean { return this._processing; }
 
+  private clearBackgroundWaitTimer(): void {
+    if (this.backgroundWaitTimer !== null) {
+      clearTimeout(this.backgroundWaitTimer);
+      this.backgroundWaitTimer = null;
+    }
+  }
+
   /**
    * Extend Telegram's working state only while a parent session is waiting for
    * background Agent/Workflow work. A bounded expiry releases the state if the
@@ -1326,6 +1335,7 @@ export class SessionProcess extends EventEmitter {
           this.emit('backgroundWorkExpired');
         }
       }, remaining);
+      this.backgroundWaitTimer.unref();
     }
     return true;
   }
@@ -1339,10 +1349,7 @@ export class SessionProcess extends EventEmitter {
         // it (moot either way). isProcessing now covers this session correctly
         // on its own, so the idle-window concern this field exists for is over.
         this.lastBackgroundAgentDispatchAt = null;
-        if (this.backgroundWaitTimer !== null) {
-          clearTimeout(this.backgroundWaitTimer);
-          this.backgroundWaitTimer = null;
-        }
+        this.clearBackgroundWaitTimer();
       }
       this.emit('processingChange', active);
       if (this.source === 'telegram') {
@@ -1452,6 +1459,8 @@ export class SessionProcess extends EventEmitter {
 
   async stop(): Promise<void> {
     this.stopping = true;
+    this.lastBackgroundAgentDispatchAt = null;
+    this.clearBackgroundWaitTimer();
     await this.restartWatcher?.close();
     this.restartWatcher = null;
     try { fs.rmSync(this.restartSignalPath, { force: true }); } catch {}

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -4805,7 +4805,12 @@ describe('AgentRunner — gateway turn queue, coalesce, and /stop', () => {
   // U-AR-Q2-BG: after dispatching an asynchronous Agent task, the parent PTY
   // becomes idle before the task notification arrives. Telegram typing must stay
   // active throughout that wait, then stop normally after the follow-up turn.
-  it.each(['Agent', 'Workflow'])('U-AR-Q2-BG: retains Telegram typing while a background %s task is outstanding', async (toolName) => {
+  it.each([
+    ['Agent', 'headless'],
+    ['Workflow', 'headless'],
+    ['Agent', 'pty-shell'],
+    ['Workflow', 'pty-shell'],
+  ])('U-AR-Q2-BG: retains Telegram typing for %s work on %s', async (toolName, backend) => {
     runner = new AgentRunner(agentConfig, gatewayConfig);
     await runner.start();
     const port = getCallbackPort(runner);
@@ -4815,7 +4820,7 @@ describe('AgentRunner — gateway turn queue, coalesce, and /stop', () => {
     await waitForSession(runner, chatId);
     await new Promise(r => setTimeout(r, 80));
     const session = getSessions(runner).get(chatId)!;
-    (session as unknown as { backend: string }).backend = 'pty-shell';
+    (session as unknown as { backend: string }).backend = backend;
     const rawProc = allProcesses[allProcesses.length - 1]!;
     const typingSignal = path.join(agentConfig.workspace, '.telegram-state', 'typing', chatId);
     const processingSignal = `${typingSignal}.processing`;
@@ -4826,9 +4831,12 @@ describe('AgentRunner — gateway turn queue, coalesce, and /stop', () => {
       message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_bg_typing', name: toolName, input: {} }] },
       stop_reason: 'tool_use',
     }) + '\n'));
-    // PTY emits a result for the sub-turn before its eventual session_idle.
+    // PTY emits a result for the sub-turn before session_idle; headless result
+    // itself is the true end-of-turn event.
     rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: '' }) + '\n'));
-    rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'session_idle' }) + '\n'));
+    if (backend === 'pty-shell') {
+      rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'session_idle' }) + '\n'));
+    }
     await new Promise(r => setTimeout(r, 3_100));
 
     // Pre-fix this signal was unconditionally deleted after 3 seconds.
@@ -4838,7 +4846,10 @@ describe('AgentRunner — gateway turn queue, coalesce, and /stop', () => {
     // The task notification starts and completes a new turn with no further dispatch.
     session.setProcessing(true);
     session.setProcessing(false);
-    rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'session_idle' }) + '\n'));
+    rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: '' }) + '\n'));
+    if (backend === 'pty-shell') {
+      rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'session_idle' }) + '\n'));
+    }
     await new Promise(r => setTimeout(r, 3_100));
 
     expect(fs.existsSync(typingSignal)).toBe(false);

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -4802,6 +4802,49 @@ describe('AgentRunner — gateway turn queue, coalesce, and /stop', () => {
     expect(channelWrites()[1]).toContain('second');
   }, 15000);
 
+  // U-AR-Q2-BG: after dispatching an asynchronous Agent task, the parent PTY
+  // becomes idle before the task notification arrives. Telegram typing must stay
+  // active throughout that wait, then stop normally after the follow-up turn.
+  it.each(['Agent', 'Workflow'])('U-AR-Q2-BG: retains Telegram typing while a background %s task is outstanding', async (toolName) => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+    const chatId = 'chat:q2-background';
+
+    await sendChannelPost(port, chatId, 'review this PR');
+    await waitForSession(runner, chatId);
+    await new Promise(r => setTimeout(r, 80));
+    const session = getSessions(runner).get(chatId)!;
+    (session as unknown as { backend: string }).backend = 'pty-shell';
+    const rawProc = allProcesses[allProcesses.length - 1]!;
+    const typingSignal = path.join(agentConfig.workspace, '.telegram-state', 'typing', chatId);
+    const processingSignal = `${typingSignal}.processing`;
+    expect(fs.existsSync(typingSignal)).toBe(true);
+
+    rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_bg_typing', name: toolName, input: {} }] },
+      stop_reason: 'tool_use',
+    }) + '\n'));
+    // PTY emits a result for the sub-turn before its eventual session_idle.
+    rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: '' }) + '\n'));
+    rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'session_idle' }) + '\n'));
+    await new Promise(r => setTimeout(r, 3_100));
+
+    // Pre-fix this signal was unconditionally deleted after 3 seconds.
+    expect(fs.existsSync(typingSignal)).toBe(true);
+    expect(fs.existsSync(processingSignal)).toBe(true);
+
+    // The task notification starts and completes a new turn with no further dispatch.
+    session.setProcessing(true);
+    session.setProcessing(false);
+    rawProc.stdout!.emit('data', Buffer.from(JSON.stringify({ type: 'session_idle' }) + '\n'));
+    await new Promise(r => setTimeout(r, 3_100));
+
+    expect(fs.existsSync(typingSignal)).toBe(false);
+    expect(fs.existsSync(processingSignal)).toBe(false);
+  }, 15000);
+
   // U-AR-Q3: consecutive text messages within the coalesce window merge into ONE
   // turn (A1) — each still individually written to permanent history upstream.
   it('U-AR-Q3: coalesces consecutive text messages into a single turn', async () => {


### PR DESCRIPTION
## Summary

Keep Telegram's typing indicator active when a parent session has dispatched background `Agent` or `Workflow` work and becomes idle while waiting for its task notification.

## Changes

- Retain the Telegram typing signal and `.processing` sentinel when a PTY session emits `session_idle` but has outstanding background work.
- Stop the retained state once a new notification turn starts, or after the existing 15-minute background-work grace period if no notification arrives.
- Release the typing signal on grace expiry to prevent a permanently stale indicator.
- Add regression coverage for both `Agent` and `Workflow` dispatches, including normal cleanup after the follow-up turn.

## Verification

- The regression test was run against the pre-fix implementation and failed because the typing signal was deleted after the existing three-second completion timer.
- `npm run typecheck`
- `npm test` — 188 suites, 3578 tests passed.

Closes #393
