### PR TITLE
fix(telegram): stop the status message duplicating itself on long turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,9 @@ While an agent is working, the gateway sends real-time status updates to Telegra
 - **Elapsed time** — total time since the agent started working
 - **Auto-cleanup** — status message is deleted when the agent finishes
 
-Status updates are sent every 5-10 seconds (first update at 5s, then every 10s).
+Status updates are sent every 5-10 seconds (first update at 5s, then every 10s). A single
+message is **edited in place** for the whole turn; a tick with nothing new to show issues no
+update at all, and the message is replaced only if it is deleted or becomes uneditable.
 
 ---
 

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -176,6 +176,12 @@ export const STATUS_EMOJI: Record<string, string> = {
 /**
  * Telegram reports failures as `description` on a GrammyError; anything else
  * thrown here (a network error, a plain Error in tests) carries `message`.
+ *
+ * Read structurally rather than with `err instanceof GrammyError &&
+ * err.error_code`, the convention in receiver-server.ts, for two reasons: this
+ * module deliberately has no grammy import — it takes an injected BotApi so
+ * tests can drive it — and the two cases below are both HTTP 400, so the code
+ * alone cannot tell them apart. The description is the only thing that can.
  */
 function errorText(err: unknown): string {
   if (typeof err === 'object' && err !== null) {
@@ -203,7 +209,7 @@ export function isNotModifiedError(err: unknown): boolean {
  * still there, and re-sending would leave a duplicate behind.
  */
 export function isMessageGoneError(err: unknown): boolean {
-  return /message to (?:edit|be edited) not found|message can'?t be edited|message not found|MESSAGE_ID_INVALID/i.test(
+  return /message to (?:edit|be edited) not found|message can'?t be edited|message not found/i.test(
     errorText(err),
   )
 }
@@ -690,10 +696,20 @@ export function createWorkingStateManager(
         if (s.statusMessageId === null) {
           try {
             const sent = await botApi.sendMessage(chatId, text)
-            s.statusMessageId = sent.message_id
-            s.lastStatusText = text
+            // Re-read rather than writing through the captured `s`: the turn
+            // can end while the send is in flight, and the state this records
+            // against must be the live one or none at all.
+            const current = states.get(chatId)
+            if (current) {
+              current.statusMessageId = sent.message_id
+              current.lastStatusText = text
+            }
           } catch {}
         } else if (text !== s.lastStatusText) {
+          // Nothing to say, so nothing is sent. The cost is that a status
+          // message deleted by hand is not noticed until the next edit — but
+          // the elapsed line advances every minute even at `Xh Ym`, so that
+          // wait is bounded, and it buys immunity from the duplicate loop.
           try {
             await botApi.editMessageText(chatId, s.statusMessageId, text)
             s.lastStatusText = text
@@ -707,9 +723,16 @@ export function createWorkingStateManager(
             } else if (isMessageGoneError(err)) {
               current.statusMessageId = null
               current.lastStatusText = null
+            } else {
+              // Keep the id — the message is still there, and the next tick
+              // edits it again; re-sending would leave a duplicate behind.
+              // Logged because a silently swallowed edit failure is exactly
+              // what let the duplicate loop run unnoticed: if Telegram ever
+              // returns something this does not classify, it should be
+              // visible in the receiver log rather than inferred from
+              // symptoms.
+              console.error(`[typing] status edit failed (retrying next tick): ${errorText(err)}`)
             }
-            // Any other failure keeps the id: the message is still there, and
-            // the next tick edits it again.
           }
         }
       } finally {

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -173,6 +173,41 @@ export const STATUS_EMOJI: Record<string, string> = {
   error:    '😱',
 }
 
+/**
+ * Telegram reports failures as `description` on a GrammyError; anything else
+ * thrown here (a network error, a plain Error in tests) carries `message`.
+ */
+function errorText(err: unknown): string {
+  if (typeof err === 'object' && err !== null) {
+    const e = err as { description?: unknown; message?: unknown }
+    if (typeof e.description === 'string') return e.description
+    if (typeof e.message === 'string') return e.message
+  }
+  return String(err)
+}
+
+/**
+ * Telegram rejects an edit whose new text is byte-identical to what the
+ * message already shows. That is not a failure to recover from — the message
+ * is intact and already correct — so the status loop must keep editing it
+ * rather than concluding it is gone and posting a replacement.
+ */
+export function isNotModifiedError(err: unknown): boolean {
+  return /message is not modified/i.test(errorText(err))
+}
+
+/**
+ * The message can never be edited again: deleted, or past Telegram's edit
+ * window. Only these justify dropping the id and sending a fresh message.
+ * A transient failure (network, 429) deliberately does NOT — the message is
+ * still there, and re-sending would leave a duplicate behind.
+ */
+export function isMessageGoneError(err: unknown): boolean {
+  return /message to (?:edit|be edited) not found|message can'?t be edited|message not found|MESSAGE_ID_INVALID/i.test(
+    errorText(err),
+  )
+}
+
 export function parseStatusFile(content: string): { status: string; detail?: string } {
   try {
     const parsed = JSON.parse(content);
@@ -193,6 +228,10 @@ export interface WorkingState {
   currentReaction: string | null
   lastDetail: string | null
   recentDetails: string[]
+  /** Text the status message currently displays. An edit that would rewrite a
+   *  message with the exact text it already has is rejected by Telegram, so it
+   *  is never issued. */
+  lastStatusText: string | null
   /** Last stage an incident was raised for — dedupes the turn-trace watchdog
    *  so one contiguous stalled episode emits a single incident, not one per
    *  15s tick. Reset to null once the turn is no longer stalled. */
@@ -618,6 +657,7 @@ export function createWorkingStateManager(
       currentReaction: null,
       lastDetail: null,
       recentDetails: [],
+      lastStatusText: null,
       lastIncidentStage: null,
     }
     states.set(chatId, state)
@@ -651,12 +691,26 @@ export function createWorkingStateManager(
           try {
             const sent = await botApi.sendMessage(chatId, text)
             s.statusMessageId = sent.message_id
+            s.lastStatusText = text
           } catch {}
-        } else {
-          await botApi.editMessageText(chatId, s.statusMessageId, text).catch(async () => {
+        } else if (text !== s.lastStatusText) {
+          try {
+            await botApi.editMessageText(chatId, s.statusMessageId, text)
+            s.lastStatusText = text
+          } catch (err) {
             const current = states.get(chatId)
-            if (current) current.statusMessageId = null
-          })
+            if (!current) {
+              // The turn ended while the edit was in flight.
+            } else if (isNotModifiedError(err)) {
+              // The message already shows this text — nothing to recover from.
+              current.lastStatusText = text
+            } else if (isMessageGoneError(err)) {
+              current.statusMessageId = null
+              current.lastStatusText = null
+            }
+            // Any other failure keeps the id: the message is still there, and
+            // the next tick edits it again.
+          }
         }
       } finally {
         statusUpdatePending = false

--- a/tests/unit/telegram-plugin/typing.test.ts
+++ b/tests/unit/telegram-plugin/typing.test.ts
@@ -242,6 +242,108 @@ describe('createWorkingStateManager', () => {
       expect(bot.editMessageText).toHaveBeenCalledWith(CHAT_ID, 77, expect.any(String))
     })
 
+    // ── Issue #403 ──────────────────────────────────────────────────────────
+    // Past one hour the elapsed line renders as `Xh Ym`, so with a steady detail
+    // the status text stops changing while the timer keeps firing every 10s.
+    // Telegram rejects an edit whose text is identical to the message's current
+    // text, and treating that rejection as "the message is gone" made the next
+    // tick post a replacement — roughly five duplicates a minute for the rest of
+    // the turn.
+
+    test('U-TY-403a: identical text issues no edit at all', async () => {
+      const bot = makeBotApi()
+      bot.sendMessage.mockResolvedValue({ message_id: 90 })
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      const state = mgr.states.get(CHAT_ID)!
+      // A turn that started over an hour ago: `Xh Ym` has no seconds, so ten
+      // seconds of wall clock leaves the rendered text byte-identical.
+      state.startedAt = Date.now() - 3_600_000
+      state.lastDetail = 'Running: the same tool as a moment ago'
+
+      jest.advanceTimersByTime(STATUS_INTERVAL_MS)
+      await Promise.resolve()
+      expect(bot.sendMessage).toHaveBeenCalledTimes(1)
+
+      jest.advanceTimersByTime(STATUS_INTERVAL_MS)
+      await Promise.resolve()
+
+      expect(bot.editMessageText).not.toHaveBeenCalled()
+      expect(bot.sendMessage).toHaveBeenCalledTimes(1)
+    })
+
+    test('U-TY-403b: a "message is not modified" rejection keeps the status message', async () => {
+      const bot = makeBotApi()
+      bot.editMessageText.mockRejectedValue(
+        new Error('Bad Request: message is not modified: specified new message content and reply markup are exactly the same'),
+      )
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      const state = mgr.states.get(CHAT_ID)!
+      state.statusMessageId = 55
+
+      jest.advanceTimersByTime(STATUS_INTERVAL_MS)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(bot.editMessageText).toHaveBeenCalled()
+      // The message is intact and already correct — keep editing it.
+      expect(state.statusMessageId).toBe(55)
+      expect(bot.sendMessage).not.toHaveBeenCalled()
+    })
+
+    test('U-TY-403c: a turn past one hour keeps exactly one status message', async () => {
+      const bot = makeBotApi()
+      bot.sendMessage.mockResolvedValue({ message_id: 91 })
+      // Whatever slips past the identical-text guard is rejected the way
+      // Telegram rejects it, so both guards are exercised together.
+      bot.editMessageText.mockRejectedValue(new Error('Bad Request: message is not modified'))
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      const state = mgr.states.get(CHAT_ID)!
+      state.startedAt = Date.now() - 3_600_000
+      state.lastDetail = 'Running: a long tool call'
+
+      for (let tick = 0; tick < 12; tick++) {
+        jest.advanceTimersByTime(STATUS_INTERVAL_MS)
+        await Promise.resolve()
+        await Promise.resolve()
+      }
+
+      // Two minutes of ticks, one status message. Pre-fix this posted a fresh
+      // message on roughly every other tick.
+      expect(bot.sendMessage).toHaveBeenCalledTimes(1)
+    })
+
+    test('U-TY-403d: a transient failure keeps the id rather than posting a replacement', async () => {
+      const bot = makeBotApi()
+      bot.editMessageText.mockRejectedValue(new Error('ETIMEDOUT: socket hang up'))
+      const fsApi = makeFsApi()
+      const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+
+      mgr.start(CHAT_ID)
+
+      const state = mgr.states.get(CHAT_ID)!
+      state.statusMessageId = 56
+
+      jest.advanceTimersByTime(STATUS_INTERVAL_MS)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // The message is still in the chat; a replacement would leave a duplicate.
+      expect(state.statusMessageId).toBe(56)
+      expect(bot.sendMessage).not.toHaveBeenCalled()
+    })
+
     test('resets statusMessageId to null when editMessageText fails (message deleted)', async () => {
       const bot = makeBotApi()
       bot.editMessageText.mockRejectedValue(new Error('message not found'))

--- a/tests/unit/telegram-plugin/typing.test.ts
+++ b/tests/unit/telegram-plugin/typing.test.ts
@@ -14,6 +14,8 @@ import {
   STATUS_MESSAGES,
   ERROR_MESSAGES,
   STATUS_EMOJI,
+  isNotModifiedError,
+  isMessageGoneError,
   TYPING_INTERVAL_MS,
   STATUS_INTERVAL_MS,
   STALLED_TIMEOUT_MS,
@@ -324,24 +326,32 @@ describe('createWorkingStateManager', () => {
       expect(bot.sendMessage).toHaveBeenCalledTimes(1)
     })
 
-    test('U-TY-403d: a transient failure keeps the id rather than posting a replacement', async () => {
+    test('U-TY-403d: a transient failure keeps the id, and says so in the log', async () => {
       const bot = makeBotApi()
       bot.editMessageText.mockRejectedValue(new Error('ETIMEDOUT: socket hang up'))
       const fsApi = makeFsApi()
       const mgr = createWorkingStateManager(TYPING_DIR, bot, fsApi)
+      const logged = jest.spyOn(console, 'error').mockImplementation(() => {})
 
-      mgr.start(CHAT_ID)
+      try {
+        mgr.start(CHAT_ID)
 
-      const state = mgr.states.get(CHAT_ID)!
-      state.statusMessageId = 56
+        const state = mgr.states.get(CHAT_ID)!
+        state.statusMessageId = 56
 
-      jest.advanceTimersByTime(STATUS_INTERVAL_MS)
-      await Promise.resolve()
-      await Promise.resolve()
+        jest.advanceTimersByTime(STATUS_INTERVAL_MS)
+        await Promise.resolve()
+        await Promise.resolve()
 
-      // The message is still in the chat; a replacement would leave a duplicate.
-      expect(state.statusMessageId).toBe(56)
-      expect(bot.sendMessage).not.toHaveBeenCalled()
+        // The message is still in the chat; a replacement would leave a duplicate.
+        expect(state.statusMessageId).toBe(56)
+        expect(bot.sendMessage).not.toHaveBeenCalled()
+        // An unclassified failure must leave a trace — a silently swallowed one
+        // is what let the duplicate loop run unnoticed in the first place.
+        expect(logged).toHaveBeenCalledWith(expect.stringContaining('ETIMEDOUT'))
+      } finally {
+        logged.mockRestore()
+      }
     })
 
     test('resets statusMessageId to null when editMessageText fails (message deleted)', async () => {
@@ -360,6 +370,52 @@ describe('createWorkingStateManager', () => {
       await Promise.resolve()
 
       expect(state.statusMessageId).toBeNull()
+    })
+  })
+
+  // The two classifiers decide whether a failed edit means "keep editing this
+  // message" or "it is gone, send a new one" — getting that backwards is what
+  // produced issue #403. They match on Telegram's English descriptions because
+  // both cases are HTTP 400 and the code cannot separate them, so the exact
+  // strings are pinned here rather than only exercised through the timer loop.
+  describe('edit-failure classification (#403)', () => {
+    const NOT_MODIFIED =
+      "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message"
+
+    test('U-TY-403e: recognises the not-modified rejection, however it is thrown', () => {
+      expect(isNotModifiedError(new Error(NOT_MODIFIED))).toBe(true)
+      // grammY surfaces the API text on `description`, with `message` wrapping it.
+      expect(isNotModifiedError({ description: NOT_MODIFIED, error_code: 400 })).toBe(true)
+      expect(isNotModifiedError({ message: `Call to 'editMessageText' failed! (400: ${NOT_MODIFIED})` })).toBe(true)
+    })
+
+    test('U-TY-403f: a not-modified rejection is never read as a gone message', () => {
+      expect(isMessageGoneError(new Error(NOT_MODIFIED))).toBe(false)
+    })
+
+    test('U-TY-403g: recognises the descriptions that mean the message cannot be edited', () => {
+      for (const description of [
+        'Bad Request: message to edit not found',
+        'Bad Request: message to be edited not found',
+        "Bad Request: message can't be edited",
+        'Bad Request: message not found',
+      ]) {
+        expect(isMessageGoneError({ description, error_code: 400 })).toBe(true)
+        expect(isNotModifiedError({ description, error_code: 400 })).toBe(false)
+      }
+    })
+
+    test('U-TY-403h: a transient failure matches neither, so the id is kept', () => {
+      for (const err of [
+        new Error('ETIMEDOUT: socket hang up'),
+        { description: 'Too Many Requests: retry after 5', error_code: 429 },
+        { description: 'Bad Gateway', error_code: 502 },
+        undefined,
+        null,
+      ]) {
+        expect(isNotModifiedError(err)).toBe(false)
+        expect(isMessageGoneError(err)).toBe(false)
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

A turn running past one hour made the Telegram working-status message post a fresh duplicate roughly every 10 seconds instead of being edited in place. The status loop now skips an edit that would change nothing, and stops treating a benign edit rejection as proof the message is gone.

## Related Issue

Closes #403

## Root cause

Three things combined; none is wrong on its own.

1. `mcp/tools/telegram/typing.ts` renders elapsed time as `${hours}h ${mins}m` past one hour — no seconds — while `STATUS_INTERVAL_MS` is 10s. With the detail line steady, 5 of every 6 ticks built byte-identical text.
2. Telegram rejects an edit whose text is identical to what the message already shows, with `400 Bad Request: message is not modified`. Confirmed against the live Bot API: identical text is rejected, changed text succeeds.
3. The edit's error handler treated **any** rejection as "the message is gone" and cleared `statusMessageId`, so the next tick took the `sendMessage` branch and posted a replacement — which then repeated for the rest of the turn.

The bare `.catch()` logged nothing, so the failure left no trace to find it by.

## Changes Made

- `mcp/tools/telegram/typing.ts`
  - `WorkingState` gains `lastStatusText`; `sendStatusUpdate()` returns early when the newly rendered text matches it, so a no-op edit is never issued.
  - The edit rejection is now classified. `isNotModifiedError()` keeps `statusMessageId` — the message is intact and already correct. `isMessageGoneError()` clears it, preserving the recovery this handler was written for. Anything else (a network blip, a 429) also keeps the id and retries on the next tick, since re-sending would leave a duplicate behind a message that is still there — **and is logged**, because a silently swallowed edit failure is exactly what let this loop run unnoticed.
  - Both classifiers read the error structurally rather than via `err instanceof GrammyError && err.error_code`, the convention in `receiver-server.ts`: this module deliberately takes an injected `BotApi` and imports no grammy, and both cases are HTTP 400 anyway, so only the description separates them.
- `README.md` — the Live Status Messages section now states that one message is edited in place for the whole turn, that a tick with nothing new issues no update, and that the message is replaced only when it is deleted or becomes uneditable.

The elapsed-time format is deliberately unchanged: adding seconds past one hour would hide this bug by making the text always differ, without fixing the error handling that turns any failed edit into a duplicate.

## Testing

Four regression tests in `tests/unit/telegram-plugin/typing.test.ts`, each **verified to fail on the pre-fix code** by reverting the change:

- `U-TY-403a` — identical text issues no `editMessageText` call at all.
- `U-TY-403b` — a `message is not modified` rejection leaves `statusMessageId` intact.
- `U-TY-403c` — twelve ticks on a turn started over an hour ago leave exactly one status message. On the pre-fix code this asserts `Expected 1, Received 4`, reproducing the flood.
- `U-TY-403d` — a transient failure keeps the id rather than posting a replacement, and leaves a line in the log. Removing just the log statement turns this test red.

Four more (`U-TY-403e`–`h`) pin the classifiers directly against Telegram's real description strings, in each shape the error arrives in — a plain `Error`, a GrammyError-style `description`, and a wrapped `message` — including that a not-modified rejection is never read as a gone message, and that a 429, a socket error, `undefined` and `null` match neither. These cover functions that do not exist before this PR, so unlike `403a`–`d` they cannot be run against the pre-fix code; the suite simply fails to compile there.

The existing `resets statusMessageId to null when editMessageText fails (message deleted)` still passes: a genuinely gone message is still recovered from.

Full suite: **191 suites / 3658 tests**, zero failures.

Note on gates: `npm run typecheck` only covers `src/**/*` (`tsconfig.json` excludes everything else), so `mcp/` is typechecked by ts-jest when its suite runs, not by `tsc`.

### Known trade-off

Skipping the edit when the text is unchanged means a status message deleted by hand is not noticed until the next edit is issued. The elapsed line advances every minute even at `Xh Ym`, so that wait is bounded at roughly a minute, and it is recorded in a comment at the call site.
