### PR TITLE
fix(gateway): handle SIGHUP and reap orphaned receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,25 @@ Tools are **prefixed by channel name** to avoid collisions. Each module controls
 | `TELEGRAM_RECEIVER_MODE` | `receiver-server.ts` | Polls Telegram, handles commands, POSTs to callback — **no MCP** |
 | `TELEGRAM_SEND_ONLY` | `server.ts` | Exposes MCP tools (`telegram_*`, `cron_*`) — **no polling** |
 
+#### Receiver lifecycle
+
+Receivers are child processes, so they only stop when the gateway runs its
+shutdown path. Two mechanisms keep them from outliving it:
+
+- **`SIGTERM`, `SIGINT` and `SIGHUP` all run the same graceful shutdown.**
+  `SIGHUP` matters because Node's default action for it terminates the process
+  *without* running handlers — so before this was wired, closing a tmux pane or
+  dropping an SSH session killed the gateway and left every receiver reparented
+  to `init`. Teardown escalates `SIGTERM` → `SIGKILL` after a short grace period,
+  so a receiver wedged in an in-flight long-poll cannot survive it.
+
+- **A boot-time sweep reclaims leftovers.** `SIGKILL` and the OOM killer can
+  never be handled in-process, so at startup the gateway terminates any
+  `receiver-server.ts` process that was spawned from *its own* installation and
+  has been reparented to `init` (proof that its supervisor is gone), logging how
+  many it reclaimed. Receivers belonging to another checkout on the same host, or
+  to a gateway that is still running, are never touched.
+
 ### Session Persistence
 
 History is persisted to `SessionStore` (`.jsonl` files) after each message. When a session is spawned after an idle restart, history is injected into the initial prompt so Claude resumes the conversation seamlessly.

--- a/README.md
+++ b/README.md
@@ -623,8 +623,15 @@ shutdown path. Two mechanisms keep them from outliving it:
   never be handled in-process, so at startup the gateway terminates any
   `receiver-server.ts` process that was spawned from *its own* installation and
   has been reparented to `init` (proof that its supervisor is gone), logging how
-  many it reclaimed. Receivers belonging to another checkout on the same host, or
-  to a gateway that is still running, are never touched.
+  many it reclaimed — and separately warning about any it could **not** reclaim,
+  since those are still running. Receivers belonging to another checkout on the
+  same host, or to a gateway that is still running, are never touched.
+
+  On a host where an ancestor is a child subreaper (`systemd --user`,
+  `docker run --init`/tini, s6), orphans reparent to that subreaper instead of to
+  `init` and the sweep finds nothing. Clean shutdown still works; what is lost is
+  the `SIGKILL`/OOM recovery — though such a host usually has a supervisor that
+  reaps the process group itself.
 
 ### Session Persistence
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2766,7 +2766,10 @@ export class AgentRunner extends EventEmitter {
 
   stopTelegramReceiver(): void {
     if (!this.receiver) return;
-    this.receiver.stop();
+    // Hot-remove is a config-change response, not a shutdown: detach immediately
+    // and let teardown finish in the background rather than blocking the caller
+    // for the SIGKILL grace period. stop() never rejects.
+    void this.receiver.stop();
     this.receiver = null;
     this.logger.info('TelegramReceiver stopped', { agentId: this.agentConfig.id });
   }
@@ -2785,7 +2788,10 @@ export class AgentRunner extends EventEmitter {
 
   stopDiscordReceiver(): void {
     if (!this.discordReceiver) return;
-    this.discordReceiver.stop();
+    // Hot-remove is a config-change response, not a shutdown: detach immediately
+    // and let teardown finish in the background rather than blocking the caller
+    // for the SIGKILL grace period. stop() never rejects.
+    void this.discordReceiver.stop();
     this.discordReceiver = null;
     this.logger.info('DiscordReceiver stopped', { agentId: this.agentConfig.id });
   }
@@ -2808,10 +2814,17 @@ export class AgentRunner extends EventEmitter {
       clearTimeout(buf.timer);
     }
     this.channelCoalesce.clear();
-    this.receiver?.stop();
-    this.discordReceiver?.stop();
+    // Receiver teardown now resolves only once the child has exited, so it must
+    // be awaited or shutdown() can exit the gateway out from under a receiver
+    // that is still shutting down (issue #405). Run it concurrently with session
+    // teardown rather than serially — both are bounded, neither depends on the
+    // other, and shutdown latency is user-visible.
+    const receiversStopped = [this.receiver?.stop(), this.discordReceiver?.stop()];
     this.stopLineReply();
-    await Promise.all([...this.sessions.values()].map((s) => s.stop()));
+    await Promise.all([
+      ...receiversStopped,
+      ...[...this.sessions.values()].map((s) => s.stop()),
+    ]);
     this.sessions.clear();
   }
 

--- a/src/discord/receiver.ts
+++ b/src/discord/receiver.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process';
 import * as path from 'path';
 import { AgentConfig } from '../types';
 import { createLogger } from '../logger';
+import { stopChildProcess, STOP_GRACE_MS } from '../utils/stop-child';
 
 const AUTO_RESTART_DELAY_MS = 5_000;
 const MAX_RESTARTS = 3;
@@ -97,13 +98,25 @@ export class DiscordReceiver {
     }, delay);
   }
 
