### PR TITLE
fix: preserve bind-mounted data during app updates

### DIFF
--- a/API.md
+++ b/API.md
@@ -3259,6 +3259,8 @@ If the updated release also ships content at a bind path (a tracked `.gitkeep`, 
 
 Update scratch directories (`.cg-update-*`, `<appDir>-old-*`, `<appDir>-failed-*`) left behind by a crash mid-update are swept on gateway boot.
 
+If the app declares an agent, its registration follows the new release: an agent whose name changed is deregistered under the old name before the new one is registered, and an agent the release no longer declares is deregistered entirely. Either way the agent's directory and session history are preserved (only the `workspace` symlink and the `config.json` entry are removed), and `MEMORY.md` is carried forward — written after the new registration exists, so it survives a rename.
+
 The update target depends on the app's `source`:
 - `registry` — the latest published registry version.
 - `custom` (installed from a GitHub URL) — the current default-branch `HEAD` of the app's repo, resolved via `git ls-remote`. If the resolved commit already matches the installed one, the job completes as a no-op.

--- a/API.md
+++ b/API.md
@@ -3251,7 +3251,13 @@ For custom/local apps, `latest` and `latest_commit` are `null` and `updateable` 
 
 ### POST /api/v1/apps/:name/update
 
-Start an async update. Uses blue/green swap: build new version in `/tmp/`, stop old containers, start new, swap directories, rollback automatically if new containers fail health check. The `.env` from the previous install is copied forward, so volumes and secrets are preserved.
+Start an async update. Uses blue/green swap: the new version is cloned and built in a hidden `.cg-update-*` staging directory **beside the app's install path** (same filesystem, so the swap is a rename), old containers are stopped, the staging directory is swapped into the permanent install path, and only then are the new containers started. Rollback is automatic if the new containers fail their health check. The `.env` from the previous install is copied forward, so volumes and secrets are preserved.
+
+Starting *after* the swap is what keeps relative bind mounts (`./postgres/pgdata`) pointing at the app's permanent directory — a stack started from the staging path would bind newly created empty data and a stateful service would re-initialise (issue #396). App-owned bind directories are carried across the swap by rename, preserving inode and ownership.
+
+If the updated release also ships content at a bind path (a tracked `.gitkeep`, seed files, an `init.sql`), the two are merged: **existing data always wins**, and release-provided files the previous version did not have are kept. A collision on a non-directory path preserves the existing file and logs a warning naming it — the release's copy of that one path is discarded, so a config file you bind-mount from the repo must be re-applied by hand after the update.
+
+Update scratch directories (`.cg-update-*`, `<appDir>-old-*`, `<appDir>-failed-*`) left behind by a crash mid-update are swept on gateway boot.
 
 The update target depends on the app's `source`:
 - `registry` — the latest published registry version.
@@ -3471,7 +3477,7 @@ services:
 | `command` | Override container command |
 | `entrypoint` | Override container entrypoint |
 | `environment` | Static env vars (`KEY=value`), secret keys to prompt for (`KEY` without `=`), or self-generating secrets (`KEY=!generate:<encoding>:<bytes>`) |
-| `volumes` | Volume mounts (named volumes or host paths within app dir) |
+| `volumes` | Volume mounts (named volumes or host paths within app dir). A relative source must start with `./` and stay inside the app dir — `../` is rejected at parse time, as is any embedded `/../`. **Breaking change:** an app installed before this rule that declares a `../` source can no longer be updated or reconfigured until its manifest is corrected. |
 | `ports` | Array of port declarations (see **Port fields** below) |
 | `depends_on` | Service dependency list |
 | `healthcheck` | Docker healthcheck (test, interval, timeout, retries) |

--- a/API.md
+++ b/API.md
@@ -3259,6 +3259,8 @@ If the updated release also ships content at a bind path (a tracked `.gitkeep`, 
 
 Update scratch directories (`.cg-update-*`, `<appDir>-old-*`, `<appDir>-failed-*`) left behind by a crash mid-update are swept on gateway boot.
 
+A rollback restores the previous **image** as well as the previous source. A `build:` service's new image reuses the running one's tag (`<project>-<service>:latest`), so before building, the update tags each of the app's built images `<project>-<service>:cg-rollback-<id>` — that keeps the old image addressable and alive (under the containerd image store an untagged image is not retained as a `<none>` image). A rollback points the tag back at it, so the app returns on the exact release it was serving; the private tag is dropped once the update settles either way. If an image cannot be restored, the rollback rebuilds from the rolled-back source instead of starting the failed release's build, and logs which reference it could not restore.
+
 If the app declares an agent, its registration follows the new release: an agent whose name changed is deregistered under the old name before the new one is registered, and an agent the release no longer declares is deregistered entirely. Either way the agent's directory and session history are preserved (only the `workspace` symlink and the `config.json` entry are removed), and `MEMORY.md` is carried forward — written after the new registration exists, so it survives a rename.
 
 The update target depends on the app's `source`:

--- a/src/apps/compose-generator.ts
+++ b/src/apps/compose-generator.ts
@@ -452,8 +452,8 @@ export function generateCompose(
     const composeVolumes: string[] = [];
     for (const vol of svc.volumes ?? []) {
       const [src, ...rest] = vol.split(':');
-      if (src.startsWith('./') || src.startsWith('../')) {
-        // Relative bind mount — resolve to absolute path so Docker daemon gets a real path
+      if (src.startsWith('./')) {
+        // Relative bind mount — resolve to an absolute path for Docker.
         const absPath = path.resolve(appDir, src);
         composeVolumes.push([absPath, ...rest].join(':'));
       } else {
@@ -862,13 +862,17 @@ function validateVolumes(svcName: string, volList: unknown): void {
           `Service "${svcName}".volumes source contains path traversal: "${src}"`,
         );
       }
-    } else if (src.startsWith('./') || src.startsWith('../')) {
-      // Relative bind mount (e.g. ./postgres) — validate no double traversal beyond ./
+    } else if (src.startsWith('./')) {
+      // Relative bind mounts are allowed only beneath the app directory.
       if (src.includes('/../') || src.endsWith('/..')) {
         throw new Error(
           `Service "${svcName}".volumes source contains path traversal: "${src}"`,
         );
       }
+    } else if (src.startsWith('../')) {
+      throw new Error(
+        `Service "${svcName}".volumes source must stay within the app directory: "${src}"`,
+      );
     } else {
       // Named volume
       if (!NAMED_VOLUME_RE.test(src)) {

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -262,6 +262,42 @@ const STALE_UPDATE_DIR_RE = new RegExp(
   `^\\.cg-update-.+-${UUID_RE_SRC}$|-(?:old|failed)-${UUID_RE_SRC}$`,
 );
 
+/**
+ * Rows from a `docker compose … --format json` call. Compose has emitted both a
+ * single JSON array and one object per line across its 2.x line, so accept
+ * either rather than silently reading a newer/older daemon as "nothing here".
+ */
+function parseJsonRows(stdout: string): unknown[] {
+  const text = stdout.trim();
+  if (!text) return [];
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch { /* not a single document — try line-delimited below */ }
+  const rows: unknown[] = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      rows.push(JSON.parse(trimmed));
+    } catch { /* skip a line that is not JSON */ }
+  }
+  return rows;
+}
+
+/** Private tag the update holds on an image so a rollback can put it back. */
+const ROLLBACK_TAG_PREFIX = 'cg-rollback-';
+
+/**
+ * An image reference and the private tag pinning its pre-update build. An empty
+ * `backupRef` records a reference that could *not* be pinned — the rollback
+ * treats it as unrestorable and rebuilds instead.
+ */
+interface PreservedImage {
+  ref: string;
+  backupRef: string;
+}
+
 export class AppInstaller {
   private readonly jobs = new Map<string, JobState>();
   private readonly appsDir: string;
@@ -1719,6 +1755,9 @@ export class AppInstaller {
       path.dirname(entry.installPath),
       `.cg-update-${appName}-${crypto.randomUUID()}`,
     );
+    // Rollback tags held on the images this update is about to build over.
+    // Declared out here so every exit path can drop them again.
+    let preservedImages: PreservedImage[] = [];
     try {
       // ── Shallow fetch of specific commit into tmp dir ─────────────────────
       this.log(job, `Cloning ${target.repo}`);
@@ -1766,6 +1805,15 @@ export class AppInstaller {
       if (generated.agentDeclaration && this.agentManager && agentPaths) {
         this.agentManager.injectAgentService(newEntry);
       }
+
+      // Pin the images the app is running before the build takes their tags
+      // over. A `build:` service's new image reuses the old tag
+      // (`<project>-<service>`), so once the build succeeds that tag names the
+      // new release: rolling only the source back would bring the app up on the
+      // failed release's image and crash-loop on a "successful" rollback. This
+      // has to happen before the build — afterwards the old image has no
+      // reference left to grab it by.
+      preservedImages = this.preserveRunningImages(appName, entry.installPath, job);
 
       // ── Build new images in tmp dir ───────────────────────────────────────
       this.log(job, 'Building new images');
@@ -1840,7 +1888,14 @@ export class AppInstaller {
           } else if (fs.existsSync(oldBackupDir)) {
             fs.renameSync(oldBackupDir, finalDir);
           }
-          this.run(['docker', 'compose', '-p', appName, 'up', '-d'], finalDir, 120_000);
+          // Point every tag back at the image the app was actually running
+          // before this update built over it, so the restored source and the
+          // restored image are the same release. Falls back to rebuilding from
+          // the restored source when an old image is no longer on disk.
+          const rebuild = !this.restorePreservedImages(preservedImages, finalDir, job);
+          const upArgs = ['docker', 'compose', '-p', appName, 'up', '-d'];
+          if (rebuild) upArgs.push('--build');
+          this.run(upArgs, finalDir, rebuild ? 600_000 : 120_000);
           this.callbacks.registerRoutes(appName, entry.ports.map((p) => ({
             name: p.name,
             service: p.service,
@@ -1860,6 +1915,12 @@ export class AppInstaller {
         }
         throw upErr;
       }
+
+      // The new stack is up: the previous images are no longer a rollback
+      // target. Untag them before the reclaim below, which removes by image ID
+      // and would be refused while a second reference exists.
+      this.dropPreservedImageTags(preservedImages);
+      preservedImages = [];
 
       // Capture the new stack's image IDs from its permanent compose file so
       // cleanup below never removes an image the new containers depend on.
@@ -1951,6 +2012,7 @@ export class AppInstaller {
       this.log(job, `Update complete → ${newVersion}`);
 
     } catch (err) {
+      this.dropPreservedImageTags(preservedImages);
       if (fs.existsSync(tmpDir)) {
         this.safeRmrf(tmpDir, job, 'update temp dir');
       }
@@ -2699,6 +2761,122 @@ export class AppInstaller {
    * container back down (issue #283). Returns a de-duplicated list of image
    * IDs, or `[]` on any error (nothing to reclaim / docker unavailable).
    */
+  /**
+   * Tag every image the app is *currently* running under a private
+   * `<repo>:cg-rollback-<id>` name, and return the pairs.
+   *
+   * A `build:` service's new image reuses the tag of the one in production
+   * (`<project>-<service>:latest`), so once the update's build succeeds that
+   * tag names the new release. Rolling only the source directory back would
+   * bring the app up on the failed release's image. Holding a second tag keeps
+   * the old image addressable *and* alive — under the containerd image store an
+   * untagged image is not kept around as a `<none>` image to find later.
+   *
+   * Only images this app builds are preserved: compose names them
+   * `<project>-<service>`, and a pulled tag (`postgres:16-alpine`) is never
+   * overwritten by a build, so it needs no protection. Best-effort throughout —
+   * anything that cannot be preserved is simply absent from the result, and the
+   * rollback rebuilds from the restored source instead.
+   */
+  private preserveRunningImages(
+    appName: string,
+    dir: string,
+    job: JobState,
+  ): PreservedImage[] {
+    let rows: unknown[];
+    try {
+      const { stdout } = this.run(
+        ['docker', 'compose', '-p', appName, 'images', '--format', 'json'],
+        dir,
+        15_000,
+      );
+      rows = parseJsonRows(stdout);
+    } catch {
+      return [];
+    }
+
+    const preserved: PreservedImage[] = [];
+    const seen = new Set<string>();
+    for (const row of rows) {
+      if (typeof row !== 'object' || row === null) continue;
+      const r = row as { ID?: unknown; Repository?: unknown; Tag?: unknown };
+      const id = typeof r.ID === 'string' ? r.ID.trim() : '';
+      const repo = typeof r.Repository === 'string' ? r.Repository.trim() : '';
+      const tag = typeof r.Tag === 'string' && r.Tag.trim() ? r.Tag.trim() : 'latest';
+      if (!id || !repo.startsWith(`${appName}-`)) continue;
+      const ref = `${repo}:${tag}`;
+      if (seen.has(ref)) continue;
+      seen.add(ref);
+      const backupRef = `${repo}:${ROLLBACK_TAG_PREFIX}${id.replace(/^sha256:/, '').slice(0, 12)}`;
+      try {
+        this.run(['docker', 'image', 'tag', id, backupRef], dir, 15_000);
+        preserved.push({ ref, backupRef });
+      } catch (err) {
+        // Recorded with no backup reference: the rollback must know this tag is
+        // unprotected and rebuild, rather than read an empty list as "no built
+        // images, nothing at risk".
+        preserved.push({ ref, backupRef: '' });
+        this.log(
+          job,
+          `Warning: could not preserve image "${ref}" for rollback (${
+            err instanceof Error ? err.message : String(err)
+          })`,
+        );
+      }
+    }
+    return preserved;
+  }
+
+  /**
+   * Put each preserved image back on the reference the update's build took
+   * over. Returns true when nothing is at risk (an empty list — the app builds
+   * no images) or every reference is back on its original image; false when at
+   * least one could not be, so the caller rebuilds from the rolled-back source
+   * rather than starting the failed release's build.
+   */
+  private restorePreservedImages(
+    images: PreservedImage[],
+    dir: string,
+    job: JobState,
+  ): boolean {
+    let allRestored = true;
+    for (const { ref, backupRef } of images) {
+      if (!backupRef) {
+        allRestored = false;
+        this.log(job, `Image "${ref}" was not preserved — rebuilding from the rolled-back source`);
+        continue;
+      }
+      try {
+        this.run(['docker', 'image', 'tag', backupRef, ref], dir, 15_000);
+        this.log(job, `Restored image "${ref}" to the pre-update build`);
+      } catch (err) {
+        allRestored = false;
+        this.log(
+          job,
+          `Warning: could not restore image "${ref}" (${
+            err instanceof Error ? err.message : String(err)
+          }) — rebuilding from the rolled-back source instead`,
+        );
+      }
+    }
+    return allRestored;
+  }
+
+  /**
+   * Drop the private rollback tags. Removing a reference only untags the image
+   * while another tag remains, so this never deletes an image the app still
+   * uses. Must run before the post-update image reclaim: an extra tag would
+   * make `docker image rm <id>` refuse.
+   */
+  private dropPreservedImageTags(images: PreservedImage[]): void {
+    for (const { backupRef } of images) {
+      if (!backupRef) continue;
+      try {
+        this.run(['docker', 'image', 'rm', backupRef], os.tmpdir(), 15_000);
+      } catch { /* already gone — non-fatal */ }
+    }
+  }
+
   private captureComposeImageIds(appName: string, dir: string): string[] {
     try {
       const { stdout } = this.run(

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -1866,12 +1866,6 @@ export class AppInstaller {
       const newImageIds = this.captureComposeImageIds(appName, finalDir);
       const newImageRefs = this.captureComposeImageRefs(appName, finalDir);
 
-      // ── Restore MEMORY.md ─────────────────────────────────────────────────
-      if (memoryBackup !== null && generated.agentDeclaration && this.agentManager) {
-        this.agentManager.restoreMemory(generated.agentDeclaration.name, memoryBackup);
-        this.log(job, 'MEMORY.md restored');
-      }
-
       // ── Update registry ───────────────────────────────────────────────────
       const finalEntry: AppEntry = {
         ...newEntry,
@@ -1881,13 +1875,31 @@ export class AppInstaller {
       };
       await this.registry.upsert(finalEntry);
 
-      // ── Re-create or remove the app-agent registration ────────────────────
-      if (entry.agentDeclaration && !generated.agentDeclaration && this.agentManager) {
-        await this.agentManager.deleteAgent(entry);
-        this.log(job, `Agent "${entry.agentDeclaration.name}" removed`);
-      } else if (generated.agentDeclaration && this.agentManager) {
+      // ── Re-create, rename, or remove the app-agent registration ───────────
+      // `upsertAgent` keys off the *new* agent name, so a release that drops or
+      // renames its agent would otherwise strand the previous workspace symlink
+      // and config.json entry. Both transitions are the same deregistration.
+      const oldAgentName = entry.agentDeclaration?.name ?? null;
+      const newAgentName = generated.agentDeclaration?.name ?? null;
+      if (this.agentManager && oldAgentName !== null && oldAgentName !== newAgentName) {
+        await this.agentManager.deleteAgentByName(oldAgentName);
+        this.log(
+          job,
+          newAgentName === null
+            ? `Agent "${oldAgentName}" removed`
+            : `Agent "${oldAgentName}" deregistered (renamed to "${newAgentName}")`,
+        );
+      }
+      if (generated.agentDeclaration && this.agentManager) {
         await this.agentManager.upsertAgent(finalEntry);
         this.log(job, `Agent "${generated.agentDeclaration.name}" re-registered`);
+        // MEMORY.md must be written *after* registration: restoreMemory resolves
+        // the workspace through config.json, so on a rename the new name is not
+        // resolvable until upsertAgent has written its entry.
+        if (memoryBackup !== null) {
+          this.agentManager.restoreMemory(generated.agentDeclaration.name, memoryBackup);
+          this.log(job, 'MEMORY.md restored');
+        }
         await this.callbacks.reinitializeAgent?.(generated.agentDeclaration.name);
       }
 
@@ -2440,6 +2452,12 @@ export class AppInstaller {
    * symlink. The check runs **before** each segment is created — a `mkdir -p`
    * that ran first would already have materialised directories on the far side
    * of a symlink, leaving the guard with nothing left to prevent.
+   *
+   * Scope: this guards the **destination** side — the freshly checked-out
+   * release, which is the side an app repo controls. A bind path that was
+   * already a symlink in the *previous* app dir is carried across as-is; that
+   * preserves an escape the operator set up themselves rather than creating
+   * one, and is the behaviour every release before this one had.
    */
   private ensureDirWithinNoSymlink(baseDir: string, targetDir: string): void {
     const relative = path.relative(baseDir, targetDir);
@@ -2460,7 +2478,7 @@ export class AppInstaller {
         continue;
       }
       if (stat.isSymbolicLink()) {
-        throw new Error(`Updated app bind-mount path contains a symlink: "${current}"`);
+        throw new Error(`Updated app bind-mount source must not be a symlink: "${current}"`);
       }
       if (!stat.isDirectory()) {
         throw new Error(`Updated app bind-mount path is not a directory: "${current}"`);
@@ -2529,6 +2547,14 @@ export class AppInstaller {
     }
     if (destStat.isDirectory() && fs.lstatSync(source).isDirectory()) {
       // Merge: recurse so a release-only file inside the directory survives.
+      //
+      // Entry-by-entry on purpose. Swapping the trees (move the live dir over
+      // wholesale, then re-apply the release's own files on top) would be one
+      // rename instead of one per live file, but `moved` would no longer be an
+      // exact inverse: a rollback would carry those re-applied release files
+      // into the restored previous app dir. Exact rollback beats the renames,
+      // which are same-filesystem and only walk a directory the release also
+      // ships content in.
       for (const name of fs.readdirSync(source)) {
         this.moveBindEntry(fromDir, toDir, `${rel}/${name}`, job, moved);
       }
@@ -2549,7 +2575,10 @@ export class AppInstaller {
    */
   private restoreBindMounts(fromDir: string, toDir: string, moved: string[], job: JobState): void {
     for (const rel of [...moved].reverse()) {
-      if (!this.isSafeBindRel(fromDir, toDir, rel)) continue;
+      if (!this.isSafeBindRel(fromDir, toDir, rel)) {
+        this.log(job, `Warning: skipping bind-mount path outside the app directory: "${rel}"`);
+        continue;
+      }
       const source = path.resolve(fromDir, rel);
       const destination = path.resolve(toDir, rel);
       if (!fs.existsSync(source) || fs.existsSync(destination)) continue;

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -251,6 +251,17 @@ const GITHUB_URL_RE = /^https:\/\/github\.com\/(?!.*\.\.)[A-Za-z0-9][A-Za-z0-9_.
 
 // ─── Installer ────────────────────────────────────────────────────────────────
 
+const UUID_RE_SRC = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+/**
+ * Scratch directories `runUpdate` creates beside an app's install path:
+ * `.cg-update-<app>-<uuid>` (staging checkout) and `<appDir>-old-<uuid>` /
+ * `<appDir>-failed-<uuid>` (release snapshots). All three carry a v4 UUID, so
+ * the pattern cannot match an app directory named by a user.
+ */
+const STALE_UPDATE_DIR_RE = new RegExp(
+  `^\\.cg-update-.+-${UUID_RE_SRC}$|-(?:old|failed)-${UUID_RE_SRC}$`,
+);
+
 export class AppInstaller {
   private readonly jobs = new Map<string, JobState>();
   private readonly appsDir: string;
@@ -956,42 +967,6 @@ export class AppInstaller {
     }
   }
 
-  private discoverBindMountsOrThrow(appName: string, appDir: string): string[] {
-    try {
-      const { stdout } = this.run(
-        ['docker', 'compose', '-p', appName, 'config', '--format', 'json'],
-        appDir,
-        30_000,
-      );
-      const parsed = JSON.parse(stdout) as {
-        services?: Record<string, { volumes?: Array<{ type?: string; source?: string }> }>;
-      };
-      const bases = [appDir];
-      try {
-        const real = fs.realpathSync(appDir);
-        if (real !== appDir) bases.push(real);
-      } catch { /* app dir unreadable — use literal base */ }
-      const rels = new Set<string>();
-      for (const svc of Object.values(parsed.services ?? {})) {
-        for (const vol of svc.volumes ?? []) {
-          if (vol.type !== 'bind' || typeof vol.source !== 'string') continue;
-          const abs = path.resolve(appDir, vol.source);
-          const matched = bases.find((base) => abs !== base && abs.startsWith(base + path.sep));
-          if (!matched) continue;
-          rels.add(path.relative(matched, abs).split(path.sep).join('/'));
-        }
-      }
-      return Array.from(rels).sort();
-    } catch (err) {
-      // A config query is only optional for apps whose stored compose declares no
-      // app-local bind source. If it does, continuing would discard unknown state.
-      const composePath = path.join(appDir, 'docker-compose.yml');
-      const compose = fs.existsSync(composePath) ? fs.readFileSync(composePath, 'utf-8') : '';
-      if (!compose.includes(appDir)) return [];
-      throw new Error(`Cannot safely discover bind mounts for update: ${(err as Error).message}`);
-    }
-  }
-
   /**
    * Discover bind-mount source directories that live **under the app dir**
    * (e.g. `./data/photos` → `data/photos`). These hold app-owned data that is
@@ -1003,7 +978,29 @@ export class AppInstaller {
    * read-only `~/.claude/projects`) are intentionally excluded. Best-effort:
    * returns `[]` on any failure, mirroring {@link discoverVolumes}.
    */
-  private discoverBindMounts(appName: string, appDir: string): string[] {
+  /**
+   * The paths a generated compose file may have resolved this app dir to.
+   * Local-dev installs symlink the app dir into appsDir, and the generated
+   * compose resolves bind sources against the symlink's *realpath*, so both the
+   * symlink path and its target must be treated as the app root.
+   */
+  private bindMountBases(appDir: string): string[] {
+    const bases = [appDir];
+    try {
+      const real = fs.realpathSync(appDir);
+      if (real !== appDir) bases.push(real);
+    } catch {
+      /* app dir unreadable — fall back to the literal path */
+    }
+    return bases;
+  }
+
+  private discoverBindMounts(
+    appName: string,
+    appDir: string,
+    onError: 'empty' | 'throw' = 'empty',
+  ): string[] {
+    const bases = this.bindMountBases(appDir);
     try {
       const { stdout } = this.run(
         ['docker', 'compose', '-p', appName, 'config', '--format', 'json'],
@@ -1013,17 +1010,6 @@ export class AppInstaller {
       const parsed = JSON.parse(stdout) as {
         services?: Record<string, { volumes?: Array<{ type?: string; source?: string }> }>;
       };
-      // Local-dev installs symlink the app dir into appsDir, and the generated
-      // compose resolves bind sources against the symlink's *realpath*. Match a
-      // source that sits under either the symlink path or its target, so those
-      // bind mounts are not wrongly excluded.
-      const bases = [appDir];
-      try {
-        const real = fs.realpathSync(appDir);
-        if (real !== appDir) bases.push(real);
-      } catch {
-        /* app dir unreadable — fall back to the literal path */
-      }
       const rels = new Set<string>();
       for (const svc of Object.values(parsed.services ?? {})) {
         for (const vol of svc.volumes ?? []) {
@@ -1036,8 +1022,16 @@ export class AppInstaller {
         }
       }
       return Array.from(rels).sort();
-    } catch {
-      return [];
+    } catch (err) {
+      if (onError === 'empty') return [];
+      // Fail closed: the caller is about to move this app's directory, so an
+      // unknown bind set would silently strand live state. Only an app whose
+      // stored compose anchors nothing to the app dir (under either base) is
+      // safe to treat as bind-free.
+      const composePath = path.join(appDir, 'docker-compose.yml');
+      const compose = fs.existsSync(composePath) ? fs.readFileSync(composePath, 'utf-8') : '';
+      if (!bases.some((b) => compose.includes(b))) return [];
+      throw new Error(`Cannot safely discover bind mounts for update: ${(err as Error).message}`);
     }
   }
 
@@ -1100,6 +1094,48 @@ export class AppInstaller {
    * Returns a cancel function. No-op (returns a noop canceller) when both caps
    * are disabled. The timer is `unref`'d so it never holds the event loop open.
    */
+  /**
+   * Reclaim update scratch directories a crashed or killed update left behind:
+   * the `.cg-update-*` staging checkout and the `-old-`/`-failed-` release
+   * snapshots. Staging moved next to the install path so the swap is a
+   * same-filesystem rename, which also means `/tmp` cleanup no longer collects
+   * it — without this sweep a mid-update crash leaks a full app checkout
+   * forever.
+   *
+   * **Boot only.** An update in flight owns directories matching these names,
+   * so this must run before any update can start. Never throws; a directory it
+   * cannot remove is reported and skipped.
+   */
+  async sweepStaleUpdateDirs(): Promise<string[]> {
+    const swept: string[] = [];
+    let names: string[];
+    try {
+      names = fs.readdirSync(this.appsDir);
+    } catch {
+      return swept; // no apps dir yet
+    }
+    // An installPath is authoritative — never remove a directory an app still
+    // points at, however its name happens to look.
+    let live: Set<string>;
+    try {
+      live = new Set((await this.registry.list()).map((a) => a.installPath));
+    } catch {
+      return swept; // registry unreadable — do not guess
+    }
+    for (const name of names) {
+      if (!STALE_UPDATE_DIR_RE.test(name)) continue;
+      const full = path.join(this.appsDir, name);
+      if (live.has(full)) continue;
+      try {
+        this.rmrf(full);
+        swept.push(full);
+      } catch (err) {
+        console.warn(`[installer] failed to sweep stale update dir "${full}": ${(err as Error).message}`);
+      }
+    }
+    return swept;
+  }
+
   startBackupCleanup(): () => void {
     const { retention, maxAgeDays, cleanupHour, cleanupTimezone } = this.appBackupConfig;
     if (retention <= 0 && maxAgeDays <= 0) return () => {};
@@ -1744,16 +1780,21 @@ export class AppInstaller {
         }
       }
 
+      // Discover the app-owned bind paths while the old compose file still points
+      // at the durable install directory. They must move with the release swap so
+      // cleanup cannot delete live state. This query fails closed, so it runs
+      // *before* routes and sockets come down — a throw here would otherwise
+      // leave the app running but unreachable, with no path back.
+      const oldBindMounts = this.discoverBindMounts(appName, entry.installPath, 'throw');
+
       // ── Deregister old routes before taking down containers ───────────────
       this.callbacks.deregisterRoutes(appName);
       this.callbacks.stopSockets(appName);
 
-      // Capture the current (old) image IDs and app-owned bind paths while the old
-      // compose file still points at the durable install directory. The bind paths
-      // must move with the release swap so cleanup cannot delete live state.
+      // Capture the current (old) image IDs while the old compose file is still
+      // the live one, so the reclaim below targets exactly this app's images.
       const oldImageIds = this.captureComposeImageIds(appName, entry.installPath);
       const oldImageRefs = this.captureComposeImageRefs(appName, entry.installPath);
-      const oldBindMounts = this.discoverBindMountsOrThrow(appName, entry.installPath);
 
       // ── Swap dirs before starting the new containers ───────────────────────
       // The new compose file's bind sources are anchored to finalDir. Starting
@@ -1770,14 +1811,17 @@ export class AppInstaller {
         fs.renameSync(finalDir, oldBackupDir);
         fs.renameSync(tmpDir, finalDir);
         swapped = true;
-        this.moveBindMounts(oldBackupDir, finalDir, oldBindMounts, movedBindMounts);
+        this.moveBindMounts(oldBackupDir, finalDir, oldBindMounts, job, movedBindMounts);
 
-        // The source checkout is now permanent. Regenerate so build contexts stay
-        // relative to it and agent injection never retains a staging path.
+        // The source checkout is now permanent. Rewrite the compose file with
+        // finalDir as its base so every bind source and build context resolves
+        // to the durable path — this call is kept for that side effect; its
+        // return value necessarily matches `generated` (same app.yaml). The
+        // rewrite drops the injected agent service, so re-inject it after.
         const finalComposePath = path.join(finalDir, 'docker-compose.yml');
         const finalYaml = parseAppYaml(fs.readFileSync(path.join(finalDir, 'app.yaml'), 'utf-8'), finalDir);
-        const finalGenerated = generateCompose(finalYaml, appName, finalDir, finalComposePath);
-        if (finalGenerated.agentDeclaration && this.agentManager && agentPaths) {
+        generateCompose(finalYaml, appName, finalDir, finalComposePath);
+        if (generated.agentDeclaration && this.agentManager && agentPaths) {
           this.agentManager.injectAgentService({ ...newEntry, installPath: finalDir });
         }
 
@@ -1792,7 +1836,7 @@ export class AppInstaller {
           if (swapped) {
             fs.renameSync(finalDir, failedDir);
             fs.renameSync(oldBackupDir, finalDir);
-            this.moveBindMounts(failedDir, finalDir, movedBindMounts);
+            this.restoreBindMounts(failedDir, finalDir, movedBindMounts, job);
           } else if (fs.existsSync(oldBackupDir)) {
             fs.renameSync(oldBackupDir, finalDir);
           }
@@ -2391,47 +2435,130 @@ export class AppInstaller {
     }
   }
 
-  private assertNoSymlinkAncestors(baseDir: string, targetDir: string): void {
+  /**
+   * Create `targetDir` under `baseDir`, refusing to traverse or create through a
+   * symlink. The check runs **before** each segment is created — a `mkdir -p`
+   * that ran first would already have materialised directories on the far side
+   * of a symlink, leaving the guard with nothing left to prevent.
+   */
+  private ensureDirWithinNoSymlink(baseDir: string, targetDir: string): void {
     const relative = path.relative(baseDir, targetDir);
+    if (path.isAbsolute(relative) || relative.split(path.sep).includes('..')) {
+      throw new Error(`Bind-mount path escapes the app directory: "${targetDir}"`);
+    }
     let current = baseDir;
     for (const segment of relative.split(path.sep).filter(Boolean)) {
       current = path.join(current, segment);
-      if (fs.existsSync(current) && fs.lstatSync(current).isSymbolicLink()) {
+      let stat: fs.Stats | null;
+      try {
+        stat = fs.lstatSync(current);
+      } catch {
+        stat = null;
+      }
+      if (stat === null) {
+        fs.mkdirSync(current);
+        continue;
+      }
+      if (stat.isSymbolicLink()) {
         throw new Error(`Updated app bind-mount path contains a symlink: "${current}"`);
+      }
+      if (!stat.isDirectory()) {
+        throw new Error(`Updated app bind-mount path is not a directory: "${current}"`);
       }
     }
   }
 
+  /** Reject a discovered bind path that does not stay inside both app roots. */
+  private isSafeBindRel(fromDir: string, toDir: string, rel: string): boolean {
+    if (rel.length === 0 || path.isAbsolute(rel)) return false;
+    const fromBase = fromDir.endsWith(path.sep) ? fromDir : fromDir + path.sep;
+    const toBase = toDir.endsWith(path.sep) ? toDir : toDir + path.sep;
+    return path.resolve(fromDir, rel).startsWith(fromBase)
+      && path.resolve(toDir, rel).startsWith(toBase);
+  }
+
   /**
-   * Move app-owned relative bind directories across an update directory swap.
-   * Renaming preserves the database's ownership and inode, unlike copying, and
-   * every path is constrained to its respective app root before use.
+   * Move app-owned relative bind data across an update directory swap.
+   * Renaming preserves the database's ownership and inode, unlike copying.
+   *
+   * A release legitimately ships content at a bind path (a `.gitkeep`, seed
+   * files, a tracked `init.sql`), so a collision is normal, not an error. Live
+   * state always wins — it is the data the issue exists to protect — but a
+   * directory collision is **merged** entry by entry so release-provided files
+   * the previous version never had still land. Every rename performed is
+   * recorded, app-relative and in order, so a rollback can replay it backwards.
    */
   private moveBindMounts(
     fromDir: string,
     toDir: string,
     rels: string[],
+    job: JobState,
     moved?: string[],
   ): void {
     for (const rel of rels) {
-      const source = path.resolve(fromDir, rel);
-      const destination = path.resolve(toDir, rel);
-      const fromBase = fromDir.endsWith(path.sep) ? fromDir : fromDir + path.sep;
-      const toBase = toDir.endsWith(path.sep) ? toDir : toDir + path.sep;
-      if (
-        rel.length === 0 || path.isAbsolute(rel)
-        || !source.startsWith(fromBase) || !destination.startsWith(toBase)
-        || !fs.existsSync(source)
-      ) {
+      if (!this.isSafeBindRel(fromDir, toDir, rel)) {
+        this.log(job, `Warning: skipping bind-mount path outside the app directory: "${rel}"`);
         continue;
       }
-      fs.mkdirSync(path.dirname(destination), { recursive: true });
-      this.assertNoSymlinkAncestors(toDir, path.dirname(destination));
-      if (fs.existsSync(destination)) {
-        throw new Error(`Updated app already contains bind-mount path "${rel}"`);
-      }
+      if (!fs.existsSync(path.resolve(fromDir, rel))) continue; // never created
+      this.moveBindEntry(fromDir, toDir, rel, job, moved);
+    }
+  }
+
+  private moveBindEntry(
+    fromDir: string,
+    toDir: string,
+    rel: string,
+    job: JobState,
+    moved?: string[],
+  ): void {
+    const source = path.resolve(fromDir, rel);
+    const destination = path.resolve(toDir, rel);
+    this.ensureDirWithinNoSymlink(toDir, path.dirname(destination));
+
+    let destStat: fs.Stats | null;
+    try {
+      destStat = fs.lstatSync(destination);
+    } catch {
+      destStat = null;
+    }
+    if (destStat === null) {
       fs.renameSync(source, destination);
       moved?.push(rel);
+      return;
+    }
+    if (destStat.isDirectory() && fs.lstatSync(source).isDirectory()) {
+      // Merge: recurse so a release-only file inside the directory survives.
+      for (const name of fs.readdirSync(source)) {
+        this.moveBindEntry(fromDir, toDir, `${rel}/${name}`, job, moved);
+      }
+      return;
+    }
+    this.log(
+      job,
+      `Warning: preserved existing bind-mount data at "${rel}" — the updated release's copy of that path was discarded`,
+    );
+    fs.rmSync(destination, { recursive: true, force: true });
+    fs.renameSync(source, destination);
+    moved?.push(rel);
+  }
+
+  /**
+   * Undo {@link moveBindMounts} after a failed update: replay the recorded
+   * renames backwards so the restored previous app dir gets its state back.
+   */
+  private restoreBindMounts(fromDir: string, toDir: string, moved: string[], job: JobState): void {
+    for (const rel of [...moved].reverse()) {
+      if (!this.isSafeBindRel(fromDir, toDir, rel)) continue;
+      const source = path.resolve(fromDir, rel);
+      const destination = path.resolve(toDir, rel);
+      if (!fs.existsSync(source) || fs.existsSync(destination)) continue;
+      try {
+        this.ensureDirWithinNoSymlink(toDir, path.dirname(destination));
+        fs.renameSync(source, destination);
+      } catch (err) {
+        this.log(job, `Warning: could not restore bind-mount path "${rel}": ${(err as Error).message}`);
+      }
     }
   }
 

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -956,6 +956,42 @@ export class AppInstaller {
     }
   }
 
+  private discoverBindMountsOrThrow(appName: string, appDir: string): string[] {
+    try {
+      const { stdout } = this.run(
+        ['docker', 'compose', '-p', appName, 'config', '--format', 'json'],
+        appDir,
+        30_000,
+      );
+      const parsed = JSON.parse(stdout) as {
+        services?: Record<string, { volumes?: Array<{ type?: string; source?: string }> }>;
+      };
+      const bases = [appDir];
+      try {
+        const real = fs.realpathSync(appDir);
+        if (real !== appDir) bases.push(real);
+      } catch { /* app dir unreadable — use literal base */ }
+      const rels = new Set<string>();
+      for (const svc of Object.values(parsed.services ?? {})) {
+        for (const vol of svc.volumes ?? []) {
+          if (vol.type !== 'bind' || typeof vol.source !== 'string') continue;
+          const abs = path.resolve(appDir, vol.source);
+          const matched = bases.find((base) => abs !== base && abs.startsWith(base + path.sep));
+          if (!matched) continue;
+          rels.add(path.relative(matched, abs).split(path.sep).join('/'));
+        }
+      }
+      return Array.from(rels).sort();
+    } catch (err) {
+      // A config query is only optional for apps whose stored compose declares no
+      // app-local bind source. If it does, continuing would discard unknown state.
+      const composePath = path.join(appDir, 'docker-compose.yml');
+      const compose = fs.existsSync(composePath) ? fs.readFileSync(composePath, 'utf-8') : '';
+      if (!compose.includes(appDir)) return [];
+      throw new Error(`Cannot safely discover bind mounts for update: ${(err as Error).message}`);
+    }
+  }
+
   /**
    * Discover bind-mount source directories that live **under the app dir**
    * (e.g. `./data/photos` → `data/photos`). These hold app-owned data that is
@@ -1641,7 +1677,12 @@ export class AppInstaller {
       }
     }
 
-    const tmpDir = path.join(os.tmpdir(), `cg-update-${appName}-${crypto.randomUUID()}`);
+    // Stage beside the durable install path so the directory swap and bind-data
+    // moves are same-filesystem renames, not cross-device copies/failures.
+    const tmpDir = path.join(
+      path.dirname(entry.installPath),
+      `.cg-update-${appName}-${crypto.randomUUID()}`,
+    );
     try {
       // ── Shallow fetch of specific commit into tmp dir ─────────────────────
       this.log(job, `Cloning ${target.repo}`);
@@ -1682,7 +1723,7 @@ export class AppInstaller {
         version: newVersion,
         commit: target.newCommit,
         installPath: tmpDir,
-        ...(generated.agentDeclaration !== null ? { agentDeclaration: generated.agentDeclaration } : {}),
+        agentDeclaration: generated.agentDeclaration,
         ...(agentPaths ? { agentPaths } : {}),
       };
 
@@ -1707,28 +1748,55 @@ export class AppInstaller {
       this.callbacks.deregisterRoutes(appName);
       this.callbacks.stopSockets(appName);
 
-      // Capture the current (old) image IDs while the old stack is still up, so
-      // we can reclaim exactly those images after the update — without a
-      // `compose down` that would collide with the new stack (issue #283).
+      // Capture the current (old) image IDs and app-owned bind paths while the old
+      // compose file still points at the durable install directory. The bind paths
+      // must move with the release swap so cleanup cannot delete live state.
       const oldImageIds = this.captureComposeImageIds(appName, entry.installPath);
-      // Also capture the app's declared image refs (repo:tag) so a superseded
-      // *pulled* tag can be reclaimed after the update (issue #302).
       const oldImageRefs = this.captureComposeImageRefs(appName, entry.installPath);
+      const oldBindMounts = this.discoverBindMountsOrThrow(appName, entry.installPath);
 
-      // ── Bring old containers down (keeps images for rollback) ─────────────
+      // ── Swap dirs before starting the new containers ───────────────────────
+      // The new compose file's bind sources are anchored to finalDir. Starting
+      // before this swap would bind the old directory inode then delete it.
       this.log(job, 'Stopping old containers');
       this.run(['docker', 'compose', '-p', appName, 'down'], entry.installPath, 120_000);
-
-      // ── Start new containers ──────────────────────────────────────────────
-      this.log(job, 'Starting new containers');
+      this.log(job, 'Swapping app directories');
+      const finalDir = entry.installPath;
+      const oldBackupDir = `${finalDir}-old-${crypto.randomUUID()}`;
+      let swapped = false;
+      let failedDir: string | null = null;
+      const movedBindMounts: string[] = [];
       try {
-        this.composeUp(appName, tmpDir, job);
+        fs.renameSync(finalDir, oldBackupDir);
+        fs.renameSync(tmpDir, finalDir);
+        swapped = true;
+        this.moveBindMounts(oldBackupDir, finalDir, oldBindMounts, movedBindMounts);
+
+        // The source checkout is now permanent. Regenerate so build contexts stay
+        // relative to it and agent injection never retains a staging path.
+        const finalComposePath = path.join(finalDir, 'docker-compose.yml');
+        const finalYaml = parseAppYaml(fs.readFileSync(path.join(finalDir, 'app.yaml'), 'utf-8'), finalDir);
+        const finalGenerated = generateCompose(finalYaml, appName, finalDir, finalComposePath);
+        if (finalGenerated.agentDeclaration && this.agentManager && agentPaths) {
+          this.agentManager.injectAgentService({ ...newEntry, installPath: finalDir });
+        }
+
+        // ── Start new containers ────────────────────────────────────────────
+        this.log(job, 'Starting new containers');
+        this.composeUp(appName, finalDir, job);
       } catch (upErr) {
-        // Rollback: bring old containers back up from old install path
         this.log(job, 'New containers failed — rolling back to previous version');
         let rollbackFailed = false;
+        failedDir = `${finalDir}-failed-${crypto.randomUUID()}`;
         try {
-          this.run(['docker', 'compose', '-p', appName, 'up', '-d'], entry.installPath, 120_000);
+          if (swapped) {
+            fs.renameSync(finalDir, failedDir);
+            fs.renameSync(oldBackupDir, finalDir);
+            this.moveBindMounts(failedDir, finalDir, movedBindMounts);
+          } else if (fs.existsSync(oldBackupDir)) {
+            fs.renameSync(oldBackupDir, finalDir);
+          }
+          this.run(['docker', 'compose', '-p', appName, 'up', '-d'], finalDir, 120_000);
           this.callbacks.registerRoutes(appName, entry.ports.map((p) => ({
             name: p.name,
             service: p.service,
@@ -1738,34 +1806,21 @@ export class AppInstaller {
             rateLimit: p.rateLimit,
           })));
           await this.registry.updateStatus(appName, 'running');
+          if (failedDir !== null) this.safeRmrf(failedDir, job, 'failed update dir');
         } catch (rollbackErr) {
           rollbackFailed = true;
           this.log(job, `ROLLBACK FAILED — app "${appName}" may be in a broken state: ${(rollbackErr as Error).message}`);
         }
-        this.safeRmrf(tmpDir, job, 'update temp dir');
         if (rollbackFailed) {
           throw new Error(`Update failed and rollback also failed — app "${appName}" may be in a broken state. Check job logs for details.`);
         }
         throw upErr;
       }
 
-      // Capture the new stack's image IDs (still at tmpDir) so image reclamation
-      // below never removes an image the new containers depend on (e.g. when the
-      // old and new versions happen to share a base/image).
-      const newImageIds = this.captureComposeImageIds(appName, tmpDir);
-      const newImageRefs = this.captureComposeImageRefs(appName, tmpDir);
-
-      // ── Swap dirs ─────────────────────────────────────────────────────────
-      // Swap in place at the recorded install path — NOT path.join(appsDir, appName).
-      // For legacy installs the on-disk dir is named after the source repo/URL
-      // basename, so `installPath` basename can differ from the app name. Using
-      // the app name here throws ENOENT (issue #275). `entry.installPath` is the
-      // authoritative location the `down`/rollback steps above already use.
-      this.log(job, 'Swapping app directories');
-      const finalDir = entry.installPath;
-      const oldBackupDir = `${finalDir}-old-${crypto.randomUUID()}`;
-      fs.renameSync(finalDir, oldBackupDir);
-      fs.renameSync(tmpDir, finalDir);
+      // Capture the new stack's image IDs from its permanent compose file so
+      // cleanup below never removes an image the new containers depend on.
+      const newImageIds = this.captureComposeImageIds(appName, finalDir);
+      const newImageRefs = this.captureComposeImageRefs(appName, finalDir);
 
       // ── Restore MEMORY.md ─────────────────────────────────────────────────
       if (memoryBackup !== null && generated.agentDeclaration && this.agentManager) {
@@ -1782,8 +1837,11 @@ export class AppInstaller {
       };
       await this.registry.upsert(finalEntry);
 
-      // ── Re-create agent symlink + config.json entry ───────────────────────
-      if (generated.agentDeclaration && this.agentManager) {
+      // ── Re-create or remove the app-agent registration ────────────────────
+      if (entry.agentDeclaration && !generated.agentDeclaration && this.agentManager) {
+        await this.agentManager.deleteAgent(entry);
+        this.log(job, `Agent "${entry.agentDeclaration.name}" removed`);
+      } else if (generated.agentDeclaration && this.agentManager) {
         await this.agentManager.upsertAgent(finalEntry);
         this.log(job, `Agent "${generated.agentDeclaration.name}" re-registered`);
         await this.callbacks.reinitializeAgent?.(generated.agentDeclaration.name);
@@ -2330,6 +2388,50 @@ export class AppInstaller {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         this.log(job, `Warning: failed to remove ${label} "${dirPath}": ${(err as Error).message}`);
       }
+    }
+  }
+
+  private assertNoSymlinkAncestors(baseDir: string, targetDir: string): void {
+    const relative = path.relative(baseDir, targetDir);
+    let current = baseDir;
+    for (const segment of relative.split(path.sep).filter(Boolean)) {
+      current = path.join(current, segment);
+      if (fs.existsSync(current) && fs.lstatSync(current).isSymbolicLink()) {
+        throw new Error(`Updated app bind-mount path contains a symlink: "${current}"`);
+      }
+    }
+  }
+
+  /**
+   * Move app-owned relative bind directories across an update directory swap.
+   * Renaming preserves the database's ownership and inode, unlike copying, and
+   * every path is constrained to its respective app root before use.
+   */
+  private moveBindMounts(
+    fromDir: string,
+    toDir: string,
+    rels: string[],
+    moved?: string[],
+  ): void {
+    for (const rel of rels) {
+      const source = path.resolve(fromDir, rel);
+      const destination = path.resolve(toDir, rel);
+      const fromBase = fromDir.endsWith(path.sep) ? fromDir : fromDir + path.sep;
+      const toBase = toDir.endsWith(path.sep) ? toDir : toDir + path.sep;
+      if (
+        rel.length === 0 || path.isAbsolute(rel)
+        || !source.startsWith(fromBase) || !destination.startsWith(toBase)
+        || !fs.existsSync(source)
+      ) {
+        continue;
+      }
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      this.assertNoSymlinkAncestors(toDir, path.dirname(destination));
+      if (fs.existsSync(destination)) {
+        throw new Error(`Updated app already contains bind-mount path "${rel}"`);
+      }
+      fs.renameSync(source, destination);
+      moved?.push(rel);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -739,6 +739,17 @@ async function main(): Promise<void> {
     config.gateway?.appBackup,
   );
 
+  // Reclaim update scratch dirs a previous crash left beside an install path.
+  // Must run at boot, before any update can claim one of those names.
+  try {
+    const swept = await appInstaller.sweepStaleUpdateDirs();
+    if (swept.length > 0) {
+      console.log(`[gateway] Swept ${swept.length} stale app update director${swept.length === 1 ? 'y' : 'ies'}`);
+    }
+  } catch (err) {
+    console.warn(`[gateway] Failed to sweep stale app update directories: ${(err as Error).message}`);
+  }
+
   // Daily backup-cleanup scheduler (issue #310): prunes every app's backups by
   // the retention-count + max-age union policy. Timer is unref'd, so it never
   // keeps the process alive.

--- a/tests/unit/apps/compose-generator.test.ts
+++ b/tests/unit/apps/compose-generator.test.ts
@@ -374,6 +374,19 @@ describe('generateCompose()', () => {
     return generateCompose(appYaml, appName, appDir, outputPath);
   }
 
+  it('rejects a bind mount that escapes the app directory', () => {
+    expect(() => generate(`
+apiVersion: apps.getpod.ai/v1
+name: bound-app
+version: 1.0.0
+services:
+  app:
+    image: nginx:1.25
+    volumes:
+      - ../other-app/data:/data
+`)).toThrow(/stay within the app directory/);
+  });
+
   it('writes a valid YAML file', () => {
     generate(MINIMAL_IMAGE_YAML);
     expect(() => readCompose(outputPath)).not.toThrow();

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1009,6 +1009,140 @@ services:
       expect(readEnvFile(entry!.installPath)['APP_SECRET']).toBe('keep-me');
     });
 
+    it('keeps relative bind mounts at the permanent path across an update (issue #396)', async () => {
+      const githubUrl = 'https://github.com/test/stateful-app';
+      const appName = 'stateful-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0' };
+      const dockerCalls: Array<{ args: string[]; cwd?: string }> = [];
+      const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(path.join(opts.cwd, 'app.yaml'), `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: postgres:16-alpine
+    volumes:
+      - ./data/photos:/photos
+      - ./postgres/pgdata:/var/lib/postgresql/data
+    ports:
+      - name: api
+        host: 5410
+        container: 5410
+        type: api
+    healthcheck:
+      test: pg_isready
+      interval: 30s
+`.trim(), 'utf-8');
+        }
+        if (cmd === 'docker') {
+          dockerCalls.push({ args, cwd: opts?.cwd });
+          if (args.includes('config') && args.includes('--format') && opts?.cwd) {
+            return {
+              stdout: JSON.stringify({ services: { app: { volumes: [
+                { type: 'bind', source: path.join(opts.cwd, 'data', 'photos') },
+                { type: 'bind', source: path.join(opts.cwd, 'postgres', 'pgdata') },
+              ] } } }),
+              stderr: '', status: 0,
+            };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeInstaller(spawn);
+
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+      const before = await registry.get(appName);
+      const pgdata = path.join(before!.installPath, 'postgres', 'pgdata');
+      const photos = path.join(before!.installPath, 'data', 'photos');
+      fs.mkdirSync(pgdata, { recursive: true });
+      fs.mkdirSync(photos, { recursive: true });
+      fs.writeFileSync(path.join(pgdata, 'PG_VERSION'), '16');
+      fs.writeFileSync(path.join(photos, 'photo.jpg'), 'persisted');
+
+      dockerCalls.length = 0;
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+      expect(job.status).toBe('completed');
+
+      const after = await registry.get(appName);
+      expect(after?.installPath).toBe(before?.installPath);
+      expect(fs.readFileSync(path.join(pgdata, 'PG_VERSION'), 'utf-8')).toBe('16');
+      expect(fs.readFileSync(path.join(photos, 'photo.jpg'), 'utf-8')).toBe('persisted');
+      const compose = fs.readFileSync(path.join(after!.installPath, 'docker-compose.yml'), 'utf-8');
+      expect(compose).toContain(pgdata);
+      expect(compose).toContain(photos);
+      expect(compose).not.toContain('cg-update-');
+      const updateUp = dockerCalls.find((call) => call.args.includes('up') && call.args.includes('--wait'));
+      expect(updateUp?.cwd).toBe(after?.installPath);
+    });
+
+    it('rolls back preserved bind mounts when the updated stack cannot start (issue #396)', async () => {
+      const githubUrl = 'https://github.com/test/rollback-stateful-app';
+      const appName = 'rollback-stateful-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0', failNewUp: false, upCalls: 0 };
+      const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(path.join(opts.cwd, 'app.yaml'), `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: postgres:16-alpine
+    volumes:
+      - ./postgres/pgdata:/var/lib/postgresql/data
+    ports:
+      - name: api
+        host: 5411
+        container: 5411
+        type: api
+    healthcheck:
+      test: pg_isready
+      interval: 30s
+`.trim(), 'utf-8');
+        }
+        if (cmd === 'docker' && args.includes('config') && args.includes('--format') && opts?.cwd) {
+          return { stdout: JSON.stringify({ services: { app: { volumes: [
+            { type: 'bind', source: path.join(opts.cwd, 'postgres', 'pgdata') },
+          ] } } }), stderr: '', status: 0 };
+        }
+        if (cmd === 'docker' && args.includes('up')) {
+          state.upCalls += 1;
+          if (state.failNewUp && state.upCalls === 1) {
+            return { stdout: '', stderr: 'new stack failed', status: 1 };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeInstaller(spawn);
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+      const before = await registry.get(appName);
+      const marker = path.join(before!.installPath, 'postgres', 'pgdata', 'PG_VERSION');
+      fs.mkdirSync(path.dirname(marker), { recursive: true });
+      fs.writeFileSync(marker, '16');
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      state.failNewUp = true;
+      state.upCalls = 0;
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+      expect(job.status).toBe('failed');
+      const after = await registry.get(appName);
+      expect(after?.commit).toBe('a'.repeat(40));
+      expect(fs.readFileSync(marker, 'utf-8')).toBe('16');
+    });
+
     it('updates an app whose on-disk dir name ≠ app.yaml name (legacy install, issue #275)', async () => {
       // Legacy installs named the on-disk dir after the source repo basename,
       // so installPath basename can differ from the app name. The dir-swap must
@@ -1088,12 +1222,12 @@ services:
         }
         if (cmd === 'docker') {
           dockerCalls.push({ args, cwd: opts?.cwd });
-          // `docker compose -p <app> images --quiet` → a distinct image id per
-          // stack, keyed off the working dir (new stack builds under a
-          // `cg-update-*` tmp dir; the old stack lives under appsDir).
+          // Image inspection runs before/after the directory swap. Distinguish
+          // the update's new-stack query by order, not a staging cwd: the fixed
+          // stack is intentionally started from the permanent app directory.
           if (args.includes('images') && args.includes('--quiet')) {
-            const isNew = (opts?.cwd ?? '').includes('cg-update-');
-            return { stdout: `${isNew ? 'sha-new' : 'sha-old'}\n`, stderr: '', status: 0 };
+            const imagesCalls = dockerCalls.filter((c) => c.args.includes('images') && c.args.includes('--quiet'));
+            return { stdout: `${imagesCalls.length >= 2 ? 'sha-new' : 'sha-old'}\n`, stderr: '', status: 0 };
           }
         }
         return { stdout: '', stderr: '', status: 0 };

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1472,6 +1472,191 @@ services:
       expect(fs.readFileSync(marker, 'utf-8')).toBe('16');
     });
 
+    /**
+     * A `build:` service's new image reuses the tag of the one in production,
+     * so a failed update leaves that tag on the broken release. Rolling the
+     * source back is not enough — the image has to come back too.
+     */
+    function rollbackImageSpawn(opts: {
+      appName: string;
+      state: { head: string; version: string; upCalls: number; failNewUp: boolean };
+      calls: Array<{ args: string[] }>;
+      oldImageId: string;
+      tagFails?: boolean;
+      ndjson?: boolean;
+    }) {
+      const { appName, state, calls, oldImageId } = opts;
+      return jest.fn((cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && spawnOpts?.cwd) {
+          fs.writeFileSync(path.join(spawnOpts.cwd, 'app.yaml'), `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    build: .
+    volumes:
+      - ./data/photos:/photos
+    ports:
+      - name: api
+        host: 5412
+        container: 5412
+        type: api
+    healthcheck:
+      test: exit 0
+      interval: 30s
+`.trim(), 'utf-8');
+        }
+        if (cmd !== 'docker') return { stdout: '', stderr: '', status: 0 };
+        calls.push({ args });
+        if (args.includes('config') && args.includes('--format') && spawnOpts?.cwd) {
+          return { stdout: JSON.stringify({ services: { app: { volumes: [
+            { type: 'bind', source: path.join(spawnOpts.cwd, 'data', 'photos') },
+          ] } } }), stderr: '', status: 0 };
+        }
+        if (args.includes('images') && args.includes('json')) {
+          const row = { ID: oldImageId, Repository: `${appName}-app`, Tag: 'latest' };
+          return {
+            // Compose has shipped both dialects: a single array, and one object
+            // per line.
+            stdout: opts.ndjson ? `${JSON.stringify(row)}\n` : JSON.stringify([row]),
+            stderr: '', status: 0,
+          };
+        }
+        // `docker image tag <src> <dst>`: preserving the pre-update build, then
+        // (on rollback) putting it back. `tagFails` simulates an image the
+        // containerd store already dropped.
+        if (args[0] === 'image' && args[1] === 'tag') {
+          return opts.tagFails
+            ? { stdout: '', stderr: 'No such image', status: 1 }
+            : { stdout: '', stderr: '', status: 0 };
+        }
+        if (args.includes('up')) {
+          state.upCalls += 1;
+          if (state.failNewUp && state.upCalls === 1) {
+            return { stdout: '', stderr: 'new stack failed', status: 1 };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    it('rolls the image back with the source when the updated stack cannot start', async () => {
+      const githubUrl = 'https://github.com/test/rollback-image-app';
+      const appName = 'rollback-image-app';
+      const oldImageId = 'previousgoodrelease0000';
+      const state = { head: 'a'.repeat(40), version: '1.0.0', upCalls: 0, failNewUp: false };
+      const calls: Array<{ args: string[] }> = [];
+      const installer = makeInstaller(
+        rollbackImageSpawn({ appName, state, calls, oldImageId }),
+      );
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      state.failNewUp = true;
+      state.upCalls = 0;
+      calls.length = 0;
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+      expect(job.status).toBe('failed');
+
+      const backupRef = `${appName}-app:cg-rollback-${oldImageId.slice(0, 12)}`;
+      const tagIdx = calls.findIndex(
+        (c) => c.args[0] === 'image' && c.args[1] === 'tag'
+          && c.args[2] === backupRef && c.args[3] === `${appName}-app:latest`,
+      );
+      expect(tagIdx).toBeGreaterThanOrEqual(0);
+      // The rollback `up` must follow the retag, and must not need a rebuild.
+      const rollbackUpIdx = calls.findIndex(
+        (c, i) => i > tagIdx && c.args.includes('up') && !c.args.includes('--wait'),
+      );
+      expect(rollbackUpIdx).toBeGreaterThan(tagIdx);
+      expect(calls[rollbackUpIdx].args).not.toContain('--build');
+      expect(job.logs.some((l) => l.includes('Restored image'))).toBe(true);
+    });
+
+    it('drops its rollback tag once the updated stack is up', async () => {
+      const githubUrl = 'https://github.com/test/rollback-cleanup-app';
+      const appName = 'rollback-cleanup-app';
+      const oldImageId = 'previousgoodrelease0000';
+      const state = { head: 'a'.repeat(40), version: '1.0.0', upCalls: 0, failNewUp: false };
+      const calls: Array<{ args: string[] }> = [];
+      const installer = makeInstaller(
+        rollbackImageSpawn({ appName, state, calls, oldImageId }),
+      );
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      calls.length = 0;
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+      expect(job.status).toBe('completed');
+
+      const backupRef = `${appName}-app:cg-rollback-${oldImageId.slice(0, 12)}`;
+      // Left behind, the extra reference would make the post-update reclaim's
+      // `docker image rm <id>` refuse.
+      expect(calls.some(
+        (c) => c.args[0] === 'image' && c.args[1] === 'rm' && c.args[2] === backupRef,
+      )).toBe(true);
+    });
+
+    it('reads a line-delimited `compose images` dialect as well as an array', async () => {
+      const githubUrl = 'https://github.com/test/rollback-ndjson-app';
+      const appName = 'rollback-ndjson-app';
+      const oldImageId = 'previousgoodrelease0000';
+      const state = { head: 'a'.repeat(40), version: '1.0.0', upCalls: 0, failNewUp: false };
+      const calls: Array<{ args: string[] }> = [];
+      const installer = makeInstaller(
+        rollbackImageSpawn({ appName, state, calls, oldImageId, ndjson: true }),
+      );
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      state.failNewUp = true;
+      state.upCalls = 0;
+      calls.length = 0;
+      await waitForJob(installer, installer.update(appName), 5000);
+
+      const backupRef = `${appName}-app:cg-rollback-${oldImageId.slice(0, 12)}`;
+      expect(calls.some(
+        (c) => c.args[0] === 'image' && c.args[1] === 'tag'
+          && c.args[2] === backupRef && c.args[3] === `${appName}-app:latest`,
+      )).toBe(true);
+    });
+
+    it('rebuilds from the rolled-back source when the previous image is gone', async () => {
+      const githubUrl = 'https://github.com/test/rollback-rebuild-app';
+      const appName = 'rollback-rebuild-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0', upCalls: 0, failNewUp: false };
+      const calls: Array<{ args: string[] }> = [];
+      const installer = makeInstaller(
+        rollbackImageSpawn({
+          appName, state, calls, oldImageId: 'prunedawayimage0000', tagFails: true,
+        }),
+      );
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      state.failNewUp = true;
+      state.upCalls = 0;
+      calls.length = 0;
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+      expect(job.status).toBe('failed');
+
+      const rollbackUp = calls.find(
+        (c) => c.args.includes('up') && !c.args.includes('--wait'),
+      );
+      expect(rollbackUp?.args).toContain('--build');
+      expect(job.logs.some((l) => l.includes('could not preserve image'))).toBe(true);
+      expect(job.logs.some((l) => l.includes('was not preserved'))).toBe(true);
+    });
+
     it('updates an app whose on-disk dir name ≠ app.yaml name (legacy install, issue #275)', async () => {
       // Legacy installs named the on-disk dir after the source repo basename,
       // so installPath basename can differ from the app name. The dir-swap must

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1009,6 +1009,302 @@ services:
       expect(readEnvFile(entry!.installPath)['APP_SECRET']).toBe('keep-me');
     });
 
+    // ── Review follow-ups on the #396 fix ────────────────────────────────
+    //
+    // Shared harness: an app that declares a directory bind (`./data/photos`)
+    // and a file bind (`./config/app.conf`). `shipTracked` decides whether the
+    // updated release also carries content at those paths — the realistic case
+    // a repo creates with a `.gitkeep`, seed data, or a tracked config file.
+    function statefulAppSpawn(opts: {
+      appName: string;
+      state: { head: string; version: string };
+      hostPort: number;
+      shipTracked?: boolean;
+      failConfig?: () => boolean;
+      onCheckout?: (cwd: string) => void;
+      calls?: Array<{ args: string[]; cwd?: string }>;
+    }) {
+      const { appName, state, hostPort } = opts;
+      return jest.fn((cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && spawnOpts?.cwd) {
+          const cwd = spawnOpts.cwd;
+          fs.writeFileSync(path.join(cwd, 'app.yaml'), `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: postgres:16-alpine
+    volumes:
+      - ./data/photos:/photos
+      - ./config/app.conf:/etc/app.conf
+    ports:
+      - name: api
+        host: ${hostPort}
+        container: ${hostPort}
+        type: api
+    healthcheck:
+      test: pg_isready
+      interval: 30s
+`.trim(), 'utf-8');
+          if (opts.shipTracked) {
+            // What a real `git checkout` of the new release produces.
+            fs.mkdirSync(path.join(cwd, 'data', 'photos'), { recursive: true });
+            fs.writeFileSync(path.join(cwd, 'data', 'photos', '.gitkeep'), '', 'utf-8');
+            fs.mkdirSync(path.join(cwd, 'config'), { recursive: true });
+            fs.writeFileSync(path.join(cwd, 'config', 'app.conf'), 'release-default', 'utf-8');
+          }
+          opts.onCheckout?.(cwd);
+        }
+        if (cmd === 'docker') {
+          opts.calls?.push({ args, cwd: spawnOpts?.cwd });
+          if (args.includes('config') && args.includes('--format') && spawnOpts?.cwd) {
+            if (opts.failConfig?.()) {
+              return { stdout: '', stderr: 'docker daemon unreachable', status: 1 };
+            }
+            return {
+              stdout: JSON.stringify({ services: { app: { volumes: [
+                { type: 'bind', source: path.join(spawnOpts.cwd, 'data', 'photos') },
+                { type: 'bind', source: path.join(spawnOpts.cwd, 'config', 'app.conf') },
+              ] } } }),
+              stderr: '', status: 0,
+            };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    /** Install the app, then seed live state into its bind paths. */
+    async function installWithLiveState(
+      installer: AppInstaller,
+      githubUrl: string,
+      appName: string,
+    ) {
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+      const entry = await registry.get(appName);
+      const photos = path.join(entry!.installPath, 'data', 'photos');
+      const conf = path.join(entry!.installPath, 'config', 'app.conf');
+      fs.mkdirSync(photos, { recursive: true });
+      fs.mkdirSync(path.dirname(conf), { recursive: true });
+      fs.writeFileSync(path.join(photos, 'photo.jpg'), 'persisted', 'utf-8');
+      fs.writeFileSync(conf, 'operator-edited', 'utf-8');
+      return { entry: entry!, photos, conf };
+    }
+
+    it('merges live bind data into a release that ships tracked content at the same paths', async () => {
+      // REVIEW #1 — the fix threw `Updated app already contains bind-mount path`
+      // whenever the new checkout carried the bind path, making every update of
+      // such an app fail-and-roll-back forever.
+      const appName = 'merge-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0' };
+      const spawn = statefulAppSpawn({ appName, state, hostPort: 5420, shipTracked: true });
+      const installer = makeInstaller(spawn as typeof successSpawn);
+      const { photos, conf } = await installWithLiveState(
+        installer, 'https://github.com/test/merge-app', appName,
+      );
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+
+      expect(job.status).toBe('completed');
+      // Live data survives the collision …
+      expect(fs.readFileSync(path.join(photos, 'photo.jpg'), 'utf-8')).toBe('persisted');
+      // … and the release's own file inside that directory still lands.
+      expect(fs.existsSync(path.join(photos, '.gitkeep'))).toBe(true);
+      // A non-directory collision keeps the live copy, and says so.
+      expect(fs.readFileSync(conf, 'utf-8')).toBe('operator-edited');
+      expect(job.logs.join('\n')).toContain('preserved existing bind-mount data at "config/app.conf"');
+    });
+
+    it('leaves routes and containers untouched when bind discovery fails closed', async () => {
+      // REVIEW #2 — discovery ran after deregisterRoutes()/stopSockets(), so a
+      // docker failure left the app running but unreachable with no path back.
+      const appName = 'discovery-fail-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0' };
+      const calls: Array<{ args: string[]; cwd?: string }> = [];
+      let failConfig = false;
+      const spawn = statefulAppSpawn({
+        appName, state, hostPort: 5421, calls, failConfig: () => failConfig,
+      });
+      const installer = makeInstaller(spawn as typeof successSpawn);
+      await installWithLiveState(installer, 'https://github.com/test/discovery-fail-app', appName);
+
+      callbacks.deregistered.length = 0;
+      calls.length = 0;
+      failConfig = true;
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+
+      expect(job.status).toBe('failed');
+      expect(job.logs.join('\n')).toContain('Cannot safely discover bind mounts');
+      // The app was never disturbed: routes still registered, stack still up.
+      expect(callbacks.deregistered).not.toContain(appName);
+      expect(calls.some((c) => c.args.includes('down'))).toBe(false);
+    });
+
+    it('still treats bind discovery as best-effort for backups', async () => {
+      // REVIEW #4 — one helper now serves both callers. Backup must stay
+      // best-effort ([] on failure) while update fails closed (test above).
+      const appName = 'backup-besteffort-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0' };
+      let failConfig = false;
+      const spawn = statefulAppSpawn({
+        appName, state, hostPort: 5422, failConfig: () => failConfig,
+      });
+      const installer = makeInstaller(spawn as typeof successSpawn);
+      const { entry } = await installWithLiveState(
+        installer, 'https://github.com/test/backup-besteffort-app', appName,
+      );
+
+      failConfig = true;
+      const job = await waitForJob(installer, installer.backup(appName), 5000);
+      expect(job.status).toBe('completed'); // best-effort: never fails the backup
+      expect(job.logs.join('\n')).toContain('0 bind mount(s)');
+
+      // Sanity: with docker healthy the same helper finds both binds.
+      failConfig = false;
+      const ok = await waitForJob(installer, installer.backup(appName), 5000);
+      expect(ok.logs.join('\n')).toContain('2 bind mount(s)');
+      expect(ok.logs.join('\n')).toContain('Archiving bind mount "data/photos"');
+      expect(entry.installPath).toBeTruthy();
+    });
+
+    it('refuses a bind path that traverses a symlink, before creating anything through it', async () => {
+      // REVIEW #3 — the guard ran *after* `mkdir -p`, so any directory level
+      // below the symlink had already been materialised outside the app dir.
+      const appName = 'symlink-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0' };
+      const escapeTarget = path.join(tmpDir, 'escape-target');
+      fs.mkdirSync(escapeTarget, { recursive: true });
+      // `data/media/photos` has a level below `data`, which the release turns
+      // into a symlink — `mkdir -p .../data/media` would create it in the target.
+      const spawn = jest.fn((cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && spawnOpts?.cwd) {
+          fs.writeFileSync(path.join(spawnOpts.cwd, 'app.yaml'), `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: postgres:16-alpine
+    volumes:
+      - ./data/media/photos:/photos
+    ports:
+      - name: api
+        host: 5423
+        container: 5423
+        type: api
+    healthcheck:
+      test: pg_isready
+      interval: 30s
+`.trim(), 'utf-8');
+          // Only the *updated* release ships `data` as a symlink out of the app dir.
+          if (state.head === 'b'.repeat(40)) {
+            fs.symlinkSync(escapeTarget, path.join(spawnOpts.cwd, 'data'));
+          }
+        }
+        if (cmd === 'docker' && args.includes('config') && args.includes('--format') && spawnOpts?.cwd) {
+          return {
+            stdout: JSON.stringify({ services: { app: { volumes: [
+              { type: 'bind', source: path.join(spawnOpts.cwd, 'data', 'media', 'photos') },
+            ] } } }),
+            stderr: '', status: 0,
+          };
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeInstaller(spawn as typeof successSpawn);
+      await waitForJob(installer, installer.install({ githubUrl: 'https://github.com/test/symlink-app' }), 5000);
+      const entry = (await registry.get(appName))!;
+      const photos = path.join(entry.installPath, 'data', 'media', 'photos');
+      fs.mkdirSync(photos, { recursive: true });
+      fs.writeFileSync(path.join(photos, 'photo.jpg'), 'persisted', 'utf-8');
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+
+      expect(job.status).toBe('failed');
+      expect(job.logs.join('\n')).toContain('contains a symlink');
+      // Nothing was created through the symlink …
+      expect(fs.readdirSync(escapeTarget)).toEqual([]);
+      // … and the rollback put the live state back.
+      expect(fs.readFileSync(path.join(photos, 'photo.jpg'), 'utf-8')).toBe('persisted');
+    });
+
+    it('fails closed when a symlinked app dir hides its own bind sources', async () => {
+      // REVIEW #6 — the fallback compared the compose text against the literal
+      // app dir only, so a compose anchored to the realpath read as "no bind
+      // mounts" and the update proceeded, stranding live state.
+      const appName = 'symlinked-dir-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0' };
+      let failConfig = false;
+      const spawn = statefulAppSpawn({
+        appName, state, hostPort: 5424, failConfig: () => failConfig,
+      });
+      const installer = makeInstaller(spawn as typeof successSpawn);
+      const { entry } = await installWithLiveState(
+        installer, 'https://github.com/test/symlinked-dir-app', appName,
+      );
+
+      // Turn the install path into a symlink whose compose references only the
+      // realpath — exactly the shape a local-dev install leaves behind.
+      const realDir = path.join(tmpDir, 'symlinked-dir-app-real');
+      fs.renameSync(entry.installPath, realDir);
+      fs.symlinkSync(realDir, entry.installPath);
+      fs.writeFileSync(
+        path.join(entry.installPath, 'docker-compose.yml'),
+        `services:\n  app:\n    volumes:\n      - ${path.join(realDir, 'data', 'photos')}:/photos\n`,
+        'utf-8',
+      );
+
+      failConfig = true;
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+
+      expect(job.status).toBe('failed');
+      expect(job.logs.join('\n')).toContain('Cannot safely discover bind mounts');
+    });
+
+    it('sweeps stale update scratch dirs at boot, sparing real app dirs', async () => {
+      // REVIEW #7 — staging moved beside the install path, so /tmp cleanup no
+      // longer collects a checkout left by a crash mid-update.
+      const uuid = '11111111-2222-4333-8444-555555555555';
+      const installer = makeInstaller();
+      await waitForJob(installer, installer.install({ localPath: makeAppDir(srcDir, 'keep-app') }), 5000);
+      const live = (await registry.get('keep-app'))!.installPath;
+
+      const stale = [
+        path.join(appsDir, `.cg-update-keep-app-${uuid}`),
+        path.join(appsDir, `keep-app-old-${uuid}`),
+        path.join(appsDir, `keep-app-failed-${uuid}`),
+      ];
+      const decoys = [
+        path.join(appsDir, 'my-old-app'),
+        path.join(appsDir, 'cg-update-not-a-uuid'),
+      ];
+      for (const d of [...stale, ...decoys]) fs.mkdirSync(d, { recursive: true });
+
+      const swept = await installer.sweepStaleUpdateDirs();
+
+      expect(swept.sort()).toEqual([...stale].sort());
+      for (const d of stale) expect(fs.existsSync(d)).toBe(false);
+      for (const d of decoys) expect(fs.existsSync(d)).toBe(true);
+      expect(fs.existsSync(live)).toBe(true);
+    });
+
     it('keeps relative bind mounts at the permanent path across an update (issue #396)', async () => {
       const githubUrl = 'https://github.com/test/stateful-app';
       const appName = 'stateful-app';

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -58,6 +58,24 @@ services:
   return appDir;
 }
 
+/** Stub AgentManager. `existingAgentName` is the only name it reports as taken. */
+function makeAgentMgr(existingAgentName: string) {
+  return {
+    findAgentByName: jest.fn(async (n: string) => (n === existingAgentName ? n : null)),
+    deleteAgentByName: jest.fn(async () => {}),
+    deleteAgent: jest.fn(async () => {}),
+    detectAgentPaths: jest.fn(() => ({
+      claudeBin: '/usr/bin/claude',
+      nodeBin: '/usr/bin/node',
+      npmRoot: '/usr/lib/node_modules',
+    })),
+    injectAgentService: jest.fn(() => {}),
+    upsertAgent: jest.fn(async () => {}),
+    backupMemory: jest.fn((): string | null => null),
+    restoreMemory: jest.fn(() => {}),
+  };
+}
+
 /** Spawn mock that always succeeds */
 const successSpawn = jest.fn(
   (_cmd: string, _args: string[], _opts?: object) => ({
@@ -127,6 +145,108 @@ describe('AppInstaller', () => {
       asyncSpawnFn as unknown as ConstructorParameters<typeof AppInstaller>[6],
     );
   }
+
+  function makeInstallerWithAgent(
+    spawn: typeof successSpawn,
+    agentMgr: ReturnType<typeof makeAgentMgr>,
+  ) {
+    return new AppInstaller(
+      registry,
+      new RegistryClient(),
+      callbacks,
+      spawn,
+      appsDir,
+      agentMgr as unknown as ConstructorParameters<typeof AppInstaller>[5],
+      successAsyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
+    );
+  }
+
+  /**
+   * Spawn mock for an app that declares a directory bind (`./data/photos`) and
+   * a file bind (`./config/app.conf`). `shipTracked` decides whether the updated
+   * release also carries content at those paths — the realistic case a repo
+   * creates with a `.gitkeep`, seed data, or a tracked config file.
+   */
+    function statefulAppSpawn(opts: {
+      appName: string;
+      state: { head: string; version: string };
+      hostPort: number;
+      shipTracked?: boolean;
+      failConfig?: () => boolean;
+      onCheckout?: (cwd: string) => void;
+      calls?: Array<{ args: string[]; cwd?: string }>;
+    }) {
+      const { appName, state, hostPort } = opts;
+      return jest.fn((cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && spawnOpts?.cwd) {
+          const cwd = spawnOpts.cwd;
+          fs.writeFileSync(path.join(cwd, 'app.yaml'), `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: postgres:16-alpine
+    volumes:
+      - ./data/photos:/photos
+      - ./config/app.conf:/etc/app.conf
+    ports:
+      - name: api
+        host: ${hostPort}
+        container: ${hostPort}
+        type: api
+    healthcheck:
+      test: pg_isready
+      interval: 30s
+`.trim(), 'utf-8');
+          if (opts.shipTracked) {
+            // What a real `git checkout` of the new release produces.
+            fs.mkdirSync(path.join(cwd, 'data', 'photos'), { recursive: true });
+            fs.writeFileSync(path.join(cwd, 'data', 'photos', '.gitkeep'), '', 'utf-8');
+            fs.mkdirSync(path.join(cwd, 'config'), { recursive: true });
+            fs.writeFileSync(path.join(cwd, 'config', 'app.conf'), 'release-default', 'utf-8');
+          }
+          opts.onCheckout?.(cwd);
+        }
+        if (cmd === 'docker') {
+          opts.calls?.push({ args, cwd: spawnOpts?.cwd });
+          if (args.includes('config') && args.includes('--format') && spawnOpts?.cwd) {
+            if (opts.failConfig?.()) {
+              return { stdout: '', stderr: 'docker daemon unreachable', status: 1 };
+            }
+            return {
+              stdout: JSON.stringify({ services: { app: { volumes: [
+                { type: 'bind', source: path.join(spawnOpts.cwd, 'data', 'photos') },
+                { type: 'bind', source: path.join(spawnOpts.cwd, 'config', 'app.conf') },
+              ] } } }),
+              stderr: '', status: 0,
+            };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    /** Install the app, then seed live state into its bind paths. */
+    async function installWithLiveState(
+      installer: AppInstaller,
+      githubUrl: string,
+      appName: string,
+    ) {
+      await waitForJob(installer, installer.install({ githubUrl }), 5000);
+      const entry = await registry.get(appName);
+      const photos = path.join(entry!.installPath, 'data', 'photos');
+      const conf = path.join(entry!.installPath, 'config', 'app.conf');
+      fs.mkdirSync(photos, { recursive: true });
+      fs.mkdirSync(path.dirname(conf), { recursive: true });
+      fs.writeFileSync(path.join(photos, 'photo.jpg'), 'persisted', 'utf-8');
+      fs.writeFileSync(conf, 'operator-edited', 'utf-8');
+      return { entry: entry!, photos, conf };
+    }
 
   // ─── install() — local path mode ─────────────────────────────────────────
 
@@ -1009,93 +1129,6 @@ services:
       expect(readEnvFile(entry!.installPath)['APP_SECRET']).toBe('keep-me');
     });
 
-    // ── Review follow-ups on the #396 fix ────────────────────────────────
-    //
-    // Shared harness: an app that declares a directory bind (`./data/photos`)
-    // and a file bind (`./config/app.conf`). `shipTracked` decides whether the
-    // updated release also carries content at those paths — the realistic case
-    // a repo creates with a `.gitkeep`, seed data, or a tracked config file.
-    function statefulAppSpawn(opts: {
-      appName: string;
-      state: { head: string; version: string };
-      hostPort: number;
-      shipTracked?: boolean;
-      failConfig?: () => boolean;
-      onCheckout?: (cwd: string) => void;
-      calls?: Array<{ args: string[]; cwd?: string }>;
-    }) {
-      const { appName, state, hostPort } = opts;
-      return jest.fn((cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
-        if (cmd === 'git' && args[0] === 'ls-remote') {
-          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
-        }
-        if (cmd === 'git' && args[0] === 'checkout' && spawnOpts?.cwd) {
-          const cwd = spawnOpts.cwd;
-          fs.writeFileSync(path.join(cwd, 'app.yaml'), `
-apiVersion: apps.getpod.ai/v1
-name: ${appName}
-version: ${state.version}
-commit: "${state.head}"
-services:
-  app:
-    image: postgres:16-alpine
-    volumes:
-      - ./data/photos:/photos
-      - ./config/app.conf:/etc/app.conf
-    ports:
-      - name: api
-        host: ${hostPort}
-        container: ${hostPort}
-        type: api
-    healthcheck:
-      test: pg_isready
-      interval: 30s
-`.trim(), 'utf-8');
-          if (opts.shipTracked) {
-            // What a real `git checkout` of the new release produces.
-            fs.mkdirSync(path.join(cwd, 'data', 'photos'), { recursive: true });
-            fs.writeFileSync(path.join(cwd, 'data', 'photos', '.gitkeep'), '', 'utf-8');
-            fs.mkdirSync(path.join(cwd, 'config'), { recursive: true });
-            fs.writeFileSync(path.join(cwd, 'config', 'app.conf'), 'release-default', 'utf-8');
-          }
-          opts.onCheckout?.(cwd);
-        }
-        if (cmd === 'docker') {
-          opts.calls?.push({ args, cwd: spawnOpts?.cwd });
-          if (args.includes('config') && args.includes('--format') && spawnOpts?.cwd) {
-            if (opts.failConfig?.()) {
-              return { stdout: '', stderr: 'docker daemon unreachable', status: 1 };
-            }
-            return {
-              stdout: JSON.stringify({ services: { app: { volumes: [
-                { type: 'bind', source: path.join(spawnOpts.cwd, 'data', 'photos') },
-                { type: 'bind', source: path.join(spawnOpts.cwd, 'config', 'app.conf') },
-              ] } } }),
-              stderr: '', status: 0,
-            };
-          }
-        }
-        return { stdout: '', stderr: '', status: 0 };
-      });
-    }
-
-    /** Install the app, then seed live state into its bind paths. */
-    async function installWithLiveState(
-      installer: AppInstaller,
-      githubUrl: string,
-      appName: string,
-    ) {
-      await waitForJob(installer, installer.install({ githubUrl }), 5000);
-      const entry = await registry.get(appName);
-      const photos = path.join(entry!.installPath, 'data', 'photos');
-      const conf = path.join(entry!.installPath, 'config', 'app.conf');
-      fs.mkdirSync(photos, { recursive: true });
-      fs.mkdirSync(path.dirname(conf), { recursive: true });
-      fs.writeFileSync(path.join(photos, 'photo.jpg'), 'persisted', 'utf-8');
-      fs.writeFileSync(conf, 'operator-edited', 'utf-8');
-      return { entry: entry!, photos, conf };
-    }
-
     it('merges live bind data into a release that ships tracked content at the same paths', async () => {
       // REVIEW #1 — the fix threw `Updated app already contains bind-mount path`
       // whenever the new checkout carried the bind path, making every update of
@@ -1236,7 +1269,7 @@ services:
       const job = await waitForJob(installer, installer.update(appName), 5000);
 
       expect(job.status).toBe('failed');
-      expect(job.logs.join('\n')).toContain('contains a symlink');
+      expect(job.logs.join('\n')).toContain('must not be a symlink');
       // Nothing was created through the symlink …
       expect(fs.readdirSync(escapeTarget)).toEqual([]);
       // … and the rollback put the live state back.
@@ -1734,40 +1767,156 @@ services:
     );
   });
 
+  // ── App-agent lifecycle across an update ───────────────────────────────────
+  describe('update() — app-agent lifecycle', () => {
+    /** GitHub app whose agent declaration can change (or vanish) per release. */
+    function agentUpdateSpawn(
+      appName: string,
+      port: number,
+      state: { head: string; version: string; agentName: string | null },
+    ) {
+      return jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          const agentBlock = state.agentName === null
+            ? ''
+            : `\n  agent:\n    path: ./agent\n    name: ${state.agentName}`;
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    image: nginx:1.25
+    ports:
+      - name: api
+        host: ${port}
+        container: ${port}
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:${port}/health
+      interval: 30s
+`.trim() + agentBlock,
+            'utf-8',
+          );
+          if (state.agentName !== null) {
+            fs.mkdirSync(path.join(opts.cwd, 'agent'), { recursive: true });
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+    }
+
+    async function installThenUpdate(opts: {
+      appName: string;
+      port: number;
+      firstAgent: string | null;
+      secondAgent: string | null;
+    }) {
+      const state = { head: 'a'.repeat(40), version: '1.0.0', agentName: opts.firstAgent };
+      const agentMgr = makeAgentMgr('unrelated-bot'); // nothing conflicts
+      const spawn = agentUpdateSpawn(opts.appName, opts.port, state);
+      const installer = makeInstallerWithAgent(spawn as unknown as typeof successSpawn, agentMgr);
+
+      const install = await waitForJob(
+        installer,
+        installer.install({ githubUrl: `https://github.com/test/${opts.appName}` }),
+        5000,
+      );
+      expect(install.status).toBe('completed');
+      agentMgr.deleteAgentByName.mockClear();
+      agentMgr.upsertAgent.mockClear();
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      state.agentName = opts.secondAgent;
+      const update = await waitForJob(installer, installer.update(opts.appName), 5000);
+      return { agentMgr, update };
+    }
+
+    it('deregisters the old agent when a release renames it', async () => {
+      // REVIEW #A — upsertAgent() keys off the new name, so without an explicit
+      // deregistration the old workspace symlink and config entry are orphaned.
+      const { agentMgr, update } = await installThenUpdate({
+        appName: 'rename-agent-app', port: 5730,
+        firstAgent: 'old-bot', secondAgent: 'new-bot',
+      });
+
+      expect(update.status).toBe('completed');
+      expect(agentMgr.deleteAgentByName).toHaveBeenCalledWith('old-bot');
+      expect(agentMgr.upsertAgent).toHaveBeenCalledTimes(1);
+      expect(agentMgr.upsertAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ agentDeclaration: { path: './agent', name: 'new-bot' } }),
+      );
+      expect(update.logs.join('\n')).toContain('renamed to "new-bot"');
+    });
+
+    it('removes the registration when a release drops its agent', async () => {
+      // REVIEW #B — this branch shipped untested; every other update test passes
+      // agentManager: undefined, so it never ran.
+      const { agentMgr, update } = await installThenUpdate({
+        appName: 'drop-agent-app', port: 5731,
+        firstAgent: 'old-bot', secondAgent: null,
+      });
+
+      expect(update.status).toBe('completed');
+      expect(agentMgr.deleteAgentByName).toHaveBeenCalledWith('old-bot');
+      expect(agentMgr.upsertAgent).not.toHaveBeenCalled();
+      expect(update.logs.join('\n')).toContain('Agent "old-bot" removed');
+      expect((await registry.get('drop-agent-app'))?.agentDeclaration ?? null).toBeNull();
+    });
+
+    it('never deregisters when the agent name is unchanged', async () => {
+      // Guard against over-deleting: the ordinary update must not touch the
+      // registration it is about to re-upsert.
+      const { agentMgr, update } = await installThenUpdate({
+        appName: 'same-agent-app', port: 5732,
+        firstAgent: 'same-bot', secondAgent: 'same-bot',
+      });
+
+      expect(update.status).toBe('completed');
+      expect(agentMgr.deleteAgentByName).not.toHaveBeenCalled();
+      expect(agentMgr.upsertAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores MEMORY.md under the new name, after the rename is registered', async () => {
+      // restoreMemory() resolves the workspace through config.json, so writing
+      // it before upsertAgent silently dropped the memory on a rename.
+      const state = { head: 'a'.repeat(40), version: '1.0.0', agentName: 'old-bot' as string | null };
+      const agentMgr = makeAgentMgr('unrelated-bot');
+      agentMgr.backupMemory.mockReturnValue('remembered');
+      const spawn = agentUpdateSpawn('memory-agent-app', 5733, state);
+      const installer = makeInstallerWithAgent(spawn as unknown as typeof successSpawn, agentMgr);
+
+      await waitForJob(
+        installer,
+        installer.install({ githubUrl: 'https://github.com/test/memory-agent-app' }),
+        5000,
+      );
+      // The install already called upsertAgent — compare ordering within the
+      // update alone, not against that first registration.
+      agentMgr.upsertAgent.mockClear();
+      agentMgr.restoreMemory.mockClear();
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      state.agentName = 'new-bot';
+      const update = await waitForJob(installer, installer.update('memory-agent-app'), 5000);
+
+      expect(update.status).toBe('completed');
+      expect(agentMgr.restoreMemory).toHaveBeenCalledWith('new-bot', 'remembered');
+      expect(agentMgr.restoreMemory.mock.invocationCallOrder[0])
+        .toBeGreaterThan(agentMgr.upsertAgent.mock.invocationCallOrder[0]);
+    });
+  });
+
   // ── Agent-name conflict / orphan reclaim (issue #263) ──────────────────────
   describe('install — agent-name conflict vs orphan reclaim', () => {
-    function makeAgentMgr(existingAgentName: string) {
-      return {
-        findAgentByName: jest.fn(async (n: string) => (n === existingAgentName ? n : null)),
-        deleteAgentByName: jest.fn(async () => {}),
-        deleteAgent: jest.fn(async () => {}),
-        detectAgentPaths: jest.fn(() => ({
-          claudeBin: '/usr/bin/claude',
-          nodeBin: '/usr/bin/node',
-          npmRoot: '/usr/lib/node_modules',
-        })),
-        injectAgentService: jest.fn(() => {}),
-        upsertAgent: jest.fn(async () => {}),
-        backupMemory: jest.fn(() => null),
-        restoreMemory: jest.fn(() => {}),
-      };
-    }
-
-    function makeInstallerWithAgent(
-      spawn: typeof successSpawn,
-      agentMgr: ReturnType<typeof makeAgentMgr>,
-    ) {
-      return new AppInstaller(
-        registry,
-        new RegistryClient(),
-        callbacks,
-        spawn,
-        appsDir,
-        agentMgr as unknown as ConstructorParameters<typeof AppInstaller>[5],
-        successAsyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
-      );
-    }
-
     // GitHub install of an app that declares an agent service.
     function agentGitSpawn(appName: string, agentName: string, port: number, head: string) {
       return jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {


### PR DESCRIPTION
## Summary
- swap staged app code into its permanent directory before starting the updated Compose stack
- carry app-local bind-mounted state across the swap and restore it on any failed update phase
- merge live bind data with content the new release ships at the same path (existing data always wins)
- roll the app **image** back with its source when an update fails, so a rollback cannot leave the app on the failed release's build
- stage on the install filesystem, reject escaping bind paths, fail closed when bind discovery is uncertain, sweep stale scratch dirs on boot, and deregister an app-agent the release renames or drops

## Verified against a real Docker daemon
Not only mocked `spawn` — a throwaway app (real git repo, real `docker build`, real `compose up --wait`, real bind mounts) was installed, seeded with live state, then updated, in an isolated apps directory.

- **`main` (pre-fix):** the update reported `completed` while the seeded files were destroyed and the operator-edited config was overwritten; the running container's binds pointed at `/tmp/cg-update-*`, and the *persisted* compose file named that vanished path — a later `compose up` recreated it as empty directories and the app failed with `EISDIR`.
- **this branch:** every file survived on its original inode, the operator's config won over the release's copy, the container bound the permanent install path, and no scratch directory was left behind.
- **rollback:** a deliberately broken release rolled back to the *exact* pre-update image ID with data intact and no leftover `cg-rollback-*` tag. Before the image fix the same scenario left the container in a `Restarting (1)` crash loop.

The same defect was found live on the test host: an app-agent container had `/workspace` bound to a `/tmp/cg-update-*` directory Docker had recreated empty, so the agent had been running with none of its workspace files.

## Tests
- `npm run typecheck`
- `npm run build`
- `npm test -- --runInBand tests/unit/apps/` (8 suites / 303 tests)
- `npm test -- --runInBand` (191 suites / 3616 tests)

## Regression proof
Each fix was reverted in isolation and the test covering it re-run:

| reverted fix | result |
| --- | --- |
| start Compose from `finalDir` (#396) | 1 failed |
| merge instead of reject release content at a bind path | 1 failed |
| discover binds before deregistering routes | 1 failed |
| check for symlinks before `mkdir` | 1 failed |
| compare the fallback against the realpath too | 1 failed |
| sweep stale scratch dirs on boot | 1 failed |
| reject `../` in a volume source | 1 failed |
| deregister a renamed/dropped app-agent | 3 failed |
| restore `MEMORY.md` after registration | 1 failed |
| restore the pre-update image on rollback | 3 failed |

Closes #396
