### PR TITLE
feat(shell): always-on submit-retry diagnostics (#370 phase 1)

### DIFF
--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -23,6 +23,7 @@ import { decideMenuCancel } from './menu-cancel';
 import { shouldAdoptOrphanWake } from './orphan-wake';
 import { parseControlCommand, keystrokesFor, KEY_ENTER, isAcceptablePtyInput, MAX_PTY_INPUT_BYTES } from './control-channel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
+import { buildSubmitDiag } from './submit-diag';
 
 const POLL_MS = 200;
 const STARTUP_QUIET_MS = 600;
@@ -91,6 +92,15 @@ interface ActiveTurn {
   enterRetries: number;
   sawBusy: boolean;
   sawAssistant: boolean;
+  /** True once the literal "esc to interrupt" busy marker has been seen this
+   *  turn (distinct from `sawBusy`, which also flips from echo-immune assistant
+   *  records). Lets the submit-retry diagnostics tell a genuine swallowed Enter
+   *  (marker never seen, draft still on screen) apart from a busy-marker-drift
+   *  false-positive (#370). */
+  sawBusyMarker: boolean;
+  /** Timestamp (ms) of the first assistant record this turn, 0 if none yet —
+   *  the record-timing discriminator for the submit-retry diagnostics (#370). */
+  firstRecordAt: number;
   lastProgressAt: number;
   texts: string[];
   usage: UsageInfo | null;
@@ -433,6 +443,10 @@ class Driver {
     }
     if (this.turn) {
       this.turn.sawAssistant = true;
+      // First transcript output of this turn — the record-timing signal that
+      // distinguishes a busy-marker-drift false-positive from a genuine
+      // swallowed Enter in the submit-retry diagnostics (#370).
+      if (this.turn.firstRecordAt === 0) this.turn.firstRecordAt = Date.now();
       // Transcript output is the authoritative "Claude is working" signal, and it
       // is echo-immune (only Claude writes assistant records). Set sawBusy from it
       // so the fallback end-of-turn (tick(): sawBusy && sawAssistant) and the
@@ -504,6 +518,11 @@ class Driver {
     const turn = this.turn;
     if (!turn) return;
     this.turn = null;
+    // #370 instrumentation: a turn that hit ≥1 Enter-retry yet still completed
+    // successfully is the signature of a busy-marker-drift false-positive
+    // (cause 2) — the Enter was NOT actually swallowed. Log it to pair with the
+    // give-up snapshot. Gated on a retry having fired, so it never runs per-turn.
+    if (!isError && turn.enterRetries > 0) this.logSubmitDiag('recovered', turn, Date.now());
     // Clear any armed interrupt-settle — the turn is ending now regardless of how
     // (interrupt path, normal turn_duration, or error), so a stale flag must not
     // linger and block the next trySubmit().
@@ -526,6 +545,35 @@ class Driver {
       this.idleNotified = true;
       this.emitter.emitSessionIdle(this.args.sessionId);
     }
+  }
+
+  /** Emit one structured, prod-safe diagnostic line for the swallowed-Enter
+   *  submit-retry path (#370). Captures the give-up decision inputs so a genuine
+   *  swallowed Enter (cause 1: draft still on screen, marker never seen) can be
+   *  told apart in prod logs from a busy-marker-drift false-positive (cause 2:
+   *  draft empty, records appear right after). Never logs raw draft text — only
+   *  its length + a stable hash. Behavior-neutral: reads screen/turn state only.
+   *  Confined to the retry / give-up / recovery sites (never per-tick) to keep
+   *  log noise low. */
+  private logSubmitDiag(event: 'retry' | 'giveup' | 'recovered', turn: ActiveTurn, now: number): void {
+    const snapshot = buildSubmitDiag({
+      event,
+      enterRetries: turn.enterRetries,
+      sawBusy: turn.sawBusy,
+      sawBusyMarker: turn.sawBusyMarker,
+      sawAssistant: turn.sawAssistant,
+      recordsDelta: this.tailer.seenRecords - turn.recordsAtStart,
+      draft: this.screen.inputDraft(),
+      quietMs: this.screen.quietMs(),
+      msSinceSubmit: turn.submittedAt > 0 ? now - turn.submittedAt : null,
+      msSinceStart: now - turn.startedAt,
+      msSinceFirstRecord: turn.firstRecordAt > 0 ? now - turn.firstRecordAt : null,
+      hasPrompt: this.screen.hasPrompt(),
+      dialog: this.screen.detectDialog(),
+      fromMenuSelection: turn.fromMenuSelection,
+      probeRounds: turn.probe ? turn.probe.rounds : null,
+    });
+    logWarn(`submit-diag ${JSON.stringify(snapshot)}`);
   }
 
   // ---- turn submission -----------------------------------------------------
@@ -551,6 +599,8 @@ class Driver {
       enterRetries: 0,
       sawBusy: false,
       sawAssistant: false,
+      sawBusyMarker: false,
+      firstRecordAt: 0,
       lastProgressAt: now,
       texts: [],
       usage: null,
@@ -781,6 +831,10 @@ class Driver {
 
     if (this.screen.consumeBusySeen() || this.screen.isBusy()) {
       turn.sawBusy = true;
+      // Both checks above match only the literal "esc to interrupt" marker, so
+      // this is the one place the marker (not an assistant record) proves Claude
+      // is working — record it for the submit-retry diagnostics (#370).
+      turn.sawBusyMarker = true;
       turn.lastProgressAt = now;
       // Real activity resumed — a probe that ran out of rounds during this
       // stall gets a fresh budget if the turn genuinely stalls again later.
@@ -833,11 +887,13 @@ class Driver {
       // the exact retry this state needs and wedging the turn into the
       // 30-min watchdog (review round 2, finding 1).
       if (turn.enterRetries < MAX_ENTER_RETRIES) {
+        this.logSubmitDiag('retry', turn, now);
         turn.enterRetries++;
         turn.submittedAt = now;
         logWarn(`Enter appears swallowed — retry ${turn.enterRetries}/${MAX_ENTER_RETRIES}`);
         this.host.writeRaw('\r');
       } else {
+        this.logSubmitDiag('giveup', turn, now);
         this.finishTurn(true, 'failed to submit turn to the TUI input');
       }
       return;

--- a/src/shell/submit-diag.ts
+++ b/src/shell/submit-diag.ts
@@ -50,16 +50,39 @@ export interface SubmitDiagInputs {
   probeRounds: number | null;
 }
 
+/** Classification of a submit-retry snapshot into the two known failure modes,
+ *  or `unknown` when the evidence fits neither. This is a *label to aid reading*
+ *  — the raw fields (`draftLen`, `recordsDelta`, `sawBusyMarker`, …) remain the
+ *  source of truth and are always emitted, so a novel case is never lost to a
+ *  wrong bucket.
+ *
+ *  - `cause1-swallowed`: a non-empty draft is still sitting in the input box
+ *    (`draftLen > 0`) ⇒ the Enter was genuinely swallowed.
+ *  - `cause2-marker-drift`: the draft is empty and records arrived
+ *    (`draftLen === 0 && recordsDelta > 0`) ⇒ the Enter went through; the
+ *    give-up was a busy-marker-drift false positive.
+ *  - `unknown`: empty draft and no records (`draftLen === 0 && recordsDelta === 0`)
+ *    ⇒ Enter cleared but nothing followed — fits neither known cause. */
+export type LikelyCause = 'cause1-swallowed' | 'cause2-marker-drift' | 'unknown';
+
+export function classifyLikelyCause(draftLen: number, recordsDelta: number): LikelyCause {
+  if (draftLen > 0) return 'cause1-swallowed';
+  if (recordsDelta > 0) return 'cause2-marker-drift';
+  return 'unknown';
+}
+
 /** Build the prod-safe, structured diagnostic snapshot for the swallowed-Enter
  *  submit-retry path. Pure: the raw draft is reduced to `draftLen` + `draftHash`
  *  here and NEVER passed through verbatim, so no user text, token, or secret can
  *  reach the logs. `event` distinguishes an Enter-retry, the final give-up
  *  (cause 1 proof: non-empty draft still on screen), and a later successful
  *  completion (`recovered` — cause 2 proof: the Enter was not actually
- *  swallowed). */
+ *  swallowed). `likelyCause` is a reading aid derived from the raw fields; those
+ *  fields remain the source of truth. */
 export function buildSubmitDiag(i: SubmitDiagInputs): Record<string, unknown> {
   return {
     event: i.event,
+    likelyCause: classifyLikelyCause(i.draft.length, i.recordsDelta),
     enterRetries: i.enterRetries,
     sawBusy: i.sawBusy,
     sawBusyMarker: i.sawBusyMarker,

--- a/src/shell/submit-diag.ts
+++ b/src/shell/submit-diag.ts
@@ -1,0 +1,79 @@
+/**
+ * Diagnostics for the swallowed-Enter submit-retry path (#370).
+ *
+ * A turn intermittently fails with "failed to submit turn to the TUI input" for
+ * two indistinguishable reasons in today's logs:
+ *   (1) the Enter was genuinely swallowed — the draft is still sitting in the
+ *       input box at give-up (`draftLen > 0`), or
+ *   (2) a busy-marker-drift false-positive — newer Claude Code renders a random
+ *       gerund spinner instead of the "esc to interrupt" marker, so the
+ *       give-up branch trips even though Claude is working (draft empty, records
+ *       appear right after — surfaced by the paired `recovered` event).
+ *
+ * These pure helpers build one prod-safe structured snapshot per retry/give-up/
+ * recovery. Extracted from claude-pty-shell.ts so they are unit-testable without
+ * importing that module (which starts the driver on load).
+ */
+
+/** Stable 32-bit FNV-1a hash of a string, hex. Used only to correlate the input
+ *  draft across submit-retry snapshots (an unchanged hash ⇒ a genuinely stuck,
+ *  unsubmitted draft) WITHOUT ever logging the raw user text. */
+export function shortHash(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+/** Decision inputs for one submit-retry diagnostic snapshot. */
+export interface SubmitDiagInputs {
+  event: 'retry' | 'giveup' | 'recovered';
+  enterRetries: number;
+  sawBusy: boolean;
+  /** True if the literal "esc to interrupt" marker was ever seen this turn —
+   *  distinct from `sawBusy` (which also flips from echo-immune assistant
+   *  records). Its absence, with records still arriving, is the cause-2 tell. */
+  sawBusyMarker: boolean;
+  sawAssistant: boolean;
+  recordsDelta: number;
+  /** Raw input draft — redacted to length + hash by buildSubmitDiag; never emitted. */
+  draft: string;
+  quietMs: number;
+  msSinceSubmit: number | null;
+  msSinceStart: number;
+  msSinceFirstRecord: number | null;
+  hasPrompt: boolean;
+  dialog: string | null;
+  fromMenuSelection: boolean;
+  probeRounds: number | null;
+}
+
+/** Build the prod-safe, structured diagnostic snapshot for the swallowed-Enter
+ *  submit-retry path. Pure: the raw draft is reduced to `draftLen` + `draftHash`
+ *  here and NEVER passed through verbatim, so no user text, token, or secret can
+ *  reach the logs. `event` distinguishes an Enter-retry, the final give-up
+ *  (cause 1 proof: non-empty draft still on screen), and a later successful
+ *  completion (`recovered` — cause 2 proof: the Enter was not actually
+ *  swallowed). */
+export function buildSubmitDiag(i: SubmitDiagInputs): Record<string, unknown> {
+  return {
+    event: i.event,
+    enterRetries: i.enterRetries,
+    sawBusy: i.sawBusy,
+    sawBusyMarker: i.sawBusyMarker,
+    sawAssistant: i.sawAssistant,
+    recordsDelta: i.recordsDelta,
+    draftLen: i.draft.length,
+    draftHash: i.draft.length > 0 ? shortHash(i.draft) : null,
+    quietMs: i.quietMs,
+    msSinceSubmit: i.msSinceSubmit,
+    msSinceStart: i.msSinceStart,
+    msSinceFirstRecord: i.msSinceFirstRecord,
+    hasPrompt: i.hasPrompt,
+    dialog: i.dialog,
+    fromMenuSelection: i.fromMenuSelection,
+    probeRounds: i.probeRounds,
+  };
+}

--- a/tests/unit/submit-diag.test.ts
+++ b/tests/unit/submit-diag.test.ts
@@ -1,4 +1,4 @@
-import { shortHash, buildSubmitDiag, SubmitDiagInputs } from '../../src/shell/submit-diag';
+import { shortHash, buildSubmitDiag, classifyLikelyCause, SubmitDiagInputs } from '../../src/shell/submit-diag';
 
 // Diagnostics for the swallowed-Enter submit-retry path (#370). These are pure
 // helpers, so the tests mirror the menu-probe/decideMenuCancel style: no
@@ -134,6 +134,7 @@ describe('submit-diag buildSubmitDiag (structured snapshot)', () => {
       'event',
       'fromMenuSelection',
       'hasPrompt',
+      'likelyCause',
       'msSinceFirstRecord',
       'msSinceStart',
       'msSinceSubmit',
@@ -144,5 +145,28 @@ describe('submit-diag buildSubmitDiag (structured snapshot)', () => {
       'sawBusy',
       'sawBusyMarker',
     ]);
+  });
+});
+
+describe('submit-diag classifyLikelyCause (reading-aid label)', () => {
+  it('labels a non-empty draft as cause1-swallowed (Enter genuinely swallowed)', () => {
+    expect(classifyLikelyCause(156, 0)).toBe('cause1-swallowed');
+    // draftLen wins even if records also arrived — the draft is still on screen.
+    expect(classifyLikelyCause(156, 9)).toBe('cause1-swallowed');
+  });
+
+  it('labels an empty draft with records as cause2-marker-drift (Enter went through)', () => {
+    expect(classifyLikelyCause(0, 9)).toBe('cause2-marker-drift');
+    expect(classifyLikelyCause(0, 1)).toBe('cause2-marker-drift');
+  });
+
+  it('labels an empty draft with no records as unknown (fits neither known cause)', () => {
+    expect(classifyLikelyCause(0, 0)).toBe('unknown');
+  });
+
+  it('is reflected in the snapshot and derived only from raw fields', () => {
+    expect(buildSubmitDiag(baseInputs({ draft: 'unsent', recordsDelta: 0 })).likelyCause).toBe('cause1-swallowed');
+    expect(buildSubmitDiag(baseInputs({ draft: '', recordsDelta: 3 })).likelyCause).toBe('cause2-marker-drift');
+    expect(buildSubmitDiag(baseInputs({ draft: '', recordsDelta: 0 })).likelyCause).toBe('unknown');
   });
 });

--- a/tests/unit/submit-diag.test.ts
+++ b/tests/unit/submit-diag.test.ts
@@ -1,0 +1,148 @@
+import { shortHash, buildSubmitDiag, SubmitDiagInputs } from '../../src/shell/submit-diag';
+
+// Diagnostics for the swallowed-Enter submit-retry path (#370). These are pure
+// helpers, so the tests mirror the menu-probe/decideMenuCancel style: no
+// node-pty/screen imports, just field- and redaction-level assertions.
+
+const baseInputs = (over: Partial<SubmitDiagInputs> = {}): SubmitDiagInputs => ({
+  event: 'giveup',
+  enterRetries: 2,
+  sawBusy: false,
+  sawBusyMarker: false,
+  sawAssistant: false,
+  recordsDelta: 0,
+  draft: '',
+  quietMs: 2000,
+  msSinceSubmit: 4200,
+  msSinceStart: 8600,
+  msSinceFirstRecord: null,
+  hasPrompt: true,
+  dialog: null,
+  fromMenuSelection: false,
+  probeRounds: null,
+  ...over,
+});
+
+describe('submit-diag shortHash (draft redaction primitive)', () => {
+  it('is deterministic — same input yields the same hash', () => {
+    expect(shortHash('deploy the staging build now')).toBe(shortHash('deploy the staging build now'));
+  });
+
+  it('differs for different inputs (so a changed draft is detectable across retries)', () => {
+    expect(shortHash('draft A')).not.toBe(shortHash('draft B'));
+  });
+
+  it('returns a fixed-width 8-char hex string', () => {
+    expect(shortHash('x')).toMatch(/^[0-9a-f]{8}$/);
+    expect(shortHash('a much longer draft with spaces and symbols !@#')).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('never contains the raw input text', () => {
+    const secret = 'sk-super-secret-token-value';
+    expect(shortHash(secret)).not.toContain('secret');
+    expect(shortHash(secret)).not.toContain(secret);
+  });
+});
+
+describe('submit-diag buildSubmitDiag (structured snapshot)', () => {
+  it('redacts the draft to length + hash — the raw text never appears in the snapshot', () => {
+    const draft = 'please retry the failed deployment';
+    const snap = buildSubmitDiag(baseInputs({ draft }));
+    expect(snap.draftLen).toBe(draft.length);
+    expect(snap.draftHash).toBe(shortHash(draft));
+    // Acceptance criterion: no raw user text, tokens, or secrets in the snapshot.
+    const serialized = JSON.stringify(snap);
+    expect(serialized).not.toContain(draft);
+    expect(serialized).not.toContain('please retry');
+    expect(Object.prototype.hasOwnProperty.call(snap, 'draft')).toBe(false);
+  });
+
+  it('reports an empty draft as length 0 with a null hash (the cause-2 tell)', () => {
+    const snap = buildSubmitDiag(baseInputs({ draft: '' }));
+    expect(snap.draftLen).toBe(0);
+    expect(snap.draftHash).toBeNull();
+  });
+
+  it('carries the give-up decision inputs verbatim (cause-1 snapshot: draft still on screen)', () => {
+    const snap = buildSubmitDiag(baseInputs({
+      event: 'giveup',
+      draft: 'unsent text',
+      sawBusy: false,
+      sawBusyMarker: false,
+      sawAssistant: false,
+      recordsDelta: 0,
+      quietMs: 1800,
+      hasPrompt: true,
+    }));
+    expect(snap.event).toBe('giveup');
+    expect(snap.draftLen).toBe('unsent text'.length);
+    expect(snap.recordsDelta).toBe(0);
+    expect(snap.sawBusyMarker).toBe(false);
+    expect(snap.hasPrompt).toBe(true);
+  });
+
+  it('distinguishes a recovered turn (cause-2: records arrived, no marker) from a give-up', () => {
+    const snap = buildSubmitDiag(baseInputs({
+      event: 'recovered',
+      draft: '',
+      enterRetries: 1,
+      sawBusy: true,        // flipped from an assistant record, not the marker
+      sawBusyMarker: false, // the literal "esc to interrupt" was never seen
+      sawAssistant: true,
+      recordsDelta: 3,      // Claude did produce output — the Enter was NOT swallowed
+      msSinceFirstRecord: 900,
+    }));
+    expect(snap.event).toBe('recovered');
+    expect(snap.sawBusyMarker).toBe(false);
+    expect(snap.sawAssistant).toBe(true);
+    expect(snap.recordsDelta).toBe(3);
+    expect(snap.msSinceFirstRecord).toBe(900);
+  });
+
+  it('passes through the record-timing / probe / dialog discriminators', () => {
+    const snap = buildSubmitDiag(baseInputs({
+      event: 'retry',
+      fromMenuSelection: true,
+      probeRounds: 2,
+      dialog: 'bypass-permissions',
+      msSinceFirstRecord: 1200,
+      msSinceSubmit: 4100,
+      msSinceStart: 9000,
+    }));
+    expect(snap.event).toBe('retry');
+    expect(snap.fromMenuSelection).toBe(true);
+    expect(snap.probeRounds).toBe(2);
+    expect(snap.dialog).toBe('bypass-permissions');
+    expect(snap.msSinceFirstRecord).toBe(1200);
+    expect(snap.msSinceSubmit).toBe(4100);
+    expect(snap.msSinceStart).toBe(9000);
+  });
+
+  it('preserves null timing fields (submit/first-record not yet observed)', () => {
+    const snap = buildSubmitDiag(baseInputs({ msSinceSubmit: null, msSinceFirstRecord: null }));
+    expect(snap.msSinceSubmit).toBeNull();
+    expect(snap.msSinceFirstRecord).toBeNull();
+  });
+
+  it('emits exactly the documented field set (no accidental raw-state leak)', () => {
+    const snap = buildSubmitDiag(baseInputs({ draft: 'x' }));
+    expect(Object.keys(snap).sort()).toEqual([
+      'dialog',
+      'draftHash',
+      'draftLen',
+      'enterRetries',
+      'event',
+      'fromMenuSelection',
+      'hasPrompt',
+      'msSinceFirstRecord',
+      'msSinceStart',
+      'msSinceSubmit',
+      'probeRounds',
+      'quietMs',
+      'recordsDelta',
+      'sawAssistant',
+      'sawBusy',
+      'sawBusyMarker',
+    ]);
+  });
+});


### PR DESCRIPTION
Phase 1 of #370 — instrumentation only, no behavior change.

These two commits already exist on `feat/cli-command-surface` (PR #375), folded into unrelated CLI work, and have been running in prod since 22 Aug. This PR lifts them onto `main` on their own so the diagnostics do not have to wait on that PR. Cherry-picked verbatim (`db28f7d`, `fd417a1`) — no edits, clean apply.

## What it adds

- `src/shell/submit-diag.ts` — pure helpers: `shortHash` (FNV-1a), `buildSubmitDiag`, `classifyLikelyCause`. Extracted from `claude-pty-shell.ts` so they unit-test without importing the module that starts the driver on load.
- `logSubmitDiag()` in the driver, called at exactly three sites: each Enter-retry, the final give-up, and — when a turn that hit ≥1 retry later completes successfully — a paired `recovered` event.
- Two new write-only fields on `ActiveTurn`: `sawBusyMarker` (was the literal `"esc to interrupt"` marker ever seen, distinct from `sawBusy`, which also flips from echo-immune assistant records) and `firstRecordAt`.

## Acceptance criteria from the issue

- [x] Structured snapshot at every Enter-retry and at final give-up with the documented fields
- [x] Draft redacted to `draftLen` + `draftHash` — no raw user text, tokens, or secrets (`buildSubmitDiag` reduces it; the raw string never leaves the function, and a test asserts the exact emitted field set)
- [x] `submit-retry-recovered` equivalent — the `recovered` event, gated on `turn.enterRetries > 0` so it never fires on an ordinary turn
- [x] Zero change to retry/give-up control flow — the diff adds two write-only fields, one private method, and three call sites; nothing reads the new fields for a decision
- [x] Confined to the retry/give-up path, never per-tick

## It already answered the question

31 `submit-diag` lines from prod across 5 agents (22–25 Aug), counted by event — only `giveup` is an actual turn failure:

| event | cause1-swallowed | cause2-marker-drift | unknown |
|---|---|---|---|
| **giveup** | **6** | **0** | 1 |
| retry | 16 | 0 | 2 |
| recovered | 2 | 1 | 0 |

Cause 1 (Enter genuinely swallowed, draft still in the box) dominates; cause 2 has never failed a turn. `sawBusyMarker` is `false` in every sample, and `dialog` is `null` in every sample. Full analysis in https://github.com/0xMaxMa/claude-gateway/issues/370#issuecomment-5420399053.

## Note for reviewers

`logSubmitDiag('retry', …)` runs *before* `turn.enterRetries++`, so a `retry` snapshot reports the pre-increment count — the first retry logs `enterRetries: 0`. Intentional (it records the state the decision was made on), but worth knowing when reading the logs.

## Verification

```
npm run typecheck                      pass
tests/unit/submit-diag.test.ts         15/15
tests/unit/pty-shell.test.ts (+serialize) 125/125
```

Refs #370. Phase 2 (the actual fix, now evidence-directed at cause 1) follows in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