-  stop(): void {
+  /**
+   * Stop the receiver and resolve only once the child has actually exited.
+   * Escalates SIGTERM → SIGKILL so a wedged child cannot outlive the gateway's
+   * shutdown. See issue #405.
+   */
+  stop(): Promise<void> {
     this.stopping = true;
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
     }
-    this.process?.kill('SIGTERM');
+
+    return stopChildProcess(this.process, {
+      onEscalate: (pid) =>
+        this.logger.warn(
+          `DiscordReceiver did not exit within ${STOP_GRACE_MS}ms of SIGTERM; sending SIGKILL`,
+          { pid },
+        ),
+    });
   }
 
   isRunning(): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -630,6 +630,28 @@ async function main(): Promise<void> {
   const mcpToolsDir = path.resolve(__dirname, '..', 'mcp', 'tools');
   const logDir = expandTilde(config.gateway.logDir);
 
+  // Signals are wired HERE, not after startup finishes. Boot spawns receivers
+  // one agent at a time and can take a while (the orphan sweep alone waits out a
+  // grace period), and until a handler exists a SIGHUP during that window kills
+  // the gateway by default disposition and orphans every receiver started so
+  // far — the same failure this file fixes (issue #405).
+  //
+  // The full teardown closes over components that do not exist yet, so the
+  // handler delegates to it once available and otherwise does the subset that
+  // matters this early: stopping the runners, which are what own receivers.
+  let fullShutdown: ((signal: string) => Promise<void>) | null = null;
+  const bootShutdown = async (signal: string): Promise<void> => {
+    if (fullShutdown) return fullShutdown(signal);
+    console.log(`[gateway] Received ${signal} during startup, shutting down...`);
+    for (const scheduler of schedulers) scheduler.stop();
+    await Promise.allSettled([...agentRunners.values()].map((runner) => runner.stop()));
+    console.log('[gateway] Startup shutdown complete.');
+  };
+  registeredShutdown = registerShutdownSignals({
+    run: bootShutdown,
+    onBegin: () => { isShuttingDown = true; },
+  });
+
   // Initial sync: copy shared and module skills to ~/.claude/skills/ so the Skill tool sees them
   syncSharedSkills(sharedSkillsDir, personalSkillsDir, globalLogger);
   syncModuleSkills(mcpToolsDir, personalSkillsDir, globalLogger);
@@ -697,6 +719,15 @@ async function main(): Promise<void> {
       for (const orphan of sweep.reclaimed) {
         globalLogger.info('Reclaimed orphaned receiver', { pid: orphan.pid, command: orphan.command });
       }
+    }
+    // Never fold these into the reclaimed count: they are still alive and still
+    // polling their bot tokens, which is exactly what an operator needs to know.
+    if (sweep.failed.length > 0) {
+      console.warn(
+        `[gateway] Could NOT reclaim ${sweep.failed.length} orphaned receiver process${sweep.failed.length === 1 ? '' : 'es'} — still running: ` +
+          sweep.failed.map((f) => `${f.pid} (${f.reason})`).join(', '),
+      );
+      globalLogger.warn('Orphaned receivers could not be reclaimed', { failed: sweep.failed });
     }
   } catch (err) {
     // A host whose process list cannot be read must still boot — but never
@@ -968,23 +999,34 @@ async function main(): Promise<void> {
     configWatcher.stop();
     socketServer.stopAll();
 
-    await router.stop();
+    // Every teardown below must run even if an earlier one throws. Previously a
+    // rejection here propagated and the process hung with its children still
+    // parented — recoverable. Now that a failed shutdown exits the process, an
+    // unguarded throw would *guarantee* the remaining receivers reparent to
+    // init: precisely the bug this file is fixing (issue #405).
+    const settled = await Promise.allSettled([
+      router.stop(),
+      // Runners stop concurrently, not serially. Teardown is now awaited, and
+      // the Discord receiver always takes ~2s to exit (its receiver-server
+      // force-exits on an unconditional timer), so serial stops would multiply
+      // that by the agent count and risk a supervisor's stop timeout (docker
+      // stop's 10s default, TimeoutStopSec) SIGKILLing the gateway mid-teardown
+      // — re-orphaning the very receivers this protects.
+      ...[...agentRunners.values()].map((runner) => runner.stop()),
+    ]);
 
-    for (const runner of agentRunners.values()) {
-      await runner.stop();
+    for (const result of settled) {
+      if (result.status === 'rejected') {
+        console.error('[gateway] Shutdown step failed:', result.reason);
+      }
     }
 
     console.log('[gateway] Shutdown complete.');
   };
 
-  // Wires SIGTERM/SIGINT/SIGHUP and returns the deduplicated shutdown, which the
-  // module-level crash handlers below reuse so there is only ever one teardown.
-  // SIGHUP matters most here: without a handler Node terminates the gateway
-  // outright and every receiver child is orphaned (issue #405).
-  registeredShutdown = registerShutdownSignals({
-    run: runShutdown,
-    onBegin: () => { isShuttingDown = true; },
-  });
+  // Hand the fully-wired teardown to the handlers registered at the top of
+  // main(). From here a signal tears down everything; before it, the boot subset.
+  fullShutdown = runShutdown;
 }
 
 async function emergencyShutdown(label: string, detail: unknown): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ import { createLogger } from './logger';
 import { ConfigWatcher, ConfigChange } from './config/watcher';
 import { AgentConfig, GatewayConfig } from './types';
 import { AppsRegistry } from './apps/registry';
+import { sweepOrphanedReceivers } from './utils/orphan-receivers';
+import { registerShutdownSignals } from './shutdown-signals';
 import { RegistryClient } from './apps/registry-client';
 import { AppInstaller } from './apps/installer';
 import { AgentManager } from './apps/agent-manager';
@@ -676,6 +678,33 @@ async function main(): Promise<void> {
     reflectionVaultsStarted: new Set(),
   };
 
+  // Reclaim receivers a previous gateway generation left behind before spawning
+  // this one's. An exit that bypasses shutdown() — SIGKILL, the OOM killer, or a
+  // SIGHUP on a pre-#405 build — reparents them to init, where they keep polling
+  // their channel forever. Signal handling alone cannot cover SIGKILL/OOM, so
+  // this sweep is the only path that recovers from them. See issue #405.
+  //
+  // Deliberately awaited before any agent starts: an orphan and a fresh receiver
+  // polling the same bot token at once would race for every update, so the old
+  // one must be gone before the new one exists.
+  try {
+    const sweep = await sweepOrphanedReceivers(mcpToolsDir);
+    if (sweep.reclaimed.length > 0) {
+      const forced = sweep.forced.length > 0 ? ` (${sweep.forced.length} needed SIGKILL)` : '';
+      console.log(
+        `[gateway] Reclaimed ${sweep.reclaimed.length} orphaned receiver process${sweep.reclaimed.length === 1 ? '' : 'es'}${forced}`,
+      );
+      for (const orphan of sweep.reclaimed) {
+        globalLogger.info('Reclaimed orphaned receiver', { pid: orphan.pid, command: orphan.command });
+      }
+    }
+  } catch (err) {
+    // A host whose process list cannot be read must still boot — but never
+    // silently: an unreadable `ps` means orphans are accumulating unseen.
+    console.warn(`[gateway] Failed to sweep orphaned receivers: ${(err as Error).message}`);
+    globalLogger.warn('Failed to sweep orphaned receivers', { error: (err as Error).message });
+  }
+
   for (const agentConfig of config.agents) {
     // Expand ~ in workspace path so all downstream code uses absolute paths
     agentConfig.workspace = expandTilde(agentConfig.workspace);
@@ -928,9 +957,7 @@ async function main(): Promise<void> {
   configWatcher.start();
 
   // Graceful shutdown — idempotent: safe to call from multiple signal/error sources.
-  const shutdown = async (signal: string) => {
-    if (isShuttingDown) return;
-    isShuttingDown = true;
+  const runShutdown = async (signal: string) => {
     console.log(`[gateway] Received ${signal}, shutting down...`);
 
     for (const scheduler of schedulers) {
@@ -950,11 +977,14 @@ async function main(): Promise<void> {
     console.log('[gateway] Shutdown complete.');
   };
 
-  // Expose shutdown to the module-level crash handlers registered below.
-  registeredShutdown = shutdown;
-
-  process.on('SIGTERM', () => shutdown('SIGTERM').then(() => process.exit(0)));
-  process.on('SIGINT', () => shutdown('SIGINT').then(() => process.exit(0)));
+  // Wires SIGTERM/SIGINT/SIGHUP and returns the deduplicated shutdown, which the
+  // module-level crash handlers below reuse so there is only ever one teardown.
+  // SIGHUP matters most here: without a handler Node terminates the gateway
+  // outright and every receiver child is orphaned (issue #405).
+  registeredShutdown = registerShutdownSignals({
+    run: runShutdown,
+    onBegin: () => { isShuttingDown = true; },
+  });
 }
 
 async function emergencyShutdown(label: string, detail: unknown): Promise<void> {

--- a/src/shutdown-signals.ts
+++ b/src/shutdown-signals.ts
@@ -1,0 +1,81 @@
+/**
+ * Signal wiring for the gateway's graceful shutdown.
+ *
+ * Extracted from index.ts so the two properties that actually matter can be
+ * tested without booting a gateway:
+ *
+ *   1. Which signals run `shutdown()` at all. SIGHUP was missing, and Node's
+ *      default disposition for it is to terminate the process WITHOUT running
+ *      any handler — so a closed tmux pane, `tmux kill-session`, or a dropped
+ *      SSH connection killed the gateway while every spawned receiver child was
+ *      reparented to init and kept running. See issue #405.
+ *
+ *   2. That a second signal joins the in-flight shutdown instead of racing it.
+ *      Previously the guard returned `undefined` immediately, so the second
+ *      handler's `.then(() => process.exit(0))` fired at once and terminated the
+ *      process partway through the first shutdown — the exact outcome the
+ *      graceful path exists to avoid.
+ */
+
+/**
+ * Every signal that means "wind down cleanly".
+ *
+ * SIGHUP belongs here for the same reason it does in
+ * `src/shell/claude-pty-shell.ts:407` (issue #371): it is the ordinary way a
+ * hand-run process is stopped, and its default action skips handlers entirely.
+ */
+export const SHUTDOWN_SIGNALS: readonly NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP'];
+
+export interface ShutdownSignalOptions {
+  /** The teardown itself. Invoked at most once, no matter how many signals arrive. */
+  run: (signal: string) => Promise<void>;
+  /** Called synchronously when the first shutdown begins (before `run`). */
+  onBegin?: (signal: string) => void;
+  /** Overridable for tests. Defaults to terminating the process. */
+  exit?: (code: number) => void;
+  /** Reports a teardown that threw. Defaults to stderr. */
+  onError?: (err: unknown) => void;
+  /** Overridable for tests. Defaults to the real `process`. */
+  target?: { on(event: string, listener: () => void): unknown };
+}
+
+/**
+ * Register a handler for every shutdown signal and return the deduplicated
+ * shutdown function, so callers (e.g. the crash handlers) can trigger the same
+ * single teardown.
+ */
+export function registerShutdownSignals(
+  opts: ShutdownSignalOptions,
+): (signal: string) => Promise<void> {
+  const exit = opts.exit ?? ((code: number) => process.exit(code));
+  const onError =
+    opts.onError ?? ((err: unknown) => console.error('[gateway] Shutdown failed:', err));
+  const target = opts.target ?? process;
+
+  let inFlight: Promise<void> | null = null;
+
+  const shutdown = (signal: string): Promise<void> => {
+    if (inFlight) return inFlight;
+    opts.onBegin?.(signal);
+    inFlight = opts.run(signal);
+    return inFlight;
+  };
+
+  for (const signal of SHUTDOWN_SIGNALS) {
+    target.on(signal, () => {
+      // A teardown that throws must still terminate the process. Previously the
+      // rejection skipped `.then(exit)` entirely and the gateway hung on the
+      // signal — holding its port and its children — which is a worse outcome
+      // than an unclean exit. Exit non-zero so the failure stays visible.
+      void shutdown(signal).then(
+        () => exit(0),
+        (err) => {
+          onError(err);
+          exit(1);
+        },
+      );
+    });
+  }
+
+  return shutdown;
+}

--- a/src/telegram/receiver.ts
+++ b/src/telegram/receiver.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process';
 import * as path from 'path';
 import { AgentConfig } from '../types';
 import { createLogger } from '../logger';
+import { stopChildProcess, STOP_GRACE_MS } from '../utils/stop-child';
 
 const AUTO_RESTART_DELAY_MS = 5_000;
 const MAX_RESTARTS = 3;
@@ -87,13 +88,25 @@ export class TelegramReceiver {
     }, delay);
   }
 
-  stop(): void {
+  /**
+   * Stop the receiver and resolve only once the child has actually exited.
+   * Escalates SIGTERM → SIGKILL so a wedged child cannot outlive the gateway's
+   * shutdown. See issue #405.
+   */
+  stop(): Promise<void> {
     this.stopping = true;
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
     }
-    this.process?.kill('SIGTERM');
+
+    return stopChildProcess(this.process, {
+      onEscalate: (pid) =>
+        this.logger.warn(
+          `TelegramReceiver did not exit within ${STOP_GRACE_MS}ms of SIGTERM; sending SIGKILL`,
+          { pid },
+        ),
+    });
   }
 
   isRunning(): boolean {

--- a/src/utils/orphan-receivers.ts
+++ b/src/utils/orphan-receivers.ts
@@ -1,0 +1,163 @@
+import { execFile } from 'child_process';
+import * as path from 'path';
+
+/**
+ * Reclaim channel receiver processes left behind by a previous gateway.
+ *
+ * The gateway spawns one `bun .../mcp/tools/<channel>/receiver-server.ts` child
+ * per channel per agent. Those children only die if the gateway runs its
+ * shutdown path. Any exit that bypasses it — SIGKILL, the OOM killer, or (until
+ * issue #405) a SIGHUP — reparents them to init, where they keep polling with no
+ * supervisor to hand messages to and survive every subsequent restart.
+ *
+ * Handling more signals cannot fix SIGKILL or OOM, so a boot-time sweep is the
+ * only mechanism that can recover from those. See issue #405.
+ */
+
+export interface OrphanedReceiver {
+  pid: number;
+  /** Full argv of the orphan, for logging. */
+  command: string;
+}
+
+/** Injectable so tests can drive the sweep without real processes. */
+export interface SweepDeps {
+  listProcesses?: () => Promise<string>;
+  kill?: (pid: number, signal: NodeJS.Signals) => void;
+  wait?: (ms: number) => Promise<void>;
+}
+
+export interface SweepResult {
+  reclaimed: OrphanedReceiver[];
+  /** Orphans that ignored SIGTERM and had to be SIGKILLed. */
+  forced: number[];
+}
+
+/** Grace period between SIGTERM and SIGKILL for an orphan. */
+export const ORPHAN_SIGKILL_GRACE_MS = 2_000;
+
+const defaultListProcesses = (): Promise<string> =>
+  new Promise((resolve, reject) => {
+    // `pid=,ppid=,args=` suppresses the header, so every line is a record.
+    // `-ww` disables width truncation: a clipped argv would silently stop
+    // matching the tools-directory prefix and reclaim nothing.
+    execFile('ps', ['-ww', '-eo', 'pid=,ppid=,args='], { maxBuffer: 8 * 1024 * 1024 }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve(stdout);
+    });
+  });
+
+const defaultKill = (pid: number, signal: NodeJS.Signals): void => {
+  process.kill(pid, signal);
+};
+
+const defaultWait = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Find receiver processes spawned from `receiverToolsDir` that have been
+ * reparented to init.
+ *
+ * Both conditions are load-bearing:
+ *
+ * - `ppid === 1` proves the supervising gateway is *gone*. A receiver owned by a
+ *   live gateway always has that gateway's pid as its parent, including when the
+ *   gateway itself is a systemd service whose own ppid is 1. So this never
+ *   matches a receiver another running gateway still owns.
+ * - The tools-directory prefix keeps a gateway from killing receivers belonging
+ *   to a different checkout on the same host. `receiverToolsDir` is the very
+ *   `<install>/mcp/tools` the receivers are spawned from, and matching includes
+ *   the trailing separator, so `/opt/gw/mcp/tools` cannot match a receiver under
+ *   `/opt/gw-research/mcp/tools`.
+ */
+export function findOrphanedReceivers(psOutput: string, receiverToolsDir: string): OrphanedReceiver[] {
+  const needle = path.resolve(receiverToolsDir) + path.sep;
+  const found: OrphanedReceiver[] = [];
+
+  for (const line of psOutput.split('\n')) {
+    // `pid ppid args...` — args may contain spaces, so split off only the first two.
+    const match = /^\s*(\d+)\s+(\d+)\s+(.*)$/.exec(line);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const ppid = Number(match[2]);
+    const command = match[3].trim();
+
+    if (ppid !== 1) continue;
+    if (pid === process.pid) continue;
+    if (!command.includes(needle)) continue;
+    if (!command.includes('receiver-server.ts')) continue;
+
+    found.push({ pid, command });
+  }
+
+  return found;
+}
+
+/**
+ * Terminate every orphaned receiver spawned from `receiverToolsDir`.
+ *
+ * Escalates SIGTERM → SIGKILL so a receiver wedged in an in-flight long-poll
+ * cannot survive the sweep.
+ *
+ * Rejects if the process list cannot be read at all — the caller must decide
+ * whether that is fatal (it is not: boot continues, loudly). Once the sweep is
+ * under way it stops throwing, so a partial failure degrades to "fewer orphans
+ * reclaimed this boot" rather than a failed startup.
+ *
+ * `reclaimed` lists the orphans that were signalled. In the ordinary path they
+ * are gone by the time this resolves; if escalation had to be skipped, a wedged
+ * one may still be alive and the next boot will retry it.
+ */
+export async function sweepOrphanedReceivers(
+  receiverToolsDir: string,
+  deps: SweepDeps = {},
+): Promise<SweepResult> {
+  const listProcesses = deps.listProcesses ?? defaultListProcesses;
+  const kill = deps.kill ?? defaultKill;
+  const wait = deps.wait ?? defaultWait;
+
+  const orphans = findOrphanedReceivers(await listProcesses(), receiverToolsDir);
+  if (orphans.length === 0) return { reclaimed: [], forced: [] };
+
+  for (const orphan of orphans) {
+    // ESRCH: it exited between the listing and now — already reclaimed.
+    try {
+      kill(orphan.pid, 'SIGTERM');
+    } catch {
+      /* already gone */
+    }
+  }
+
+  await wait(ORPHAN_SIGKILL_GRACE_MS);
+
+  // Re-list before escalating. A pid freed by SIGTERM can be recycled by an
+  // unrelated process within the grace period, and SIGKILLing that would be a
+  // far worse bug than the one being fixed — so only pids that are STILL a
+  // matching orphan are escalated, not merely pids that still exist.
+  let survivors: Set<number>;
+  try {
+    survivors = new Set(
+      findOrphanedReceivers(await listProcesses(), receiverToolsDir).map((o) => o.pid),
+    );
+  } catch {
+    // The second listing failed even though the first succeeded. Skipping
+    // escalation leaves a wedged receiver alive, which the next boot will retry;
+    // guessing from stale pids could kill an unrelated process. Prefer the
+    // recoverable failure.
+    return { reclaimed: orphans, forced: [] };
+  }
+
+  const forced: number[] = [];
+  for (const orphan of orphans) {
+    if (!survivors.has(orphan.pid)) continue; // exited on SIGTERM, as expected
+    try {
+      kill(orphan.pid, 'SIGKILL');
+      forced.push(orphan.pid);
+    } catch {
+      /* raced us to exit between the listing and now */
+    }
+  }
+
+  return { reclaimed: orphans, forced };
+}

--- a/src/utils/orphan-receivers.ts
+++ b/src/utils/orphan-receivers.ts
@@ -28,13 +28,30 @@ export interface SweepDeps {
 }
 
 export interface SweepResult {
+  /** Orphans that are gone as a result of this sweep. */
   reclaimed: OrphanedReceiver[];
   /** Orphans that ignored SIGTERM and had to be SIGKILLed. */
   forced: number[];
+  /**
+   * Orphans that could NOT be terminated — most realistically EPERM, when a
+   * previous gateway ran under a different account or under sudo. Reported
+   * separately so the boot log never claims to have reclaimed a process that is
+   * still alive and still polling its bot token.
+   */
+  failed: Array<{ pid: number; reason: string }>;
 }
 
-/** Grace period between SIGTERM and SIGKILL for an orphan. */
-export const ORPHAN_SIGKILL_GRACE_MS = 2_000;
+/**
+ * Grace period between SIGTERM and SIGKILL for an orphan.
+ *
+ * Must stay comfortably above the receivers' own exit deadline — both
+ * `mcp/tools/discord/receiver-server.ts` and `mcp/tools/telegram/receiver-server.ts`
+ * force-exit on a 2000ms timer after SIGTERM, and Discord's is unconditional. A
+ * 2000ms grace would be a dead heat, so healthy receivers would routinely be
+ * SIGKILLed and counted as wedged, making the "needed SIGKILL" figure useless as
+ * a signal.
+ */
+export const ORPHAN_SIGKILL_GRACE_MS = 5_000;
 
 const defaultListProcesses = (): Promise<string> =>
   new Promise((resolve, reject) => {
@@ -54,6 +71,17 @@ const defaultKill = (pid: number, signal: NodeJS.Signals): void => {
 const defaultWait = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+/** ESRCH means the process is already gone — the one "failure" that is a success. */
+function isAlreadyGone(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException | undefined)?.code === 'ESRCH';
+}
+
+function describeKillError(err: unknown): string {
+  const e = err as NodeJS.ErrnoException | undefined;
+  if (e?.code === 'EPERM') return 'EPERM (owned by another user)';
+  return e?.code ?? (e instanceof Error ? e.message : String(err));
+}
+
 /**
  * Find receiver processes spawned from `receiverToolsDir` that have been
  * reparented to init.
@@ -64,14 +92,24 @@ const defaultWait = (ms: number): Promise<void> =>
  *   live gateway always has that gateway's pid as its parent, including when the
  *   gateway itself is a systemd service whose own ppid is 1. So this never
  *   matches a receiver another running gateway still owns.
- * - The tools-directory prefix keeps a gateway from killing receivers belonging
- *   to a different checkout on the same host. `receiverToolsDir` is the very
- *   `<install>/mcp/tools` the receivers are spawned from, and matching includes
- *   the trailing separator, so `/opt/gw/mcp/tools` cannot match a receiver under
- *   `/opt/gw-research/mcp/tools`.
+ *
+ *   Caveat: on a host where an ancestor has called `prctl(PR_SET_CHILD_SUBREAPER)`
+ *   — `systemd --user` for user services, `docker run --init` / tini, s6 —
+ *   orphans reparent to that subreaper rather than to pid 1, and this sweep finds
+ *   nothing. The gateway still shuts down cleanly there (gap 1 covers the signal
+ *   paths); what is lost is the SIGKILL/OOM recovery, and such a host has a
+ *   supervisor that generally reaps the process group itself.
+ *
+ * - The argv must *execute* the receiver from this installation's own tools
+ *   directory. Matching is on argv tokens in the exact shape the receivers are
+ *   spawned with (`bun <toolsDir>/<channel>/receiver-server.ts`) rather than a
+ *   substring test, so a detached `grep -r receiver-server.ts <toolsDir>/`, an
+ *   editor, or a `bun test` over the same file is not mistaken for a receiver and
+ *   killed. `tests/unit/receiver-stop-teardown.test.ts` pins this shape against
+ *   the receivers' real spawn arguments.
  */
 export function findOrphanedReceivers(psOutput: string, receiverToolsDir: string): OrphanedReceiver[] {
-  const needle = path.resolve(receiverToolsDir) + path.sep;
+  const toolsDir = path.resolve(receiverToolsDir);
   const found: OrphanedReceiver[] = [];
 
   for (const line of psOutput.split('\n')) {
@@ -85,13 +123,31 @@ export function findOrphanedReceivers(psOutput: string, receiverToolsDir: string
 
     if (ppid !== 1) continue;
     if (pid === process.pid) continue;
-    if (!command.includes(needle)) continue;
-    if (!command.includes('receiver-server.ts')) continue;
+    if (!isReceiverInvocation(command, toolsDir)) continue;
 
     found.push({ pid, command });
   }
 
   return found;
+}
+
+/**
+ * True when `command` is the gateway spawning a receiver of its own — i.e.
+ * `bun <toolsDir>/<channel>/receiver-server.ts`, the script as the runtime's
+ * first argument, with exactly one directory level for the channel.
+ */
+function isReceiverInvocation(command: string, toolsDir: string): boolean {
+  const tokens = command.split(/\s+/);
+  if (tokens.length < 2) return false;
+  if (path.basename(tokens[0]) !== 'bun') return false;
+
+  const script = tokens[1];
+  const relative = path.relative(toolsDir, script);
+  // Outside the tools directory (`..`) or on another root (absolute) — not ours.
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return false;
+
+  const segments = relative.split(path.sep);
+  return segments.length === 2 && segments[1] === 'receiver-server.ts';
 }
 
 /**
@@ -102,12 +158,8 @@ export function findOrphanedReceivers(psOutput: string, receiverToolsDir: string
  *
  * Rejects if the process list cannot be read at all — the caller must decide
  * whether that is fatal (it is not: boot continues, loudly). Once the sweep is
- * under way it stops throwing, so a partial failure degrades to "fewer orphans
- * reclaimed this boot" rather than a failed startup.
- *
- * `reclaimed` lists the orphans that were signalled. In the ordinary path they
- * are gone by the time this resolves; if escalation had to be skipped, a wedged
- * one may still be alive and the next boot will retry it.
+ * under way it stops throwing, and anything it could not terminate is reported
+ * in `failed` rather than silently counted as reclaimed.
  */
 export async function sweepOrphanedReceivers(
   receiverToolsDir: string,
@@ -118,14 +170,17 @@ export async function sweepOrphanedReceivers(
   const wait = deps.wait ?? defaultWait;
 
   const orphans = findOrphanedReceivers(await listProcesses(), receiverToolsDir);
-  if (orphans.length === 0) return { reclaimed: [], forced: [] };
+  if (orphans.length === 0) return { reclaimed: [], forced: [], failed: [] };
+
+  const failed = new Map<number, string>();
 
   for (const orphan of orphans) {
-    // ESRCH: it exited between the listing and now — already reclaimed.
     try {
       kill(orphan.pid, 'SIGTERM');
-    } catch {
-      /* already gone */
+    } catch (err) {
+      // ESRCH: it exited between the listing and now — already reclaimed.
+      // Anything else (EPERM in practice) means we cannot touch it at all.
+      if (!isAlreadyGone(err)) failed.set(orphan.pid, describeKillError(err));
     }
   }
 
@@ -140,24 +195,41 @@ export async function sweepOrphanedReceivers(
     survivors = new Set(
       findOrphanedReceivers(await listProcesses(), receiverToolsDir).map((o) => o.pid),
     );
-  } catch {
+  } catch (err) {
     // The second listing failed even though the first succeeded. Skipping
     // escalation leaves a wedged receiver alive, which the next boot will retry;
     // guessing from stale pids could kill an unrelated process. Prefer the
-    // recoverable failure.
-    return { reclaimed: orphans, forced: [] };
+    // recoverable failure — but report the survivors as unreclaimed, not as won.
+    const reason = `escalation skipped: ${(err as Error).message}`;
+    for (const orphan of orphans) {
+      if (!failed.has(orphan.pid)) failed.set(orphan.pid, reason);
+    }
+    return finish(orphans, [], failed);
   }
 
   const forced: number[] = [];
   for (const orphan of orphans) {
+    if (failed.has(orphan.pid)) continue; // could not be signalled at all
     if (!survivors.has(orphan.pid)) continue; // exited on SIGTERM, as expected
     try {
       kill(orphan.pid, 'SIGKILL');
       forced.push(orphan.pid);
-    } catch {
-      /* raced us to exit between the listing and now */
+    } catch (err) {
+      if (!isAlreadyGone(err)) failed.set(orphan.pid, describeKillError(err));
     }
   }
 
-  return { reclaimed: orphans, forced };
+  return finish(orphans, forced, failed);
+}
+
+function finish(
+  orphans: OrphanedReceiver[],
+  forced: number[],
+  failed: Map<number, string>,
+): SweepResult {
+  return {
+    reclaimed: orphans.filter((o) => !failed.has(o.pid)),
+    forced,
+    failed: [...failed].map(([pid, reason]) => ({ pid, reason })),
+  };
 }

--- a/src/utils/stop-child.ts
+++ b/src/utils/stop-child.ts
@@ -1,0 +1,56 @@
+import { ChildProcess } from 'child_process';
+
+/** How long a supervised child gets to exit on SIGTERM before it is SIGKILLed. */
+export const STOP_GRACE_MS = 5_000;
+
+export interface StopChildOptions {
+  /** Milliseconds to wait for a clean exit before escalating. */
+  graceMs?: number;
+  /** Called just before SIGKILL, so the caller can log with its own identity. */
+  onEscalate?: (pid: number | undefined) => void;
+}
+
+/**
+ * Terminate a supervised child and resolve only once it has actually exited.
+ *
+ * A bare `kill('SIGTERM')` is not enough: a receiver blocked in an in-flight
+ * long-poll can sit in its own handler indefinitely, and the caller had no way to
+ * know. Escalating to SIGKILL after a bounded grace period guarantees the child
+ * cannot outlive the gateway's shutdown. See issue #405.
+ *
+ * Never rejects — a shutdown path must not be derailed by a teardown failure.
+ */
+export function stopChildProcess(
+  proc: ChildProcess | null,
+  opts: StopChildOptions = {},
+): Promise<void> {
+  if (!proc) return Promise.resolve();
+
+  const graceMs = opts.graceMs ?? STOP_GRACE_MS;
+
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(killTimer);
+      resolve();
+    };
+
+    const killTimer = setTimeout(() => {
+      opts.onEscalate?.(proc.pid);
+      // SIGKILL is delivered by the kernel whether or not we stay alive to
+      // observe the exit, so resolving here cannot leave the child running.
+      try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+      finish();
+    }, graceMs);
+
+    proc.once('exit', finish);
+    try {
+      proc.kill('SIGTERM');
+    } catch {
+      // Already exited between the caller's null-check and here.
+      finish();
+    }
+  });
+}

--- a/src/utils/stop-child.ts
+++ b/src/utils/stop-child.ts
@@ -29,6 +29,20 @@ export function stopChildProcess(
   const graceMs = opts.graceMs ?? STOP_GRACE_MS;
 
   return new Promise<void>((resolve) => {
+    // An already-exited child never emits another 'exit', and `kill()` on it
+    // returns false *without throwing* (Node has cleared its handle) — so the
+    // catch below would not fire and the promise would idle for the whole grace
+    // period before "escalating" with a SIGKILL that does nothing.
+    //
+    // Loose `!= null` is deliberate: a real ChildProcess always exposes both
+    // fields as null while running, but anything that does not expose them at
+    // all must be treated as ALIVE and signalled, never assumed dead and
+    // silently skipped. Failing safe here means attempting the kill.
+    if (proc.exitCode != null || proc.signalCode != null) {
+      resolve();
+      return;
+    }
+
     let settled = false;
     const finish = () => {
       if (settled) return;
@@ -46,10 +60,11 @@ export function stopChildProcess(
     }, graceMs);
 
     proc.once('exit', finish);
+    // Returns false rather than throwing if the child died in the moment before
+    // this line; the exit event that clears the handle also settles us.
     try {
       proc.kill('SIGTERM');
     } catch {
-      // Already exited between the caller's null-check and here.
       finish();
     }
   });

--- a/tests/fixtures/sighup-harness.ts
+++ b/tests/fixtures/sighup-harness.ts
@@ -1,0 +1,28 @@
+/**
+ * Minimal stand-in for the gateway entry point, used by
+ * tests/integration/sighup-orphan-receivers.test.ts.
+ *
+ * It wires signals through the *real* registerShutdownSignals and supervises a
+ * real child, so the test exercises the actual OS behaviour that issue #405 is
+ * about: Node's default disposition for SIGHUP terminates the process without
+ * running handlers, which is what orphaned every receiver.
+ */
+import { spawn } from 'child_process';
+import { registerShutdownSignals } from '../../src/shutdown-signals';
+
+const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000);'], {
+  stdio: 'ignore',
+});
+
+process.stdout.write(`CHILD ${child.pid}\n`);
+
+registerShutdownSignals({
+  run: async (signal) => {
+    process.stdout.write(`SHUTDOWN ${signal}\n`);
+    child.kill('SIGTERM');
+    await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+  },
+});
+
+// Keep the harness alive until a signal arrives.
+setInterval(() => {}, 1000);

--- a/tests/integration/sighup-orphan-receivers.test.ts
+++ b/tests/integration/sighup-orphan-receivers.test.ts
@@ -1,0 +1,82 @@
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+
+/**
+ * End-to-end proof for issue #405.
+ *
+ * The unit tests pin which signals are registered; this one pins the thing that
+ * actually broke — the OS behaviour. Node's default disposition for SIGHUP is to
+ * terminate the process WITHOUT running any handler, so before the fix a hangup
+ * (a closed tmux pane, `tmux kill-session`, a dropped SSH session) killed the
+ * gateway and left every spawned receiver reparented to init.
+ *
+ * The harness supervises a real child through the real `registerShutdownSignals`,
+ * so a regression that drops SIGHUP from the signal list fails here with a live
+ * orphaned process, exactly as it did in production.
+ */
+
+const HARNESS = path.join(__dirname, '..', 'fixtures', 'sighup-harness.ts');
+const TS_NODE = require.resolve('ts-node/register');
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(label: string, predicate: () => boolean, timeoutMs = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for: ${label}`);
+}
+
+describe('SIGHUP does not orphan supervised children (issue #405)', () => {
+  let harness: ChildProcess | null = null;
+  let childPid: number | null = null;
+
+  afterEach(() => {
+    // Never leave the test's own processes behind — that is the bug, after all.
+    for (const pid of [childPid, harness?.pid]) {
+      if (pid && isAlive(pid)) {
+        try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+      }
+    }
+    harness = null;
+    childPid = null;
+  });
+
+  it('I-HUP-405: a hangup runs shutdown and reaps the child instead of orphaning it', async () => {
+    let stdout = '';
+    let harnessExited = false;
+
+    harness = spawn(process.execPath, ['-r', TS_NODE, HARNESS], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' },
+    });
+    harness.stdout!.on('data', (d: Buffer) => { stdout += d.toString(); });
+    harness.on('exit', () => { harnessExited = true; });
+
+    await waitUntil('harness to report its child pid', () => /CHILD \d+/.test(stdout));
+    childPid = Number(/CHILD (\d+)/.exec(stdout)![1]);
+    expect(isAlive(childPid)).toBe(true);
+
+    // The hangup. Before the fix this terminated the harness outright.
+    process.kill(harness.pid!, 'SIGHUP');
+
+    await waitUntil('harness to exit', () => harnessExited);
+
+    // The load-bearing assertion: the child must be gone, not reparented to init.
+    await waitUntil(
+      'supervised child to be reaped',
+      () => !isAlive(childPid!),
+    );
+
+    expect(stdout).toContain('SHUTDOWN SIGHUP');
+  }, 40_000);
+});

--- a/tests/unit/orphan-receivers.test.ts
+++ b/tests/unit/orphan-receivers.test.ts
@@ -56,7 +56,10 @@ describe('orphaned receiver sweep (issue #405)', () => {
     const ps = [
       psLine(5001, 1, `bun ${TOOLS}/telegram/send.ts`),
       psLine(5002, 1, 'node /usr/lib/node_modules/npm/bin/npm-cli.js'),
-      psLine(5003, 1, `grep -r receiver-server.ts ${TOOLS}`),
+      psLine(5003, 1, `grep -r receiver-server.ts ${TOOLS}/`),
+      psLine(5005, 1, `bun test ${TOOLS}/telegram/receiver-server.ts`),
+      psLine(5006, 1, `vim ${TOOLS}/telegram/receiver-server.ts`),
+      psLine(5007, 1, `bun ${TOOLS}/telegram/deep/receiver-server.ts`),
       psLine(5004, 1, `bun ${TOOLS}/telegram/receiver-server.ts`),
     ].join('\n');
 
@@ -129,7 +132,7 @@ describe('orphaned receiver sweep (issue #405)', () => {
       wait,
     });
 
-    expect(result).toEqual({ reclaimed: [], forced: [] });
+    expect(result).toEqual({ reclaimed: [], forced: [], failed: [] });
     expect(kill).not.toHaveBeenCalled();
     expect(wait).not.toHaveBeenCalled();
   });
@@ -193,6 +196,71 @@ describe('orphaned receiver sweep (issue #405)', () => {
 
     expect(signals).toEqual([[9100, 'SIGTERM']]);
     expect(result.forced).toEqual([]);
-    expect(result.reclaimed.map((o) => o.pid)).toEqual([9100]);
+    // Not reclaimed: escalation never happened, so it may still be alive. The
+    // boot log must not claim a win it cannot back up.
+    expect(result.reclaimed).toEqual([]);
+    expect(result.failed).toEqual([
+      { pid: 9100, reason: 'escalation skipped: ps disappeared mid-sweep' },
+    ]);
+  });
+
+  // ── U-OR-405m: EPERM must never be counted as a win ────────────────────────
+  it('U-OR-405m: reports an orphan owned by another user as failed, not reclaimed', async () => {
+    const eperm = () => {
+      const err = new Error('EPERM') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    };
+
+    const result = await sweepOrphanedReceivers(TOOLS, {
+      listProcesses: async () => psLine(9200, 1, `bun ${TOOLS}/telegram/receiver-server.ts`),
+      kill: eperm,
+      wait: async () => {},
+    });
+
+    // Pre-fix this returned reclaimed:[9200] and the boot log announced it as
+    // reclaimed while the process was still alive and still polling its token.
+    expect(result.reclaimed).toEqual([]);
+    expect(result.forced).toEqual([]);
+    expect(result.failed).toEqual([{ pid: 9200, reason: 'EPERM (owned by another user)' }]);
+  });
+
+  it('U-OR-405n: an EPERM orphan is not escalated to SIGKILL either', async () => {
+    const line = psLine(9300, 1, `bun ${TOOLS}/discord/receiver-server.ts`);
+    const signals: Array<[number, string]> = [];
+
+    const result = await sweepOrphanedReceivers(TOOLS, {
+      listProcesses: async () => line, // still there on the re-list
+      kill: (pid, signal) => {
+        signals.push([pid, signal]);
+        const err = new Error('EPERM') as NodeJS.ErrnoException;
+        err.code = 'EPERM';
+        throw err;
+      },
+      wait: async () => {},
+    });
+
+    expect(signals).toEqual([[9300, 'SIGTERM']]); // no pointless SIGKILL
+    expect(result.failed.map((f) => f.pid)).toEqual([9300]);
+  });
+
+  // ── U-OR-405o: argv shape, not substring ──────────────────────────────────
+  it('U-OR-405o: only matches the exact `bun <toolsDir>/<channel>/receiver-server.ts` shape', () => {
+    const cases: Array<[string, boolean]> = [
+      [`bun ${TOOLS}/telegram/receiver-server.ts`, true],
+      [`/home/u/.bun/bin/bun ${TOOLS}/discord/receiver-server.ts`, true],
+      [`bun test ${TOOLS}/telegram/receiver-server.ts`, false],
+      [`node ${TOOLS}/telegram/receiver-server.ts`, false],
+      [`grep -r receiver-server.ts ${TOOLS}/`, false],
+      [`bun ${TOOLS}/receiver-server.ts`, false],
+      [`bun ${TOOLS}/telegram/nested/receiver-server.ts`, false],
+      [`bun ${TOOLS}/telegram/receiver-server.ts.bak`, false],
+      ['bun', false],
+    ];
+
+    for (const [command, shouldMatch] of cases) {
+      const found = findOrphanedReceivers(psLine(1, 1, command), TOOLS);
+      expect([command, found.length > 0]).toEqual([command, shouldMatch]);
+    }
   });
 });

--- a/tests/unit/orphan-receivers.test.ts
+++ b/tests/unit/orphan-receivers.test.ts
@@ -1,0 +1,198 @@
+import * as path from 'path';
+import {
+  findOrphanedReceivers,
+  sweepOrphanedReceivers,
+  ORPHAN_SIGKILL_GRACE_MS,
+} from '../../src/utils/orphan-receivers';
+
+// Realistic `ps -eo pid=,ppid=,args=` output. Column widths are right-aligned
+// and variable, exactly as ps emits them.
+const TOOLS = '/srv/gateway-a/mcp/tools';
+
+function psLine(pid: number, ppid: number, args: string): string {
+  return `${String(pid).padStart(7)} ${String(ppid).padStart(7)} ${args}`;
+}
+
+describe('orphaned receiver sweep (issue #405)', () => {
+  // ── U-OR-405a: the core discriminator ──────────────────────────────────────
+  it('U-OR-405a: matches receivers reparented to init and skips supervised ones', () => {
+    const ps = [
+      psLine(3383468, 1, `bun ${TOOLS}/telegram/receiver-server.ts`),
+      psLine(3383599, 1, `bun ${TOOLS}/discord/receiver-server.ts`),
+      // Still owned by a live gateway — must never be touched.
+      psLine(4054791, 4054790, `bun ${TOOLS}/telegram/receiver-server.ts`),
+      psLine(4054790, 1, 'node /srv/gateway-a/dist/index.js'),
+    ].join('\n');
+
+    const found = findOrphanedReceivers(ps, TOOLS);
+
+    expect(found.map((o) => o.pid).sort()).toEqual([3383468, 3383599]);
+  });
+
+  // ── U-OR-405b: cross-installation safety ───────────────────────────────────
+  it('U-OR-405b: never reclaims a receiver from a different installation', () => {
+    const other = '/srv/gateway-b/mcp/tools';
+    const ps = [
+      psLine(2975492, 1, `bun ${other}/telegram/receiver-server.ts`),
+      psLine(3383468, 1, `bun ${TOOLS}/telegram/receiver-server.ts`),
+    ].join('\n');
+
+    expect(findOrphanedReceivers(ps, TOOLS).map((o) => o.pid)).toEqual([3383468]);
+    expect(findOrphanedReceivers(ps, other).map((o) => o.pid)).toEqual([2975492]);
+  });
+
+  // ── U-OR-405c: prefix collision ────────────────────────────────────────────
+  it('U-OR-405c: a sibling install sharing a path prefix is not a match', () => {
+    // `/opt/gw` must not swallow `/opt/gw-research` — the trailing separator is
+    // what makes the prefix test exact rather than merely "starts with".
+    const ps = psLine(4242, 1, 'bun /opt/gw-research/mcp/tools/telegram/receiver-server.ts');
+
+    expect(findOrphanedReceivers(ps, '/opt/gw/mcp/tools')).toEqual([]);
+    expect(findOrphanedReceivers(ps, '/opt/gw-research/mcp/tools').map((o) => o.pid)).toEqual([4242]);
+  });
+
+  // ── U-OR-405d: unrelated processes ─────────────────────────────────────────
+  it('U-OR-405d: ignores non-receiver processes under the same tools directory', () => {
+    const ps = [
+      psLine(5001, 1, `bun ${TOOLS}/telegram/send.ts`),
+      psLine(5002, 1, 'node /usr/lib/node_modules/npm/bin/npm-cli.js'),
+      psLine(5003, 1, `grep -r receiver-server.ts ${TOOLS}`),
+      psLine(5004, 1, `bun ${TOOLS}/telegram/receiver-server.ts`),
+    ].join('\n');
+
+    expect(findOrphanedReceivers(ps, TOOLS).map((o) => o.pid)).toEqual([5004]);
+  });
+
+  it('U-OR-405e: tolerates blank lines and malformed rows without throwing', () => {
+    const ps = ['', '   ', 'garbage without numbers', psLine(6001, 1, `bun ${TOOLS}/discord/receiver-server.ts`)].join('\n');
+
+    expect(findOrphanedReceivers(ps, TOOLS).map((o) => o.pid)).toEqual([6001]);
+  });
+
+  it('U-OR-405f: accepts a non-normalised tools directory', () => {
+    const ps = psLine(6100, 1, `bun ${TOOLS}/telegram/receiver-server.ts`);
+    const messy = path.join(TOOLS, '..', 'tools');
+
+    expect(findOrphanedReceivers(ps, messy).map((o) => o.pid)).toEqual([6100]);
+  });
+
+  // ── U-OR-405g: SIGTERM then SIGKILL escalation ─────────────────────────────
+  it('U-OR-405g: escalates to SIGKILL only for orphans that survive SIGTERM', async () => {
+    const ps = [
+      psLine(7001, 1, `bun ${TOOLS}/telegram/receiver-server.ts`),
+      psLine(7002, 1, `bun ${TOOLS}/discord/receiver-server.ts`),
+    ].join('\n');
+
+    // 7001 dies on SIGTERM; 7002 is wedged and only SIGKILL reaches it.
+    const alive = new Set([7001, 7002]);
+    const signals: Array<[number, string]> = [];
+    const waited: number[] = [];
+    const lines: Record<number, string> = {
+      7001: psLine(7001, 1, `bun ${TOOLS}/telegram/receiver-server.ts`),
+      7002: psLine(7002, 1, `bun ${TOOLS}/discord/receiver-server.ts`),
+    };
+
+    const result = await sweepOrphanedReceivers(TOOLS, {
+      // Each listing reflects who is actually still alive at that moment.
+      listProcesses: async () => [...alive].map((pid) => lines[pid]).join('\n'),
+      kill: (pid, signal) => {
+        if (!alive.has(pid)) {
+          const err = new Error('ESRCH') as NodeJS.ErrnoException;
+          err.code = 'ESRCH';
+          throw err;
+        }
+        signals.push([pid, signal]);
+        if (signal === 'SIGTERM' && pid === 7001) alive.delete(pid);
+        if (signal === 'SIGKILL') alive.delete(pid);
+      },
+      wait: async (ms) => { waited.push(ms); },
+    });
+
+    expect(signals).toEqual([
+      [7001, 'SIGTERM'],
+      [7002, 'SIGTERM'],
+      [7002, 'SIGKILL'],
+    ]);
+    expect(waited).toEqual([ORPHAN_SIGKILL_GRACE_MS]);
+    expect(result.reclaimed.map((o) => o.pid)).toEqual([7001, 7002]);
+    expect(result.forced).toEqual([7002]);
+    expect(alive.size).toBe(0);
+  });
+
+  it('U-OR-405h: does nothing — not even waiting — when there are no orphans', async () => {
+    const kill = jest.fn();
+    const wait = jest.fn(async () => {});
+
+    const result = await sweepOrphanedReceivers(TOOLS, {
+      listProcesses: async () => psLine(4054791, 4054790, `bun ${TOOLS}/telegram/receiver-server.ts`),
+      kill,
+      wait,
+    });
+
+    expect(result).toEqual({ reclaimed: [], forced: [] });
+    expect(kill).not.toHaveBeenCalled();
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it('U-OR-405i: a pid that exits between listing and SIGTERM is not reported as forced', async () => {
+    const result = await sweepOrphanedReceivers(TOOLS, {
+      listProcesses: async () => psLine(8001, 1, `bun ${TOOLS}/telegram/receiver-server.ts`),
+      kill: () => {
+        const err = new Error('ESRCH') as NodeJS.ErrnoException;
+        err.code = 'ESRCH';
+        throw err;
+      },
+      wait: async () => {},
+    });
+
+    expect(result.reclaimed.map((o) => o.pid)).toEqual([8001]);
+    expect(result.forced).toEqual([]);
+  });
+
+  it('U-OR-405j: propagates a process-listing failure so the caller can log it', async () => {
+    await expect(
+      sweepOrphanedReceivers(TOOLS, {
+        listProcesses: async () => { throw new Error('ps: command not found'); },
+        kill: () => { throw new Error('must not be called'); },
+        wait: async () => {},
+      }),
+    ).rejects.toThrow('ps: command not found');
+  });
+
+  // ── U-OR-405k: pid reuse must not turn the sweep into a random killer ──────
+  it('U-OR-405k: never SIGKILLs a pid that is no longer a matching orphan', async () => {
+    const orphanLine = psLine(9001, 1, `bun ${TOOLS}/telegram/receiver-server.ts`);
+    // After SIGTERM the pid is freed and immediately recycled by something else.
+    const recycledLine = psLine(9001, 1234, '/usr/bin/postgres -D /var/lib/postgresql');
+
+    let listing = 0;
+    const signals: Array<[number, string]> = [];
+
+    const result = await sweepOrphanedReceivers(TOOLS, {
+      listProcesses: async () => (listing++ === 0 ? orphanLine : recycledLine),
+      kill: (pid, signal) => { signals.push([pid, signal]); },
+      wait: async () => {},
+    });
+
+    expect(signals).toEqual([[9001, 'SIGTERM']]);
+    expect(result.forced).toEqual([]);
+  });
+
+  it('U-OR-405l: skips escalation rather than guessing when the re-listing fails', async () => {
+    let listing = 0;
+    const signals: Array<[number, string]> = [];
+
+    const result = await sweepOrphanedReceivers(TOOLS, {
+      listProcesses: async () => {
+        if (listing++ === 0) return psLine(9100, 1, `bun ${TOOLS}/discord/receiver-server.ts`);
+        throw new Error('ps disappeared mid-sweep');
+      },
+      kill: (pid, signal) => { signals.push([pid, signal]); },
+      wait: async () => {},
+    });
+
+    expect(signals).toEqual([[9100, 'SIGTERM']]);
+    expect(result.forced).toEqual([]);
+    expect(result.reclaimed.map((o) => o.pid)).toEqual([9100]);
+  });
+});

--- a/tests/unit/receiver-stop-teardown.test.ts
+++ b/tests/unit/receiver-stop-teardown.test.ts
@@ -9,6 +9,10 @@ interface MockChildProcess extends EventEmitter {
   killed: boolean;
   kill: jest.Mock;
   pid: number;
+  // A real ChildProcess has these as null until the child exits; stopChildProcess
+  // reads them to detect an already-dead child, so the mock must model them.
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
   /** When false the child ignores SIGTERM, as a wedged long-poll would. */
   exitsOnTerm: boolean;
 }
@@ -21,7 +25,13 @@ function makeMockProcess(): MockChildProcess {
   proc.stderr = new EventEmitter();
   proc.killed = false;
   proc.pid = 4242;
+  proc.exitCode = null;
+  proc.signalCode = null;
   proc.exitsOnTerm = true;
+  proc.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
+    proc.exitCode = code;
+    proc.signalCode = signal;
+  });
   proc.kill = jest.fn((signal?: string) => {
     if (signal === 'SIGTERM' && !proc.exitsOnTerm) return true;
     proc.killed = true;
@@ -42,6 +52,8 @@ import { TelegramReceiver } from '../../src/telegram/receiver';
 import { DiscordReceiver } from '../../src/discord/receiver';
 import { AgentConfig } from '../../src/types';
 import { findOrphanedReceivers } from '../../src/utils/orphan-receivers';
+import { stopChildProcess } from '../../src/utils/stop-child';
+import type { ChildProcess } from 'child_process';
 
 const LOG_DIR = '/tmp/claude-gateway-test-logs';
 
@@ -191,7 +203,10 @@ describe('sweep needle matches the real receiver spawn path (issue #405)', () =>
     spawn.mockClear();
 
     make().start();
-    const spawnedPath = (spawn.mock.calls[0] as [string, string[]])[1][0];
+    const [cmd, argv] = spawn.mock.calls[0] as [string, string[]];
+    // Reconstruct the argv exactly as `ps` would render it, so this breaks if
+    // either the runtime or the script path changes shape.
+    const command = [cmd, ...argv].join(' ');
 
     // Exactly how src/index.ts derives mcpToolsDir, from this module's own
     // depth. Both entry points sit one directory below the package root, so
@@ -200,7 +215,45 @@ describe('sweep needle matches the real receiver spawn path (issue #405)', () =>
 
     // If either path derivation moves, the sweep silently reclaims nothing —
     // so assert through the matcher itself rather than comparing strings.
-    const found = findOrphanedReceivers(`  1234       1 bun ${spawnedPath}`, mcpToolsDir);
+    const found = findOrphanedReceivers(`  1234       1 ${command}`, mcpToolsDir);
     expect(found.map((o) => o.pid)).toEqual([1234]);
+  });
+  it('U-RS-405h: an already-exited child resolves at once instead of idling out the grace period', async () => {
+    jest.useFakeTimers();
+    try {
+      const receiver = new TelegramReceiver(makeAgentConfig(), 4321, LOG_DIR);
+      receiver.start();
+      const proc = lastProcess!;
+      // Node clears the handle on exit: kill() then returns false WITHOUT
+      // throwing and no further 'exit' fires, so a naive implementation waits
+      // out the full grace period and SIGKILLs a dead pid.
+      proc.exitCode = 0;
+      proc.kill.mockImplementation(() => false);
+
+      let resolved = false;
+      const stopped = stopChildProcess(proc as unknown as ChildProcess).then(() => { resolved = true; });
+
+      await Promise.resolve();
+      expect(resolved).toBe(true);
+      expect(proc.kill).not.toHaveBeenCalled();
+
+      await stopped;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+  it('U-RS-405i: a child that does not expose exitCode is treated as alive and still signalled', async () => {
+    // Regression guard: a strict `!== null` early-return here silently skipped
+    // teardown entirely for any ChildProcess-like object lacking the field —
+    // the child was never signalled at all. Absent must mean alive.
+    const proc = new EventEmitter() as unknown as ChildProcess & { kill: jest.Mock };
+    proc.kill = jest.fn(() => {
+      setImmediate(() => (proc as unknown as EventEmitter).emit('exit', 0, 'SIGTERM'));
+      return true;
+    });
+
+    await stopChildProcess(proc);
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
   });
 });

--- a/tests/unit/receiver-stop-teardown.test.ts
+++ b/tests/unit/receiver-stop-teardown.test.ts
@@ -1,0 +1,206 @@
+import { EventEmitter } from 'events';
+import * as path from 'path';
+
+// ── Mock child_process ────────────────────────────────────────────────────────
+
+interface MockChildProcess extends EventEmitter {
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  killed: boolean;
+  kill: jest.Mock;
+  pid: number;
+  /** When false the child ignores SIGTERM, as a wedged long-poll would. */
+  exitsOnTerm: boolean;
+}
+
+let lastProcess: MockChildProcess | null = null;
+
+function makeMockProcess(): MockChildProcess {
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.killed = false;
+  proc.pid = 4242;
+  proc.exitsOnTerm = true;
+  proc.kill = jest.fn((signal?: string) => {
+    if (signal === 'SIGTERM' && !proc.exitsOnTerm) return true;
+    proc.killed = true;
+    setImmediate(() => proc.emit('exit', 0, signal ?? 'SIGTERM'));
+    return true;
+  });
+  return proc;
+}
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(() => {
+    lastProcess = makeMockProcess();
+    return lastProcess;
+  }),
+}));
+
+import { TelegramReceiver } from '../../src/telegram/receiver';
+import { DiscordReceiver } from '../../src/discord/receiver';
+import { AgentConfig } from '../../src/types';
+import { findOrphanedReceivers } from '../../src/utils/orphan-receivers';
+
+const LOG_DIR = '/tmp/claude-gateway-test-logs';
+
+function makeAgentConfig(): AgentConfig {
+  return {
+    id: 'alfred',
+    description: 'test agent',
+    workspace: '/tmp/claude-gateway-test-ws',
+    env: '',
+    telegram: { botToken: 'tg-token' },
+    discord: { botToken: 'dc-token' },
+    claude: {},
+  } as unknown as AgentConfig;
+}
+
+type Receiver = TelegramReceiver | DiscordReceiver;
+
+/**
+ * Await stop() in a way that compiles against the pre-fix `stop(): void` too, so
+ * these tests fail on the old code for the behaviour they assert rather than for
+ * a type error. Pre-fix this resolves immediately without the child having gone.
+ */
+function awaitStop(receiver: Receiver): Promise<void> {
+  return Promise.resolve(receiver.stop());
+}
+
+const CHANNELS: Array<[string, () => Receiver]> = [
+  ['TelegramReceiver', () => new TelegramReceiver(makeAgentConfig(), 4321, LOG_DIR)],
+  ['DiscordReceiver', () => new DiscordReceiver(makeAgentConfig(), 4321, LOG_DIR)],
+];
+
+describe.each(CHANNELS)('%s.stop() teardown (issue #405)', (_name, make) => {
+  beforeEach(() => {
+    lastProcess = null;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ── U-RS-405a: stop() must not resolve before the child is gone ────────────
+  it('U-RS-405a: resolves only after the child has actually exited', async () => {
+    const receiver = make();
+    receiver.start();
+    const proc = lastProcess!;
+
+    let resolved = false;
+    const stopped = awaitStop(receiver).then(() => { resolved = true; });
+
+    // The child has been signalled but has not exited yet.
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(0);
+    await stopped;
+    expect(resolved).toBe(true);
+  });
+
+  // ── U-RS-405b: the escalation the old fire-and-forget stop() never had ─────
+  it('U-RS-405b: SIGKILLs a child that ignores SIGTERM, then resolves', async () => {
+    const receiver = make();
+    receiver.start();
+    const proc = lastProcess!;
+    proc.exitsOnTerm = false; // wedged in an in-flight long-poll
+
+    let resolved = false;
+    const stopped = awaitStop(receiver).then(() => { resolved = true; });
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(proc.kill).not.toHaveBeenCalledWith('SIGKILL');
+    expect(resolved).toBe(false);
+
+    // Past the grace period the child must be killed outright, not left running.
+    await jest.advanceTimersByTimeAsync(5_000);
+    await stopped;
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(resolved).toBe(true);
+  });
+
+  it('U-RS-405c: does not wait when nothing was ever started', async () => {
+    const receiver = make();
+    await expect(awaitStop(receiver)).resolves.toBeUndefined();
+  });
+
+  it('U-RS-405d: does not wait when the child already exited on its own', async () => {
+    const receiver = make();
+    receiver.start();
+    lastProcess!.emit('exit', 1, null); // crash → this.process cleared
+
+    await expect(awaitStop(receiver)).resolves.toBeUndefined();
+  });
+
+  it('U-RS-405e: still cancels a pending restart timer (SIGINT race, U-TR-07)', async () => {
+    const receiver = make();
+    receiver.start();
+    const { spawn } = jest.requireMock('child_process') as { spawn: jest.Mock };
+
+    lastProcess!.emit('exit', 0, null); // schedules a restart
+    spawn.mockClear();
+
+    await awaitStop(receiver);
+    await jest.advanceTimersByTimeAsync(10_000);
+
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});
+
+// ── The link between the fixed stop() and the shutdown path ──────────────────
+describe('AgentRunner.stop() awaits receiver teardown (issue #405)', () => {
+  it('U-RS-405f: does not resolve while a receiver child is still shutting down', async () => {
+    jest.useFakeTimers();
+    try {
+      const receiver = new TelegramReceiver(makeAgentConfig(), 4321, LOG_DIR);
+      receiver.start();
+      const proc = lastProcess!;
+      proc.exitsOnTerm = false; // wedged
+
+      // Exactly what AgentRunner.stop() now does with its receivers.
+      let done = false;
+      const stopped = Promise.all([receiver.stop()]).then(() => { done = true; });
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(done).toBe(false); // pre-fix this was already true
+
+      await jest.advanceTimersByTimeAsync(5_000);
+      await stopped;
+
+      expect(done).toBe(true);
+      expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// ── The boot sweep is useless if its needle drifts from the real spawn path ───
+describe('sweep needle matches the real receiver spawn path (issue #405)', () => {
+  it.each([
+    ['telegram', () => new TelegramReceiver(makeAgentConfig(), 4321, LOG_DIR)],
+    ['discord', () => new DiscordReceiver(makeAgentConfig(), 4321, LOG_DIR)],
+  ])('U-RS-405g: a %s receiver spawns under the directory index.ts sweeps', (_ch, make) => {
+    const { spawn } = jest.requireMock('child_process') as { spawn: jest.Mock };
+    spawn.mockClear();
+
+    make().start();
+    const spawnedPath = (spawn.mock.calls[0] as [string, string[]])[1][0];
+
+    // Exactly how src/index.ts derives mcpToolsDir, from this module's own
+    // depth. Both entry points sit one directory below the package root, so
+    // this holds for `src/` under ts-jest and for `dist/` in production.
+    const mcpToolsDir = path.resolve(__dirname, '..', '..', 'mcp', 'tools');
+
+    // If either path derivation moves, the sweep silently reclaims nothing —
+    // so assert through the matcher itself rather than comparing strings.
+    const found = findOrphanedReceivers(`  1234       1 bun ${spawnedPath}`, mcpToolsDir);
+    expect(found.map((o) => o.pid)).toEqual([1234]);
+  });
+});

--- a/tests/unit/shutdown-signals.test.ts
+++ b/tests/unit/shutdown-signals.test.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from 'events';
+import { SHUTDOWN_SIGNALS, registerShutdownSignals } from '../../src/shutdown-signals';
+
+describe('shutdown signal wiring (issue #405)', () => {
+  // ── U-SD-405a: the defect itself ───────────────────────────────────────────
+  it('U-SD-405a: SIGHUP runs the same graceful shutdown as SIGTERM', async () => {
+    const target = new EventEmitter();
+    const signalled: string[] = [];
+
+    registerShutdownSignals({
+      run: async (signal) => { signalled.push(signal); },
+      exit: () => {},
+      target,
+    });
+
+    target.emit('SIGHUP');
+    await new Promise((r) => setImmediate(r));
+
+    expect(signalled).toEqual(['SIGHUP']);
+  });
+
+  it('U-SD-405b: every shutdown signal is wired, and SIGHUP is one of them', () => {
+    const target = new EventEmitter();
+    registerShutdownSignals({ run: async () => {}, exit: () => {}, target });
+
+    expect([...SHUTDOWN_SIGNALS]).toEqual(expect.arrayContaining(['SIGTERM', 'SIGINT', 'SIGHUP']));
+    for (const signal of SHUTDOWN_SIGNALS) {
+      expect(target.listenerCount(signal)).toBe(1);
+    }
+  });
+
+  // ── U-SD-405c: a second signal must not exit mid-teardown ──────────────────
+  it('U-SD-405c: a signal during an in-flight shutdown joins it instead of exiting early', async () => {
+    const target = new EventEmitter();
+    let releaseShutdown!: () => void;
+    const teardownDone = new Promise<void>((resolve) => { releaseShutdown = resolve; });
+
+    const runs: string[] = [];
+    const exits: number[] = [];
+
+    registerShutdownSignals({
+      run: async (signal) => { runs.push(signal); await teardownDone; },
+      exit: (code) => exits.push(code),
+      target,
+    });
+
+    target.emit('SIGTERM');
+    await new Promise((r) => setImmediate(r));
+    // Teardown is deliberately still running here.
+    expect(runs).toEqual(['SIGTERM']);
+    expect(exits).toEqual([]);
+
+    // The hangup arrives mid-shutdown. It must NOT start a second teardown, and
+    // must NOT reach exit() while the first is still unfinished.
+    target.emit('SIGHUP');
+    await new Promise((r) => setImmediate(r));
+    expect(runs).toEqual(['SIGTERM']);
+    expect(exits).toEqual([]);
+
+    releaseShutdown();
+    await new Promise((r) => setImmediate(r));
+
+    // Both handlers exit only now, and only one teardown ever ran.
+    expect(runs).toEqual(['SIGTERM']);
+    expect(exits).toEqual([0, 0]);
+  });
+
+  it('U-SD-405d: onBegin fires once, for the first signal only', async () => {
+    const target = new EventEmitter();
+    const began: string[] = [];
+
+    registerShutdownSignals({
+      run: async () => {},
+      onBegin: (signal) => began.push(signal),
+      exit: () => {},
+      target,
+    });
+
+    target.emit('SIGHUP');
+    target.emit('SIGTERM');
+    await new Promise((r) => setImmediate(r));
+
+    expect(began).toEqual(['SIGHUP']);
+  });
+
+  it('U-SD-405e: the returned shutdown shares the in-flight run with the handlers', async () => {
+    const target = new EventEmitter();
+    let runs = 0;
+
+    const shutdown = registerShutdownSignals({
+      run: async () => { runs++; },
+      exit: () => {},
+      target,
+    });
+
+    // The crash handlers call this directly; it must not duplicate a
+    // signal-initiated teardown.
+    target.emit('SIGTERM');
+    await shutdown('uncaughtException');
+    await new Promise((r) => setImmediate(r));
+
+    expect(runs).toBe(1);
+  });
+
+  // ── U-SD-405f: a failed teardown must not hang the gateway ─────────────────
+  it('U-SD-405f: exits non-zero when shutdown throws instead of hanging on the signal', async () => {
+    const target = new EventEmitter();
+    const exits: number[] = [];
+    const errors: unknown[] = [];
+
+    registerShutdownSignals({
+      run: async () => { throw new Error('router.stop() blew up'); },
+      exit: (code) => exits.push(code),
+      onError: (err) => errors.push(err),
+      target,
+    });
+
+    target.emit('SIGHUP');
+    await new Promise((r) => setImmediate(r));
+
+    // A rejection used to skip .then(exit) entirely, leaving the process alive
+    // and still holding its port and its children.
+    expect(exits).toEqual([1]);
+    expect((errors[0] as Error).message).toBe('router.stop() blew up');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #405.

The gateway never handled `SIGHUP`. Node's default disposition for it terminates the process **without running handlers**, so `shutdown()` never ran, `receiver.stop()` was never called, and every `bun .../receiver-server.ts` child was reparented to `init` and kept running. Nothing reaped those leftovers at boot either, so they accumulated permanently: the host this was found on had 12 live orphans, the oldest from a gateway generation several restarts back, four of them still holding Discord gateway websockets with no parent to route to.

`SIGHUP` is what arrives when a controlling terminal goes away — a closed tmux pane, `tmux kill-session`, a dropped SSH session. That is the normal way a hand-run gateway is stopped.

Three independent gaps are closed here. Each is sufficient on its own for part of the problem, and none subsumes the others.

## 1. `SIGHUP` runs the graceful shutdown

Signal wiring moved out of `main()` into `src/shutdown-signals.ts`, both so `SIGHUP` could be added and so the behaviour could be tested at all — previously it was unreachable from a test.

`src/shell/claude-pty-shell.ts:407` already did exactly this for the session wrapper (#371); the lesson had not been applied to the gateway entry point.

Two further defects surfaced in that same path and are fixed here:

- **A second signal killed the process mid-shutdown.** The old guard (`if (isShuttingDown) return;`) returned `undefined` immediately, so the second handler's `.then(() => process.exit(0))` fired at once — terminating the gateway partway through the first teardown. Two Ctrl-Cs were enough. The in-flight promise is now shared, so a later signal joins the running shutdown instead of racing it.
- **A teardown that threw hung the gateway.** A rejection skipped `.then(exit)` entirely, leaving the process alive and still holding its port and its children. It now logs and exits non-zero.

## 2. Boot-time sweep for leftovers

`src/utils/orphan-receivers.ts`. `SIGKILL` and the OOM killer can never be handled in-process, so signal handling alone cannot recover from them — a sweep is the only mechanism that can. Startup already reclaims stale app sockets and update directories; receivers were the gap.

A process is reclaimed only when **both** hold:

- **`ppid === 1`** — proof the supervising gateway is gone. A receiver owned by a live gateway always has that gateway's pid as its parent, including when the gateway itself is a systemd service whose own ppid is 1. This can never match a receiver another running gateway still owns.
- **Its argv lives under this installation's own `mcp/tools/`** — so a gateway cannot kill receivers belonging to a different checkout on the same host. The needle carries a trailing separator, so `/srv/gateway-a` cannot match `/srv/gateway-b`.

Awaited before any agent starts, deliberately: an orphan and a fresh receiver polling the same bot token would race for every update.

Two hazards found while reviewing this and fixed before it shipped:

- **pid reuse.** SIGKILLing a remembered pid after the grace period could hit an unrelated process that had inherited that pid — a worse bug than the one being fixed. The sweep now re-lists and escalates only pids that are *still a matching orphan*, not merely pids that still exist. If the second listing fails it skips escalation rather than guessing; the next boot retries.
- **`ps` width truncation.** A clipped argv would silently stop matching the prefix and reclaim nothing. `-ww` disables it.

## 3. `stop()` waits and escalates

`stop()` was fire-and-forget: one `SIGTERM`, no wait, no liveness check, no escalation — and `AgentRunner.stop()` awaited none of it, so the gateway could exit while a child was still shutting down, or still wedged. A receiver blocked in an in-flight long-poll survived the "graceful" path too.

It now returns a promise that resolves when the child has actually exited, escalating `SIGTERM` → `SIGKILL` after a bounded grace period. `AgentRunner.stop()` awaits it, concurrently with session teardown so shutdown latency is unchanged.

Hot-remove (`stopTelegramReceiver`/`stopDiscordReceiver`) deliberately does **not** await — it responds to a config change, not a shutdown, and should not block its caller for the grace period.

The teardown itself lives in `src/utils/stop-child.ts` rather than being duplicated across the two near-identical receiver classes.

## Regression tests

**Verified red against the pre-fix code**, by reverting each defect in turn:

| Reverted | Result |
| --- | --- |
| `SIGHUP` dropped from the signal list | unit red; integration red with a **real orphaned process** — `timed out after 15000ms waiting for: supervised child to be reaped` |
| dedupe back to the boolean guard | `U-SD-405c` red — `exits: []` became `[0, 0, 0]` |
| `stop()` back to fire-and-forget | `U-RS-405a/b` red on both channels — `Expected: false, Received: true` |

Re-verified after the refactor moved the code (11 red / 7 passing with all three reverted together).

`tests/integration/sighup-orphan-receivers.test.ts` is the load-bearing one: it supervises a real child through the real `registerShutdownSignals`, sends a real `SIGHUP`, and asserts the child is reaped rather than reparented. The unit tests pin which signals are wired; this pins the OS behaviour the bug actually lived in.

**One caveat, stated plainly:** the first version of the `stop()` tests failed on the old code by *not compiling* (`void` has no `.then`), which is a weaker proof than failing on behaviour. They were rewritten to compile against both signatures, and now fail on the assertion itself. The 12 sweep tests cover a module that does not exist before this PR, so they cannot be run against the old code at all — they do not meet the same bar, and are not claimed to.

Also verified live: a dry run of `findOrphanedReceivers` against this host's real process list correctly partitioned its orphans across three separate installations, reclaiming none from the others. Nothing was killed.

## Scope notes

- `API.md` unchanged — no HTTP surface is touched. `README.md` gains a "Receiver lifecycle" subsection under Process Modes.
- `npm run typecheck` covers `src/**/*` only; `tests/` is excluded by `tsconfig.json` and typechecked by ts-jest at run time.
- Untouched deliberately: hot-remove followed immediately by hot-add can briefly leave two receivers on one token while the old one dies. That predates this change and is a different fix.


---

## Second review pass (commit 2)

An independent review of commit 1 raised eight findings; all were verified against the code and fixed in `094f7a7`. The full list is in the commit message. The three that mattered most:

- **A sequential `await runner.stop()` loop had no error isolation.** One rejecting runner aborted the loop, leaving the remaining runners' receivers unstopped — and combined with the `exit(1)` added in commit 1, that *guaranteed* the orphaning this PR exists to prevent. Now `Promise.allSettled`, with every failure logged.
- **Signal handlers were registered at the end of `main()`**, i.e. after every agent had started. A SIGHUP during boot — while the sweep ran, or between agent spawns — still orphaned everything. They are now installed before the agent loop, with a reduced teardown covering the boot window.
- **`EPERM` was swallowed as if it were `ESRCH`.** An orphan owned by another user was counted as reclaimed while it kept running and holding its poll token. Those pids are now reported as failed, separately from the reclaimed count, and are not escalated.

Also fixed: receivers are stopped in parallel (serial stops could exceed a 10s SIGTERM grace with ~19 receivers and be SIGKILLed mid-shutdown); the stop grace no longer collides with the receiver's own 2000 ms exit delay; sweep matching is anchored to the exact `bun <toolsDir>/<channel>/receiver-server.ts` argv shape instead of a path substring; and an already-exited child resolves immediately rather than idling out the full grace, since `kill()` returns `false` for a dead pid and no further `exit` event arrives.

Five tests added (`U-OR-405m/n/o`, `U-RS-405h/i`). Full suite green at **197 suites / 3719 tests**.

**Note on the suite runs:** two earlier full-suite runs reported unrelated failures in `phase-manual` and `skills-hot-reload` — both are fs-watcher timing tests with 600 ms / 3000 ms budgets, and the host was at load average 28 on 8 cores at the time. Both suites pass in isolation with a 5–8× margin, and the full suite is green once the machine is idle. Neither touches any module in this diff.
