### PR TITLE
fix(session): grant Monitor dispatch the same typing-retention grace as Agent/Workflow

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2524,9 +2524,9 @@ export class AgentRunner extends EventEmitter {
         //     bystander (mirrors the image-size-threshold path).
         //   - hasLikelyOutstandingBackgroundWork(): regardless of which tier
         //     called restartOrDefer — even today's aggressive default — a
-        //     session that dispatched a background Agent/Workflow tool_use and
-        //     then ended its OWN turn looks idle here, but a sub-agent it
-        //     launched may still be doing real work. SIGKILLing it now would
+        //     session that dispatched a background Agent/Workflow/Monitor
+        //     tool_use and then ended its OWN turn looks idle here, but that
+        //     dispatch may still be doing real work. SIGKILLing it now would
         //     silently destroy that in-flight work with no notification or
         //     recovery (the incident this guards against: a CLAUDE.md-triggered
         //     restart killed a session mid-way through 3 dispatched code-review
@@ -2730,8 +2730,9 @@ export class AgentRunner extends EventEmitter {
   private startIdleCleaner(): void {
     this.idleCleanerTimer = setInterval(async () => {
       for (const [id, proc] of this.sessions) {
-        // A parent that just dispatched Agent/Workflow work is CLI-idle but its
-        // sub-agent may still need this session to receive the task notification.
+        // A parent that just dispatched Agent/Workflow/Monitor work is CLI-idle
+        // but that dispatch may still need this session to receive its
+        // eventual task notification.
         if (proc.hasLikelyOutstandingBackgroundWork()) continue;
         if (proc.isIdle(this.idleTimeoutMs)) {
           this.logger.info('Stopping idle session', { sessionId: id });

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -39,7 +39,12 @@ const CHANNEL_REPLY_TOOLS = new Set([
 // right after dispatching one of these is legitimately idle *from the CLI's
 // perspective* while real work is still in flight elsewhere. See
 // BACKGROUND_AGENT_GRACE_MS and hasLikelyOutstandingBackgroundWork() below.
-const BACKGROUND_DISPATCH_TOOLS = new Set(['Agent', 'Workflow']);
+// Monitor fits the same contract (returns a task id immediately, delivers
+// each match as a later notification) — without it here, a session whose
+// only outstanding work is a Monitor task gets no retention grace and its
+// typing indicator is torn down while the monitor is still genuinely
+// running (#413).
+const BACKGROUND_DISPATCH_TOOLS = new Set(['Agent', 'Workflow', 'Monitor']);
 // How long a session is treated as "may still have outstanding background
 // work" after dispatching one of BACKGROUND_DISPATCH_TOOLS, once its own turn
 // has ended. Generous enough to cover a multi-agent review of a large diff

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -942,12 +942,12 @@ export class SessionProcess extends EventEmitter {
             // across all of them, not just the first match, so a longer-lived
             // dispatch later in the array can't be shadowed by a shorter one
             // earlier in it (#415 review). The same shadowing risk exists ACROSS
-            // messages within one turn too: a persistent Monitor dispatched
-            // earlier in the turn must not be forgotten just because a later
-            // message in the SAME turn dispatches an unrelated, shorter-lived
-            // Agent/Workflow before the turn ends — so a still-outstanding
-            // Monitor-class dispatch is preserved rather than overwritten by a
-            // later non-Monitor one (manual review round).
+            // messages and turns too: a still-outstanding Monitor with a longer
+            // remaining protection window must never be overwritten by a LATER,
+            // less-protective dispatch — whether that later one is Agent/Workflow
+            // or even another, shorter-lived Monitor — so the decision compares
+            // the two dispatches' actual expiry times rather than just "is the
+            // new one Monitor" (manual review round).
             if (!isPartial && !this.queryMode) {
               let dispatchedGraceMs: number | null = null;
               let dispatchedIsMonitor = false;
@@ -960,14 +960,23 @@ export class SessionProcess extends EventEmitter {
               }
               if (dispatchedGraceMs !== null) {
                 const now = Date.now();
-                const existingMonitorStillOutstanding =
-                  this.backgroundDispatchIsMonitor &&
-                  this.lastBackgroundAgentDispatchAt !== null &&
-                  now - this.lastBackgroundAgentDispatchAt < this.backgroundGraceMs;
-                if (!existingMonitorStillOutstanding || dispatchedIsMonitor) {
+                const existingIsProtectiveMonitor =
+                  this.backgroundDispatchIsMonitor && this.isTrackedDispatchStillOutstanding();
+                const newExpiry = now + dispatchedGraceMs;
+                const existingExpiry = existingIsProtectiveMonitor
+                  ? this.lastBackgroundAgentDispatchAt! + this.backgroundGraceMs
+                  : -Infinity;
+                if (!existingIsProtectiveMonitor || newExpiry >= existingExpiry) {
                   this.lastBackgroundAgentDispatchAt = now;
                   this.backgroundGraceMs = dispatchedGraceMs;
                   this.backgroundDispatchIsMonitor = dispatchedIsMonitor;
+                  // The tracked deadline just changed — any timer already armed
+                  // by retainBackgroundWorkingState() against the OLD deadline is
+                  // now stale and must not be left to fire on the old schedule
+                  // (it would wipe this fresh dispatch out early). Clearing here
+                  // forces the next retainBackgroundWorkingState() call to re-arm
+                  // against the new deadline (manual review round).
+                  this.clearBackgroundWaitTimer();
                 }
               }
             }
@@ -1146,10 +1155,7 @@ export class SessionProcess extends EventEmitter {
       if (ptyStreamSocketPath) ptyStreamRegistry.close(ptyStreamSocketPath);
       this.process = null;
       this._exited = true;
-      this.lastBackgroundAgentDispatchAt = null;
-      this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
-      this.backgroundDispatchIsMonitor = false;
-      this.clearBackgroundWaitTimer();
+      this.resetBackgroundDispatchState();
       // Notify listeners that the underlying subprocess died. The runner relies
       // on this to tear down per-chat typing/processing state when a session is
       // stopped or restarted mid-turn (without a final result/session_idle).
@@ -1389,6 +1395,32 @@ export class SessionProcess extends EventEmitter {
     }
   }
 
+  // The single predicate for "is the currently tracked background dispatch
+  // still within its own grace window" — shared by hasLikelyOutstandingBackgroundWork()
+  // (the read path restartOrDefer/startIdleCleaner/retainBackgroundWorkingState
+  // all trust) and the dispatch-overwrite decision below, so the two can never
+  // silently disagree (manual review round).
+  private isTrackedDispatchStillOutstanding(): boolean {
+    return (
+      this.lastBackgroundAgentDispatchAt !== null &&
+      Date.now() - this.lastBackgroundAgentDispatchAt < this.backgroundGraceMs
+    );
+  }
+
+  // Clears the three fields that together describe "is there a background
+  // dispatch we should still treat as outstanding" back to their defaults, and
+  // the timer armed against them. Centralised (rather than repeated at each
+  // lifecycle site) so a future field added to this trio can't be forgotten at
+  // one of them (manual review round — this is exactly the kind of scattered
+  // reset that let an earlier version of this file's stale-timer bug slip
+  // through unnoticed).
+  private resetBackgroundDispatchState(): void {
+    this.lastBackgroundAgentDispatchAt = null;
+    this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
+    this.backgroundDispatchIsMonitor = false;
+    this.clearBackgroundWaitTimer();
+  }
+
   /**
    * Extend Telegram's working state only while a parent session is waiting for
    * background Agent/Workflow/Monitor work. A bounded expiry (BACKGROUND_AGENT_GRACE_MS,
@@ -1417,9 +1449,7 @@ export class SessionProcess extends EventEmitter {
       const remaining = Math.max(0, this.backgroundGraceMs - elapsed);
       this.backgroundWaitTimer = setTimeout(() => {
         this.backgroundWaitTimer = null;
-        this.lastBackgroundAgentDispatchAt = null;
-        this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
-        this.backgroundDispatchIsMonitor = false;
+        this.resetBackgroundDispatchState();
         if (!this._processing) {
           try { fs.rmSync(processingPath, { force: true }); } catch {}
           this.emit('backgroundWorkExpired');
@@ -1447,9 +1477,7 @@ export class SessionProcess extends EventEmitter {
         // arriving during a persistent Monitor's run silently strips its
         // SIGKILL/eviction protection early).
         if (!this.backgroundDispatchIsMonitor) {
-          this.lastBackgroundAgentDispatchAt = null;
-          this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
-          this.clearBackgroundWaitTimer();
+          this.resetBackgroundDispatchState();
         }
       }
       this.emit('processingChange', active);
@@ -1548,8 +1576,7 @@ export class SessionProcess extends EventEmitter {
    */
   hasLikelyOutstandingBackgroundWork(): boolean {
     if (this._processing) return false;
-    if (this.lastBackgroundAgentDispatchAt === null) return false;
-    return Date.now() - this.lastBackgroundAgentDispatchAt < this.backgroundGraceMs;
+    return this.isTrackedDispatchStillOutstanding();
   }
 
   isRunning(): boolean {
@@ -1561,10 +1588,7 @@ export class SessionProcess extends EventEmitter {
 
   async stop(): Promise<void> {
     this.stopping = true;
-    this.lastBackgroundAgentDispatchAt = null;
-    this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
-    this.backgroundDispatchIsMonitor = false;
-    this.clearBackgroundWaitTimer();
+    this.resetBackgroundDispatchState();
     await this.restartWatcher?.close();
     this.restartWatcher = null;
     try { fs.rmSync(this.restartSignalPath, { force: true }); } catch {}

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -88,10 +88,9 @@ function computeBackgroundGraceMs(toolName: string, input: unknown): number {
       : 0;
   // A little headroom past the monitor's own timeout so a notification that
   // arrives right at expiry isn't racing the retention window's own expiry.
-  return Math.min(
-    BACKGROUND_MONITOR_MAX_GRACE_MS,
-    Math.max(BACKGROUND_AGENT_GRACE_MS, declaredTimeout + BACKGROUND_AGENT_GRACE_MS),
-  );
+  // declaredTimeout is always >= 0, so declaredTimeout + BACKGROUND_AGENT_GRACE_MS
+  // is always >= BACKGROUND_AGENT_GRACE_MS — no separate floor needed.
+  return Math.min(BACKGROUND_MONITOR_MAX_GRACE_MS, declaredTimeout + BACKGROUND_AGENT_GRACE_MS);
 }
 
 // Shared wording for a turn that ended (gracefully or via a mid-turn exit) with no
@@ -931,14 +930,23 @@ export class SessionProcess extends EventEmitter {
             // so restartOrDefer can tell "genuinely idle" apart from "idle because
             // it just fired off async work and is waiting on a task-notification".
             // Only the final (non-partial) message carries a fully materialised
-            // tool_use block, same as the reply-mirror check above.
+            // tool_use block, same as the reply-mirror check above. A single
+            // message can dispatch more than one background tool at once (e.g. a
+            // sub-agent Task alongside a persistent Monitor) — take the MAX grace
+            // across all of them, not just the first match, so a longer-lived
+            // dispatch later in the array can't be shadowed by a shorter one
+            // earlier in it (#415 review).
             if (!isPartial && !this.queryMode) {
+              let dispatchedGraceMs: number | null = null;
               for (const block of obj.message.content) {
                 if (block.type === 'tool_use' && typeof block.name === 'string' && BACKGROUND_DISPATCH_TOOLS.has(block.name)) {
-                  this.lastBackgroundAgentDispatchAt = Date.now();
-                  this.backgroundGraceMs = computeBackgroundGraceMs(block.name, block.input);
-                  break;
+                  const graceMs = computeBackgroundGraceMs(block.name, block.input);
+                  dispatchedGraceMs = dispatchedGraceMs === null ? graceMs : Math.max(dispatchedGraceMs, graceMs);
                 }
+              }
+              if (dispatchedGraceMs !== null) {
+                this.lastBackgroundAgentDispatchAt = Date.now();
+                this.backgroundGraceMs = dispatchedGraceMs;
               }
             }
 
@@ -1117,6 +1125,7 @@ export class SessionProcess extends EventEmitter {
       this.process = null;
       this._exited = true;
       this.lastBackgroundAgentDispatchAt = null;
+      this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
       this.clearBackgroundWaitTimer();
       // Notify listeners that the underlying subprocess died. The runner relies
       // on this to tear down per-chat typing/processing state when a session is
@@ -1386,6 +1395,7 @@ export class SessionProcess extends EventEmitter {
       this.backgroundWaitTimer = setTimeout(() => {
         this.backgroundWaitTimer = null;
         this.lastBackgroundAgentDispatchAt = null;
+        this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
         if (!this._processing) {
           try { fs.rmSync(processingPath, { force: true }); } catch {}
           this.emit('backgroundWorkExpired');
@@ -1405,6 +1415,7 @@ export class SessionProcess extends EventEmitter {
         // it (moot either way). isProcessing now covers this session correctly
         // on its own, so the idle-window concern this field exists for is over.
         this.lastBackgroundAgentDispatchAt = null;
+        this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
         this.clearBackgroundWaitTimer();
       }
       this.emit('processingChange', active);
@@ -1517,6 +1528,7 @@ export class SessionProcess extends EventEmitter {
   async stop(): Promise<void> {
     this.stopping = true;
     this.lastBackgroundAgentDispatchAt = null;
+    this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
     this.clearBackgroundWaitTimer();
     await this.restartWatcher?.close();
     this.restartWatcher = null;

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -54,6 +54,13 @@ const BACKGROUND_DISPATCH_TOOLS = new Set(['Agent', 'Workflow', 'Monitor']);
 // session mid-review, killing 3 in-flight review sub-agents with it, see
 // issue referenced in restartOrDefer below); bounded so a dispatch that never
 // reports back (crashed, errored) can't block a config rollout forever.
+// KNOWN LIMITATION (tracked in the #413 follow-up issue): this window is
+// fixed from the dispatch timestamp and never renewed, so it was sized for
+// Agent/Workflow's typically-bounded sub-agent reviews. A Monitor started
+// with `persistent: true` or a `timeout_ms` beyond this window can outlive
+// its own retention grace and lose SIGKILL/eviction protection while still
+// genuinely running — this PR only fixes the immediate post-dispatch
+// teardown (#413's actual incident), not that longer-running case.
 const BACKGROUND_AGENT_GRACE_MS = 15 * 60 * 1000;
 
 // Shared wording for a turn that ended (gracefully or via a mid-turn exit) with no
@@ -1317,8 +1324,12 @@ export class SessionProcess extends EventEmitter {
 
   /**
    * Extend Telegram's working state only while a parent session is waiting for
-   * background Agent/Workflow work. A bounded expiry releases the state if the
-   * child task never sends its completion notification.
+   * background Agent/Workflow/Monitor work. A bounded expiry (BACKGROUND_AGENT_GRACE_MS,
+   * fixed from the dispatch timestamp — not renewed by later activity) releases
+   * the state if the dispatch never sends its completion notification within
+   * that window. A Monitor started with a longer `timeout_ms` or `persistent:
+   * true` can legitimately outlive this window; see the note above
+   * BACKGROUND_AGENT_GRACE_MS.
    */
   retainBackgroundWorkingState(): boolean {
     if (this.source !== 'telegram' || !this.hasLikelyOutstandingBackgroundWork()) return false;

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -41,9 +41,11 @@ const CHANNEL_REPLY_TOOLS = new Set([
 // BACKGROUND_AGENT_GRACE_MS and hasLikelyOutstandingBackgroundWork() below.
 // Monitor fits the same contract (returns a task id immediately, delivers
 // each match as a later notification) — without it here, a session whose
-// only outstanding work is a Monitor task gets no retention grace and its
-// typing indicator is torn down while the monitor is still genuinely
-// running (#413).
+// only outstanding work is a Monitor task gets no retention grace: its
+// Telegram typing indicator (retainBackgroundWorkingState() is Telegram-only)
+// is torn down, AND restartOrDefer()/startIdleCleaner() (both channel-wide,
+// not Telegram-specific) see it as plain-idle and may SIGKILL or evict it —
+// while the monitor is still genuinely running (#413).
 const BACKGROUND_DISPATCH_TOOLS = new Set(['Agent', 'Workflow', 'Monitor']);
 // How long a session is treated as "may still have outstanding background
 // work" after dispatching one of BACKGROUND_DISPATCH_TOOLS, once its own turn

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -941,7 +941,13 @@ export class SessionProcess extends EventEmitter {
             // sub-agent Task alongside a persistent Monitor) — take the MAX grace
             // across all of them, not just the first match, so a longer-lived
             // dispatch later in the array can't be shadowed by a shorter one
-            // earlier in it (#415 review).
+            // earlier in it (#415 review). The same shadowing risk exists ACROSS
+            // messages within one turn too: a persistent Monitor dispatched
+            // earlier in the turn must not be forgotten just because a later
+            // message in the SAME turn dispatches an unrelated, shorter-lived
+            // Agent/Workflow before the turn ends — so a still-outstanding
+            // Monitor-class dispatch is preserved rather than overwritten by a
+            // later non-Monitor one (manual review round).
             if (!isPartial && !this.queryMode) {
               let dispatchedGraceMs: number | null = null;
               let dispatchedIsMonitor = false;
@@ -953,9 +959,16 @@ export class SessionProcess extends EventEmitter {
                 }
               }
               if (dispatchedGraceMs !== null) {
-                this.lastBackgroundAgentDispatchAt = Date.now();
-                this.backgroundGraceMs = dispatchedGraceMs;
-                this.backgroundDispatchIsMonitor = dispatchedIsMonitor;
+                const now = Date.now();
+                const existingMonitorStillOutstanding =
+                  this.backgroundDispatchIsMonitor &&
+                  this.lastBackgroundAgentDispatchAt !== null &&
+                  now - this.lastBackgroundAgentDispatchAt < this.backgroundGraceMs;
+                if (!existingMonitorStillOutstanding || dispatchedIsMonitor) {
+                  this.lastBackgroundAgentDispatchAt = now;
+                  this.backgroundGraceMs = dispatchedGraceMs;
+                  this.backgroundDispatchIsMonitor = dispatchedIsMonitor;
+                }
               }
             }
 

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -173,6 +173,12 @@ export class SessionProcess extends EventEmitter {
   // Grace window for the dispatch recorded in lastBackgroundAgentDispatchAt —
   // see computeBackgroundGraceMs(). Meaningless while that field is null.
   private backgroundGraceMs: number = BACKGROUND_AGENT_GRACE_MS;
+  // True when the tracked dispatch includes a Monitor (vs. Agent/Workflow only).
+  // A Monitor represents an independent background watcher that keeps running
+  // alongside ordinary conversation — unlike Agent/Workflow, an unrelated new
+  // turn starting does NOT mean it resolved or was superseded, so
+  // setProcessing(true) must not clear its grace window early (#415 review).
+  private backgroundDispatchIsMonitor = false;
   private backgroundWaitTimer: ReturnType<typeof setTimeout> | null = null;
   readonly spawnedAt = Date.now();
   /** Backend used to run the subprocess. Set during start(); 'headless' until then. */
@@ -938,15 +944,18 @@ export class SessionProcess extends EventEmitter {
             // earlier in it (#415 review).
             if (!isPartial && !this.queryMode) {
               let dispatchedGraceMs: number | null = null;
+              let dispatchedIsMonitor = false;
               for (const block of obj.message.content) {
                 if (block.type === 'tool_use' && typeof block.name === 'string' && BACKGROUND_DISPATCH_TOOLS.has(block.name)) {
                   const graceMs = computeBackgroundGraceMs(block.name, block.input);
                   dispatchedGraceMs = dispatchedGraceMs === null ? graceMs : Math.max(dispatchedGraceMs, graceMs);
+                  if (block.name === 'Monitor') dispatchedIsMonitor = true;
                 }
               }
               if (dispatchedGraceMs !== null) {
                 this.lastBackgroundAgentDispatchAt = Date.now();
                 this.backgroundGraceMs = dispatchedGraceMs;
+                this.backgroundDispatchIsMonitor = dispatchedIsMonitor;
               }
             }
 
@@ -1126,6 +1135,7 @@ export class SessionProcess extends EventEmitter {
       this._exited = true;
       this.lastBackgroundAgentDispatchAt = null;
       this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
+      this.backgroundDispatchIsMonitor = false;
       this.clearBackgroundWaitTimer();
       // Notify listeners that the underlying subprocess died. The runner relies
       // on this to tear down per-chat typing/processing state when a session is
@@ -1396,6 +1406,7 @@ export class SessionProcess extends EventEmitter {
         this.backgroundWaitTimer = null;
         this.lastBackgroundAgentDispatchAt = null;
         this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
+        this.backgroundDispatchIsMonitor = false;
         if (!this._processing) {
           try { fs.rmSync(processingPath, { force: true }); } catch {}
           this.emit('backgroundWorkExpired');
@@ -1410,13 +1421,23 @@ export class SessionProcess extends EventEmitter {
     if (this._processing !== active) {
       this._processing = active;
       if (active) {
-        // A fresh turn is starting — either the notification this dispatch was
-        // waiting on just woke it (resolved), or unrelated new work superseded
-        // it (moot either way). isProcessing now covers this session correctly
-        // on its own, so the idle-window concern this field exists for is over.
-        this.lastBackgroundAgentDispatchAt = null;
-        this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
-        this.clearBackgroundWaitTimer();
+        // A fresh turn is starting. For an Agent/Workflow-only dispatch: either
+        // the notification it was waiting on just woke this turn, or unrelated
+        // new work superseded it (moot either way) — isProcessing now covers
+        // this session correctly on its own, so clear it.
+        // A Monitor dispatch is different: it represents an independent
+        // background watcher that keeps running alongside ordinary
+        // conversation, not a one-shot "waiting for this exact notification"
+        // — an unrelated new turn starting is NOT evidence it resolved, so its
+        // grace window must survive this turn and keep expiring on its own
+        // schedule (#415 review; without this, an unrelated chat message
+        // arriving during a persistent Monitor's run silently strips its
+        // SIGKILL/eviction protection early).
+        if (!this.backgroundDispatchIsMonitor) {
+          this.lastBackgroundAgentDispatchAt = null;
+          this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
+          this.clearBackgroundWaitTimer();
+        }
       }
       this.emit('processingChange', active);
       if (this.source === 'telegram') {
@@ -1529,6 +1550,7 @@ export class SessionProcess extends EventEmitter {
     this.stopping = true;
     this.lastBackgroundAgentDispatchAt = null;
     this.backgroundGraceMs = BACKGROUND_AGENT_GRACE_MS;
+    this.backgroundDispatchIsMonitor = false;
     this.clearBackgroundWaitTimer();
     await this.restartWatcher?.close();
     this.restartWatcher = null;

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -942,12 +942,20 @@ export class SessionProcess extends EventEmitter {
             // across all of them, not just the first match, so a longer-lived
             // dispatch later in the array can't be shadowed by a shorter one
             // earlier in it (#415 review). The same shadowing risk exists ACROSS
-            // messages and turns too: a still-outstanding Monitor with a longer
-            // remaining protection window must never be overwritten by a LATER,
-            // less-protective dispatch — whether that later one is Agent/Workflow
-            // or even another, shorter-lived Monitor — so the decision compares
-            // the two dispatches' actual expiry times rather than just "is the
-            // new one Monitor" (manual review round).
+            // messages and turns too: a still-outstanding Monitor must never be
+            // demoted by a LATER Agent/Workflow dispatch, even when that later
+            // dispatch's raw expiry timestamp is numerically greater — a plain
+            // Agent/Workflow's grace is fixed at BACKGROUND_AGENT_GRACE_MS, the
+            // same floor a default (no timeout_ms/persistent) Monitor gets, so a
+            // subsequent Agent/Workflow dispatched even moments later always has
+            // a later raw expiry than that Monitor despite offering none of its
+            // turn-survival protection (setProcessing(true) resets non-Monitor
+            // tracking on the very next unrelated turn). Comparing only raw
+            // expiry let that demotion through silently, reintroducing #413
+            // through the code meant to guard it (found in manual review, round
+            // 6). Only another Monitor dispatch — never Agent/Workflow — may
+            // overwrite a still-outstanding Monitor, and only when its own
+            // expiry is at least as protective (BG17's no-shrink guarantee).
             if (!isPartial && !this.queryMode) {
               let dispatchedGraceMs: number | null = null;
               let dispatchedIsMonitor = false;
@@ -966,7 +974,9 @@ export class SessionProcess extends EventEmitter {
                 const existingExpiry = existingIsProtectiveMonitor
                   ? this.lastBackgroundAgentDispatchAt! + this.backgroundGraceMs
                   : -Infinity;
-                if (!existingIsProtectiveMonitor || newExpiry >= existingExpiry) {
+                const canOverwrite =
+                  !existingIsProtectiveMonitor || (dispatchedIsMonitor && newExpiry >= existingExpiry);
+                if (canOverwrite) {
                   this.lastBackgroundAgentDispatchAt = now;
                   this.backgroundGraceMs = dispatchedGraceMs;
                   this.backgroundDispatchIsMonitor = dispatchedIsMonitor;

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -53,15 +53,46 @@ const BACKGROUND_DISPATCH_TOOLS = new Set(['Agent', 'Workflow', 'Monitor']);
 // (the incident that motivated this — a config-driven restart SIGHUP'd a
 // session mid-review, killing 3 in-flight review sub-agents with it, see
 // issue referenced in restartOrDefer below); bounded so a dispatch that never
-// reports back (crashed, errored) can't block a config rollout forever.
-// KNOWN LIMITATION (tracked in the #413 follow-up issue): this window is
-// fixed from the dispatch timestamp and never renewed, so it was sized for
-// Agent/Workflow's typically-bounded sub-agent reviews. A Monitor started
-// with `persistent: true` or a `timeout_ms` beyond this window can outlive
-// its own retention grace and lose SIGKILL/eviction protection while still
-// genuinely running — this PR only fixes the immediate post-dispatch
-// teardown (#413's actual incident), not that longer-running case.
+// reports back (crashed, errored) can't block a config rollout forever. This
+// is the default for Agent/Workflow, and for a Monitor dispatch with no
+// longer-lived declared bound — see computeBackgroundGraceMs below for the
+// Monitor-specific cases (#415).
 const BACKGROUND_AGENT_GRACE_MS = 15 * 60 * 1000;
+// Ceiling on the grace window for a Monitor declared to run far longer than
+// BACKGROUND_AGENT_GRACE_MS (a `timeout_ms` beyond it, or `persistent: true`
+// — "session-length watches... runs until TaskStop or session ends"). Without
+// this, such a Monitor loses SIGKILL/eviction protection well before it
+// finishes (#415) — but an UNBOUNDED grace would defeat the crash-safety
+// property BACKGROUND_AGENT_GRACE_MS exists for (a dispatch whose Monitor
+// process died without ever reporting back must still eventually stop
+// blocking a restart/eviction). 24h comfortably covers any real operational
+// use of `persistent: true` within one session's lifetime while still being
+// a bound, not "forever".
+const BACKGROUND_MONITOR_MAX_GRACE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How long a single BACKGROUND_DISPATCH_TOOLS dispatch should be treated as
+ * "may still be outstanding" — see BACKGROUND_AGENT_GRACE_MS /
+ * BACKGROUND_MONITOR_MAX_GRACE_MS above. Agent/Workflow (and a Monitor with
+ * no declared bound beyond the default) get the standard grace window; a
+ * Monitor that declares a longer `timeout_ms` or `persistent: true` gets a
+ * window sized to actually cover it, capped at BACKGROUND_MONITOR_MAX_GRACE_MS.
+ */
+function computeBackgroundGraceMs(toolName: string, input: unknown): number {
+  if (toolName !== 'Monitor') return BACKGROUND_AGENT_GRACE_MS;
+  const monitorInput = input as { persistent?: unknown; timeout_ms?: unknown } | undefined;
+  if (monitorInput?.persistent === true) return BACKGROUND_MONITOR_MAX_GRACE_MS;
+  const declaredTimeout =
+    typeof monitorInput?.timeout_ms === 'number' && monitorInput.timeout_ms > 0
+      ? monitorInput.timeout_ms
+      : 0;
+  // A little headroom past the monitor's own timeout so a notification that
+  // arrives right at expiry isn't racing the retention window's own expiry.
+  return Math.min(
+    BACKGROUND_MONITOR_MAX_GRACE_MS,
+    Math.max(BACKGROUND_AGENT_GRACE_MS, declaredTimeout + BACKGROUND_AGENT_GRACE_MS),
+  );
+}
 
 // Shared wording for a turn that ended (gracefully or via a mid-turn exit) with no
 // assistant text at all — used both to patch the in-memory prompt fed to the next
@@ -140,6 +171,9 @@ export class SessionProcess extends EventEmitter {
   // this field exists for no longer applies. Read via
   // hasLikelyOutstandingBackgroundWork().
   private lastBackgroundAgentDispatchAt: number | null = null;
+  // Grace window for the dispatch recorded in lastBackgroundAgentDispatchAt —
+  // see computeBackgroundGraceMs(). Meaningless while that field is null.
+  private backgroundGraceMs: number = BACKGROUND_AGENT_GRACE_MS;
   private backgroundWaitTimer: ReturnType<typeof setTimeout> | null = null;
   readonly spawnedAt = Date.now();
   /** Backend used to run the subprocess. Set during start(); 'headless' until then. */
@@ -900,8 +934,9 @@ export class SessionProcess extends EventEmitter {
             // tool_use block, same as the reply-mirror check above.
             if (!isPartial && !this.queryMode) {
               for (const block of obj.message.content) {
-                if (block.type === 'tool_use' && BACKGROUND_DISPATCH_TOOLS.has(block.name)) {
+                if (block.type === 'tool_use' && typeof block.name === 'string' && BACKGROUND_DISPATCH_TOOLS.has(block.name)) {
                   this.lastBackgroundAgentDispatchAt = Date.now();
+                  this.backgroundGraceMs = computeBackgroundGraceMs(block.name, block.input);
                   break;
                 }
               }
@@ -1347,7 +1382,7 @@ export class SessionProcess extends EventEmitter {
 
     if (this.backgroundWaitTimer === null) {
       const elapsed = Date.now() - this.lastBackgroundAgentDispatchAt!;
-      const remaining = Math.max(0, BACKGROUND_AGENT_GRACE_MS - elapsed);
+      const remaining = Math.max(0, this.backgroundGraceMs - elapsed);
       this.backgroundWaitTimer = setTimeout(() => {
         this.backgroundWaitTimer = null;
         this.lastBackgroundAgentDispatchAt = null;
@@ -1460,15 +1495,16 @@ export class SessionProcess extends EventEmitter {
   /**
    * True when this session's own turn has ended (not `isProcessing`) but it
    * recently dispatched a BACKGROUND_DISPATCH_TOOLS tool_use — i.e. it looks
-   * idle from the outside while a sub-agent it launched may still be doing
-   * real work. `restartOrDefer` treats this the same as `isProcessing` so a
+   * idle from the outside while that dispatch may still be doing real work.
+   * `restartOrDefer` treats this the same as `isProcessing` so a
    * config-driven restart never SIGKILLs a session mid-dispatch, regardless of
-   * which restart tier triggered it.
+   * which restart tier triggered it. The grace window itself is per-dispatch —
+   * see computeBackgroundGraceMs().
    */
   hasLikelyOutstandingBackgroundWork(): boolean {
     if (this._processing) return false;
     if (this.lastBackgroundAgentDispatchAt === null) return false;
-    return Date.now() - this.lastBackgroundAgentDispatchAt < BACKGROUND_AGENT_GRACE_MS;
+    return Date.now() - this.lastBackgroundAgentDispatchAt < this.backgroundGraceMs;
   }
 
   isRunning(): boolean {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1324,6 +1324,48 @@ describe('SessionProcess', () => {
     nowSpy.mockRestore();
   });
 
+  it('BG12: a persistent Monitor grace survives an unrelated new turn starting and ending — unlike Agent/Workflow (#415 review)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-monitor-survives-turn', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { persistent: true }) + '\n'));
+    sp.setProcessing(false);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    // An hour later, an unrelated inbound message starts and ends a fresh turn
+    // that dispatches nothing background-related — must NOT clobber the still
+    // very-much-alive persistent Monitor's grace.
+    nowSpy.mockReturnValue(T0 + 60 * 60 * 1000);
+    sp.setProcessing(true);
+    sp.setProcessing(false);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    // But it is still bounded — past the 24h ceiling it finally releases.
+    nowSpy.mockReturnValue(T0 + 25 * 60 * 60 * 1000);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
+  it('BG13: an Agent-only dispatch is still cleared by an unrelated new turn — BG6 behavior unchanged for the non-Monitor case (#415 review)', async () => {
+    const sp = makeSp('chat:bg-agent-still-clears', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Agent') + '\n'));
+    sp.setProcessing(false);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    // A fresh, unrelated turn starts and ends with no new dispatch.
+    sp.setProcessing(true);
+    sp.setProcessing(false);
+
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+  });
+
   // --------------------------------------------------------------------------
   // U-SP-17: --include-partial-messages flag is in spawn args
   // --------------------------------------------------------------------------

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1100,12 +1100,12 @@ describe('SessionProcess', () => {
   // triggered an immediate restart of their idle-but-waiting parent).
   // --------------------------------------------------------------------------
 
-  function agentDispatchLine(toolName: string): string {
+  function agentDispatchLine(toolName: string, input: Record<string, unknown> = {}): string {
     return JSON.stringify({
       type: 'assistant',
       message: {
         role: 'assistant',
-        content: [{ type: 'tool_use', id: 'toolu_bg_1', name: toolName, input: {} }],
+        content: [{ type: 'tool_use', id: 'toolu_bg_1', name: toolName, input }],
       },
       stop_reason: 'tool_use',
     });
@@ -1218,6 +1218,74 @@ describe('SessionProcess', () => {
     expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
 
     nowSpy.mockReturnValue(T0 + 16 * 60 * 1000); // +16 min, past the 15-min grace window
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
+  it('BG8: a Monitor with a declared timeout_ms beyond 15 min stays retained past the flat window (#415)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-monitor-timeout', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { timeout_ms: 30 * 60 * 1000 }) + '\n'));
+    sp.setProcessing(false);
+
+    // Past the old flat 15-min window, but well inside a 30-min declared timeout.
+    nowSpy.mockReturnValue(T0 + 20 * 60 * 1000);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    // Past timeout_ms plus its buffer (30min + 15min headroom).
+    nowSpy.mockReturnValue(T0 + 46 * 60 * 1000);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
+  it('BG9: a persistent:true Monitor stays retained far past 15 min but is still bounded, not forever (#415)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-monitor-persistent', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { persistent: true }) + '\n'));
+    sp.setProcessing(false);
+
+    // 2 hours in — still well inside the 24h ceiling.
+    nowSpy.mockReturnValue(T0 + 2 * 60 * 60 * 1000);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    // Past the 24h ceiling — the crash-safety backstop still applies even to persistent monitors.
+    nowSpy.mockReturnValue(T0 + 25 * 60 * 60 * 1000);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
+  it('BG10: a declared timeout_ms far beyond the 24h ceiling is still capped, not honored verbatim (#415)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-monitor-huge-timeout', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { timeout_ms: 72 * 60 * 60 * 1000 }) + '\n'));
+    sp.setProcessing(false);
+
+    // 20h in: past the old flat 15-min window (proves scaling happened at all —
+    // this alone would be false without the fix) and still inside the 24h cap.
+    nowSpy.mockReturnValue(T0 + 20 * 60 * 60 * 1000);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    // 25h in: past the 24h ceiling — proves the 72h timeout_ms was NOT honored
+    // verbatim (an uncapped scale would still read true here).
+    nowSpy.mockReturnValue(T0 + 25 * 60 * 60 * 1000);
     expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
 
     nowSpy.mockRestore();

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1482,6 +1482,40 @@ describe('SessionProcess', () => {
     nowSpy.mockRestore();
   });
 
+  it('BG18: a later Agent/Workflow dispatch must never demote a still-outstanding default-grace Monitor, even when its raw expiry is numerically later (gateway-code-review round 6)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-monitor-no-demote', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    // Default Monitor: no timeout_ms/persistent, so its grace is the same flat
+    // BACKGROUND_AGENT_GRACE_MS floor as Agent/Workflow — the exact condition
+    // under which a later Agent/Workflow's raw expiry can outrun it.
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor') + '\n'));
+
+    // 2 min later, an unrelated Agent dispatch's fresh 15-min window has a
+    // numerically LATER raw expiry than the Monitor's (T0+17min vs T0+15min),
+    // but must not overwrite it — an Agent/Workflow dispatch offers none of a
+    // Monitor's turn-survival protection.
+    nowSpy.mockReturnValue(T0 + 2 * 60 * 1000);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Agent') + '\n'));
+    sp.setProcessing(false);
+
+    // An unrelated new turn starting must not clear the Monitor's tracking —
+    // it would if the Agent dispatch above had silently taken over.
+    nowSpy.mockReturnValue(T0 + 3 * 60 * 1000);
+    sp.setProcessing(true);
+    sp.setProcessing(false);
+
+    // Still well within the ORIGINAL Monitor's own 15-min window.
+    nowSpy.mockReturnValue(T0 + 5 * 60 * 1000);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+
   // --------------------------------------------------------------------------
   // U-SP-17: --include-partial-messages flag is in spawn args
   // --------------------------------------------------------------------------

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1139,6 +1139,16 @@ describe('SessionProcess', () => {
     expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
   });
 
+  it('BG3b: true after a Monitor dispatch too — Monitor returns a task id immediately and notifies later, same contract as Agent/Workflow (#413)', async () => {
+    const sp = makeSp('chat:bg-monitor', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor') + '\n'));
+    sp.setProcessing(false); // turn ends right after — the observed #413 incident shape
+
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+  });
+
   it('BG4: an ordinary tool_use (e.g. Bash) never arms it — no false positive', async () => {
     const sp = makeSp('chat:bg-bash', 'telegram', agentConfig, gatewayConfig, sessionStore);
     await sp.start();
@@ -1186,6 +1196,24 @@ describe('SessionProcess', () => {
     await sp.start();
     sp.setProcessing(true);
     lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Agent') + '\n'));
+    sp.setProcessing(false);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    nowSpy.mockReturnValue(T0 + 16 * 60 * 1000); // +16 min, past the 15-min grace window
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
+  it('BG7b: a Monitor dispatch expires after BACKGROUND_AGENT_GRACE_MS too — the safety valve is not Agent/Workflow-specific (#413)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-monitor-ttl', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor') + '\n'));
     sp.setProcessing(false);
     expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
 

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1422,6 +1422,66 @@ describe('SessionProcess', () => {
     nowSpy.mockRestore();
   });
 
+  it('BG16: a fresh dispatch clears an already-armed timer so it re-arms against the NEW deadline instead of firing on the stale one (manual review round)', async () => {
+    const sp = makeSp('chat:bg-stale-timer', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    jest.useFakeTimers();
+    try {
+      // t=0: dispatch a persistent Monitor and let the turn's own idle handling
+      // arm retainBackgroundWorkingState()'s timer for the 24h deadline.
+      sp.setProcessing(true);
+      lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { persistent: true }) + '\n'));
+      sp.setProcessing(false);
+      expect(sp.retainBackgroundWorkingState()).toBe(true);
+
+      // t=1h: a fresh Monitor dispatch arrives mid-way through the old window —
+      // the real deadline is now 25h (1h + 24h), not the original 24h.
+      jest.advanceTimersByTime(60 * 60 * 1000);
+      sp.setProcessing(true);
+      lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { persistent: true }) + '\n'));
+      sp.setProcessing(false);
+      expect(sp.retainBackgroundWorkingState()).toBe(true);
+
+      // Advance to the OLD (stale) deadline: 24h from t=0 is 23h from here.
+      // A timer left armed against the stale deadline would fire now and wipe
+      // out the fresh dispatch's tracking a full hour early.
+      jest.advanceTimersByTime(23 * 60 * 60 * 1000);
+
+      expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('BG17: a later, SHORTER Monitor dispatch does not shrink a still-outstanding, longer-lived Monitor already being tracked (manual review round)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-monitor-no-shrink', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { persistent: true }) + '\n'));
+    sp.setProcessing(false);
+    // Tracked deadline: T0 + 24h.
+
+    // 2h later, an unrelated one-shot Monitor with a much shorter declared
+    // timeout dispatches — a naive "any new Monitor overwrites" rule would
+    // collapse the deadline down to roughly T0+2h16min.
+    nowSpy.mockReturnValue(T0 + 2 * 60 * 60 * 1000);
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { timeout_ms: 60_000 }) + '\n'));
+    sp.setProcessing(false);
+
+    // Past what the short monitor alone would protect, but still well inside
+    // the ORIGINAL persistent Monitor's 24h window.
+    nowSpy.mockReturnValue(T0 + 10 * 60 * 60 * 1000);
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+
   // --------------------------------------------------------------------------
   // U-SP-17: --include-partial-messages flag is in spawn args
   // --------------------------------------------------------------------------

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1366,6 +1366,62 @@ describe('SessionProcess', () => {
     expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
   });
 
+  it('BG14: a still-outstanding persistent Monitor from an EARLIER message in the turn is not shadowed by a later, unrelated Agent dispatch in the SAME turn (manual review round)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-cross-message', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+
+    // First message in the turn: dispatch a persistent Monitor.
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { persistent: true }) + '\n'));
+
+    // A little later, still the SAME turn (isProcessing never went false in
+    // between): an unrelated Agent tool_use in a LATER message must not
+    // overwrite the still-outstanding persistent Monitor's tracking.
+    nowSpy.mockReturnValue(T0 + 5 * 60 * 1000); // +5 min
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Agent') + '\n'));
+
+    sp.setProcessing(false);
+
+    // Past what a bare Agent dispatch (15 min from T0+5min) would have given —
+    // must still be retained because of the persistent Monitor dispatched first.
+    nowSpy.mockReturnValue(T0 + 3 * 60 * 60 * 1000); // +3h from T0
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+
+  it('BG15: a NEW Monitor dispatch in a later message still refreshes tracking normally, even over an existing outstanding one (manual review round)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    const sp = makeSp('chat:bg-cross-message-refresh', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { timeout_ms: 20 * 60 * 1000 }) + '\n'));
+
+    // A second Monitor dispatch later in the same turn refreshes the tracked
+    // timestamp — the dispatch-detection code always accepts a NEW Monitor.
+    nowSpy.mockReturnValue(T0 + 10 * 60 * 1000);
+    lastProcess!.stdout!.emit('data', Buffer.from(agentDispatchLine('Monitor', { timeout_ms: 20 * 60 * 1000 }) + '\n'));
+
+    sp.setProcessing(false);
+
+    // Grace counts from the SECOND dispatch (T0+10min), not the first.
+    nowSpy.mockReturnValue(T0 + 40 * 60 * 1000); // 30 min after the second dispatch — still within its 35-min window
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    nowSpy.mockReturnValue(T0 + 50 * 60 * 1000); // 40 min after the second dispatch — past its window
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
   // --------------------------------------------------------------------------
   // U-SP-17: --include-partial-messages flag is in spawn args
   // --------------------------------------------------------------------------

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -1291,6 +1291,39 @@ describe('SessionProcess', () => {
     nowSpy.mockRestore();
   });
 
+  it('BG11: when one message dispatches two background tools, the LONGER grace wins regardless of array order (#415 review)', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const T0 = 3_000_000_000;
+    nowSpy.mockReturnValue(T0);
+
+    // Agent (15-min grace) listed BEFORE a persistent Monitor (24h grace) in the
+    // same assistant message — the shorter-lived tool must not shadow the longer one.
+    const multiDispatchLine = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'toolu_bg_agent', name: 'Agent', input: {} },
+          { type: 'tool_use', id: 'toolu_bg_monitor', name: 'Monitor', input: { persistent: true } },
+        ],
+      },
+      stop_reason: 'tool_use',
+    });
+
+    const sp = makeSp('chat:bg-multi-dispatch', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    sp.setProcessing(true);
+    lastProcess!.stdout!.emit('data', Buffer.from(multiDispatchLine + '\n'));
+    sp.setProcessing(false);
+
+    // Past the Agent-only 15-min window — must still be retained because of the
+    // persistent Monitor also dispatched in the same message.
+    nowSpy.mockReturnValue(T0 + 60 * 60 * 1000); // +1h
+    expect(sp.hasLikelyOutstandingBackgroundWork()).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+
   // --------------------------------------------------------------------------
   // U-SP-17: --include-partial-messages flag is in spawn args
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
A session whose only outstanding background dispatch is `Monitor` gets no typing-retention grace, so the Telegram typing/status indicator is torn down ~3s after the turn ends even while the monitor is still genuinely running in the background. The retention window also didn't scale to a `Monitor` declared to run longer than 15 minutes (`persistent: true` or a long `timeout_ms`).

## Related Issues
Closes #413
Closes #415

## Changes Made
- `src/session/process.ts`:
  - Add `'Monitor'` to `BACKGROUND_DISPATCH_TOOLS`, so a `Monitor` dispatch grants retention grace like `Agent`/`Workflow` (#413).
  - `computeBackgroundGraceMs()` sizes the grace window per dispatch: `Agent`/`Workflow` (and a `Monitor` with no longer-lived declared bound) keep the 15-minute default; a `Monitor` with `timeout_ms` gets that timeout plus headroom; `persistent: true` gets a 24-hour ceiling (#415).
  - When one message dispatches multiple background tools, the longest grace among them wins, not just the first one seen.
  - A `Monitor`-sourced grace window survives an unrelated new turn starting and ending (it represents an independent background watcher, not a one-shot wait) — `Agent`/`Workflow` dispatches are still cleared on any new turn, unchanged.
- `tests/unit/session-process.test.ts`: `BG3b`/`BG7b` (Monitor arms/expires retention like Agent/Workflow), `BG8`-`BG10` (timeout_ms scaling, persistent 24h ceiling, huge timeout_ms still capped), `BG11` (longest grace wins across multiple dispatches in one message), `BG12`/`BG13` (Monitor grace survives an unrelated turn; Agent/Workflow behavior unchanged).

## Scope — self-review correction
An earlier revision of this description said "Telegram/Discord". That was wrong: `retainBackgroundWorkingState()` — the code path that actually keeps the typing indicator alive — gates on `this.source === 'telegram'` explicitly, and Discord has no equivalent per-chat typing/status message mechanism at all. This fix changes zero UI behavior on Discord.

It does still benefit Discord (and every non-`api` channel) differently: `hasLikelyOutstandingBackgroundWork()` is also read, channel-wide, by `restartOrDefer()` (skips SIGKILLing a session mid-dispatch during a config-driven restart) and `startIdleCleaner()` (skips evicting it as idle).

## Review rounds — independent `/code-review`, 3 passes total (base + 2 extra, the documented cap)
**Pass 1:** comment drift (fixed) + grace window didn't scale to Monitor's own contract (originally deferred to #415, folded back into this PR at the user's request and implemented).

**Pass 2** (after folding in #415): a message dispatching two background tools only used the first match's grace, silently under-protecting a longer-lived dispatch listed after a shorter one — fixed to take the max across all matches in the message. Also simplified a dead `Math.max`, and defensively reset the new per-dispatch grace field everywhere the dispatch timestamp is cleared. Two findings declined: reaching into `Monitor`'s specific input shape inside otherwise tool-agnostic code matches this file's existing `CHANNEL_REPLY_TOOLS` convention, not a new anti-pattern; a shared clamp-into-range helper would deduplicate against two unrelated pre-existing call sites in `router.ts`/`share-router.ts`, which is out of scope for this PR.

**Pass 3** (final, cap reached): `setProcessing(true)` unconditionally cleared the new per-dispatch grace fields at the start of every new turn — correct for `Agent`/`Workflow` (an existing test, `BG6`, requires this), wrong for `Monitor`: an unrelated inbound chat message starting and finishing its own turn is not evidence a persistent Monitor resolved, and was silently discarding up to 24h of intended protection. Fixed with a `backgroundDispatchIsMonitor` flag that gates the clear — Monitor-sourced grace now survives an unrelated turn and keeps expiring on its own schedule; Agent/Workflow is unchanged (`BG13`). One lower-confidence finding declined: `timeout_ms`'s strict `typeof === 'number'` check falls back to the default grace for a non-number value, but the Monitor tool's own JSON schema types it as a number, so a string value isn't a shape the tool contract allows — treating it as a live risk would be speculative hardening without evidence.

## Testing
- `npm run typecheck`: pass
- `npm run build`: pass
- De-fix proof for every fix above: reverted in isolation, confirmed the matching test(s) fail; restored, all green. (`BG10` was corrected mid-review after its first version passed even on reverted code — it wasn't actually discriminating the fix; the corrected version fails red on revert.)
- `npm test`: 224 suites / 4014 tests pass (exit code 0, captured directly — not piped), re-run clean on the final tree after every round.

## What is not covered by a test
`Bash` with `run_in_background: true` (same "background work, notified later" shape as Monitor, but needs its own input-conditional logic) remains explicitly out of scope — no live-evidence proof of that specific gap exists yet.



## Review round 4 — manual `/gateway-code-review` self-review
While re-reading the final diff line by line: the existing "max grace across tool_use blocks in one message" fix (`BG11`) didn't cover the same shadowing risk one level up — a persistent Monitor dispatched in an EARLIER message of a multi-tool-round-trip turn was still silently overwritten by an unrelated, shorter-lived Agent/Workflow dispatched in a LATER message of the SAME turn, before the turn even ended. Fixed: a later dispatch only overwrites the tracked state if the existing one isn't a still-outstanding Monitor, or the new dispatch is itself Monitor-class (a genuine refresh). `BG14` proves the preservation; `BG15` proves a second real Monitor dispatch still refreshes tracking normally. De-fix proof: reverted, `BG14` failed red, `BG15` unaffected; restored, both green.

Final gates: typecheck ✅ · build ✅ · full suite 224/224 suites · 4016/4016 tests · exit 0.



## Review round 5 — user-requested `/code-review` (after the auto-pilot's own review cap)
Two more confirmed correctness bugs, both in round 4's own fix, plus a consolidation:

1. `retainBackgroundWorkingState()`'s timer only arms when `null`. Round 4 made `setProcessing(true)` skip clearing it for a Monitor dispatch (intentional — that's the survive-a-turn fix) — but that meant a SECOND Monitor dispatch arriving while the original timer was still pending updated the tracked deadline without re-arming the timer, so the stale timer fired on the OLD schedule and wiped the fresh dispatch's protection early. Fixed: any update to the tracked dispatch now clears the existing timer so it re-arms against the new deadline.
2. The cross-message preservation guard from round 4 only checked "is the new dispatch Monitor-class", not whether it was actually more protective — a later short-lived Monitor call could collapse a still-running persistent Monitor's 24h window down to minutes. Fixed: the decision now compares actual expiry times and never regresses to an earlier one.
3. Extracted `isTrackedDispatchStillOutstanding()` (shared by the read path and the new overwrite decision) and `resetBackgroundDispatchState()` (replacing the same reset hand-copied at 4 lifecycle sites) — per the reviewer's own framing, that duplication is exactly what let bug #1 slip through unnoticed.

New tests `BG16` (fake-timer proof of the stale-timer fix) and `BG17` (never-shrink proof). De-fix proof for both, full suite re-run clean: 224/224 suites, 4018/4018 tests, exit 0.

Three findings from this round declined, with reasons: consolidating the dispatch-tracking loop with other pre-existing, unrelated loops over the same small array (negligible perf, out of scope); an explicit upper-bound check on `timeout_ms` duplicating `router.ts`'s validation style (the existing `Math.min` clamp already fully bounds the result — no reachable bad outcome); a generic per-tool grace policy table for a hypothetical future 4th background-dispatch tool (none exists yet — speculative).

## Review round 6 — user-requested `/gateway-code-review`
One confirmed correctness bug, again in the immediately preceding round's own fix:

Round 5's overwrite guard compared only raw expiry timestamps (`newExpiry >= existingExpiry`), never checking whether the *new* dispatch was itself Monitor-class. A default-grace `Monitor` (no `timeout_ms`/`persistent`) shares Agent/Workflow's flat 15-minute grace floor, so an Agent/Workflow dispatched even moments later always has a numerically later raw expiry — the comparison let it silently overwrite the tracked Monitor and clear `backgroundDispatchIsMonitor`, after which the very next unrelated turn wiped the tracking immediately via `setProcessing(true)`, stripping the Monitor's SIGKILL/eviction protection well before its own window expired. Reproduced #413 through the code written specifically to guard it — reachable with the most ordinary Monitor call (no special input), not an edge case requiring `persistent`/long `timeout_ms`.

Proven with a temporary probe test before any fix was written (reverted after confirming red, not committed). Fixed: only another Monitor dispatch may now overwrite a still-outstanding Monitor, and only when at least as protective — Agent/Workflow can never demote it regardless of raw expiry math.

New test `BG18`. De-fix proof: reverted the `dispatchedIsMonitor` check from the condition, `BG18` failed red (`BG14`/`BG15`/`BG17` unaffected), restored and green.

Final gates: typecheck ✅ · build ✅ · full suite 224/224 suites · 4019/4019 tests · exit 0 (one unrelated flake in `cron-manager.test.ts` T15 on the first full run under CPU contention — confirmed passing standalone and on a clean re-run of the whole suite; not related to this change).
