### PR TITLE
fix(shell): stop an interactive overlay from masquerading as an unsubmitted draft (#370 phase 2)

### DIFF
--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -20,7 +20,7 @@ import { TranscriptTailer, AssistantRecord, UsageInfo } from './tailer';
 import { ProtocolEmitter } from './emitter';
 import { preTrustWorkspace, checkAuthStatus } from './trust';
 import { decideMenuCancel } from './menu-cancel';
-import { classifyPhantomDraft, unsubmittedDraft } from './draft-phantom';
+import { classifyPhantomDraft, unsubmittedDraft as discountPhantom } from './draft-phantom';
 import { shouldAdoptOrphanWake } from './orphan-wake';
 import { parseControlCommand, keystrokesFor, KEY_ENTER, isAcceptablePtyInput, MAX_PTY_INPUT_BYTES } from './control-channel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
@@ -99,7 +99,10 @@ interface ActiveTurn {
   /** Text that `inputDraft()` reported before this turn's paste and that the full
    *  Ctrl+U budget provably could NOT change — i.e. screen furniture the reader
    *  mistook for a live draft, not text sitting in the input box. Null when the
-   *  input cleared normally (the overwhelmingly common case). Consumed by
+   *  input cleared normally (the overwhelmingly common case). Captured once,
+   *  pre-paste, and never refreshed: a phantom that only appears mid-turn is not
+   *  recorded, so this fails toward the pre-#370 behavior (counting it as a draft)
+   *  rather than toward discounting something unproven. Consumed by
    *  {@link Driver.unsubmittedDraft}. */
   phantomDraft: string | null;
   /** Snapshot of tailer.seenRecords at turn start — used to detect per-turn output. */
@@ -634,15 +637,17 @@ class Driver {
    * refusing to submit would break far more turns than it saves.
    */
   private async clearInput(): Promise<string | null> {
+    // Read once and reuse: two reads of a live screen can disagree, and `before`
+    // must be the very value the burst below is judged against.
+    const before = this.screen.inputDraft();
     // Fast path (the common case): the input is already empty, so send a single
     // Ctrl+U as a harmless no-op — exactly the pre-#296 behavior — and skip the
     // settle loop entirely so a clean submit gains no latency.
-    if (this.screen.inputDraft() === '') {
+    if (before === '') {
       this.host.writeRaw('\x15');
       return null;
     }
     // A draft is present: clear it a line at a time until the input reads empty.
-    const before = this.screen.inputDraft();
     for (let i = 0; i < INPUT_CLEAR_MAX_KEYS; i++) {
       this.host.writeRaw('\x15'); // Ctrl+U: clear one input line
       await new Promise((r) => setTimeout(r, INPUT_CLEAR_SETTLE_MS));
@@ -684,9 +689,23 @@ class Driver {
    * turn's unsubmitted text. Anything else — including a real draft that merely
    * *looks* like a menu, which Ctrl+U does clear — counts as before, so the #296
    * fix this arm exists for is untouched.
+   *
+   * SCOPE: this closes the draft arm only. The branch's other arm (no new records
+   * since turn start) is untouched, and fires on its own — 3 of the 7 give-ups in
+   * the prod sample had `recordsDelta === 0` and are unaffected by this. What it
+   * does cover is the 4 give-ups (and all 4 recoveries) where the draft arm was the
+   * sole trigger, i.e. where a `\r` was written into an on-screen overlay for
+   * nothing.
+   *
+   * TRADE-OFF: a draft that is genuinely in the input box but that Ctrl+U cannot
+   * move (a TUI momentarily not accepting input) is misread as a phantom, and with
+   * the records arm also quiet the turn then waits out the 30-min watchdog instead
+   * of erroring in ~12s. The branch's own preconditions make that narrow — it
+   * requires `!sawBusy` and `quietMs > 1500`, which a TUI busy enough to drop
+   * keystrokes does not satisfy — but it is the price of discounting anything here.
    */
   private unsubmittedDraft(turn: ActiveTurn): string {
-    return unsubmittedDraft(this.screen.inputDraft(), turn.phantomDraft);
+    return discountPhantom(this.screen.inputDraft(), turn.phantomDraft);
   }
 
   // ---- periodic liveness poll ----------------------------------------------
@@ -876,7 +895,9 @@ class Driver {
       // pre-paste Ctrl+U burst proved it cannot touch — an overlay's
       // caret row the draft reader cannot tell from the input box. Without
       // that, (b) is permanently true whenever an overlay is up, so the
-      // branch fires on turns whose Enter went through (#370).
+      // branch fires on turns whose Enter went through (#370). Arm (a) is
+      // unchanged and still fires on its own, so this narrows the branch
+      // rather than gating it.
       //
       // The interactivePromptBlocking() suppression applies ONLY to a
       // menu-selection turn: there a live menu genuinely can still be on

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -20,6 +20,7 @@ import { TranscriptTailer, AssistantRecord, UsageInfo } from './tailer';
 import { ProtocolEmitter } from './emitter';
 import { preTrustWorkspace, checkAuthStatus } from './trust';
 import { decideMenuCancel } from './menu-cancel';
+import { classifyPhantomDraft, unsubmittedDraft } from './draft-phantom';
 import { shouldAdoptOrphanWake } from './orphan-wake';
 import { parseControlCommand, keystrokesFor, KEY_ENTER, isAcceptablePtyInput, MAX_PTY_INPUT_BYTES } from './control-channel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
@@ -95,6 +96,12 @@ interface ActiveTurn {
   texts: string[];
   usage: UsageInfo | null;
   dialogEscapes: number;
+  /** Text that `inputDraft()` reported before this turn's paste and that the full
+   *  Ctrl+U budget provably could NOT change — i.e. screen furniture the reader
+   *  mistook for a live draft, not text sitting in the input box. Null when the
+   *  input cleared normally (the overwhelmingly common case). Consumed by
+   *  {@link Driver.unsubmittedDraft}. */
+  phantomDraft: string | null;
   /** Snapshot of tailer.seenRecords at turn start — used to detect per-turn output. */
   recordsAtStart: number;
   /** True when this turn was begun by a menu selection (handleMenuReply) — the
@@ -555,6 +562,7 @@ class Driver {
       texts: [],
       usage: null,
       dialogEscapes: 0,
+      phantomDraft: null,
       recordsAtStart: this.tailer.seenRecords,
       fromMenuSelection,
       probe: null,
@@ -576,7 +584,8 @@ class Driver {
     // clears one line, so a MULTI-line stale draft would survive partially and
     // concatenate with the paste below — clearInput() loops until the input is
     // empty. A no-op at an already-empty idle prompt.
-    await this.clearInput();
+    const phantomDraft = await this.clearInput();
+    if (this.turn) this.turn.phantomDraft = phantomDraft;
     if (this.abortIfInterrupted()) return;
     if (NO_BRACKETED_PASTE) {
       // Fallback: sanitizeUserText() strips all CR, so '\r' below is the only
@@ -610,22 +619,44 @@ class Driver {
    * costs one more Ctrl+U (a harmless no-op at an empty prompt), never an early
    * stop that leaves a remnant behind. At an already-empty prompt this sends a
    * single no-op Ctrl+U and returns.
+   *
+   * Returns the *phantom* draft when the budget is exhausted and the reported text
+   * never changed across it, else null. Ctrl+U edits the input line, so a real
+   * draft always changes under it; text that survives the whole burst byte-for-byte
+   * is not in the input box at all. `inputDraft()` scans the visible screen for a
+   * `❯ ` caret, and an interactive overlay's highlighted row uses that same caret,
+   * so an on-screen menu/permission prompt reads back as a "draft" no keystroke here
+   * can clear. Reporting it lets the submit-retry path discount it instead of
+   * treating it as proof that this turn's Enter was swallowed (#370).
+   *
+   * Deliberately still proceeds to paste in that case: across prod logs 509 of these
+   * unclearable reads occurred and only 1.4% were followed by a submit give-up, so
+   * refusing to submit would break far more turns than it saves.
    */
-  private async clearInput(): Promise<void> {
+  private async clearInput(): Promise<string | null> {
     // Fast path (the common case): the input is already empty, so send a single
     // Ctrl+U as a harmless no-op — exactly the pre-#296 behavior — and skip the
     // settle loop entirely so a clean submit gains no latency.
     if (this.screen.inputDraft() === '') {
       this.host.writeRaw('\x15');
-      return;
+      return null;
     }
     // A draft is present: clear it a line at a time until the input reads empty.
+    const before = this.screen.inputDraft();
     for (let i = 0; i < INPUT_CLEAR_MAX_KEYS; i++) {
       this.host.writeRaw('\x15'); // Ctrl+U: clear one input line
       await new Promise((r) => setTimeout(r, INPUT_CLEAR_SETTLE_MS));
-      if (this.screen.inputDraft() === '') return; // input empty → done
+      if (this.screen.inputDraft() === '') return null; // input empty → done
     }
-    logWarn(`clearInput: input still non-empty after ${INPUT_CLEAR_MAX_KEYS} Ctrl+U — proceeding`);
+    const after = this.screen.inputDraft();
+    const phantom = classifyPhantomDraft(before, after);
+    logWarn(
+      `clearInput: input still non-empty after ${INPUT_CLEAR_MAX_KEYS} Ctrl+U — proceeding` +
+        (phantom !== null
+          ? ' (unchanged by every Ctrl+U — not the input box; discounting it for submit-retry)'
+          : ''),
+    );
+    return phantom;
   }
 
   // Sends Ctrl+U to clear the PTY input line, drains the queue, and returns true.
@@ -635,6 +666,27 @@ class Driver {
     this.host.writeRaw('\x15'); // Ctrl+U: clear input line
     this.queue.length = 0;
     return true;
+  }
+
+  /**
+   * The input draft as evidence that THIS turn's paste is still unsubmitted.
+   *
+   * `screen.inputDraft()` finds the last `❯ ` caret on the visible screen and reads
+   * the text after it. An interactive overlay's highlighted row carries the same
+   * caret, so whenever one is up the reader returns the overlay's rows as a
+   * "draft" — text that no keystroke of ours put there and none can remove. Taking
+   * that at face value makes the swallowed-Enter branch fire on a turn whose Enter
+   * went through fine, writes a bare `\r` into whatever overlay is on screen, and
+   * then labels the give-up `cause1-swallowed` in the diagnostics (#370).
+   *
+   * `phantomDraft` is the pre-paste text the full Ctrl+U budget provably could not
+   * change, so a current read byte-identical to it is that same furniture, not this
+   * turn's unsubmitted text. Anything else — including a real draft that merely
+   * *looks* like a menu, which Ctrl+U does clear — counts as before, so the #296
+   * fix this arm exists for is untouched.
+   */
+  private unsubmittedDraft(turn: ActiveTurn): string {
+    return unsubmittedDraft(this.screen.inputDraft(), turn.phantomDraft);
   }
 
   // ---- periodic liveness poll ----------------------------------------------
@@ -809,7 +861,7 @@ class Driver {
         && !(turn.fromMenuSelection && this.screen.interactivePromptBlocking())
         && this.screen.quietMs() > 1500
         && (this.tailer.seenRecords === turn.recordsAtStart
-            || this.screen.inputDraft() !== '')) {
+            || this.unsubmittedDraft(turn) !== '')) {
       // Retry the swallowed Enter when either (a) no new records have appeared
       // since this turn started — a delta > 0 normally means Claude began writing
       // output — OR (b) the input draft is still visibly on screen. (b) is the
@@ -819,6 +871,12 @@ class Driver {
       // had written records (its count inflates seenRecords past recordsAtStart),
       // leaving a genuinely-unsubmitted draft stuck until the watchdog or the next
       // paste collided with it (#296).
+      //
+      // (b) reads through unsubmittedDraft(), which discounts a draft the
+      // pre-paste Ctrl+U burst proved it cannot touch — an overlay's
+      // caret row the draft reader cannot tell from the input box. Without
+      // that, (b) is permanently true whenever an overlay is up, so the
+      // branch fires on turns whose Enter went through (#370).
       //
       // The interactivePromptBlocking() suppression applies ONLY to a
       // menu-selection turn: there a live menu genuinely can still be on

--- a/src/shell/draft-phantom.ts
+++ b/src/shell/draft-phantom.ts
@@ -1,0 +1,49 @@
+/**
+ * Telling a real, unsubmitted input draft apart from screen furniture the draft
+ * reader mistakes for one (#370).
+ *
+ * `ScreenModel.inputDraft()` locates the last `❯ ` caret on the visible screen and
+ * returns the text after it. An interactive overlay — an AskUserQuestion menu, a
+ * tool-permission prompt — renders its highlighted row with that exact caret and
+ * hides the input box, so while one is up the reader hands back the overlay's rows
+ * as if the user had typed them. Static text cannot settle the ambiguity (a genuine
+ * draft that begins "1. …" is menu-shaped too, which is why gating on a screen-text
+ * menu check regressed #296), so this module settles it *behaviorally* instead,
+ * using a keystroke the driver already sends.
+ *
+ * Ctrl+U edits the input line. A real draft therefore always changes under a burst
+ * of them; text that survives the entire pre-paste budget byte-for-byte is not in
+ * the input box at all. That surviving text is the "phantom", and the submit-retry
+ * path must not read it as proof that this turn's Enter was swallowed.
+ *
+ * Pure helpers, kept out of claude-pty-shell.ts so they are unit-testable without
+ * importing that module (which starts the driver on load) — same reason
+ * `submit-diag.ts` exists.
+ */
+
+/**
+ * The phantom draft, or null if the reported text is (or may be) a real draft.
+ *
+ * @param before draft reported immediately before the Ctrl+U burst
+ * @param after  draft reported after the burst exhausted its budget
+ *
+ * Null when the input cleared (`after === ''`) or when any Ctrl+U moved the text —
+ * a partially-cleared real draft still counts as real, so nothing is discounted on
+ * the strength of a maybe.
+ */
+export function classifyPhantomDraft(before: string, after: string): string | null {
+  if (after === '') return null;
+  return after === before ? after : null;
+}
+
+/**
+ * The draft to treat as evidence that a turn's paste is still unsubmitted.
+ *
+ * Returns '' when the current read is byte-identical to a known phantom — the same
+ * furniture, not this turn's text. Any other draft passes through unchanged, so a
+ * real draft that merely looks menu-shaped still triggers the swallowed-Enter retry
+ * exactly as #296 requires.
+ */
+export function unsubmittedDraft(draft: string, phantom: string | null): string {
+  return phantom !== null && draft === phantom ? '' : draft;
+}

--- a/src/shell/draft-phantom.ts
+++ b/src/shell/draft-phantom.ts
@@ -19,6 +19,12 @@
  * Pure helpers, kept out of claude-pty-shell.ts so they are unit-testable without
  * importing that module (which starts the driver on load) — same reason
  * `submit-diag.ts` exists.
+ *
+ * Scope note: only the swallowed-Enter retry's draft arm consults these. The
+ * diagnostics in `submit-diag.ts` still report the raw `inputDraft()`, so a
+ * phantom still shows up there as `draftLen > 0` and is still labelled
+ * `cause1-swallowed` — feeding the phantom into that snapshot is a follow-up,
+ * kept separate because the two changes ship on independent branches.
  */
 
 /**

--- a/tests/unit/draft-phantom.test.ts
+++ b/tests/unit/draft-phantom.test.ts
@@ -1,0 +1,78 @@
+import { classifyPhantomDraft, unsubmittedDraft } from '../../src/shell/draft-phantom';
+import { ScreenModel } from '../../src/shell/screen';
+
+// Feed a screen and let xterm's async write buffer flush before reading text().
+async function render(lines: string[]): Promise<ScreenModel> {
+  const screen = new ScreenModel();
+  screen.write(lines.join('\r\n'));
+  await new Promise((r) => setTimeout(r, 40));
+  return screen;
+}
+const FILLER = (n: number) => Array.from({ length: n }, (_, i) => `conversation line ${i}`);
+const MENU_FOOTER = 'Enter to select · ↑/↓ to navigate · Esc to cancel';
+
+describe('draft-phantom classifyPhantomDraft', () => {
+  it('reports text no Ctrl+U in the budget could change as a phantom', () => {
+    const menu = '1. First choice\n2. Second choice';
+    expect(classifyPhantomDraft(menu, menu)).toBe(menu);
+  });
+
+  it('never reports a phantom once the input actually cleared', () => {
+    expect(classifyPhantomDraft('some real draft', '')).toBeNull();
+  });
+
+  it('never reports a phantom when a Ctrl+U moved the text — a part-cleared draft is still real', () => {
+    // Multi-line draft: the burst removed the tail but ran out of budget.
+    expect(classifyPhantomDraft('line one\nline two\nline three', 'line one')).toBeNull();
+  });
+});
+
+describe('draft-phantom unsubmittedDraft', () => {
+  it('discounts a read byte-identical to the known phantom', () => {
+    const menu = `1. First choice\n2. Second choice\n${MENU_FOOTER}`;
+    expect(unsubmittedDraft(menu, menu)).toBe('');
+  });
+
+  it('passes a real draft through when no phantom was recorded', () => {
+    expect(unsubmittedDraft('please run the deploy', null)).toBe('please run the deploy');
+  });
+
+  it('passes a menu-shaped USER draft through — #296 must not regress', () => {
+    // The turn cleared normally, so no phantom was recorded. This draft looks
+    // exactly like a menu; the swallowed-Enter retry must still see it, or the
+    // turn wedges into the 30-min watchdog (#296 / PR #181 review round 2).
+    expect(unsubmittedDraft('1. do the thing\n2. then the other', null)).toBe('1. do the thing\n2. then the other');
+  });
+
+  it('passes a draft through when it differs from the phantom, even by one character', () => {
+    expect(unsubmittedDraft('1. First choice!', '1. First choice')).toBe('1. First choice!');
+  });
+});
+
+describe('draft-phantom against a real ScreenModel (why the phantom exists)', () => {
+  it('inputDraft() reports an interactive overlay as a draft, and the pair discounts it', async () => {
+    const screen = await render([
+      ...FILLER(18),
+      'Which one?',
+      '❯ 1. First choice',
+      '  2. Second choice',
+      MENU_FOOTER,
+    ]);
+    const seen = screen.inputDraft();
+    // The reader cannot tell the overlay's caret row from the input box.
+    expect(seen).not.toBe('');
+    expect(seen).toContain('1. First choice');
+    // Ctrl+U cannot edit a menu, so the burst leaves it byte-identical…
+    const phantom = classifyPhantomDraft(seen, seen);
+    expect(phantom).toBe(seen);
+    // …and the submit-retry path stops reading it as unsubmitted text.
+    expect(unsubmittedDraft(screen.inputDraft(), phantom)).toBe('');
+  });
+
+  it('a genuine draft in the input box is never discounted', async () => {
+    const screen = await render([...FILLER(20), '❯ please run the deploy', '  Model: opus']);
+    expect(screen.inputDraft()).toBe('please run the deploy');
+    // Ctrl+U clears it, so clearInput() records no phantom.
+    expect(unsubmittedDraft(screen.inputDraft(), null)).toBe('please run the deploy');
+  });
+});


### PR DESCRIPTION
Phase 2 of #370. Independent of #400 (the Phase 1 instrumentation split) — both branch from `main` and touch different code.

## The defect

`screen.inputDraft()` finds the last `❯ ` caret on the visible screen and returns the text after it. An interactive overlay — an AskUserQuestion menu, a tool-permission prompt — renders its **highlighted row with that exact caret** and hides the input box. So while an overlay is up, the reader hands back the overlay's rows as if the user had typed them.

Probed against a real `ScreenModel`:

```
  ❯ 1. First choice
    2. Second choice
    Enter to select · ↑/↓ to navigate · Esc to cancel

inputDraft() → "1. First choice\n2. Second choice\nEnter to select · ↑/↓ to navigate · Esc to cancel"
hasPrompt()  → true
```

Two things trust that reader, and both are wrong while an overlay is up:

1. `clearInput()` bursts Ctrl+U at it and gives up — **509 `"input still non-empty after 8 Ctrl+U"` warnings** in the prod logs, 11–26 Aug.
2. The swallowed-Enter branch's arm `inputDraft() !== ''` is permanently true, so it can fire on a turn whose Enter went through and write a bare `\r` — into whatever overlay is on screen.

Straight from prod, five seconds apart:

```
08:34:38  WARN clearInput: input still non-empty after 8 Ctrl+U — proceeding
08:34:43  submit-diag {"event":"retry", …,"draftLen":403,"draftHash":"ac33bf6a"}
08:34:51  submit-diag {"event":"giveup",…,"draftLen":403,"draftHash":"ac33bf6a"}
```

Byte-identical to the give-up six minutes earlier. Ctrl+U edits the input line, so that text was never in the input box.

## Why not just check for a menu

Static text cannot tell them apart. A genuine user draft beginning `1. …` is menu-shaped, and gating this arm on a screen-text menu check is exactly what regressed #296 — the retry stopped firing and the turn wedged into the 30-minute watchdog. `interactivePromptBlocking()` documents itself as deliberately permissive for that reason.

## The fix — behavioral, using a keystroke already sent

Ctrl+U edits the input line, so a **real draft always changes** under the pre-paste burst. Text that survives the entire budget byte-for-byte is not in the input box.

- `clearInput()` returns that surviving text as a *phantom* (`classifyPhantomDraft`), or null.
- The retry branch reads through `unsubmittedDraft()`, which discounts only a read **byte-identical** to the recorded phantom.
- A part-cleared draft, or one differing by a single character, still counts — the #296 arm is untouched, with tests pinning that.

`clearInput()` deliberately still pastes when it hits a phantom instead of refusing to submit: of those 509 unclearable reads only **1.4%** were followed by a give-up within 90s, so failing there would break far more turns than it saves. (25% of give-ups were preceded by one.)

Extracted as pure helpers in `src/shell/draft-phantom.ts` so they are unit-testable without importing `claude-pty-shell.ts`, which starts the driver on load — same reason `submit-diag.ts` exists.

## Scope — what this does NOT cover

The retry condition is an **OR**, and only the draft arm is narrowed here:

```
(seenRecords === turn.recordsAtStart)      ← arm A, untouched
  || (unsubmittedDraft(turn) !== '')       ← arm B, discounted
```

Counted over the prod `submit-diag` sample:

| event | total | draft arm was the sole trigger (`recordsDelta > 0`) |
|---|---|---|
| giveup | 7 | **4** |
| retry | 19 | 7 |
| recovered | 4 | **4** |

So this covers 4 of the 7 observed give-ups and all 4 recoveries — the cases where a `\r` went into an on-screen overlay for nothing. The other 3 give-ups had `recordsDelta === 0`, arm A fired on its own, and they are **unaffected**. That includes the 403-byte case quoted above: it is the clearest proof that the draft was a phantom, but it is not a case this change prevents.

An earlier revision of this description claimed the fix stops the branch firing on turns whose Enter went through, without that qualification. It was overstated; commit `364edb4` corrects it in the code comments too.

## Trade-off

A draft that genuinely is in the input box but that Ctrl+U cannot move (a TUI momentarily not accepting input) is misread as a phantom. With arm A also quiet, that turn then waits out the 30-minute watchdog instead of erroring in ~12s. The branch's own preconditions keep this narrow — it requires `!sawBusy` and `quietMs > 1500`, which a TUI busy enough to drop keystrokes does not satisfy — but it is the price of discounting anything here.

## Follow-up, not fixed here

`submit-diag` still reports the raw `inputDraft()`, so a phantom still appears there as `draftLen > 0` and is still labelled `cause1-swallowed`. That mislabeling is why the cause-1 majority in the issue must be read as an upper bound ([correction comment](https://github.com/0xMaxMa/claude-gateway/issues/370#issuecomment-5420672962)). Feeding the phantom into the snapshot needs both this branch and #400, so it is deliberately left out.

## de-fix proof

Reverting both helpers to the pre-fix behaviour (`classifyPhantomDraft` → always null, `unsubmittedDraft` → returns the raw draft):

```
✕ reports text no Ctrl+U in the budget could change as a phantom
✕ discounts a read byte-identical to the known phantom
✕ inputDraft() reports an interactive overlay as a draft, and the pair discounts it
Tests: 3 failed, 6 passed, 9 total
```

Restoring the fix → 9/9. The 6 that stay green on both sides are guard tests by design (a part-cleared draft, a menu-shaped user draft, a one-character difference) — they pin what must *not* be discounted, not the fix.

## What is not covered by a test

- The wiring in `claude-pty-shell.ts` — `clearInput()` recording the phantom onto the turn, and the retry branch reading through `unsubmittedDraft(turn)`. The driver is not exported (it starts on import), so only the pure helpers are directly testable. Stated rather than demonstrated.
- Everything in `364edb4` except the single-read change is comments and a rename; there is no behavior to assert, and no test is claimed for it.

## Verification

```
npm run typecheck                    pass
npm run build                        pass
tests/unit/draft-phantom.test.ts     9/9  (new)
tests/unit/pty-shell.test.ts         116/116
tests/integration/pty-input-clear.ts 2/2
full suite                           3655 passed / 3659
```

The 4 non-passing are pre-existing load-induced timeouts in `chat-history-api` (3) and `cron-manager` (1) — that run took 1194s against a normal ~400s, and all 4 pass in isolation (73/73 in 15s). Neither suite touches the PTY shell.

Refs #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
