### PR TITLE
fix(models): expose live catalog and paginate picker

### DIFF
--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1238,7 +1238,7 @@ bot.command('models', async ctx => {
       const prefix = m.id === currentModel ? '\u2705 ' : ''
       keyboard.text(`${prefix}${m.label}`, `model:${m.id}`).row()
     }
-    if (liveModels.length) keyboard.text('More models', 'models:more:0').row()
+    if (liveModels.length) keyboard.text('More models...', 'models:more:0').row()
     keyboard.text('Dismiss', 'models:dismiss')
 
     await ctx.reply(`Current model: ${currentModel}\nSelect a model:`, {
@@ -1531,13 +1531,22 @@ bot.on('callback_query:data', async ctx => {
       return
     }
     try {
-      const res = await fetch(CALLBACK_URL_BASE + '/command', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ command: 'get_models' }),
-      })
-      if (!res.ok) throw new Error('model request failed')
-      const data = await res.json() as { liveModels?: unknown; models?: unknown }
+      const [modelRes, modelsRes] = await Promise.all([
+        fetch(CALLBACK_URL_BASE + '/command', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command: 'get_model', chat_id: String(ctx.callbackQuery.message?.chat.id) }),
+        }),
+        fetch(CALLBACK_URL_BASE + '/command', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command: 'get_models' }),
+        }),
+      ])
+      if (!modelRes.ok || !modelsRes.ok) throw new Error('model request failed')
+      const modelData = await modelRes.json() as { model?: string }
+      const currentModel = typeof modelData.model === 'string' ? modelData.model : ''
+      const data = await modelsRes.json() as { liveModels?: unknown; models?: unknown }
       const liveModels = Array.isArray(data.liveModels)
         ? validModelRows(data.liveModels)
         : validModelRows(data.models)
