### PR TITLE
fix(cron,telegram): dedupe duplicate replies within a turn, notify on cron failure, fix long-output silent drop

### DIFF
--- a/mcp/tools/cron/module.ts
+++ b/mcp/tools/cron/module.ts
@@ -56,8 +56,8 @@ export class CronModule implements ToolModule {
             type: { type: 'string', enum: ['command', 'agent'], description: 'Job type' },
             command: { type: 'string', description: 'Shell command (type=command)' },
             prompt: { type: 'string', description: 'Agent prompt (type=agent)' },
-            telegram: { type: 'string', description: 'Telegram chat_id for response' },
-            discord: { type: 'string', description: 'Discord channel_id for agent response delivery' },
+            telegram: { type: 'string', description: 'Telegram chat_id for delivery — full response on success (type=agent), or a short failure notice on error (any type)' },
+            discord: { type: 'string', description: 'Discord channel_id for delivery — full response on success (type=agent), or a short failure notice on error (any type)' },
             timeout_ms: { type: 'number', description: 'Timeout in milliseconds' },
             scheduleKind: {
               type: 'string',
@@ -101,8 +101,8 @@ export class CronModule implements ToolModule {
             type: { type: 'string', enum: ['command', 'agent'], description: 'Job type' },
             command: { type: 'string', description: 'Shell command (type=command)' },
             prompt: { type: 'string', description: 'Agent prompt (type=agent)' },
-            telegram: { type: 'string', description: 'Telegram chat_id for response' },
-            discord: { type: 'string', description: 'Discord channel_id for agent response delivery' },
+            telegram: { type: 'string', description: 'Telegram chat_id for delivery — full response on success (type=agent), or a short failure notice on error (any type)' },
+            discord: { type: 'string', description: 'Discord channel_id for delivery — full response on success (type=agent), or a short failure notice on error (any type)' },
             timeout_ms: { type: 'number', description: 'Timeout in milliseconds' },
             scheduleKind: {
               type: 'string',

--- a/mcp/tools/telegram/module.ts
+++ b/mcp/tools/telegram/module.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { migrateAccess, defaultAccess } from './pure';
-import { chunkText, htmlToPlain } from './typing';
+import { chunkText, htmlToPlain, parseRepliedTurnId } from './typing';
 import { MAX_ATTACHMENT_BYTES } from '../shared/limits';
 import type {
   ChannelModule,
@@ -105,6 +105,10 @@ export class TelegramModule implements ChannelModule {
               type: 'string',
               enum: ['text', 'html'],
               description: "Rendering mode. 'html' accepts pre-rendered Telegram HTML. Raw Markdown is detected and converted automatically. Default: auto-detect Markdown or send plain text.",
+            },
+            allow_multiple: {
+              type: 'boolean',
+              description: 'Set true to send a second reply within the same turn (e.g. an image followed by a separate text message). Default false — a second call in the same turn is blocked to prevent re-announcing the same result.',
             },
           },
           required: ['chat_id', 'text'],
@@ -301,6 +305,7 @@ export class TelegramModule implements ChannelModule {
     const reply_to = args.reply_to != null ? Number(args.reply_to) : undefined;
     const files = (args.files as string[] | undefined) ?? [];
     const explicitFormat = args.format as string | undefined;
+    const allowMultiple = args.allow_multiple === true;
     const InputFile = this._InputFile;
 
     // Single source of truth for reply format detection (shared with receiver-server).
@@ -309,6 +314,27 @@ export class TelegramModule implements ChannelModule {
     const { sendText, parseMode } = this._resolveTelegramReplyFormat!(text, explicitFormat);
 
     this.assertAllowedChat(chat_id);
+
+    // Turn-scoped reply gate: block a second telegram_reply call in the same
+    // turn (the model re-announcing the same result) before hitting the
+    // Telegram API at all, unless the caller opts in via allow_multiple.
+    // Reuses the same turnId (the live typing-signal timestamp) and .replied
+    // marker already written below — a null turnId on either side never
+    // matches, favoring an extra delivery over a silently dropped one, same
+    // as isEntryAlreadyReplied() in typing.ts.
+    let turnId: string | null = null;
+    try {
+      turnId = fs.readFileSync(path.join(this.typingDir, chat_id), 'utf8').trim() || null;
+    } catch {}
+    if (!allowMultiple && turnId !== null) {
+      let repliedTurnId: string | null = null;
+      try {
+        repliedTurnId = parseRepliedTurnId(fs.readFileSync(path.join(this.typingDir, `${chat_id}.replied`), 'utf8'));
+      } catch {}
+      if (repliedTurnId === turnId) {
+        throw new Error('telegram_reply already sent a message this turn — pass allow_multiple: true to send another (e.g. an image followed by separate text) instead of re-announcing the same result');
+      }
+    }
 
     for (const f of files) {
       this.assertSendable(f);
@@ -367,13 +393,10 @@ export class TelegramModule implements ChannelModule {
     // this turn's id — the receiver (typing.ts) only treats a queued
     // auto-forward as "already replied" when its own turnId matches this one,
     // so a marker left over from an earlier turn can never suppress a later
-    // turn's forward (see typing.ts's isEntryAlreadyReplied()).
+    // turn's forward (see typing.ts's isEntryAlreadyReplied()). Reuses the
+    // turnId read at the top of this method (the gate check above).
     try {
       fs.mkdirSync(this.typingDir, { recursive: true });
-      let turnId: string | null = null;
-      try {
-        turnId = fs.readFileSync(path.join(this.typingDir, chat_id), 'utf8').trim() || null;
-      } catch {}
       fs.writeFileSync(path.join(this.typingDir, `${chat_id}.replied`), JSON.stringify({ text: sendText, turnId }));
     } catch {}
 

--- a/mcp/tools/telegram/typing.ts
+++ b/mcp/tools/telegram/typing.ts
@@ -313,7 +313,7 @@ export function parseForwardQueue(raw: string): ForwardEntry[] {
  * satisfies dedup, so a marker from a version predating this format degrades
  * to "deliver" rather than risking a silent drop.
  */
-function parseRepliedTurnId(raw: string): string | null {
+export function parseRepliedTurnId(raw: string): string | null {
   try {
     const parsed = JSON.parse(raw.trim()) as { turnId?: unknown }
     if (parsed && typeof parsed === 'object' && typeof parsed.turnId === 'string') {

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -33,13 +33,18 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const TELEGRAM_API_BASE = 'https://api.telegram.org';
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const DISCORD_MAX_MESSAGE_LENGTH = 2000;
+const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
+const FAILURE_NOTICE_ERROR_LENGTH = 300;
 
 interface StoreFormat {
   version: 1;
   jobs: CronJob[];
 }
 
-function chunkDiscordText(text: string, limit: number): string[] {
+// Generic word/line-boundary chunker for outbound notification text — used
+// by both sendTelegram() and sendDiscord() so long output doesn't get
+// silently rejected by either API's per-message length cap.
+function chunkPlainText(text: string, limit: number): string[] {
   if (text.length <= limit) return text.length === 0 ? [] : [text];
   const chunks: string[] = [];
   let rest = text;
@@ -468,18 +473,17 @@ export class CronManager extends EventEmitter {
       this.appendRunLog(job.id, runLog),
     ]);
 
-    // Deliver agent response to configured channels (independently; one failure must not block the other)
-    if (status === 'ok' && job.type === 'agent') {
-      const deliveries: Promise<void>[] = [];
-      if (job.telegram) {
-        deliveries.push(this.sendTelegram(job.agentId, job.telegram, runLog.output));
-      }
-      if (job.discord) {
-        deliveries.push(this.sendDiscord(job.agentId, job.discord, runLog.output));
-      }
-      if (deliveries.length > 0) {
-        await Promise.allSettled(deliveries);
-      }
+    // Deliver to configured channels (independently; one failure must not block the other).
+    // Agent-type jobs deliver the full response on success and a short failure
+    // notice on failure. Command-type jobs stay silent on success (unchanged —
+    // command output is not a "response" meant for chat) but still surface a
+    // short failure notice using the SAME telegram/discord fields, so a failing
+    // command job is no longer silent everywhere except the log.
+    if (job.type === 'agent') {
+      const text = status === 'ok' ? runLog.output : this.formatFailureNotice(job.name, error);
+      await this.deliverToConfiguredChannels(job, text);
+    } else if (status === 'error') {
+      await this.deliverToConfiguredChannels(job, this.formatFailureNotice(job.name, error));
     }
 
     this.emit('job:executed', job, runLog);
@@ -522,6 +526,24 @@ export class CronManager extends EventEmitter {
     return text;
   }
 
+  private async deliverToConfiguredChannels(job: CronJob, text: string): Promise<void> {
+    const deliveries: Promise<void>[] = [];
+    if (job.telegram) {
+      deliveries.push(this.sendTelegram(job.agentId, job.telegram, text));
+    }
+    if (job.discord) {
+      deliveries.push(this.sendDiscord(job.agentId, job.discord, text));
+    }
+    if (deliveries.length > 0) {
+      await Promise.allSettled(deliveries);
+    }
+  }
+
+  private formatFailureNotice(jobName: string, error: string | null): string {
+    const short = (error ?? 'unknown error').slice(0, FAILURE_NOTICE_ERROR_LENGTH);
+    return `cron '${jobName}' failed: ${short}`;
+  }
+
   private async sendTelegram(agentId: string, chatId: string, text: string): Promise<void> {
     const agentConfig = this.agentConfigs.get(agentId);
     const botToken = agentConfig?.telegram?.botToken;
@@ -531,20 +553,26 @@ export class CronManager extends EventEmitter {
       return;
     }
 
-    try {
-      const url = `${TELEGRAM_API_BASE}/bot${botToken}/sendMessage`;
-      const resp = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ chat_id: chatId, text }),
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (!resp.ok) {
-        const body = await resp.text();
-        this.logger.warn(`Telegram notify failed: ${resp.status} ${body}`, { chatId });
+    const url = `${TELEGRAM_API_BASE}/bot${botToken}/sendMessage`;
+    const chunks = chunkPlainText(text, TELEGRAM_MAX_MESSAGE_LENGTH);
+
+    for (const chunk of chunks) {
+      try {
+        const resp = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ chat_id: chatId, text: chunk }),
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!resp.ok) {
+          const body = await resp.text();
+          this.logger.warn(`Telegram notify failed: ${resp.status} ${body}`, { chatId });
+          return;
+        }
+      } catch (err) {
+        this.logger.warn(`Telegram notify error: ${(err as Error).message}`, { chatId });
+        return;
       }
-    } catch (err) {
-      this.logger.warn(`Telegram notify error: ${(err as Error).message}`, { chatId });
     }
   }
 
@@ -558,7 +586,7 @@ export class CronManager extends EventEmitter {
     }
 
     const url = `${DISCORD_API_BASE}/channels/${channelId}/messages`;
-    const chunks = chunkDiscordText(text, DISCORD_MAX_MESSAGE_LENGTH);
+    const chunks = chunkPlainText(text, DISCORD_MAX_MESSAGE_LENGTH);
 
     for (const content of chunks) {
       try {

--- a/src/cron/manager.ts
+++ b/src/cron/manager.ts
@@ -477,13 +477,22 @@ export class CronManager extends EventEmitter {
     // Agent-type jobs deliver the full response on success and a short failure
     // notice on failure. Command-type jobs stay silent on success (unchanged —
     // command output is not a "response" meant for chat) but still surface a
-    // short failure notice using the SAME telegram/discord fields, so a failing
+    // notice on failure using the SAME telegram/discord fields, so a failing
     // command job is no longer silent everywhere except the log.
     if (job.type === 'agent') {
       const text = status === 'ok' ? runLog.output : this.formatFailureNotice(job.name, error);
       await this.deliverToConfiguredChannels(job, text);
     } else if (status === 'error') {
-      await this.deliverToConfiguredChannels(job, this.formatFailureNotice(job.name, error));
+      // Command-type errors must NEVER echo the raw error text: runCommand()'s
+      // rejection embeds Node's exec message verbatim ("Command failed: <full
+      // command line>\n<stderr>") — and the command is a user-authored shell
+      // string that commonly embeds secrets (e.g. `curl -H "Authorization:
+      // Bearer $TOKEN"`). Unlike an agent-type error (an internal framework
+      // message), forwarding it to chat would leak the secret to whoever reads
+      // that Telegram chat/Discord channel. The full detail still lands in the
+      // run log (job.state.lastError / Run History) for the operator to inspect
+      // locally — only the chat notification is generic.
+      await this.deliverToConfiguredChannels(job, `cron '${job.name}' failed — see run history for details`);
     }
 
     this.emit('job:executed', job, runLog);

--- a/src/types.ts
+++ b/src/types.ts
@@ -551,8 +551,8 @@ export interface CronJob {
   type?: CronJobType;               // default: 'command'
   command?: string;                 // shell command (type=command)
   prompt?: string;                  // agent prompt (type=agent)
-  telegram?: string;                // chat_id to deliver agent response (type=agent, required)
-  discord?: string;                 // discord channel/user id to deliver agent response (type=agent)
+  telegram?: string;                // chat_id to deliver response (agent-type) or failure notices (any type)
+  discord?: string;                 // discord channel/user id to deliver response (agent-type) or failure notices (any type)
   timeoutMs?: number;               // execution timeout ms (default 120000)
   // Lifecycle
   deleteAfterRun?: boolean;         // auto-delete after first successful run

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -793,7 +793,7 @@ describe('T20-T23: Failure notifications for command-type jobs + Telegram chunki
     fetchMock.mockRestore();
   });
 
-  it('T20: type=command failure → Telegram receives a short failure notice', async () => {
+  it('T20: type=command failure → Telegram receives a generic failure notice (no error text echoed)', async () => {
     const { manager, agentId } = makeManager({ botToken: 'TOKEN123' });
     await manager.start();
 
@@ -815,12 +815,12 @@ describe('T20-T23: Failure notifications for command-type jobs + Telegram chunki
     expect(telegramCall).toBeDefined();
     const body = JSON.parse(telegramCall![1].body);
     expect(body.chat_id).toBe('12345');
-    expect(body.text).toContain("cron 'command-fail' failed:");
+    expect(body.text).toBe("cron 'command-fail' failed — see run history for details");
 
     manager.stop();
   });
 
-  it('T21: type=command failure → Discord receives a short failure notice too', async () => {
+  it('T21: type=command failure → Discord receives the same generic notice too', async () => {
     const { manager, agentId } = makeManager({ discordBotToken: 'DISC123' });
     await manager.start();
 
@@ -841,7 +841,48 @@ describe('T20-T23: Failure notifications for command-type jobs + Telegram chunki
     );
     expect(discordCall).toBeDefined();
     const body = JSON.parse(discordCall![1].body);
-    expect(body.content).toContain("cron 'command-fail-discord' failed:");
+    expect(body.content).toBe("cron 'command-fail-discord' failed — see run history for details");
+
+    manager.stop();
+  });
+
+  it('T20b: type=command failure never echoes the raw exec error — a secret embedded in the failing command is NOT forwarded to Telegram/Discord', async () => {
+    // Node's child_process.exec rejection embeds the full command line verbatim
+    // ("Command failed: <cmd>\n<stderr>") — a user-authored command commonly
+    // embeds secrets (e.g. an Authorization header). This proves the fix: the
+    // chat notification must be generic regardless of what the command or its
+    // output contained.
+    const { manager, agentId } = makeManager({ botToken: 'TOKEN123', discordBotToken: 'DISC123' });
+    await manager.start();
+
+    const secret = 'sk-super-secret-token-do-not-leak';
+    const job = await manager.create({
+      agentId,
+      name: 'command-fail-secret',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'command',
+      command: `echo "using ${secret}" 1>&2; exit 1`,
+      telegram: '12345',
+      discord: 'CHANNEL_123',
+    });
+
+    const log = await manager.run(job.id);
+    // The secret DOES land in the run log / lastError for local operator inspection...
+    expect(log.error).toContain(secret);
+
+    // ...but must never appear in what gets sent to chat.
+    const telegramCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('/sendMessage'),
+    );
+    const discordCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    const telegramBody = JSON.parse(telegramCall![1].body);
+    const discordBody = JSON.parse(discordCall![1].body);
+    expect(telegramBody.text).not.toContain(secret);
+    expect(discordBody.content).not.toContain(secret);
+    expect(telegramBody.text).toBe("cron 'command-fail-secret' failed — see run history for details");
 
     manager.stop();
   });

--- a/tests/unit/cron-manager.test.ts
+++ b/tests/unit/cron-manager.test.ts
@@ -476,7 +476,7 @@ describe('T11-T13: Telegram delivery', () => {
     manager.stop();
   });
 
-  it('T12: type=agent error → Telegram not called', async () => {
+  it('T12: type=agent error → Telegram receives a short failure notice (not silence, not the raw output)', async () => {
     const runner = {
       sendApiMessage: jest.fn().mockRejectedValue(new Error('agent failed')),
     };
@@ -498,7 +498,10 @@ describe('T11-T13: Telegram delivery', () => {
     const telegramCall = fetchMock.mock.calls.find((c) =>
       typeof c[0] === 'string' && (c[0] as string).includes('/sendMessage'),
     );
-    expect(telegramCall).toBeUndefined();
+    expect(telegramCall).toBeDefined();
+    const body = JSON.parse(telegramCall![1].body);
+    expect(body.chat_id).toBe('12345');
+    expect(body.text).toBe("cron 'agent-error' failed: agent failed");
 
     manager.stop();
   });
@@ -589,7 +592,7 @@ describe('T14-T19: Discord delivery', () => {
     manager.stop();
   });
 
-  it('T15: runner throws → Discord fetch not called', async () => {
+  it('T15: runner throws → Discord receives a short failure notice (not silence)', async () => {
     const runner = {
       sendApiMessage: jest.fn().mockRejectedValue(new Error('agent failed')),
     };
@@ -611,7 +614,9 @@ describe('T14-T19: Discord delivery', () => {
     const discordCall = fetchMock.mock.calls.find((c) =>
       typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
     );
-    expect(discordCall).toBeUndefined();
+    expect(discordCall).toBeDefined();
+    const body = JSON.parse(discordCall![1].body);
+    expect(body.content).toBe("cron 'discord-runner-fail' failed: agent failed");
 
     manager.stop();
   });
@@ -771,7 +776,137 @@ describe('T14-T19: Discord delivery', () => {
   });
 });
 
-// ─── Fix 1 regression tests ──────────────────────────────────────────────────
+// ─── T20-T23: Failure-visibility fix (command-type notify-on-fail + Telegram chunking) ──
+
+describe('T20-T23: Failure notifications for command-type jobs + Telegram chunking', () => {
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    } as Response);
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  it('T20: type=command failure → Telegram receives a short failure notice', async () => {
+    const { manager, agentId } = makeManager({ botToken: 'TOKEN123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'command-fail',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'command',
+      command: 'exit 1',
+      telegram: '12345',
+    });
+
+    await manager.run(job.id);
+
+    const telegramCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('/sendMessage'),
+    );
+    expect(telegramCall).toBeDefined();
+    const body = JSON.parse(telegramCall![1].body);
+    expect(body.chat_id).toBe('12345');
+    expect(body.text).toContain("cron 'command-fail' failed:");
+
+    manager.stop();
+  });
+
+  it('T21: type=command failure → Discord receives a short failure notice too', async () => {
+    const { manager, agentId } = makeManager({ discordBotToken: 'DISC123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'command-fail-discord',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'command',
+      command: 'exit 1',
+      discord: 'CHANNEL_123',
+    });
+
+    await manager.run(job.id);
+
+    const discordCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    expect(discordCall).toBeDefined();
+    const body = JSON.parse(discordCall![1].body);
+    expect(body.content).toContain("cron 'command-fail-discord' failed:");
+
+    manager.stop();
+  });
+
+  it('T22: type=command SUCCESS → stays silent (unchanged design — command output is not a chat response)', async () => {
+    const { manager, agentId } = makeManager({ botToken: 'TOKEN123', discordBotToken: 'DISC123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'command-ok',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'command',
+      command: 'echo hi',
+      telegram: '12345',
+      discord: 'CHANNEL_123',
+    });
+
+    const log = await manager.run(job.id);
+    expect(log.status).toBe('ok');
+
+    const telegramCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('/sendMessage'),
+    );
+    const discordCall = fetchMock.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('discord.com/api'),
+    );
+    expect(telegramCall).toBeUndefined();
+    expect(discordCall).toBeUndefined();
+
+    manager.stop();
+  });
+
+  it('T23: output longer than 4096 chars → chunked into multiple Telegram messages', async () => {
+    const longText = 'a'.repeat(4500);
+    const runner = makeRunner(longText);
+    const { manager, agentId } = makeManager({ runner, botToken: 'TOKEN123' });
+    await manager.start();
+
+    const job = await manager.create({
+      agentId,
+      name: 'telegram-chunked',
+      scheduleKind: 'cron',
+      schedule: '* * * * *',
+      type: 'agent',
+      prompt: 'hi',
+      telegram: '12345',
+    });
+
+    await manager.run(job.id);
+
+    const telegramCalls = fetchMock.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('/sendMessage'),
+    );
+    // output truncated to 5000 chars in runLog, then split into <=4096-char chunks
+    expect(telegramCalls.length).toBeGreaterThanOrEqual(2);
+    for (const call of telegramCalls) {
+      const body = JSON.parse(call[1].body);
+      expect(body.text.length).toBeLessThanOrEqual(4096);
+    }
+
+    manager.stop();
+  });
+});
 
 describe('Fix 1: at-job does not re-fire when lastRunAt is already set', () => {
   function writeStore(storePath: string, job: Record<string, unknown>) {

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -234,13 +234,19 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
   });
 
   it('T10: claude-gateway updated — plain process warning', async () => {
-    // Remove systemd/pm2 env vars to simulate plain process
+    // Remove systemd/pm2 env vars to simulate plain process. CLAUDE_GATEWAY_SUPERVISOR
+    // must be cleared too — packages.ts:165 treats it as authoritative over the raw
+    // markers (claimSupervisorEnv() sets it at boot), so a real supervised deployment's
+    // inherited value would otherwise force the "managed" branch regardless of the
+    // INVOCATION_ID/PM2_HOME/pm_id clearing below.
     const savedInvocationId = process.env.INVOCATION_ID;
     const savedPm2Home = process.env.PM2_HOME;
     const savedPmId = process.env.pm_id;
+    const savedSupervisor = process.env.CLAUDE_GATEWAY_SUPERVISOR;
     delete process.env.INVOCATION_ID;
     delete process.env.PM2_HOME;
     delete process.env.pm_id;
+    delete process.env.CLAUDE_GATEWAY_SUPERVISOR;
 
     let callCount = 0;
     mockExecSync.mockImplementation((cmd: unknown) => {
@@ -273,6 +279,7 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
     if (savedInvocationId !== undefined) process.env.INVOCATION_ID = savedInvocationId;
     if (savedPm2Home !== undefined) process.env.PM2_HOME = savedPm2Home;
     if (savedPmId !== undefined) process.env.pm_id = savedPmId;
+    if (savedSupervisor !== undefined) process.env.CLAUDE_GATEWAY_SUPERVISOR = savedSupervisor;
 
     // process.kill(pid, 'SIGTERM') should be scheduled
     jest.runAllTimers();

--- a/tests/unit/telegram-reply-dedup.test.ts
+++ b/tests/unit/telegram-reply-dedup.test.ts
@@ -15,13 +15,17 @@ import { TelegramModule } from '../../mcp/tools/telegram/module';
 import { normalizeTelegramLineBreaks, resolveTelegramReplyFormat } from '../../mcp/tools/telegram/pure';
 
 let tmp: string;
+let savedStateDir: string | undefined;
 
 beforeEach(() => {
   tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tgdedup-'));
+  savedStateDir = process.env.TELEGRAM_STATE_DIR;
 });
 
 afterEach(() => {
   fs.rmSync(tmp, { recursive: true, force: true });
+  if (savedStateDir !== undefined) process.env.TELEGRAM_STATE_DIR = savedStateDir;
+  else delete process.env.TELEGRAM_STATE_DIR;
 });
 
 function freshModule(stateDir: string): { mod: any; sendMessage: jest.Mock } {

--- a/tests/unit/telegram-reply-dedup.test.ts
+++ b/tests/unit/telegram-reply-dedup.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression tests for the telegram_reply turn-scoped dedup gate.
+ *
+ * Root cause: handleReply() had no gate before calling sendMessage — if the
+ * model called telegram_reply multiple times in one turn (e.g. re-announcing
+ * the same result), every call hit the real Telegram API. This mirrors the
+ * turnId already written into the `.replied` marker (shared with typing.ts's
+ * auto-forward dedup) but never checked by handleReply() itself.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { TelegramModule } from '../../mcp/tools/telegram/module';
+import { normalizeTelegramLineBreaks, resolveTelegramReplyFormat } from '../../mcp/tools/telegram/pure';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tgdedup-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function freshModule(stateDir: string): { mod: any; sendMessage: jest.Mock } {
+  process.env.TELEGRAM_STATE_DIR = stateDir;
+  const mod: any = new TelegramModule();
+  const sendMessage = jest.fn(async () => ({ message_id: Math.floor(Math.random() * 100000) }));
+  mod.bot = { api: { sendMessage } };
+  mod._normalizeTelegramLineBreaks = normalizeTelegramLineBreaks;
+  mod._resolveTelegramReplyFormat = resolveTelegramReplyFormat;
+
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, 'access.json'),
+    JSON.stringify({
+      dmPolicy: 'allowlist',
+      pairing: false,
+      allowFrom: ['c1', 'c2'],
+      groupPolicy: 'allowlist',
+      groupAllowlist: [],
+      requireMention: true,
+      pending: {},
+    }),
+  );
+  return { mod, sendMessage };
+}
+
+function setTurn(stateDir: string, chatId: string, turnId: string | null): void {
+  const typingDir = path.join(stateDir, 'typing');
+  fs.mkdirSync(typingDir, { recursive: true });
+  if (turnId === null) {
+    fs.rmSync(path.join(typingDir, chatId), { force: true });
+  } else {
+    fs.writeFileSync(path.join(typingDir, chatId), turnId);
+  }
+}
+
+describe('telegram_reply turn-scoped dedup gate', () => {
+  it('TD1: a second reply in the SAME turn is blocked before hitting the Telegram API', async () => {
+    const { mod, sendMessage } = freshModule(tmp);
+    setTurn(tmp, 'c1', '1000');
+
+    const r1 = await mod.handleReply({ chat_id: 'c1', text: 'done!' });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(r1.content[0].text).toMatch(/^sent/);
+
+    // Agent re-announces the same result, reworded — must be blocked, not sent.
+    await expect(
+      mod.handleReply({ chat_id: 'c1', text: 'done again! (reworded)' }),
+    ).rejects.toThrow(/already sent a message this turn/);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('TD2: allow_multiple:true permits a second reply in the same turn', async () => {
+    const { mod, sendMessage } = freshModule(tmp);
+    setTurn(tmp, 'c1', '1000');
+
+    await mod.handleReply({ chat_id: 'c1', text: 'here is an image' });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    const r2 = await mod.handleReply({
+      chat_id: 'c1',
+      text: 'and some context',
+      allow_multiple: true,
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(r2.content[0].text).toMatch(/^sent/);
+  });
+
+  it('TD3: a reply in a NEW turn (turn signal changed) is allowed again', async () => {
+    const { mod, sendMessage } = freshModule(tmp);
+    setTurn(tmp, 'c1', '1000');
+    await mod.handleReply({ chat_id: 'c1', text: 'turn 1 result' });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    setTurn(tmp, 'c1', '2000'); // a new turn started
+    const r2 = await mod.handleReply({ chat_id: 'c1', text: 'turn 2 result' });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(r2.content[0].text).toMatch(/^sent/);
+  });
+
+  it('TD4: no active turn signal (turnId null, e.g. an autonomous reply) is never blocked', async () => {
+    const { mod, sendMessage } = freshModule(tmp);
+    setTurn(tmp, 'c1', null); // no live typing-signal file
+
+    await mod.handleReply({ chat_id: 'c1', text: 'first' });
+    await mod.handleReply({ chat_id: 'c1', text: 'second' });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('TD5: a FAILED first send does not block the retry (mark-after-success)', async () => {
+    const { mod, sendMessage } = freshModule(tmp);
+    setTurn(tmp, 'c1', '1000');
+    sendMessage.mockRejectedValueOnce(new Error('transient telegram failure'));
+
+    await expect(mod.handleReply({ chat_id: 'c1', text: 'hello' })).rejects.toThrow(/reply failed/);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    const r2 = await mod.handleReply({ chat_id: 'c1', text: 'hello retry' });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(r2.content[0].text).toMatch(/^sent/);
+  });
+
+  it('TD6: dedup is per-chat — a different chat in the same turn is not blocked', async () => {
+    const { mod, sendMessage } = freshModule(tmp);
+    setTurn(tmp, 'c1', '1000');
+    setTurn(tmp, 'c2', '1000');
+
+    await mod.handleReply({ chat_id: 'c1', text: 'for chat 1' });
+    const r2 = await mod.handleReply({ chat_id: 'c2', text: 'for chat 2' });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(r2.content[0].text).toMatch(/^sent/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #418. Three related fixes, bundled into one PR per the issue:

- **`telegram_reply` turn-scoped dedup gate** (`mcp/tools/telegram/module.ts`): a second `telegram_reply` call in the same turn is now blocked before hitting the Telegram API, unless `allow_multiple: true` is passed. Reuses the turnId already written for `typing.ts`'s auto-forward dedup (`parseRepliedTurnId` is now exported and reused instead of duplicated).
- **Cron failure notifications** (`src/cron/manager.ts`): `type: 'agent'` jobs now deliver a short failure notice on error (previously only success was ever delivered); `type: 'command'` jobs now also deliver a short failure notice on error while remaining silent on success (unchanged design).
- **Telegram chunking** (`src/cron/manager.ts`): `sendTelegram()` now chunks output the same way `sendDiscord()` already did (`chunkDiscordText` renamed to `chunkPlainText` since the implementation was always generic, and is now shared by both).
- Also fixes a pre-existing, environment-dependent gap in `tests/unit/packages-router.test.ts` T10: it cleared `INVOCATION_ID`/`PM2_HOME`/`pm_id` but not `CLAUDE_GATEWAY_SUPERVISOR`, which `src/api/packages.ts:165` also treats as authoritative — the test failed in any environment that inherits that var from a real supervised deployment.

## Test plan

- [x] `tests/unit/telegram-reply-dedup.test.ts` (new): 6 cases — same-turn block, `allow_multiple` opt-in, new-turn allowed, null-turnId never blocked, failed-send doesn't block retry, per-chat isolation. Confirmed TD1 fails on the pre-fix code (reverted `module.ts`/`typing.ts` and re-ran).
- [x] `tests/unit/cron-manager.test.ts`: updated T12/T15 (agent failure now delivers a notice instead of asserting silence) and added T20-T23 (command-type failure notify, command-type success stays silent, Telegram chunking). Confirmed all 5 fail on the pre-fix `manager.ts`.
- [x] `npm run typecheck` clean.
- [x] `npm test` — full suite, 4032/4032 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
