### PR TITLE
fix: require a proven systemd parent before trusting INVOCATION_ID

### DIFF
--- a/src/cli/command-names.ts
+++ b/src/cli/command-names.ts
@@ -82,10 +82,19 @@ export interface InvocationSignals {
  * any other platform, returns `false`. A false negative costs a legacy unit a
  * help screen instead of booting; a false positive risks a second server on
  * the gateway's port, which is the worse failure.
+ *
+ * `readComm` is injectable for tests — real pid 1 is only genuinely systemd on
+ * a systemd-based host, so a test asserting against the live `/proc/1/comm`
+ * would pass or fail depending on where it happened to run (a Docker
+ * devcontainer's pid 1 is commonly tini or dumb-init). Injecting a fake reader
+ * proves the no-special-case behavior deterministically instead.
  */
-export function isDirectSystemdChild(ppid: number = process.ppid): boolean {
+export function isDirectSystemdChild(
+  ppid: number = process.ppid,
+  readComm: (pid: number) => string = (pid) => fs.readFileSync(`/proc/${pid}/comm`, 'utf8'),
+): boolean {
   try {
-    return fs.readFileSync(`/proc/${ppid}/comm`, 'utf8').trim() === 'systemd';
+    return readComm(ppid).trim() === 'systemd';
   } catch {
     return false;
   }
@@ -201,4 +210,21 @@ export function classifyInvocation(
   const asksForHelp = argv.some((token) => HELP_OR_VERSION_FLAGS.has(token));
   if (!hasCommandToken(argv) && !asksForHelp && isSupervised(env, signals)) return 'legacy-boot';
   return 'cli';
+}
+
+/**
+ * Builds the `InvocationSignals` for the current process from real OS/env
+ * state. Shared by src/entry.ts and src/index.ts — both call
+ * `classifyInvocation()` independently (src/index.ts must keep dispatching on
+ * its own for service units written before the entry-point split), so without
+ * this the same `hasTty`/`parentIsSystemd` construction would live twice and
+ * could drift out of sync between the two call sites.
+ */
+export function resolveInvocationSignals(env: NodeJS.ProcessEnv = process.env): InvocationSignals {
+  return {
+    hasTty: process.stdin.isTTY === true,
+    // Only isSupervised()'s INVOCATION_ID branch reads this; skip the /proc
+    // read entirely otherwise (the common bare-terminal and boot cases).
+    parentIsSystemd: env.INVOCATION_ID ? isDirectSystemdChild() : undefined,
+  };
 }

--- a/src/cli/command-names.ts
+++ b/src/cli/command-names.ts
@@ -66,11 +66,17 @@ export interface InvocationSignals {
  * command. This check is what lets `isSupervised()` tell "systemd forked me
  * directly" from "I'm several processes deep inside something systemd manages".
  *
- * `ppid === 1` covers system-level units (systemd is always pid 1) and most
- * containers. A `systemd --user` unit's parent is the per-user manager
- * instead, at an unpredictable pid, so it's identified by its `comm` name —
- * the same reasoning `orphan-receivers.ts` uses for the mirror-image
- * "reparented to init" check.
+ * Identified by `comm` name rather than pid, deliberately including `ppid === 1`:
+ * on a systemd-based Linux host pid 1 *is* systemd, so its `comm` reads
+ * "systemd" like any other systemd process — but pid 1 is not always systemd.
+ * A container run with `--init` (tini, dumb-init, s6) or a non-systemd host
+ * makes pid 1 something else entirely, and `orphan-receivers.ts` documents the
+ * identical ambiguity for its own ppid-based check without resolving it (that
+ * function only proves "the parent is gone", so an unverified pid 1 costs it
+ * nothing; this one hands out `legacy-boot`, so it can't afford to guess).
+ * `systemd --user`'s per-user manager is a different, unpredictable pid, but
+ * its `comm` is "systemd" too — the same read covers both without a special
+ * case for either.
  *
  * Linux-only (systemd itself is Linux-only) and fails closed: any error, or
  * any other platform, returns `false`. A false negative costs a legacy unit a
@@ -78,7 +84,6 @@ export interface InvocationSignals {
  * the gateway's port, which is the worse failure.
  */
 export function isDirectSystemdChild(ppid: number = process.ppid): boolean {
-  if (ppid === 1) return true;
   try {
     return fs.readFileSync(`/proc/${ppid}/comm`, 'utf8').trim() === 'systemd';
   } catch {
@@ -108,6 +113,18 @@ export function isGatewayStartInvocation(argv: readonly string[]): boolean {
  * The remaining variables are not equal evidence, so they are not weighed
  * equally:
  *
+ * - `pm_id` is trusted unconditionally — checked *before* `INVOCATION_ID`, not
+ *   just alongside it, because `pm2 startup systemd` runs the PM2 daemon
+ *   itself under systemd: a PM2-managed gateway then genuinely has both
+ *   markers, `INVOCATION_ID` inherited from that systemd-started daemon and
+ *   `pm_id` set directly by PM2. Its immediate parent is PM2, not systemd, so
+ *   `parentIsSystemd` is correctly `false` — checking `INVOCATION_ID` first
+ *   would reject a real pre-1.8 PM2 unit on that basis alone, never reaching
+ *   the `pm_id` evidence that should have settled it. PM2-managed processes
+ *   aren't generally used to host an interactive terminal the way a systemd
+ *   unit can (see `isDirectSystemdChild`), so the same inheritance-based
+ *   spoofing risk fixed for `INVOCATION_ID` hasn't been observed for `pm_id`
+ *   itself — an asymmetry, not a proof it can't happen.
  * - `INVOCATION_ID` is *identity minted by systemd*, but only for the exact
  *   process it forked — every descendant of that process inherits the same
  *   value, including a shell some *other*, unrelated unit opens (a
@@ -117,19 +134,14 @@ export function isGatewayStartInvocation(argv: readonly string[]): boolean {
  *   terminal being attached doesn't overrule it, so a legacy unit with
  *   `StandardInput=tty` still boots rather than printing help at its service
  *   manager.
- * - `pm_id` is trusted unconditionally, same as before this file's
- *   `parentIsSystemd` check was added — PM2-managed processes aren't
- *   generally used to host an interactive terminal the way a systemd unit can
- *   (see `isDirectSystemdChild`), so the same inheritance risk hasn't been
- *   observed for it. That is an asymmetry, not a proof it can't happen.
  * - `PM2_HOME` is *configuration* — where PM2 keeps its data. An operator can
  *   reasonably export it from a shell profile, where it says nothing about how
  *   this process was launched. It counts only when no terminal is attached.
  */
 export function isSupervised(env: InvocationEnv, signals: InvocationSignals = {}): boolean {
   if (env[CHILD_MARKER]) return false;
-  if (env.INVOCATION_ID) return signals.parentIsSystemd === true;
   if (env.pm_id !== undefined) return true;
+  if (env.INVOCATION_ID) return signals.parentIsSystemd === true;
   return !!env.PM2_HOME && !signals.hasTty;
 }
 

--- a/src/cli/command-names.ts
+++ b/src/cli/command-names.ts
@@ -7,6 +7,8 @@
  * — a bare `claude-gateway`, `--help`, a typo — goes to the CLI, so discovery
  * can never leave a stray server listening on the port.
  */
+import * as fs from 'fs';
+
 /** How src/index.ts should handle an invocation. */
 export type Invocation =
   /** `gateway start [...]` — boot the server in the foreground. */
@@ -45,6 +47,43 @@ export interface InvocationEnv {
 export interface InvocationSignals {
   /** True when a terminal is attached to stdin. */
   hasTty?: boolean;
+  /**
+   * True when this process's immediate parent is systemd itself, per
+   * `isDirectSystemdChild()`. Undefined/false means "not proven" — callers
+   * that don't check ancestry (most unit tests) get the safe default.
+   */
+  parentIsSystemd?: boolean;
+}
+
+/**
+ * True when this process's immediate parent is systemd itself — not merely a
+ * descendant of some process that systemd happens to manage.
+ *
+ * `INVOCATION_ID` is inherited by every descendant of a systemd unit's main
+ * process, including a shell that unit opens. A unit whose only job is to host
+ * a terminal (a web-terminal service, say) taints every command a human types
+ * into it with an `INVOCATION_ID` that was never meant to identify *that*
+ * command. This check is what lets `isSupervised()` tell "systemd forked me
+ * directly" from "I'm several processes deep inside something systemd manages".
+ *
+ * `ppid === 1` covers system-level units (systemd is always pid 1) and most
+ * containers. A `systemd --user` unit's parent is the per-user manager
+ * instead, at an unpredictable pid, so it's identified by its `comm` name —
+ * the same reasoning `orphan-receivers.ts` uses for the mirror-image
+ * "reparented to init" check.
+ *
+ * Linux-only (systemd itself is Linux-only) and fails closed: any error, or
+ * any other platform, returns `false`. A false negative costs a legacy unit a
+ * help screen instead of booting; a false positive risks a second server on
+ * the gateway's port, which is the worse failure.
+ */
+export function isDirectSystemdChild(ppid: number = process.ppid): boolean {
+  if (ppid === 1) return true;
+  try {
+    return fs.readFileSync(`/proc/${ppid}/comm`, 'utf8').trim() === 'systemd';
+  } catch {
+    return false;
+  }
 }
 
 /** True only for the explicit foreground-server invocation. */
@@ -69,18 +108,28 @@ export function isGatewayStartInvocation(argv: readonly string[]): boolean {
  * The remaining variables are not equal evidence, so they are not weighed
  * equally:
  *
- * - `INVOCATION_ID` and `pm_id` are *identity*: the supervisor mints them per
- *   invocation, and they cannot be set by a shell profile. They are trusted on
- *   their own — including when a terminal is attached, so a legacy unit with
+ * - `INVOCATION_ID` is *identity minted by systemd*, but only for the exact
+ *   process it forked — every descendant of that process inherits the same
+ *   value, including a shell some *other*, unrelated unit opens (a
+ *   web-terminal service, say). So it is trusted only alongside
+ *   `signals.parentIsSystemd`, which proves this process — not some ancestor
+ *   several levels up — is the one systemd actually launched. Once proven, a
+ *   terminal being attached doesn't overrule it, so a legacy unit with
  *   `StandardInput=tty` still boots rather than printing help at its service
  *   manager.
+ * - `pm_id` is trusted unconditionally, same as before this file's
+ *   `parentIsSystemd` check was added — PM2-managed processes aren't
+ *   generally used to host an interactive terminal the way a systemd unit can
+ *   (see `isDirectSystemdChild`), so the same inheritance risk hasn't been
+ *   observed for it. That is an asymmetry, not a proof it can't happen.
  * - `PM2_HOME` is *configuration* — where PM2 keeps its data. An operator can
  *   reasonably export it from a shell profile, where it says nothing about how
  *   this process was launched. It counts only when no terminal is attached.
  */
 export function isSupervised(env: InvocationEnv, signals: InvocationSignals = {}): boolean {
   if (env[CHILD_MARKER]) return false;
-  if (env.INVOCATION_ID || env.pm_id !== undefined) return true;
+  if (env.INVOCATION_ID) return signals.parentIsSystemd === true;
+  if (env.pm_id !== undefined) return true;
   return !!env.PM2_HOME && !signals.hasTty;
 }
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -24,14 +24,9 @@ import { loadGatewayDotenv } from './load-dotenv';
 // the CLI resolves the gateway's address from the same $GATEWAY_BIND.
 loadGatewayDotenv();
 
-import { classifyInvocation, isDirectSystemdChild } from './cli/command-names';
+import { classifyInvocation, resolveInvocationSignals } from './cli/command-names';
 
-const invocation = classifyInvocation(process.argv.slice(2), process.env, {
-  hasTty: process.stdin.isTTY === true,
-  // Only `isSupervised()` -> the INVOCATION_ID branch reads this; skip the
-  // /proc read entirely otherwise (the common bare-terminal and boot cases).
-  parentIsSystemd: process.env.INVOCATION_ID ? isDirectSystemdChild() : undefined,
-});
+const invocation = classifyInvocation(process.argv.slice(2), process.env, resolveInvocationSignals());
 
 if (invocation === 'boot' || invocation === 'legacy-boot') {
   // Importing the server module runs its own dispatch, which re-classifies this

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -28,7 +28,9 @@ import { classifyInvocation, isDirectSystemdChild } from './cli/command-names';
 
 const invocation = classifyInvocation(process.argv.slice(2), process.env, {
   hasTty: process.stdin.isTTY === true,
-  parentIsSystemd: isDirectSystemdChild(),
+  // Only `isSupervised()` -> the INVOCATION_ID branch reads this; skip the
+  // /proc read entirely otherwise (the common bare-terminal and boot cases).
+  parentIsSystemd: process.env.INVOCATION_ID ? isDirectSystemdChild() : undefined,
 });
 
 if (invocation === 'boot' || invocation === 'legacy-boot') {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -24,10 +24,11 @@ import { loadGatewayDotenv } from './load-dotenv';
 // the CLI resolves the gateway's address from the same $GATEWAY_BIND.
 loadGatewayDotenv();
 
-import { classifyInvocation } from './cli/command-names';
+import { classifyInvocation, isDirectSystemdChild } from './cli/command-names';
 
 const invocation = classifyInvocation(process.argv.slice(2), process.env, {
   hasTty: process.stdin.isTTY === true,
+  parentIsSystemd: isDirectSystemdChild(),
 });
 
 if (invocation === 'boot' || invocation === 'legacy-boot') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ import { AppInstaller } from './apps/installer';
 import { AgentManager } from './apps/agent-manager';
 import { SocketServer, parseTimeoutMs } from './apps/socket-server';
 import { parseAppYaml, AppYamlService, AppYamlScript } from './apps/compose-generator';
-import { claimSupervisorEnv, classifyInvocation, isDirectSystemdChild } from './cli/command-names';
+import { claimSupervisorEnv, classifyInvocation, resolveInvocationSignals } from './cli/command-names';
 import { defaultPidfilePath } from './cli/manager';
 import { expandHome as expandTilde } from './utils/paths';
 
@@ -1078,12 +1078,7 @@ process.on('uncaughtException', (err) => {
 // The one exception is a supervised no-command launch from a pre-1.8 unit file,
 // which still boots (with a warning) so existing installs don't restart-loop.
 // The CLI runner remains lazy-loaded and is never imported on the server path.
-const invocation = classifyInvocation(process.argv.slice(2), process.env, {
-  hasTty: process.stdin.isTTY === true,
-  // Only `isSupervised()` -> the INVOCATION_ID branch reads this; skip the
-  // /proc read entirely otherwise (the common bare-terminal and boot cases).
-  parentIsSystemd: process.env.INVOCATION_ID ? isDirectSystemdChild() : undefined,
-});
+const invocation = classifyInvocation(process.argv.slice(2), process.env, resolveInvocationSignals());
 if (invocation === 'legacy-boot') {
   process.stderr.write(
     'DEPRECATED: starting the gateway with no command. Update this service to run ' +

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ import { AppInstaller } from './apps/installer';
 import { AgentManager } from './apps/agent-manager';
 import { SocketServer, parseTimeoutMs } from './apps/socket-server';
 import { parseAppYaml, AppYamlService, AppYamlScript } from './apps/compose-generator';
-import { claimSupervisorEnv, classifyInvocation } from './cli/command-names';
+import { claimSupervisorEnv, classifyInvocation, isDirectSystemdChild } from './cli/command-names';
 import { defaultPidfilePath } from './cli/manager';
 import { expandHome as expandTilde } from './utils/paths';
 
@@ -1080,6 +1080,7 @@ process.on('uncaughtException', (err) => {
 // The CLI runner remains lazy-loaded and is never imported on the server path.
 const invocation = classifyInvocation(process.argv.slice(2), process.env, {
   hasTty: process.stdin.isTTY === true,
+  parentIsSystemd: isDirectSystemdChild(),
 });
 if (invocation === 'legacy-boot') {
   process.stderr.write(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1080,7 +1080,9 @@ process.on('uncaughtException', (err) => {
 // The CLI runner remains lazy-loaded and is never imported on the server path.
 const invocation = classifyInvocation(process.argv.slice(2), process.env, {
   hasTty: process.stdin.isTTY === true,
-  parentIsSystemd: isDirectSystemdChild(),
+  // Only `isSupervised()` -> the INVOCATION_ID branch reads this; skip the
+  // /proc read entirely otherwise (the common bare-terminal and boot cases).
+  parentIsSystemd: process.env.INVOCATION_ID ? isDirectSystemdChild() : undefined,
 });
 if (invocation === 'legacy-boot') {
   process.stderr.write(

--- a/tests/integration/cli-dispatch.test.ts
+++ b/tests/integration/cli-dispatch.test.ts
@@ -209,46 +209,55 @@ describe('binary dispatch — help colouring', () => {
   }, TIMEOUT_MS);
 });
 
-describe('binary dispatch — legacy supervised units still boot', () => {
-  it('warns and enters the server path when a supervisor passes no command', async () => {
+describe('binary dispatch — inherited INVOCATION_ID from a non-systemd parent is not trusted', () => {
+  /**
+   * Regression for the bug this fixes: `INVOCATION_ID` is inherited by every
+   * descendant of *any* systemd unit's main process, not just the one systemd
+   * directly forked. A shell reached through an unrelated systemd-managed
+   * process (a web-terminal service, say) carries the same env var while its
+   * actual parent is that shell, not systemd. Before the `parentIsSystemd`
+   * check landed, this was enough to spoof a legacy-boot and start a second
+   * gateway on top of one already running.
+   *
+   * Spawned directly from this test process — a normal parent, definitely not
+   * systemd — so `isDirectSystemdChild()` reads a real, non-1 ppid and returns
+   * `false`. Must resolve to `cli` (help), never boot.
+   *
+   * Genuine `ppid === 1` legacy-boot (an actual pre-1.8 systemd unit) can't be
+   * fabricated portably from an integration test; it's covered by the pure
+   * `isDirectSystemdChild`/`isSupervised`/`classifyInvocation` unit tests in
+   * tests/unit/cli-supervisor.test.ts and tests/unit/cli-args.test.ts.
+   */
+  it('an inherited INVOCATION_ID without a systemd parent prints help and exits, never boots', async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-legacy-boot-'));
-    const child = spawn(process.execPath, [ENTRY], {
-      env: {
+    try {
+      // Built by hand rather than terminalEnv(), which unconditionally deletes
+      // INVOCATION_ID — exactly the variable this test needs to keep. Still
+      // clears CLAUDE_GATEWAY_CHILD: this suite may itself be running inside a
+      // gateway-spawned shell (an agent's own session), which would otherwise
+      // short-circuit isSupervised() to false for an unrelated reason and let
+      // this test pass without ever exercising the fix.
+      const env: NodeJS.ProcessEnv = {
         ...process.env,
-        // Inherited when the suite runs inside a gateway-spawned shell, where it
-        // makes classifyInvocation() answer 'cli' — this launch would then never
-        // reach the legacy path and the test failed for a reason that had nothing
-        // to do with the code under test.
-        CLAUDE_GATEWAY_CHILD: '',
-        HOME: home,
-        // Marks the launch as systemd-supervised, which is exactly the pre-1.8
-        // unit shape (`ExecStart=/usr/local/bin/claude-gateway`, no command).
+        NO_COLOR: '1',
+        // Same shape as a shell reached through an unrelated systemd unit:
+        // the marker is present, but this process's real parent is the test
+        // runner, not systemd.
         INVOCATION_ID: 'test-invocation',
+        HOME: home,
         GATEWAY_CONFIG: path.join(home, 'config.json'),
         PORT: '0',
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+      };
+      delete env.CLAUDE_GATEWAY_CHILD;
+      delete env.PM2_HOME;
+      delete env.pm_id;
+      delete env.FORCE_COLOR;
 
-    try {
-      const sawWarning = await new Promise<boolean>((resolve) => {
-        let stderr = '';
-        const timer = setTimeout(() => resolve(false), 10_000);
-        child.stderr.on('data', (d) => {
-          stderr += d.toString();
-          if (stderr.includes('DEPRECATED')) {
-            clearTimeout(timer);
-            resolve(true);
-          }
-        });
-        child.on('close', () => {
-          clearTimeout(timer);
-          resolve(stderr.includes('DEPRECATED'));
-        });
-      });
-      expect(sawWarning).toBe(true);
+      const { code, stdout, stderr } = await run([], env);
+      expect(code).toBe(0);
+      expect(stdout).toContain('claude-gateway');
+      expect(stderr).not.toContain('DEPRECATED');
     } finally {
-      child.kill('SIGKILL');
       fs.rmSync(home, { recursive: true, force: true });
     }
   }, TIMEOUT_MS);

--- a/tests/unit/cli-args.test.ts
+++ b/tests/unit/cli-args.test.ts
@@ -66,13 +66,13 @@ describe('cli args parseCliArgs', () => {
  */
 describe('cli command-names isSupervised', () => {
   it('accepts a service main process: markers, no child stamp, no terminal', () => {
-    expect(isSupervised({ INVOCATION_ID: 'abc' })).toBe(true);
+    expect(isSupervised({ INVOCATION_ID: 'abc' }, { parentIsSystemd: true })).toBe(true);
     expect(isSupervised({ pm_id: '0' })).toBe(true);
     expect(isSupervised({ PM2_HOME: '/home/u/.pm2' })).toBe(true);
   });
 
   it('rejects a descendant of a running gateway', () => {
-    expect(isSupervised({ INVOCATION_ID: 'abc', [CHILD_MARKER]: '1' })).toBe(false);
+    expect(isSupervised({ INVOCATION_ID: 'abc', [CHILD_MARKER]: '1' }, { parentIsSystemd: true })).toBe(false);
     expect(isSupervised({ pm_id: '0', [CHILD_MARKER]: '1' })).toBe(false);
   });
 
@@ -82,6 +82,14 @@ describe('cli command-names isSupervised', () => {
 
   it('is false without any marker', () => {
     expect(isSupervised({})).toBe(false);
+  });
+
+  // See tests/unit/cli-supervisor.test.ts for the parentIsSystemd regression
+  // coverage — INVOCATION_ID inherited from an unrelated systemd unit (e.g. a
+  // web-terminal service) must not be trusted just because it's present.
+  it('does not trust INVOCATION_ID without proof this process is systemd’s direct child', () => {
+    expect(isSupervised({ INVOCATION_ID: 'abc' })).toBe(false);
+    expect(isSupervised({ INVOCATION_ID: 'abc' }, { parentIsSystemd: false })).toBe(false);
   });
 });
 
@@ -112,9 +120,9 @@ describe('cli command-names claimSupervisorEnv', () => {
   // whatever it inherited.
   it('leaves an environment in which a bare invocation goes to the CLI', () => {
     const env: NodeJS.ProcessEnv = { INVOCATION_ID: 'abc' };
-    expect(classifyInvocation([], env)).toBe('legacy-boot');
+    expect(classifyInvocation([], env, { parentIsSystemd: true })).toBe('legacy-boot');
     claimSupervisorEnv(env);
-    expect(classifyInvocation([], env)).toBe('cli');
+    expect(classifyInvocation([], env, { parentIsSystemd: true })).toBe('cli');
   });
 
   it('records nothing when no supervisor started us', () => {
@@ -160,9 +168,18 @@ describe('cli command-names classifyInvocation', () => {
   });
 
   it('keeps pre-1.8 supervised units booting when they pass no command', () => {
-    expect(classifyInvocation([], systemd)).toBe('legacy-boot');
+    const systemdParent = { parentIsSystemd: true };
+    expect(classifyInvocation([], systemd, systemdParent)).toBe('legacy-boot');
     expect(classifyInvocation([], pm2)).toBe('legacy-boot');
-    expect(classifyInvocation(['--config', '/etc/cg.json'], systemd)).toBe('legacy-boot');
+    expect(classifyInvocation(['--config', '/etc/cg.json'], systemd, systemdParent)).toBe('legacy-boot');
+  });
+
+  // Regression: INVOCATION_ID alone used to be enough — inherited from an
+  // unrelated systemd unit (e.g. a web-terminal service) that merely happens
+  // to be an ancestor, it isn't proof systemd forked *this* process.
+  it('does not legacy-boot on an inherited INVOCATION_ID whose parent is not systemd', () => {
+    expect(classifyInvocation([], systemd)).toBe('cli');
+    expect(classifyInvocation([], systemd, { parentIsSystemd: false })).toBe('cli');
   });
 
   it('does not treat a supervised --help/--version as a boot request', () => {

--- a/tests/unit/cli-supervisor.test.ts
+++ b/tests/unit/cli-supervisor.test.ts
@@ -58,6 +58,21 @@ describe('supervisor detection', () => {
     expect(classifyInvocation([], { INVOCATION_ID: 'abc' })).toBe('cli');
   });
 
+  /**
+   * `pm2 startup systemd` runs the PM2 daemon itself under systemd, so a
+   * genuinely PM2-managed process can carry `INVOCATION_ID` — inherited from
+   * that systemd-started daemon — alongside its own `pm_id`, while its
+   * immediate parent is PM2, not systemd (`parentIsSystemd` correctly false).
+   * Checking `INVOCATION_ID` before `pm_id` would reject this on the
+   * unproven `INVOCATION_ID` alone, without ever reaching the `pm_id`
+   * evidence that should have settled it — regression for exactly that.
+   */
+  it('trusts pm_id even when an inherited, unproven INVOCATION_ID is also present', () => {
+    expect(isSupervised({ INVOCATION_ID: 'abc', pm_id: '0' })).toBe(true);
+    expect(isSupervised({ INVOCATION_ID: 'abc', pm_id: '0' }, { parentIsSystemd: false })).toBe(true);
+    expect(classifyInvocation([], { INVOCATION_ID: 'abc', pm_id: '0' })).toBe('legacy-boot');
+  });
+
   /** `PM2_HOME` is configuration, not identity: an operator can export it from
    *  a shell profile, where it says nothing about how this process started. */
   it('does not treat PM2_HOME alone as a service launch when a terminal is attached', () => {
@@ -77,11 +92,19 @@ describe('supervisor detection', () => {
  * works and just feed it the boolean. These pin the function itself.
  */
 describe('isDirectSystemdChild', () => {
-  it('trusts pid 1 unconditionally — always systemd on a system-level unit', () => {
+  /**
+   * pid 1 has no special-cased shortcut — it's read like any other pid. On
+   * this (systemd-based) test host, /proc/1/comm genuinely is "systemd", so
+   * this also happens to prove the ppid===1 case, without trusting pid 1
+   * unconditionally the way an earlier version of this function did (fixed
+   * in review: a container's pid 1 is often tini/dumb-init/s6, not systemd,
+   * and that version would have misidentified it as a systemd parent).
+   */
+  it('reads comm even for pid 1, rather than trusting the pid alone', () => {
     expect(isDirectSystemdChild(1)).toBe(true);
   });
 
-  it('rejects a parent that is not systemd and not pid 1', () => {
+  it('rejects a parent that is not systemd', () => {
     // This test process's own pid is guaranteed to exist and not be systemd.
     expect(isDirectSystemdChild(process.pid)).toBe(false);
   });

--- a/tests/unit/cli-supervisor.test.ts
+++ b/tests/unit/cli-supervisor.test.ts
@@ -3,6 +3,7 @@ import {
   claimSupervisorEnv,
   classifyInvocation,
   isDirectSystemdChild,
+  resolveInvocationSignals,
   CHILD_MARKER,
   SUPERVISOR_MARKER,
 } from '../../src/cli/command-names';
@@ -88,29 +89,63 @@ describe('supervisor detection', () => {
 
 /**
  * `isDirectSystemdChild` is what actually computes `parentIsSystemd` in
- * production (see src/entry.ts, src/index.ts) — the specs above assume it
- * works and just feed it the boolean. These pin the function itself.
+ * production (see `resolveInvocationSignals` in src/cli/command-names.ts) —
+ * the specs above assume it works and just feed it the boolean. These pin
+ * the function itself, with an injected `readComm` rather than the live
+ * `/proc/1/comm`: real pid 1 is only genuinely systemd on a systemd-based
+ * host, so asserting against the live file would pass or fail depending on
+ * where the suite happens to run (a Docker devcontainer's pid 1 is commonly
+ * tini or dumb-init, not systemd).
  */
 describe('isDirectSystemdChild', () => {
-  /**
-   * pid 1 has no special-cased shortcut — it's read like any other pid. On
-   * this (systemd-based) test host, /proc/1/comm genuinely is "systemd", so
-   * this also happens to prove the ppid===1 case, without trusting pid 1
-   * unconditionally the way an earlier version of this function did (fixed
-   * in review: a container's pid 1 is often tini/dumb-init/s6, not systemd,
-   * and that version would have misidentified it as a systemd parent).
-   */
-  it('reads comm even for pid 1, rather than trusting the pid alone', () => {
-    expect(isDirectSystemdChild(1)).toBe(true);
+  it('has no special-cased shortcut for pid 1 — a non-systemd pid 1 is rejected', () => {
+    // Regression: an earlier version of this function trusted `ppid === 1`
+    // unconditionally, without checking comm — exactly the false-positive
+    // class this PR fixes, reopened inside a container whose pid 1 is
+    // tini/dumb-init/s6 rather than systemd.
+    expect(isDirectSystemdChild(1, () => 'tini')).toBe(false);
   });
 
-  it('rejects a parent that is not systemd', () => {
-    // This test process's own pid is guaranteed to exist and not be systemd.
-    expect(isDirectSystemdChild(process.pid)).toBe(false);
+  it('accepts pid 1 when its comm really is systemd', () => {
+    expect(isDirectSystemdChild(1, () => 'systemd')).toBe(true);
   });
 
-  it('rejects a pid that does not exist at all, without throwing', () => {
-    expect(isDirectSystemdChild(999999999)).toBe(false);
+  it('rejects a parent whose comm is not systemd', () => {
+    expect(isDirectSystemdChild(4242, () => 'bash')).toBe(false);
+  });
+
+  it('accepts a systemd --user manager at an arbitrary, non-1 pid', () => {
+    expect(isDirectSystemdChild(4242, () => 'systemd')).toBe(true);
+  });
+
+  it('rejects a pid whose comm cannot be read, without throwing', () => {
+    expect(
+      isDirectSystemdChild(999999999, () => {
+        throw new Error('ENOENT');
+      }),
+    ).toBe(false);
+  });
+
+  it('defaults to the real /proc read and process.ppid when not overridden', () => {
+    // No assertion on the outcome (host-dependent) — just that it runs
+    // against the live process without an injected reader and never throws.
+    expect(() => isDirectSystemdChild()).not.toThrow();
+  });
+});
+
+/**
+ * Shared by src/entry.ts and src/index.ts (see the comment on the export) so
+ * the hasTty/parentIsSystemd construction can't drift between the two
+ * `classifyInvocation()` call sites the way it briefly did in review.
+ */
+describe('resolveInvocationSignals', () => {
+  it('skips the parentIsSystemd check entirely when INVOCATION_ID is absent', () => {
+    expect(resolveInvocationSignals({})).toEqual({ hasTty: expect.any(Boolean), parentIsSystemd: undefined });
+  });
+
+  it('computes parentIsSystemd when INVOCATION_ID is present', () => {
+    const signals = resolveInvocationSignals({ INVOCATION_ID: 'abc' });
+    expect(typeof signals.parentIsSystemd).toBe('boolean');
   });
 });
 

--- a/tests/unit/cli-supervisor.test.ts
+++ b/tests/unit/cli-supervisor.test.ts
@@ -1,4 +1,11 @@
-import { isSupervised, claimSupervisorEnv, classifyInvocation, CHILD_MARKER, SUPERVISOR_MARKER } from '../../src/cli/command-names';
+import {
+  isSupervised,
+  claimSupervisorEnv,
+  classifyInvocation,
+  isDirectSystemdChild,
+  CHILD_MARKER,
+  SUPERVISOR_MARKER,
+} from '../../src/cli/command-names';
 
 /**
  * The supervisor markers are inherited by every descendant, and the gateway
@@ -8,27 +15,47 @@ import { isSupervised, claimSupervisorEnv, classifyInvocation, CHILD_MARKER, SUP
  */
 describe('supervisor detection', () => {
   it('treats a child of the gateway as a CLI invocation, whatever else it inherited', () => {
-    expect(isSupervised({ INVOCATION_ID: 'abc', [CHILD_MARKER]: '1' })).toBe(false);
+    expect(isSupervised({ INVOCATION_ID: 'abc', [CHILD_MARKER]: '1' }, { parentIsSystemd: true })).toBe(false);
     expect(isSupervised({ PM2_HOME: '/pm2', [CHILD_MARKER]: '1' })).toBe(false);
     expect(isSupervised({ pm_id: '0', [CHILD_MARKER]: '1' })).toBe(false);
   });
 
   it('recognises a service main process', () => {
-    expect(isSupervised({ INVOCATION_ID: 'abc' })).toBe(true);
+    expect(isSupervised({ INVOCATION_ID: 'abc' }, { parentIsSystemd: true })).toBe(true);
     expect(isSupervised({ pm_id: '0' })).toBe(true);
     expect(isSupervised({ PM2_HOME: '/pm2' })).toBe(true);
   });
 
   /**
-   * `INVOCATION_ID` and `pm_id` are minted per invocation by the supervisor and
-   * cannot come from a shell profile, so a terminal does not overrule them — a
-   * legacy unit with `StandardInput=tty` must still boot rather than printing
-   * help at its service manager.
+   * `INVOCATION_ID` is minted per invocation by systemd and cannot come from a
+   * shell profile, so once `parentIsSystemd` proves it belongs to *this*
+   * process, a terminal does not overrule it — a legacy unit with
+   * `StandardInput=tty` must still boot rather than printing help at its
+   * service manager.
    */
   it('still boots a supervised launch that happens to have a terminal', () => {
-    expect(isSupervised({ INVOCATION_ID: 'abc' }, { hasTty: true })).toBe(true);
+    expect(isSupervised({ INVOCATION_ID: 'abc' }, { hasTty: true, parentIsSystemd: true })).toBe(true);
     expect(isSupervised({ pm_id: '0' }, { hasTty: true })).toBe(true);
-    expect(classifyInvocation([], { INVOCATION_ID: 'abc' }, { hasTty: true })).toBe('legacy-boot');
+    expect(classifyInvocation([], { INVOCATION_ID: 'abc' }, { hasTty: true, parentIsSystemd: true })).toBe(
+      'legacy-boot',
+    );
+  });
+
+  /**
+   * `INVOCATION_ID` is inherited by every descendant of a systemd unit's main
+   * process — not just the one systemd forked. A shell reached through an
+   * unrelated systemd-managed process (a web-terminal service, say) carries
+   * the same env var, but this process's immediate parent is that shell, not
+   * systemd. Regression for the false-positive this let through before
+   * `parentIsSystemd` existed: bare `claude-gateway`, typed by a human in such
+   * a shell, tried to boot a second gateway on top of the one already running.
+   */
+  it('does not trust an inherited INVOCATION_ID whose parent is not systemd', () => {
+    expect(isSupervised({ INVOCATION_ID: 'abc' })).toBe(false);
+    expect(isSupervised({ INVOCATION_ID: 'abc' }, { parentIsSystemd: false })).toBe(false);
+    expect(isSupervised({ INVOCATION_ID: 'abc' }, { hasTty: true, parentIsSystemd: false })).toBe(false);
+    expect(classifyInvocation([], { INVOCATION_ID: 'abc' }, { parentIsSystemd: false })).toBe('cli');
+    expect(classifyInvocation([], { INVOCATION_ID: 'abc' })).toBe('cli');
   });
 
   /** `PM2_HOME` is configuration, not identity: an operator can export it from
@@ -41,6 +68,26 @@ describe('supervisor detection', () => {
   it('leaves an unmarked interactive invocation alone', () => {
     expect(isSupervised({})).toBe(false);
     expect(isSupervised({}, { hasTty: true })).toBe(false);
+  });
+});
+
+/**
+ * `isDirectSystemdChild` is what actually computes `parentIsSystemd` in
+ * production (see src/entry.ts, src/index.ts) — the specs above assume it
+ * works and just feed it the boolean. These pin the function itself.
+ */
+describe('isDirectSystemdChild', () => {
+  it('trusts pid 1 unconditionally — always systemd on a system-level unit', () => {
+    expect(isDirectSystemdChild(1)).toBe(true);
+  });
+
+  it('rejects a parent that is not systemd and not pid 1', () => {
+    // This test process's own pid is guaranteed to exist and not be systemd.
+    expect(isDirectSystemdChild(process.pid)).toBe(false);
+  });
+
+  it('rejects a pid that does not exist at all, without throwing', () => {
+    expect(isDirectSystemdChild(999999999)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #416

## Problem

`isSupervised()` (`src/cli/command-names.ts`) trusted the mere presence of `INVOCATION_ID` as proof that systemd was directly launching this process to boot the gateway, unconditionally — even with a TTY attached. But `INVOCATION_ID` is inherited by **every descendant** of a systemd unit's main process, not just the one systemd forked. A shell reached through an unrelated systemd-managed process (a web-terminal service, say) inherits the same value while its actual parent is that shell, not systemd.

Reproduced live: on a host running `claude-gateway gateway start` as an active systemd service, a user typing plain `claude-gateway` (no subcommand) inside a web-terminal (itself a systemd unit) got classified as `legacy-boot` and the process attempted to boot a **second** gateway server on top of the one already running. `INVOCATION_ID` in that shell matched exactly the value systemd minted for the web-terminal unit (`systemctl show <unit> -p InvocationID`), confirming the inheritance path: `<unit>.service → login shell → tmux → interactive shell`.

## Fix

Add `isDirectSystemdChild()`: true only when this process's immediate parent is systemd itself — `ppid === 1` for system-level units, or the `systemd --user` manager's `comm` name for user-level units (same reasoning `orphan-receivers.ts` already uses for the mirror-image "reparented to init" check). Fails closed (returns `false`) on any error or non-Linux platform.

Wire it through `src/entry.ts` and `src/index.ts` as a new `parentIsSystemd` signal, and require it in `isSupervised()` before trusting `INVOCATION_ID`. `pm_id` (PM2) is left trusted unconditionally — noted in the comment as a known asymmetry, not a proof PM2 can't have the same issue, but out of scope here since it hasn't been observed.

A genuine pre-1.8 unit (`ExecStart=claude-gateway`, no subcommand — systemd forks the node process directly) is unaffected: its immediate parent really is systemd, so `isDirectSystemdChild()` returns `true` and it still legacy-boots with the deprecation warning, unchanged.

## Testing

- `tests/unit/cli-supervisor.test.ts` / `tests/unit/cli-args.test.ts`: updated existing specs to pass `parentIsSystemd: true` where a genuine supervised launch is being simulated, and added new specs proving the false-positive case (`INVOCATION_ID` present, `parentIsSystemd` false/unproven → `isSupervised` false, `classifyInvocation` → `'cli'`) plus direct coverage of `isDirectSystemdChild` (`ppid === 1` trusted, a real non-systemd ppid rejected, a nonexistent ppid rejected without throwing).
- `tests/integration/cli-dispatch.test.ts`: replaced the old "legacy supervised units still boot" spawn test (which only faked `INVOCATION_ID` via env var, with no way to prove the parent was actually systemd) with a regression test that reproduces the reported bug at the real-binary level — `dist/entry.js` spawned with `INVOCATION_ID` set but a normal (non-systemd) parent must print help and exit, never emit the `DEPRECATED` boot warning. Genuine `ppid === 1` legacy-boot can't be fabricated portably in CI, so that side is covered by the unit tests instead.
- De-fix proof: reverted the one-line `isSupervised()` gate back to trusting `INVOCATION_ID` unconditionally — 3 unit tests and the new integration test all failed red, with the integration test reproducing the exact live symptom (`DEPRECATED` warning printed, process never exits, "likely started a server").
- Gates: `npm run typecheck` clean, `npm run build` clean, full suite 224/224 suites, 4028/4028 tests, exit 0 (one unrelated pre-existing failure in `tests/unit/packages-router.test.ts` T10 reproduces identically on unmodified `main` in this environment — it leaks this session's own `CLAUDE_GATEWAY_SUPERVISOR=systemd` env var, which the test doesn't clear; unrelated to this change and not touched here).

---

## Review round 1 (independent `/code-review`)

Found and fixed 2 real bugs introduced by this PR's own initial fix, both in `src/cli/command-names.ts`:

1. **`isSupervised()` checked `INVOCATION_ID` before `pm_id`** — a genuinely PM2-managed process can carry both (`pm2 startup systemd` runs the PM2 daemon itself under systemd, so `INVOCATION_ID` is inherited from that daemon while `pm_id` is set directly by PM2). The unproven `INVOCATION_ID` branch rejected it before ever reaching the valid `pm_id` evidence. Fixed: `pm_id` is now checked first.
2. **`isDirectSystemdChild()` special-cased `ppid === 1` as an unconditional match**, skipping the `comm`-name verification the non-1 branch already did. Pid 1 is not always systemd (`docker --init`, tini, dumb-init, s6, non-systemd hosts) — this could reopen the exact false-positive class the PR exists to close. Fixed: the special case is removed; every ppid, including 1, is verified by `comm` name.

Also corrected a doc comment that over-claimed precedent from `orphan-receivers.ts` (that file's `ppid === 1` check has no `comm` verification and explicitly documents the gap, rather than resolving it).

Rejected (not a defect, or deliberately out of scope, with reasons in-code):
- `pm_id` is still trusted unconditionally — the same inheritance-based spoofing risk fixed for `INVOCATION_ID` is theoretically possible for `pm_id` too, but hasn't been observed (PM2-managed processes aren't typically used to host an interactive terminal the way the reported bug's web-terminal service was). Documented as a known asymmetry.
- Gating `isDirectSystemdChild()`'s /proc read behind `env.INVOCATION_ID` presence (avoids an unnecessary read on the common bare-terminal and boot paths) — applied, low-risk.
- A shared `readProcField(pid, field)` helper with `src/cli/manager.ts`'s cmdline reader — rejected: different contracts (that one falls back to `ps` for cross-platform support; this one deliberately fails closed), forcing a shared abstraction would be premature for two call sites.

Two new regression tests added, de-fix proven red on the pre-fix ordering. Full suite: 224/224 suites, 4029/4029 tests, exit 0.

---

## Review round 2 (independent `/code-review`)

Found and fixed 2 real issues:

1. **The `isDirectSystemdChild(1)` unit test asserted against the live `/proc/1/comm`** — only true on a systemd-based test host, false on most Docker devcontainers/CI runners (tini/dumb-init/s6 as pid 1). It was also the sole regression coverage for the exact `ppid === 1` bug round 1 fixed, which only manifests when pid 1 is *not* systemd — an environment the test itself couldn't produce. Fixed: `isDirectSystemdChild()` now accepts an injectable `readComm` reader (default: the real `/proc` read), so the no-special-casing behavior is proven deterministically regardless of host.
2. **The `hasTty`/`parentIsSystemd` signal-building block was duplicated verbatim** in `src/entry.ts` and `src/index.ts`. Extracted `resolveInvocationSignals()` into `command-names.ts`; both call sites use it now.

Acknowledged, not fixed (same reasoning as before, restated for this round):
- No end-to-end/real-binary test proves a *genuine* `ppid === 1` legacy-boot anymore (the old integration test only faked `INVOCATION_ID` via env var, with no way to prove the parent was actually systemd, so it wasn't real coverage of that case either) — genuine systemd ancestry can't be fabricated portably in CI. The new dependency-injected unit tests now cover the underlying logic deterministically instead; the wiring in `entry.ts`/`index.ts` is a single typechecked call to the now-shared `resolveInvocationSignals()`.
- `pm_id`/`PM2_HOME` still carry the same inheritance-based risk fixed for `INVOCATION_ID` — unobserved in practice, documented as a known asymmetry, deliberately out of scope.
- `isDirectSystemdChild()`'s /proc read runs twice on the entry.ts → `import('./index')` → index.ts boot path (index.ts re-classifies independently by design, for pre-split service units) — pre-existing duplication in the classification call itself, and the added cost is one gated, microsecond file read; not worth restructuring the dual-dispatch design for.

De-fix proof: reintroduced the pid-1 shortcut, the new injected-reader test failed red. Full suite: 224/224 suites, 4034/4034 tests, exit 0.