@@ -1549,7 +1558,7 @@ bot.on('callback_query:data', async ctx => {
       for (const [index, m] of liveModels.slice(safePage * pageSize, (safePage + 1) * pageSize).entries()) {
         const modelCallback = safeModelId(m.id)
         if (!modelCallback) continue
-        keyboard.text(m.id, `model:${modelCallback}`)
+        keyboard.text(`${m.id === currentModel ? '✅ ' : ''}${m.id}`, `model:${modelCallback}`)
         if (index % 2 === 1) keyboard.row()
       }
       if (liveModels.slice(safePage * pageSize, (safePage + 1) * pageSize).length % 2 === 1) keyboard.row()
@@ -1593,7 +1602,7 @@ bot.on('callback_query:data', async ctx => {
         if (!id) continue
         keyboard.text(`${m.id === (modelData.model ?? '') ? '✅ ' : ''}${m.label}`, `model:${id}`).row()
       }
-      if (liveModels.length) keyboard.text('More models', 'models:more:0').row()
+      if (liveModels.length) keyboard.text('More models...', 'models:more:0').row()
       keyboard.text('Dismiss', 'models:dismiss')
       await ctx.answerCallbackQuery().catch(() => {})
       await ctx.editMessageText(`Current model: ${modelData.model ?? ''}\nSelect a model:`, { reply_markup: keyboard })

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1228,8 +1228,9 @@ bot.command('models', async ctx => {
     const currentModel = typeof modelData.model === 'string' ? modelData.model : ''
     const availableRaw = validModelRows(modelsData.models)
     const availableModels = availableRaw.length ? availableRaw : validModelRows(AVAILABLE_MODELS)
-    const configuredRaw = validModelRows(modelsData.configuredModels)
-    const configuredModels = configuredRaw.length ? configuredRaw : availableModels
+    const configuredModels = Array.isArray(modelsData.configuredModels)
+      ? validModelRows(modelsData.configuredModels)
+      : availableModels
     const liveModels = validModelRows(modelsData.liveModels)
 
     const keyboard = new InlineKeyboard()
@@ -1536,8 +1537,10 @@ bot.on('callback_query:data', async ctx => {
         body: JSON.stringify({ command: 'get_models' }),
       })
       if (!res.ok) throw new Error('model request failed')
-      const data = await res.json() as { liveModels?: unknown }
-      const liveModels = validModelRows(data.liveModels)
+      const data = await res.json() as { liveModels?: unknown; models?: unknown }
+      const liveModels = Array.isArray(data.liveModels)
+        ? validModelRows(data.liveModels)
+        : validModelRows(data.models)
       const page = Number(moreMatch[1])
       const pageSize = 16
       const totalPages = Math.max(1, Math.ceil(liveModels.length / pageSize))
@@ -1577,11 +1580,15 @@ bot.on('callback_query:data', async ctx => {
       ])
       if (!modelRes.ok || !modelsRes.ok) throw new Error('model request failed')
       const modelData = await modelRes.json() as { model?: string }
-      const modelsData = await modelsRes.json() as { configuredModels?: unknown; liveModels?: unknown }
-      const configuredModels = validModelRows(modelsData.configuredModels)
-      const liveModels = validModelRows(modelsData.liveModels)
+      const modelsData = await modelsRes.json() as { configuredModels?: unknown; liveModels?: unknown; models?: unknown }
+      const configuredModels = Array.isArray(modelsData.configuredModels)
+        ? validModelRows(modelsData.configuredModels)
+        : validModelRows(AVAILABLE_MODELS)
+      const liveModels = Array.isArray(modelsData.liveModels)
+        ? validModelRows(modelsData.liveModels)
+        : validModelRows(modelsData.models).filter(m => !configuredModels.some(c => c.id === m.id))
       const keyboard = new InlineKeyboard()
-      for (const m of configuredModels.length ? configuredModels : validModelRows(AVAILABLE_MODELS)) {
+      for (const m of configuredModels) {
         const id = safeModelId(m.id)
         if (!id) continue
         keyboard.text(`${m.id === (modelData.model ?? '') ? '✅ ' : ''}${m.label}`, `model:${id}`).row()

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1198,6 +1198,62 @@ bot.command('model', async ctx => {
   }
 })
 
+/** Fetches current model + configured/live model lists. Shared by /models, models:back and models:more so all three agree on fallback behavior. */
+async function fetchModelMenuData(chatId: string): Promise<{
+  currentModel: string
+  configuredModels: Array<{ id: string; label: string }>
+  liveModels: Array<{ id: string; label: string }>
+} | null> {
+  if (!CALLBACK_URL_BASE) return null
+  const [modelRes, modelsRes] = await Promise.all([
+    fetch(CALLBACK_URL_BASE + '/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'get_model', chat_id: chatId }),
+    }),
+    fetch(CALLBACK_URL_BASE + '/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'get_models' }),
+    }),
+  ])
+  if (!modelRes.ok || !modelsRes.ok) throw new Error('model request failed')
+  const modelData = (await modelRes.json()) as { model?: string }
+  const modelsData = (await modelsRes.json()) as {
+    models?: unknown
+    configuredModels?: unknown
+    liveModels?: unknown
+  }
+  const currentModel = typeof modelData.model === 'string' ? modelData.model : ''
+  const availableRaw = validModelRows(modelsData.models)
+  const availableModels = availableRaw.length ? availableRaw : validModelRows(AVAILABLE_MODELS)
+  const configuredModels = Array.isArray(modelsData.configuredModels)
+    ? validModelRows(modelsData.configuredModels)
+    : availableModels
+  const liveModels = Array.isArray(modelsData.liveModels)
+    ? validModelRows(modelsData.liveModels)
+    : availableModels.filter(m => !configuredModels.some(c => c.id === m.id))
+  return { currentModel, configuredModels, liveModels }
+}
+
+/** Builds the root /models keyboard: one row per configured model, plus "More models..." when live-only models exist. */
+function buildModelsRootKeyboard(
+  currentModel: string,
+  configuredModels: Array<{ id: string; label: string }>,
+  liveModels: Array<{ id: string; label: string }>,
+): InlineKeyboard {
+  const keyboard = new InlineKeyboard()
+  for (const m of configuredModels) {
+    const id = safeModelId(m.id)
+    if (!id) continue
+    const prefix = m.id === currentModel ? '\u2705 ' : ''
+    keyboard.text(`${prefix}${m.label}`, `model:${id}`).row()
+  }
+  if (liveModels.length) keyboard.text('More models...', 'models:more:0').row()
+  keyboard.text('Dismiss', 'models:dismiss')
+  return keyboard
+}
+
 // /models — show model selection keyboard (receiver mode only)
 bot.command('models', async ctx => {
   if (ctx.chat?.type !== 'private') return
@@ -1206,42 +1262,10 @@ bot.command('models', async ctx => {
   if (!CALLBACK_URL_BASE) return
 
   try {
-    const [modelRes, modelsRes] = await Promise.all([
-      fetch(CALLBACK_URL_BASE + '/command', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ command: 'get_model', chat_id: String(ctx.chat.id) }),
-      }),
-      fetch(CALLBACK_URL_BASE + '/command', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ command: 'get_models' }),
-      }),
-    ])
-    if (!modelRes.ok || !modelsRes.ok) throw new Error('model request failed')
-    const modelData = (await modelRes.json()) as { model?: string }
-    const modelsData = (await modelsRes.json()) as {
-      models?: unknown
-      configuredModels?: unknown
-      liveModels?: unknown
-    }
-    const currentModel = typeof modelData.model === 'string' ? modelData.model : ''
-    const availableRaw = validModelRows(modelsData.models)
-    const availableModels = availableRaw.length ? availableRaw : validModelRows(AVAILABLE_MODELS)
-    const configuredModels = Array.isArray(modelsData.configuredModels)
-      ? validModelRows(modelsData.configuredModels)
-      : availableModels
-    const liveModels = validModelRows(modelsData.liveModels)
-
-    const keyboard = new InlineKeyboard()
-    for (const m of configuredModels) {
-      const prefix = m.id === currentModel ? '\u2705 ' : ''
-      keyboard.text(`${prefix}${m.label}`, `model:${m.id}`).row()
-    }
-    if (liveModels.length) keyboard.text('More models...', 'models:more:0').row()
-    keyboard.text('Dismiss', 'models:dismiss')
-
-    await ctx.reply(`Current model: ${currentModel}\nSelect a model:`, {
+    const menu = await fetchModelMenuData(String(ctx.chat.id))
+    if (!menu) return
+    const keyboard = buildModelsRootKeyboard(menu.currentModel, menu.configuredModels, menu.liveModels)
+    await ctx.reply(`Current model: ${menu.currentModel}\nSelect a model:`, {
       reply_markup: keyboard,
     })
   } catch (err) {
@@ -1531,25 +1555,13 @@ bot.on('callback_query:data', async ctx => {
       return
     }
     try {
-      const [modelRes, modelsRes] = await Promise.all([
-        fetch(CALLBACK_URL_BASE + '/command', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ command: 'get_model', chat_id: String(ctx.callbackQuery.message?.chat.id) }),
-        }),
-        fetch(CALLBACK_URL_BASE + '/command', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ command: 'get_models' }),
-        }),
-      ])
-      if (!modelRes.ok || !modelsRes.ok) throw new Error('model request failed')
-      const modelData = await modelRes.json() as { model?: string }
-      const currentModel = typeof modelData.model === 'string' ? modelData.model : ''
-      const data = await modelsRes.json() as { liveModels?: unknown; models?: unknown }
-      const liveModels = Array.isArray(data.liveModels)
-        ? validModelRows(data.liveModels)
-        : validModelRows(data.models)
+      const chatId = String(ctx.callbackQuery.message?.chat.id ?? ctx.from.id)
+      const menu = await fetchModelMenuData(chatId)
+      if (!menu) {
+        await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+        return
+      }
+      const { currentModel, liveModels } = menu
       const page = Number(moreMatch[1])
       const pageSize = 16
       const totalPages = Math.max(1, Math.ceil(liveModels.length / pageSize))
@@ -1558,7 +1570,7 @@ bot.on('callback_query:data', async ctx => {
       for (const [index, m] of liveModels.slice(safePage * pageSize, (safePage + 1) * pageSize).entries()) {
         const modelCallback = safeModelId(m.id)
         if (!modelCallback) continue
-        keyboard.text(`${m.id === currentModel ? '✅ ' : ''}${m.id}`, `model:${modelCallback}`)
+        keyboard.text(`${m.id === currentModel ? '\u2705 ' : ''}${m.id}`, `model:${modelCallback}`)
         if (index % 2 === 1) keyboard.row()
       }
       if (liveModels.slice(safePage * pageSize, (safePage + 1) * pageSize).length % 2 === 1) keyboard.row()
@@ -1583,29 +1595,15 @@ bot.on('callback_query:data', async ctx => {
       return
     }
     try {
-      const [modelRes, modelsRes] = await Promise.all([
-        fetch(CALLBACK_URL_BASE + '/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: 'get_model', chat_id: String(ctx.callbackQuery.message?.chat.id) }) }),
-        fetch(CALLBACK_URL_BASE + '/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: 'get_models' }) }),
-      ])
-      if (!modelRes.ok || !modelsRes.ok) throw new Error('model request failed')
-      const modelData = await modelRes.json() as { model?: string }
-      const modelsData = await modelsRes.json() as { configuredModels?: unknown; liveModels?: unknown; models?: unknown }
-      const configuredModels = Array.isArray(modelsData.configuredModels)
-        ? validModelRows(modelsData.configuredModels)
-        : validModelRows(AVAILABLE_MODELS)
-      const liveModels = Array.isArray(modelsData.liveModels)
-        ? validModelRows(modelsData.liveModels)
-        : validModelRows(modelsData.models).filter(m => !configuredModels.some(c => c.id === m.id))
-      const keyboard = new InlineKeyboard()
-      for (const m of configuredModels) {
-        const id = safeModelId(m.id)
-        if (!id) continue
-        keyboard.text(`${m.id === (modelData.model ?? '') ? '✅ ' : ''}${m.label}`, `model:${id}`).row()
+      const chatId = String(ctx.callbackQuery.message?.chat.id ?? ctx.from.id)
+      const menu = await fetchModelMenuData(chatId)
+      if (!menu) {
+        await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+        return
       }
-      if (liveModels.length) keyboard.text('More models...', 'models:more:0').row()
-      keyboard.text('Dismiss', 'models:dismiss')
+      const keyboard = buildModelsRootKeyboard(menu.currentModel, menu.configuredModels, menu.liveModels)
       await ctx.answerCallbackQuery().catch(() => {})
-      await ctx.editMessageText(`Current model: ${modelData.model ?? ''}\nSelect a model:`, { reply_markup: keyboard })
+      await ctx.editMessageText(`Current model: ${menu.currentModel}\nSelect a model:`, { reply_markup: keyboard })
     } catch {
       await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
     }

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1219,15 +1219,22 @@ bot.command('models', async ctx => {
       }),
     ])
     const modelData = (await modelRes.json()) as { model?: string }
-    const modelsData = (await modelsRes.json()) as { models?: { id: string; label: string }[] }
+    const modelsData = (await modelsRes.json()) as {
+      models?: { id: string; label: string }[]
+      configuredModels?: { id: string; label: string }[]
+      liveModels?: { id: string; label: string }[]
+    }
     const currentModel = modelData.model ?? ''
     const availableModels = modelsData.models ?? AVAILABLE_MODELS
+    const configuredModels = modelsData.configuredModels ?? availableModels
+    const liveModels = modelsData.liveModels ?? []
 
     const keyboard = new InlineKeyboard()
-    for (const m of availableModels) {
+    for (const m of configuredModels) {
       const prefix = m.id === currentModel ? '\u2705 ' : ''
       keyboard.text(`${prefix}${m.label}`, `model:${m.id}`).row()
     }
+    if (liveModels.length) keyboard.text('More models', 'models:more:0').row()
     keyboard.text('Dismiss', 'models:dismiss')
 
     await ctx.reply(`Current model: ${currentModel}\nSelect a model:`, {
@@ -1486,6 +1493,71 @@ bot.on('callback_query:data', async ctx => {
     }
     await ctx.answerCallbackQuery({ text: 'Dismissed' }).catch(() => {})
     await ctx.deleteMessage().catch(() => {})
+    return
+  }
+
+  const moreMatch = /^models:more:(\d+)$/.exec(data)
+  if (moreMatch) {
+    if (!isCallbackAuthorized(ctx)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    if (!CALLBACK_URL_BASE) {
+      await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+      return
+    }
+    try {
+      const res = await fetch(CALLBACK_URL_BASE + '/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'get_models' }),
+      })
+      const data = await res.json() as { liveModels?: { id: string; label: string }[] }
+      const liveModels = Array.isArray(data.liveModels) ? data.liveModels : []
+      const page = Number(moreMatch[1])
+      const pageSize = 16
+      const totalPages = Math.max(1, Math.ceil(liveModels.length / pageSize))
+      const safePage = Math.min(page, totalPages - 1)
+      const keyboard = new InlineKeyboard()
+      for (const [index, m] of liveModels.slice(safePage * pageSize, (safePage + 1) * pageSize).entries()) {
+        keyboard.text(m.id, `model:${m.id}`)
+        if (index % 2 === 1) keyboard.row()
+      }
+      if (liveModels.slice(safePage * pageSize, (safePage + 1) * pageSize).length % 2 === 1) keyboard.row()
+      keyboard.text('«', safePage === 0 ? 'models:back' : `models:more:${safePage - 1}`)
+      if (safePage < totalPages - 1) keyboard.text('»', `models:more:${safePage + 1}`)
+      keyboard.row().text('Dismiss', 'models:dismiss')
+      await ctx.answerCallbackQuery().catch(() => {})
+      await ctx.editMessageText(`More models (live) — page ${safePage + 1}/${totalPages}:`, { reply_markup: keyboard })
+    } catch {
+      await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
+    }
+    return
+  }
+
+  if (data === 'models:back') {
+    if (!isCallbackAuthorized(ctx)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    if (!CALLBACK_URL_BASE) return
+    try {
+      const [modelRes, modelsRes] = await Promise.all([
+        fetch(CALLBACK_URL_BASE + '/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: 'get_model', chat_id: String(ctx.callbackQuery.message?.chat.id) }) }),
+        fetch(CALLBACK_URL_BASE + '/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: 'get_models' }) }),
+      ])
+      const modelData = await modelRes.json() as { model?: string }
+      const modelsData = await modelsRes.json() as { configuredModels?: { id: string; label: string }[] }
+      const keyboard = new InlineKeyboard()
+      for (const m of (modelsData.configuredModels ?? AVAILABLE_MODELS)) {
+        keyboard.text(`${m.id === (modelData.model ?? '') ? '✅ ' : ''}${m.label}`, `model:${m.id}`).row()
+      }
+      keyboard.text('Dismiss', 'models:dismiss')
+      await ctx.answerCallbackQuery().catch(() => {})
+      await ctx.editMessageText(`Current model: ${modelData.model ?? ''}\nSelect a model:`, { reply_markup: keyboard })
+    } catch {
+      await ctx.answerCallbackQuery({ text: 'Request failed' }).catch(() => {})
+    }
     return
   }
 

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1218,16 +1218,19 @@ bot.command('models', async ctx => {
         body: JSON.stringify({ command: 'get_models' }),
       }),
     ])
+    if (!modelRes.ok || !modelsRes.ok) throw new Error('model request failed')
     const modelData = (await modelRes.json()) as { model?: string }
     const modelsData = (await modelsRes.json()) as {
-      models?: { id: string; label: string }[]
-      configuredModels?: { id: string; label: string }[]
-      liveModels?: { id: string; label: string }[]
+      models?: unknown
+      configuredModels?: unknown
+      liveModels?: unknown
     }
-    const currentModel = modelData.model ?? ''
-    const availableModels = modelsData.models ?? AVAILABLE_MODELS
-    const configuredModels = modelsData.configuredModels ?? availableModels
-    const liveModels = modelsData.liveModels ?? []
+    const currentModel = typeof modelData.model === 'string' ? modelData.model : ''
+    const availableRaw = validModelRows(modelsData.models)
+    const availableModels = availableRaw.length ? availableRaw : validModelRows(AVAILABLE_MODELS)
+    const configuredRaw = validModelRows(modelsData.configuredModels)
+    const configuredModels = configuredRaw.length ? configuredRaw : availableModels
+    const liveModels = validModelRows(modelsData.liveModels)
 
     const keyboard = new InlineKeyboard()
     for (const m of configuredModels) {
@@ -1410,6 +1413,26 @@ function isCallbackAuthorized(ctx: Context): boolean {
   return access.allowFrom.includes(String(ctx.from?.id ?? ''))
 }
 
+/** Telegram callback_data is capped at 64 UTF-8 bytes; reject untrusted ids safely. */
+function safeModelId(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const id = value.trim()
+  return id && Buffer.byteLength(`model:${id}`, 'utf8') <= 64 ? id : null
+}
+
+function validModelRows(value: unknown): Array<{ id: string; label: string }> {
+  if (!Array.isArray(value)) return []
+  const rows: Array<{ id: string; label: string }> = []
+  for (const item of value) {
+    if (typeof item !== 'object' || item === null) continue
+    const row = item as { id?: unknown; model_id?: unknown; label?: unknown; display_name?: unknown; name?: unknown }
+    const id = safeModelId(row.id) ?? safeModelId(row.model_id)
+    const labelValue = [row.label, row.display_name, row.name].find(v => typeof v === 'string' && v.trim())
+    if (id && typeof labelValue === 'string') rows.push({ id, label: labelValue.trim() })
+  }
+  return rows
+}
+
 // Inline-button handler for permission requests. Callback data is
 // `perm:allow:<id>`, `perm:deny:<id>`, or `perm:more:<id>`.
 // Security mirrors the text-reply path: allowFrom must contain the sender.
@@ -1512,15 +1535,18 @@ bot.on('callback_query:data', async ctx => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ command: 'get_models' }),
       })
-      const data = await res.json() as { liveModels?: { id: string; label: string }[] }
-      const liveModels = Array.isArray(data.liveModels) ? data.liveModels : []
+      if (!res.ok) throw new Error('model request failed')
+      const data = await res.json() as { liveModels?: unknown }
+      const liveModels = validModelRows(data.liveModels)
       const page = Number(moreMatch[1])
       const pageSize = 16
       const totalPages = Math.max(1, Math.ceil(liveModels.length / pageSize))
       const safePage = Math.min(page, totalPages - 1)
       const keyboard = new InlineKeyboard()
       for (const [index, m] of liveModels.slice(safePage * pageSize, (safePage + 1) * pageSize).entries()) {
-        keyboard.text(m.id, `model:${m.id}`)
+        const modelCallback = safeModelId(m.id)
+        if (!modelCallback) continue
+        keyboard.text(m.id, `model:${modelCallback}`)
         if (index % 2 === 1) keyboard.row()
       }
       if (liveModels.slice(safePage * pageSize, (safePage + 1) * pageSize).length % 2 === 1) keyboard.row()
@@ -1540,19 +1566,27 @@ bot.on('callback_query:data', async ctx => {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
       return
     }
-    if (!CALLBACK_URL_BASE) return
+    if (!CALLBACK_URL_BASE) {
+      await ctx.answerCallbackQuery({ text: 'Not available.' }).catch(() => {})
+      return
+    }
     try {
       const [modelRes, modelsRes] = await Promise.all([
         fetch(CALLBACK_URL_BASE + '/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: 'get_model', chat_id: String(ctx.callbackQuery.message?.chat.id) }) }),
         fetch(CALLBACK_URL_BASE + '/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: 'get_models' }) }),
       ])
+      if (!modelRes.ok || !modelsRes.ok) throw new Error('model request failed')
       const modelData = await modelRes.json() as { model?: string }
-      const modelsData = await modelsRes.json() as { configuredModels?: { id: string; label: string }[] }
+      const modelsData = await modelsRes.json() as { configuredModels?: unknown; liveModels?: unknown }
+      const configuredModels = validModelRows(modelsData.configuredModels)
+      const liveModels = validModelRows(modelsData.liveModels)
       const keyboard = new InlineKeyboard()
-      for (const m of (modelsData.configuredModels ?? AVAILABLE_MODELS)) {
-        keyboard.text(`${m.id === (modelData.model ?? '') ? '✅ ' : ''}${m.label}`, `model:${m.id}`).row()
+      for (const m of configuredModels.length ? configuredModels : validModelRows(AVAILABLE_MODELS)) {
+        const id = safeModelId(m.id)
+        if (!id) continue
+        keyboard.text(`${m.id === (modelData.model ?? '') ? '✅ ' : ''}${m.label}`, `model:${id}`).row()
       }
-      keyboard.text('Dismiss', 'models:dismiss')
+      if (liveModels.length) keyboard.text('More models', 'models:more:0').row()
       await ctx.answerCallbackQuery().catch(() => {})
       await ctx.editMessageText(`Current model: ${modelData.model ?? ''}\nSelect a model:`, { reply_markup: keyboard })
     } catch {

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -1587,6 +1587,7 @@ bot.on('callback_query:data', async ctx => {
         keyboard.text(`${m.id === (modelData.model ?? '') ? '✅ ' : ''}${m.label}`, `model:${id}`).row()
       }
       if (liveModels.length) keyboard.text('More models', 'models:more:0').row()
+      keyboard.text('Dismiss', 'models:dismiss')
       await ctx.answerCallbackQuery().catch(() => {})
       await ctx.editMessageText(`Current model: ${modelData.model ?? ''}\nSelect a model:`, { reply_markup: keyboard })
     } catch {

--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -176,9 +176,13 @@ export function parseModelCatalog(body: unknown, fallback: ModelConfig[]): Model
 
   const seen = new Set<string>();
   // Config is authoritative: retain every curated entry, including local [1m]
-  // variants, before adding upstream-only rows.
-  const models: ModelConfig[] = [...fallback];
-  for (const m of fallback) seen.add(m.id);
+  // variants, before adding upstream-only rows. Preserve first duplicate/order.
+  const models: ModelConfig[] = [];
+  for (const m of fallback) {
+    if (seen.has(m.id)) continue;
+    seen.add(m.id);
+    models.push(m);
+  }
   let usableCount = 0;
   for (const row of rows) {
     if (typeof row !== 'object' || row === null) continue;
@@ -266,7 +270,8 @@ export async function fetchModelCatalog(
   }
 
   inFlightKey = key;
-  inFlight = (async (): Promise<ModelConfig[] | null> => {
+  let request!: Promise<ModelConfig[] | null>;
+  request = (async (): Promise<ModelConfig[] | null> => {
     try {
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
       const token = catalogAuthToken();
@@ -286,9 +291,12 @@ export async function fetchModelCatalog(
     } catch {
       return stale; // unreachable, timed out, or unparseable
     } finally {
-      inFlight = null;
-      inFlightKey = null;
+      if (inFlight === request) {
+        inFlight = null;
+        inFlightKey = null;
+      }
     }
   })();
-  return inFlight;
+  inFlight = request;
+  return request;
 }

--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -73,24 +73,36 @@ export function resetModelCatalogCache(): void {
 // Parsed `env` block of the Claude Code CLI config. The CLI applies that block
 // internally rather than to the OS environment, so a value set only there is
 // invisible to `process.env` and has to be read from the file.
+//
+// This gateway is a long-lived daemon (spawned once, runs for days), while
+// settings.json is edited live by whoever is testing a different
+// ANTHROPIC_BASE_URL/token — a one-time read here used to mean the daemon
+// silently kept using whatever the file said at its own startup, forever,
+// with no way to notice the file had changed short of a full process
+// restart. Give this the same TTL treatment `fetchModelCatalog` already
+// gives the catalog response itself, so an edit is picked up within a
+// minute instead of never.
 let settingsEnvCache: Record<string, unknown> | null | undefined;
+let settingsEnvFetchedAt = 0;
 
-function settingsEnv(key: string): string {
-  if (settingsEnvCache === undefined) {
+function settingsEnv(key: string, now: number = Date.now()): string {
+  if (settingsEnvCache === undefined || now - settingsEnvFetchedAt >= CATALOG_TTL_MS) {
     try {
       const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
       settingsEnvCache = JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf8'))?.env ?? null;
     } catch {
       settingsEnvCache = null;
     }
+    settingsEnvFetchedAt = now;
   }
   const v = settingsEnvCache?.[key];
   return typeof v === 'string' ? v : '';
 }
 
-/** Tests only — the settings file is read once per process otherwise. */
+/** Tests only — the settings file is otherwise re-read at most once per {@link CATALOG_TTL_MS}. */
 export function resetSettingsEnvCache(): void {
   settingsEnvCache = undefined;
+  settingsEnvFetchedAt = 0;
 }
 
 /**
@@ -99,20 +111,20 @@ export function resetSettingsEnvCache(): void {
  * the same `ANTHROPIC_BASE_URL` the session process already uses. Empty means
  * "not configured", which is the signal to stay on the static list.
  */
-export function catalogBaseUrl(): string {
+export function catalogBaseUrl(now: number = Date.now()): string {
   const raw =
     process.env.MODELS_BASE_URL ||
     process.env.ANTHROPIC_BASE_URL ||
-    settingsEnv('ANTHROPIC_BASE_URL');
+    settingsEnv('ANTHROPIC_BASE_URL', now);
   return raw.replace(/\/+$/, '');
 }
 
-function catalogAuthToken(): string {
+function catalogAuthToken(now: number): string {
   return (
     process.env.MODELS_API_KEY ||
     process.env.ANTHROPIC_AUTH_TOKEN ||
-    settingsEnv('ANTHROPIC_AUTH_TOKEN') ||
-    settingsEnv('CLAUDE_CODE_OAUTH_TOKEN')
+    settingsEnv('ANTHROPIC_AUTH_TOKEN', now) ||
+    settingsEnv('CLAUDE_CODE_OAUTH_TOKEN', now)
   );
 }
 
@@ -247,7 +259,7 @@ export async function fetchModelCatalog(
   fallback: ModelConfig[],
   now: number = Date.now(),
 ): Promise<ModelConfig[] | null> {
-  const base = catalogBaseUrl();
+  const base = catalogBaseUrl(now);
   const key = `${base} ${JSON.stringify(fallback)}`;
   if (cache && cache.key === key && now - cache.fetchedAt < CATALOG_TTL_MS) return cache.models;
   if (inFlight && inFlightKey === key) return inFlight;
@@ -274,7 +286,7 @@ export async function fetchModelCatalog(
   request = (async (): Promise<ModelConfig[] | null> => {
     try {
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      const token = catalogAuthToken();
+      const token = catalogAuthToken(now);
       if (token) headers['Authorization'] = `Bearer ${token}`;
       const res = await fetch(`${base}/v1/models`, {
         method: 'GET',

--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -174,13 +174,11 @@ export function parseModelCatalog(body: unknown, fallback: ModelConfig[]): Model
       : null);
   if (!Array.isArray(rows)) return null;
 
-  const known = new Map(fallback.map((m) => [m.id, m]));
   const seen = new Set<string>();
   // Config is authoritative: retain every curated entry, including local [1m]
   // variants, before adding upstream-only rows.
   const models: ModelConfig[] = [...fallback];
   for (const m of fallback) seen.add(m.id);
-  let liveCount = 0;
   let usableCount = 0;
   for (const row of rows) {
     if (typeof row !== 'object' || row === null) continue;
@@ -205,9 +203,6 @@ export function parseModelCatalog(body: unknown, fallback: ModelConfig[]): Model
     usableCount++;
     if (seen.has(id)) continue;
     seen.add(id);
-    const staticEntry = known.get(id);
-    if (staticEntry) continue;
-    liveCount++;
 
     const label = [r.display_name, r.label, r.name].find((v) => typeof v === 'string' && v.trim()) ?? id;
     const ctx = [r.context_window, r.contextWindow].find((v) => typeof v === 'number' && Number.isFinite(v) && v > 0);

--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -53,21 +53,22 @@ export const DEFAULT_CONTEXT_WINDOW = 200_000;
 interface CatalogCache {
   models: ModelConfig[];
   fetchedAt: number;
+  key: string;
 }
 
 let cache: CatalogCache | null = null;
 /** In-flight fetch, so N concurrent callers make one request, not N. */
 let inFlight: Promise<ModelConfig[] | null> | null = null;
+let inFlightKey: string | null = null;
 let warnedInsecureUrl = false;
 
 /** Reset module state. Tests only — each case needs a clean cache. */
 export function resetModelCatalogCache(): void {
   cache = null;
   inFlight = null;
+  inFlightKey = null;
   warnedInsecureUrl = false;
 }
-
-// ── configuration ───────────────────────────────────────────────────────────
 
 // Parsed `env` block of the Claude Code CLI config. The CLI applies that block
 // internally rather than to the OS environment, so a value set only there is
@@ -184,11 +185,12 @@ export function parseModelCatalog(body: unknown, fallback: ModelConfig[]): Model
   for (const row of rows) {
     if (typeof row !== 'object' || row === null) continue;
     const r = row as { id?: unknown; model_id?: unknown; display_name?: unknown; label?: unknown; name?: unknown; context_window?: unknown; contextWindow?: unknown; alias?: unknown; multiplier?: unknown; token_multiplier?: unknown; kind?: unknown; type?: unknown };
-    const idValue = typeof r.id === 'string' ? r.id : r.model_id;
-    const id = typeof idValue === 'string' ? idValue.trim() : '';
+    // Prefer a non-empty trimmed `id`; older proxies use `model_id` instead.
+    // Do not let a blank/whitespace `id` mask a usable fallback field.
+    const primaryId = typeof r.id === 'string' ? r.id.trim() : '';
+    const fallbackId = typeof r.model_id === 'string' ? r.model_id.trim() : '';
+    const id = primaryId || fallbackId;
     if (!id) continue;
-    usableCount++;
-    if (seen.has(id)) continue;
     // A proxy that fronts image generation alongside chat may serve one
     // catalog for both — the image tool asks for its half with
     // `/v1/models?kind=image`. An image model in the chat picker is selectable
@@ -199,17 +201,22 @@ export function parseModelCatalog(body: unknown, fallback: ModelConfig[]): Model
     // sent because this repo has no way to know the proxy's chat kind value,
     // and guessing one risks an empty catalog on every deployment.
     const kind = [r.kind, r.type].find((v) => typeof v === 'string' && v.trim());
-    if (typeof kind === 'string' && NON_CHAT_KINDS.has(kind.toLowerCase())) continue;
+    if (typeof kind === 'string' && NON_CHAT_KINDS.has(kind.trim().toLowerCase())) continue;
     usableCount++;
+    if (seen.has(id)) continue;
     seen.add(id);
     const staticEntry = known.get(id);
     if (staticEntry) continue;
     liveCount++;
 
     const label = [r.display_name, r.label, r.name].find((v) => typeof v === 'string' && v.trim()) ?? id;
-    const ctx = [r.context_window, r.contextWindow].find((v) => typeof v === 'number' && v > 0);
-    const multiplierValue = typeof r.multiplier === 'number' ? r.multiplier : r.token_multiplier;
-    const multiplier = typeof multiplierValue === 'number' ? multiplierValue : undefined;
+    const ctx = [r.context_window, r.contextWindow].find((v) => typeof v === 'number' && Number.isFinite(v) && v > 0);
+    const multiplierValue = typeof r.multiplier === 'number' && Number.isFinite(r.multiplier)
+      ? r.multiplier
+      : r.token_multiplier;
+    const multiplier = typeof multiplierValue === 'number' && Number.isFinite(multiplierValue) && multiplierValue > 0
+      ? multiplierValue
+      : undefined;
 
     models.push({
       id,
@@ -241,14 +248,15 @@ export async function fetchModelCatalog(
   fallback: ModelConfig[],
   now: number = Date.now(),
 ): Promise<ModelConfig[] | null> {
-  if (cache && now - cache.fetchedAt < CATALOG_TTL_MS) return cache.models;
-  if (inFlight) return inFlight;
+  const base = catalogBaseUrl();
+  const key = `${base} ${JSON.stringify(fallback)}`;
+  if (cache && cache.key === key && now - cache.fetchedAt < CATALOG_TTL_MS) return cache.models;
+  if (inFlight && inFlightKey === key) return inFlight;
 
   // A catalog that is merely stale is still better than the static list, but
   // only while a fetch is actually failing — a successful one below replaces it.
-  const stale = cache && now - cache.fetchedAt < CATALOG_STALE_MS ? cache.models : null;
+  const stale = cache && cache.key === key && now - cache.fetchedAt < CATALOG_STALE_MS ? cache.models : null;
 
-  const base = catalogBaseUrl();
   if (!base) return null; // standalone deployment — static list is the catalog
 
   if (!baseUrlIsSecure(base)) {
@@ -262,6 +270,7 @@ export async function fetchModelCatalog(
     return null;
   }
 
+  inFlightKey = key;
   inFlight = (async (): Promise<ModelConfig[] | null> => {
     try {
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -277,12 +286,13 @@ export async function fetchModelCatalog(
       // Only a usable catalog is cached, and the cache stamp uses the same
       // clock the TTL check above read. Caching a failure would pin the
       // fallback for a full TTL after one blip.
-      if (parsed) cache = { models: parsed, fetchedAt: now };
+      if (parsed) cache = { models: parsed, fetchedAt: now, key };
       return parsed ?? stale;
     } catch {
       return stale; // unreachable, timed out, or unparseable
     } finally {
       inFlight = null;
+      inFlightKey = null;
     }
   })();
   return inFlight;

--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -165,19 +165,30 @@ export function baseUrlIsSecure(raw: string): boolean {
  * live model that lost those fields would silently report against 200k.
  */
 export function parseModelCatalog(body: unknown, fallback: ModelConfig[]): ModelConfig[] | null {
-  if (typeof body !== 'object' || body === null) return null;
-  const rows = (body as { data?: unknown; models?: unknown }).data
-    ?? (body as { models?: unknown }).models;
+  const rows = Array.isArray(body)
+    ? body
+    : (typeof body === 'object' && body !== null
+      ? ((body as { data?: unknown; models?: unknown }).data
+        ?? (body as { models?: unknown }).models)
+      : null);
   if (!Array.isArray(rows)) return null;
 
   const known = new Map(fallback.map((m) => [m.id, m]));
   const seen = new Set<string>();
-  const models: ModelConfig[] = [];
+  // Config is authoritative: retain every curated entry, including local [1m]
+  // variants, before adding upstream-only rows.
+  const models: ModelConfig[] = [...fallback];
+  for (const m of fallback) seen.add(m.id);
+  let liveCount = 0;
+  let usableCount = 0;
   for (const row of rows) {
     if (typeof row !== 'object' || row === null) continue;
-    const r = row as { id?: unknown; display_name?: unknown; label?: unknown; name?: unknown; context_window?: unknown; contextWindow?: unknown; alias?: unknown; multiplier?: unknown; kind?: unknown; type?: unknown };
-    const id = typeof r.id === 'string' ? r.id.trim() : '';
-    if (!id || seen.has(id)) continue;
+    const r = row as { id?: unknown; model_id?: unknown; display_name?: unknown; label?: unknown; name?: unknown; context_window?: unknown; contextWindow?: unknown; alias?: unknown; multiplier?: unknown; token_multiplier?: unknown; kind?: unknown; type?: unknown };
+    const idValue = typeof r.id === 'string' ? r.id : r.model_id;
+    const id = typeof idValue === 'string' ? idValue.trim() : '';
+    if (!id) continue;
+    usableCount++;
+    if (seen.has(id)) continue;
     // A proxy that fronts image generation alongside chat may serve one
     // catalog for both — the image tool asks for its half with
     // `/v1/models?kind=image`. An image model in the chat picker is selectable
@@ -189,28 +200,31 @@ export function parseModelCatalog(body: unknown, fallback: ModelConfig[]): Model
     // and guessing one risks an empty catalog on every deployment.
     const kind = [r.kind, r.type].find((v) => typeof v === 'string' && v.trim());
     if (typeof kind === 'string' && NON_CHAT_KINDS.has(kind.toLowerCase())) continue;
+    usableCount++;
     seen.add(id);
-
     const staticEntry = known.get(id);
-    const label = [r.display_name, r.label, r.name].find((v) => typeof v === 'string' && v.trim())
-      ?? staticEntry?.label ?? id;
+    if (staticEntry) continue;
+    liveCount++;
+
+    const label = [r.display_name, r.label, r.name].find((v) => typeof v === 'string' && v.trim()) ?? id;
     const ctx = [r.context_window, r.contextWindow].find((v) => typeof v === 'number' && v > 0);
-    const multiplier = typeof r.multiplier === 'number' ? r.multiplier : staticEntry?.multiplier;
+    const multiplierValue = typeof r.multiplier === 'number' ? r.multiplier : r.token_multiplier;
+    const multiplier = typeof multiplierValue === 'number' ? multiplierValue : undefined;
 
     models.push({
       id,
       label: String(label),
       // A live-only model has no curated alias. Falling back to the id keeps
       // `/model <alias>` working for it rather than leaving the field empty.
-      alias: (typeof r.alias === 'string' && r.alias.trim()) || staticEntry?.alias || id,
-      contextWindow: (ctx as number | undefined) ?? staticEntry?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+      alias: (typeof r.alias === 'string' && r.alias.trim()) || id,
+      contextWindow: (ctx as number | undefined) ?? DEFAULT_CONTEXT_WINDOW,
       ...(multiplier === undefined ? {} : { multiplier }),
     });
   }
   // An empty catalog is treated as a failed fetch, not as "this deployment has
   // no models": an empty picker is strictly worse than a stale one, and an
   // upstream returning [] is far more likely to be broken than correct.
-  return models.length > 0 ? models : null;
+  return usableCount > 0 ? models : null;
 }
 
 // ── fetch ───────────────────────────────────────────────────────────────────

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -762,7 +762,14 @@ export class AgentRunner extends EventEmitter {
       // it — fetchModelCatalog is bounded and never rejects.
       void this.availableModels()
         .then((availableModels) => {
-          respond({ models: availableModels.map(m => ({ id: m.id, label: m.label })) });
+          const configuredIds = new Set((this.gatewayConfig.gateway.models ?? DEFAULT_MODELS).map(m => m.id));
+          const configured = availableModels.filter(m => configuredIds.has(m.id));
+          const live = availableModels.filter(m => !configuredIds.has(m.id));
+          respond({
+            models: availableModels.map(m => ({ id: m.id, label: m.label })),
+            configuredModels: configured.map(m => ({ id: m.id, label: m.label })),
+            liveModels: live.map(m => ({ id: m.id, label: m.label })),
+          });
         })
         // Without this the request would hang and the picker with it: the
         // receiver is blocked on this response. Every other async branch in
@@ -2075,11 +2082,21 @@ export class AgentRunner extends EventEmitter {
    */
   private async handleCommandModels(chatId: string): Promise<void> {
     const models = await this.availableModels();
+    const configuredIds = new Set((this.gatewayConfig.gateway.models ?? DEFAULT_MODELS).map(m => m.id));
+    const configured = models.filter(m => configuredIds.has(m.id));
+    const live = models.filter(m => !configuredIds.has(m.id));
     const current = this.agentConfig.claude.model;
-    const lines = [`Current model: ${current}`, ''];
-    for (const m of models) {
+    const lines = [`Current model: ${current}`, '', 'Configured models'];
+    for (const m of configured) {
       const marker = m.id === current ? '✅ ' : '• ';
       lines.push(`${marker}${m.label} — \`${m.id}\``);
+    }
+    if (live.length) {
+      lines.push('', 'More models (live)');
+      for (const m of live) {
+        const marker = m.id === current ? '✅ ' : '• ';
+        lines.push(`${marker}${m.label} — \`${m.id}\``);
+      }
     }
     lines.push('', 'Switch with /model <id or alias>');
     this.writeAutoForward(chatId, lines.join('\n'));

--- a/tests/unit/api-models-endpoint.test.ts
+++ b/tests/unit/api-models-endpoint.test.ts
@@ -91,8 +91,8 @@ describe('GET /api/v1/models', () => {
     const res = await request(buildApp(STATIC_MODELS)).get('/api/v1/models').set(AUTH);
 
     expect(res.status).toBe(200);
-    expect(res.body.models.map((m: { id: string }) => m.id)).toEqual(['byok/some-model']);
-    expect(res.body.models[0].name).toBe('Some BYOK Model');
+    expect(res.body.models.map((m: { id: string }) => m.id)).toEqual(['claude-sonnet-4-6', 'byok/some-model']);
+    expect(res.body.models[1].name).toBe('Some BYOK Model');
   });
 
   it('falls back to the configured list when the catalog is unreachable', async () => {

--- a/tests/unit/model-catalog.test.ts
+++ b/tests/unit/model-catalog.test.ts
@@ -9,6 +9,9 @@
  * degrades to "use the static list" rather than throwing at a picker).
  */
 
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import {
   parseModelCatalog,
   fetchModelCatalog,
@@ -317,6 +320,45 @@ describe('model catalog — fetch policy', () => {
     const refreshed = await fetchModelCatalog(STATIC, Date.now() + 61_000);
 
     expect(refreshed!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'new']);
+  });
+
+  it('re-reads settings.json for the auth token once the settings TTL has passed', async () => {
+    // A long-lived gateway daemon must not pin whatever ~/.claude/settings.json
+    // said at its own startup forever — someone editing that file (e.g.
+    // switching ANTHROPIC_BASE_URL/token to point at a different deployment)
+    // must be picked up without a full process restart.
+    //
+    // resetModelCatalogCache() between calls forces a real fetch each time
+    // (standing in for separate, unrelated catalog fetches later in the
+    // process's life) without touching resetSettingsEnvCache — the settings
+    // cache must expire on its own, the same way it would in the daemon.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'model-catalog-settings-'));
+    process.env.CLAUDE_CONFIG_DIR = dir;
+    const settingsPath = path.join(dir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({ env: { CLAUDE_CODE_OAUTH_TOKEN: 'old-token' } }));
+    process.env.ANTHROPIC_BASE_URL = 'https://proxy.example.com';
+    fetchMock.mockResolvedValue(ok({ data: [{ id: 'live' }] }));
+
+    const t0 = Date.now();
+    await fetchModelCatalog(STATIC, t0);
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer old-token');
+
+    // Edit the file mid-run, without calling resetSettingsEnvCache — the real
+    // failure mode was exactly this: the file changes but the running process
+    // never notices.
+    fs.writeFileSync(settingsPath, JSON.stringify({ env: { CLAUDE_CODE_OAUTH_TOKEN: 'new-token' } }));
+
+    // Still within the settings TTL: the stale token is reused, not the new one.
+    resetModelCatalogCache();
+    await fetchModelCatalog(STATIC, t0 + 30_000);
+    expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe('Bearer old-token');
+
+    // Past the TTL: the file is re-read and the new token is used.
+    resetModelCatalogCache();
+    await fetchModelCatalog(STATIC, t0 + 61_000);
+    expect(fetchMock.mock.calls[2][1].headers.Authorization).toBe('Bearer new-token');
+
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   it('shares one request between concurrent callers', async () => {

--- a/tests/unit/model-catalog.test.ts
+++ b/tests/unit/model-catalog.test.ts
@@ -77,7 +77,7 @@ describe('model catalog — parse', () => {
     expect(parsed).toEqual(STATIC);
   });
 
-  it('prefers a context window the response states over the static one', () => {
+  it('keeps the static context window even when the response states a different one', () => {
     const parsed = parseModelCatalog(
       { data: [{ id: 'claude-opus-5', display_name: 'Opus 5', context_window: 400000 }] },
       STATIC,

--- a/tests/unit/model-catalog.test.ts
+++ b/tests/unit/model-catalog.test.ts
@@ -30,19 +30,40 @@ const ENV_KEYS = [
 ] as const;
 
 describe('model catalog — parse', () => {
+  it('parses the real bare-array response with model_id and token_multiplier', () => {
+    const parsed = parseModelCatalog([
+      { model_id: 'live-a', display_name: 'Live A', token_multiplier: 1 },
+      { model_id: 'live-b', display_name: 'Live B', token_multiplier: 2 },
+    ], STATIC);
+    expect(parsed).toEqual([
+      ...STATIC,
+      { id: 'live-a', label: 'Live A', alias: 'live-a', contextWindow: DEFAULT_CONTEXT_WINDOW, multiplier: 1 },
+      { id: 'live-b', label: 'Live B', alias: 'live-b', contextWindow: DEFAULT_CONTEXT_WINDOW, multiplier: 2 },
+    ]);
+  });
+
+  it('keeps static entries authoritative when live ids collide', () => {
+    const parsed = parseModelCatalog([{ model_id: 'claude-opus-5', display_name: 'Changed', token_multiplier: 9 }], STATIC);
+    expect(parsed).toEqual(STATIC);
+  });
+
   it("reads Anthropic's { data: [{ id, display_name }] } shape", () => {
     const parsed = parseModelCatalog({
       data: [{ id: 'live-model', display_name: 'Live Model', type: 'model' }],
       has_more: false,
     }, STATIC);
     expect(parsed).toEqual([
+      ...STATIC,
       { id: 'live-model', label: 'Live Model', alias: 'live-model', contextWindow: DEFAULT_CONTEXT_WINDOW },
     ]);
   });
 
   it("reads this gateway's own { models: [{ id, label }] } shape", () => {
     const parsed = parseModelCatalog({ models: [{ id: 'a', label: 'A' }] }, STATIC);
-    expect(parsed).toEqual([{ id: 'a', label: 'A', alias: 'a', contextWindow: DEFAULT_CONTEXT_WINDOW }]);
+    expect(parsed).toEqual([
+      ...STATIC,
+      { id: 'a', label: 'A', alias: 'a', contextWindow: DEFAULT_CONTEXT_WINDOW },
+    ]);
   });
 
   it('carries alias, contextWindow and multiplier over from the static entry', () => {
@@ -50,9 +71,7 @@ describe('model catalog — parse', () => {
     // would silently report a 1M model's context use against 200k in /session
     // and size /compact's window wrong.
     const parsed = parseModelCatalog({ data: [{ id: 'claude-opus-5[1m]' }] }, STATIC);
-    expect(parsed).toEqual([
-      { id: 'claude-opus-5[1m]', label: 'Opus 5 (1M)', alias: 'opus[1m]', contextWindow: 1000000, multiplier: 2 },
-    ]);
+    expect(parsed).toEqual(STATIC);
   });
 
   it('prefers a context window the response states over the static one', () => {
@@ -60,20 +79,20 @@ describe('model catalog — parse', () => {
       { data: [{ id: 'claude-opus-5', display_name: 'Opus 5', context_window: 400000 }] },
       STATIC,
     );
-    expect(parsed![0].contextWindow).toBe(400000);
+    expect(parsed!.find((m) => m.id === 'claude-opus-5')!.contextWindow).toBe(200000);
   });
 
   it('keeps the catalog order and drops duplicate ids', () => {
     const parsed = parseModelCatalog({
       data: [{ id: 'b', display_name: 'B' }, { id: 'a', display_name: 'A' }, { id: 'b', display_name: 'B again' }],
     }, STATIC);
-    expect(parsed!.map((m) => m.id)).toEqual(['b', 'a']);
-    expect(parsed![0].label).toBe('B');
+    expect(parsed!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'b', 'a']);
+    expect(parsed![2].label).toBe('B');
   });
 
   it('skips rows with no usable id instead of emitting blanks', () => {
     const parsed = parseModelCatalog({ data: [{ id: '' }, { id: '  ' }, null, 'x', { id: 'ok' }] }, STATIC);
-    expect(parsed!.map((m) => m.id)).toEqual(['ok']);
+    expect(parsed!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'ok']);
   });
 
   it('drops models that say they are not chat models', () => {
@@ -88,7 +107,7 @@ describe('model catalog — parse', () => {
         { id: 'embed-1', display_name: 'Embed', kind: 'embedding' },
       ],
     }, STATIC);
-    expect(parsed!.map((m) => m.id)).toEqual(['chat-model']);
+    expect(parsed!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'chat-model']);
   });
 
   it("keeps a row whose type says nothing useful — Anthropic's is the constant 'model'", () => {
@@ -96,7 +115,7 @@ describe('model catalog — parse', () => {
     const parsed = parseModelCatalog({
       data: [{ id: 'a', display_name: 'A', type: 'model' }, { id: 'b', display_name: 'B' }],
     }, STATIC);
-    expect(parsed!.map((m) => m.id)).toEqual(['a', 'b']);
+    expect(parsed!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'a', 'b']);
   });
 
   it('returns null for an empty catalog — an empty picker is worse than a stale one', () => {
@@ -181,7 +200,7 @@ describe('model catalog — fetch policy', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     // Trailing slash trimmed — '//v1/models' is a different path on many proxies.
     expect(fetchMock.mock.calls[0][0]).toBe('https://proxy.example.com/v1/models');
-    expect(models!.map((m) => m.id)).toEqual(['live']);
+    expect(models!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'live']);
   });
 
   it('sends the auth token as a bearer header', async () => {
@@ -276,7 +295,7 @@ describe('model catalog — fetch policy', () => {
     fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
     const afterTtl = await fetchModelCatalog(STATIC, Date.now() + 61_000);
 
-    expect(afterTtl!.map((m) => m.id)).toEqual(['live']);
+    expect(afterTtl!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'live']);
   });
 
   it('stops serving a stale catalog once it is too old', async () => {
@@ -297,7 +316,7 @@ describe('model catalog — fetch policy', () => {
     fetchMock.mockResolvedValue(ok({ data: [{ id: 'new' }] }));
     const refreshed = await fetchModelCatalog(STATIC, Date.now() + 61_000);
 
-    expect(refreshed!.map((m) => m.id)).toEqual(['new']);
+    expect(refreshed!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'new']);
   });
 
   it('shares one request between concurrent callers', async () => {
@@ -311,6 +330,6 @@ describe('model catalog — fetch policy', () => {
     const results = await all;
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    for (const r of results) expect(r!.map((m) => m.id)).toEqual(['live']);
+    for (const r of results) expect(r!.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-opus-5[1m]', 'live']);
   });
 });

--- a/tests/unit/model-picker-commands.test.ts
+++ b/tests/unit/model-picker-commands.test.ts
@@ -333,9 +333,9 @@ describe('AgentRunner — /models and /model on Discord and LINE (issue #409)', 
 
     const text = forwardText();
     expect(text).toContain('Some BYOK Model');
-    // The static entries are gone: the catalog replaces the list, it does not
-    // append to it — otherwise a model removed upstream never disappears.
-    expect(text).not.toContain('Sonnet 4.6');
+    expect(text).toContain('Configured models');
+    expect(text).toContain('More models (live)');
+    expect(text).toContain('Sonnet 4.6');
   }, 15000);
 
   it('selects and persists a model that exists only in the live catalog', async () => {
@@ -422,7 +422,11 @@ describe('AgentRunner — /models and /model on Discord and LINE (issue #409)', 
 
     const models = await getModelsOverHttp(port);
 
-    expect(models).toEqual([{ id: 'byok/some-model', label: 'Some BYOK Model' }]);
+    expect(models).toEqual([
+      { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+      { id: 'claude-opus-5', label: 'Opus 5' },
+      { id: 'byok/some-model', label: 'Some BYOK Model' },
+    ]);
   }, 15000);
 
   it('get_models answers with the static list when the catalog is unreachable', async () => {

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -266,7 +266,7 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
       from: '1.2.0',
       to: '1.3.1',
       updated: true,
-      warning: 'service will restart',
+      warning: 'process will stop — restart manually',
     });
 
     // Restore

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -266,7 +266,7 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
       from: '1.2.0',
       to: '1.3.1',
       updated: true,
-      warning: 'process will stop — restart manually',
+      warning: 'service will restart',
     });
 
     // Restore


### PR DESCRIPTION
## Summary
Fix parsing of the provider model catalog and expose live-only models without replacing curated configuration. Add a paginated Telegram picker for additional models.

## Related Issue
Closes #411

## Changes Made
- `src/agent/model-catalog.ts`: parse real provider responses and apply config-wins union semantics.
- `src/agent/runner.ts`: separate configured and live-only models for command consumers.
- `mcp/tools/telegram/receiver-server.ts`: add More models paging with navigation and Dismiss controls.
- `tests/unit/*`: update union expectations and add regression coverage.

## Testing
- `npm run typecheck`: pass
- `npm test -- --maxWorkers=2`: 224 suites / 4008 tests pass
- Regression test verified to fail against the pre-fix parser.