### PR TITLE
fix(runner): deliver the final message when a turn's second reply is rejected (#422)

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1654,7 +1654,11 @@ export class AgentRunner extends EventEmitter {
                   }
                 }
                 if (block.type === 'tool_use' && block.name === replyToolName) {
-                  const replyBlockId = (block as Record<string, unknown>)['id'] as string ?? null;
+                  // The block comes off the CLI's stdout — validate the id rather
+                  // than casting, so a malformed one degrades to the flag check
+                  // instead of poisoning the Set with a non-string key.
+                  const rawBlockId = (block as Record<string, unknown>)['id'];
+                  const replyBlockId = typeof rawBlockId === 'string' && rawBlockId ? rawBlockId : null;
                   // Skip a re-emitted snapshot of a block already handled. Blocks
                   // with no id fall back to the old flag check, which is the best
                   // dedup available without an id.

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1571,6 +1571,17 @@ export class AgentRunner extends EventEmitter {
       // Auto-forward result text to channel if agent didn't call reply tool.
       let replyCalled = false;
       let replyToolUseId: string | null = null; // track id to detect failed tool calls
+      // Reply tool_use blocks re-appear across cumulative `assistant` snapshots
+      // exactly like line_image ones, so a repeat is skipped by block id rather
+      // than by `replyCalled`. Gating on the flag also froze `replyToolUseId` on
+      // the turn's FIRST reply call, so a LATER call's failure never matched the
+      // unblock below and the turn's final message was dropped silently (#422).
+      const seenReplyToolIds = new Set<string>();
+      // Set when a reply tool call failed this turn. The fallback forward must
+      // then reach the channel even though an EARLIER successful reply in the
+      // same turn already wrote a `.replied` marker carrying this turn's id —
+      // see writeAutoForward()'s forceDeliver argument.
+      let replySendFailed = false;
       // line_image tool_use blocks re-appear across cumulative `assistant` stream
       // snapshots (--include-partial-messages), so dedupe history inserts by the
       // block id — otherwise one sent image lands in the transcript N times and
@@ -1642,9 +1653,17 @@ export class AgentRunner extends EventEmitter {
                     });
                   }
                 }
-                if (block.type === 'tool_use' && block.name === replyToolName && !replyCalled) {
+                if (block.type === 'tool_use' && block.name === replyToolName) {
+                  const replyBlockId = (block as Record<string, unknown>)['id'] as string ?? null;
+                  // Skip a re-emitted snapshot of a block already handled. Blocks
+                  // with no id fall back to the old flag check, which is the best
+                  // dedup available without an id.
+                  const alreadyHandled =
+                    replyBlockId !== null ? seenReplyToolIds.has(replyBlockId) : replyCalled;
+                  if (alreadyHandled) continue;
+                  if (replyBlockId !== null) seenReplyToolIds.add(replyBlockId);
                   replyCalled = true;
-                  replyToolUseId = (block as Record<string, unknown>)['id'] as string ?? null;
+                  replyToolUseId = replyBlockId;
                   // Persist the reply text to history so it appears in chat history API
                   const replyText = typeof block.input?.['text'] === 'string' ? block.input['text'].trim() : '';
                   // Capture any images the reply attached (reply tool's `files`)
@@ -1685,6 +1704,7 @@ export class AgentRunner extends EventEmitter {
                 if (block.type === 'tool_result' && block.tool_use_id === replyToolUseId && block.is_error) {
                   replyCalled = false;
                   replyToolUseId = null;
+                  replySendFailed = true;
                 }
               }
             }
@@ -1801,10 +1821,12 @@ export class AgentRunner extends EventEmitter {
             // Detect Anthropic API socket drop — Claude CLI emits this as is_error:false
             // with "API Error: The socket connection was closed unexpectedly". The error
             // bypasses the replyCalled gate so the user always gets notified, even when
-            // the agent already called the reply tool earlier in the same turn.
+            // the agent already called the reply tool earlier in the same turn — hence
+            // forceDeliver, or that earlier reply's `.replied` marker would dedup this
+            // notice away and defeat the bypass (#422).
             const isSocketError = !proc.queryMode && resultText.includes(ANTHROPIC_SOCKET_ERROR);
             if (isSocketError) {
-              this.writeAutoForward(mapKey, '⚡ Connection to Anthropic API dropped. Please resend your message.');
+              this.writeAutoForward(mapKey, '⚡ Connection to Anthropic API dropped. Please resend your message.', 'text', true);
             }
             // Bug B: headless (claude --print) reports a too-large request as a
             // synthetic `result` (is_error + "Request too large (max"), NOT as the
@@ -1870,9 +1892,9 @@ export class AgentRunner extends EventEmitter {
                 // Telegram HTML entities — Slack has its own mrkdwn format and
                 // would display these tags literally, so Slack skips this and
                 // falls through to the plain-text branch below.
-                this.writeAutoForward(mapKey, toTelegramHtml(channelText), 'html');
+                this.writeAutoForward(mapKey, toTelegramHtml(channelText), 'html', replySendFailed);
               } else {
-                this.writeAutoForward(mapKey, channelText);
+                this.writeAutoForward(mapKey, channelText, 'text', replySendFailed);
               }
               // Assistant output reached the channel — mark the turn delivered so
               // a later recovery does not resend a message that was answered (C1).
@@ -1881,6 +1903,8 @@ export class AgentRunner extends EventEmitter {
             }
             replyCalled = false; // reset for next turn
             replyToolUseId = null;
+            replySendFailed = false;
+            seenReplyToolIds.clear();
             seenLineImageIds.clear();
             pendingLineImageMedia.clear();
             menuSentThisTurn = false;
@@ -2661,7 +2685,7 @@ export class AgentRunner extends EventEmitter {
     this.pendingRestarts.add(chatId);
   }
 
-  private writeAutoForward(chatId: string, text: string, format: 'text' | 'html' = 'text'): void {
+  private writeAutoForward(chatId: string, text: string, format: 'text' | 'html' = 'text', forceDeliver = false): void {
     // LINE has no .forward consumer — route through LineReplyManager's push path.
     if (this.channelFor(chatId) === 'line') {
       if (this.lineReply) void this.lineReply.onAnswer(chatId, text);
@@ -2696,6 +2720,11 @@ export class AgentRunner extends EventEmitter {
       // state) must both reach the user, not have the second clobber the
       // first. turnId is the live typing-signal timestamp — the receiver uses
       // it to scope the `.replied` dedup marker to the turn that wrote it.
+      // forceDeliver writes a null turnId instead: `isEntryAlreadyReplied()`
+      // never matches a null on either side, so the entry survives a `.replied`
+      // marker left by an EARLIER successful reply in this same turn. Used for
+      // text that is NOT the one that marker covers — a fallback forward after a
+      // reply call failed, and the socket-drop notice (#422).
       let entries: Array<{ text: string; format: string; turnId: string | null }> = [];
       try {
         const raw = fs.readFileSync(forwardPath, 'utf8').trim();
@@ -2712,7 +2741,7 @@ export class AgentRunner extends EventEmitter {
       } catch {
         // No existing file — fresh queue.
       }
-      entries.push({ text, format, turnId: this.readCurrentTurnId(chatId) });
+      entries.push({ text, format, turnId: forceDeliver ? null : this.readCurrentTurnId(chatId) });
       // Atomic write (tmp + rename): the receiver polls this directory on
       // every typing tick, so a non-atomic write could be read mid-flush.
       const tmpPath = `${forwardPath}.tmp`;

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -3522,14 +3522,16 @@ describe('AgentRunner — Discord-aware auto-forward format (US-005)', () => {
     expect(session).toBeDefined();
 
     const writeForwardSpy = jest.spyOn(
-      runner as unknown as { writeAutoForward: (chatId: string, text: string, format?: string) => void },
+      runner as unknown as { writeAutoForward: (chatId: string, text: string, format?: string, forceDeliver?: boolean) => void },
       'writeAutoForward',
     );
 
     session!.emit('output', JSON.stringify({ type: 'result', result: '**bold** and `code`' }));
     await new Promise(r => setTimeout(r, 100));
 
-    expect(writeForwardSpy).toHaveBeenCalledWith('ch:disc01', '**bold** and `code`');
+    // No reply call failed this turn, so the forward is NOT force-delivered
+    // (#422) — it keeps the turn id the receiver dedups against.
+    expect(writeForwardSpy).toHaveBeenCalledWith('ch:disc01', '**bold** and `code`', 'text', false);
   }, 15000);
 
   // US5-02: Telegram result text with markdown is converted to HTML
@@ -3547,7 +3549,7 @@ describe('AgentRunner — Discord-aware auto-forward format (US-005)', () => {
     expect(session).toBeDefined();
 
     const writeForwardSpy = jest.spyOn(
-      runner as unknown as { writeAutoForward: (chatId: string, text: string, format?: string) => void },
+      runner as unknown as { writeAutoForward: (chatId: string, text: string, format?: string, forceDeliver?: boolean) => void },
       'writeAutoForward',
     );
 
@@ -3558,6 +3560,7 @@ describe('AgentRunner — Discord-aware auto-forward format (US-005)', () => {
       'ch:tg01',
       expect.stringContaining('<b>'),
       'html',
+      false,
     );
   }, 15000);
 
@@ -3576,14 +3579,14 @@ describe('AgentRunner — Discord-aware auto-forward format (US-005)', () => {
     expect(session).toBeDefined();
 
     const writeForwardSpy = jest.spyOn(
-      runner as unknown as { writeAutoForward: (chatId: string, text: string, format?: string) => void },
+      runner as unknown as { writeAutoForward: (chatId: string, text: string, format?: string, forceDeliver?: boolean) => void },
       'writeAutoForward',
     );
 
     session!.emit('output', JSON.stringify({ type: 'result', result: 'plain text no markdown' }));
     await new Promise(r => setTimeout(r, 100));
 
-    expect(writeForwardSpy).toHaveBeenCalledWith('ch:tg02', 'plain text no markdown');
+    expect(writeForwardSpy).toHaveBeenCalledWith('ch:tg02', 'plain text no markdown', 'text', false);
   }, 15000);
 
   // US5-04: per-chat image counters are independent across chatIds
@@ -4953,5 +4956,199 @@ describe('AgentRunner — gateway turn queue, coalesce, and /stop', () => {
           .some((w: string) => w.includes('<channel') && w.includes('second')),
     );
     expect(liveGotSecond).toBe(true);
+  }, 15000);
+});
+
+// ── Silent drop: the turn's SECOND reply call is rejected (Issue #422) ────────
+// A long turn that posts an interim progress update and then a final report gets
+// its final `telegram_reply` rejected by the turn-scoped guard in
+// mcp/tools/telegram/module.ts ("already sent a message this turn"). Two runner
+// bugs then swallowed the final text entirely:
+//   1. the reply tool_use handler was gated on `!replyCalled`, so
+//      `replyToolUseId` froze on the turn's FIRST call — the failing SECOND
+//      call's tool_result never matched, `replyCalled` stayed true, and the
+//      result-forwarding fallback (`!replyCalled`) never fired;
+//   2. even once it does fire, the `.forward` entry carries the live turn id,
+//      which equals the one in the `.replied` marker the earlier successful
+//      reply left — so the receiver's `isEntryAlreadyReplied()` would drop it.
+// The fix dedups reply tool_use blocks by block id and force-delivers the
+// fallback forward (null turnId) when a reply call failed this turn.
+describe('AgentRunner — reply failure after an earlier reply in the same turn (#422)', () => {
+  let tmpDir: string;
+  let agentConfig: AgentConfig;
+  let gatewayConfig: GatewayConfig;
+  let runner: AgentRunner;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ar-422-'));
+    const workspace = path.join(tmpDir, 'agents', 'alfred', 'workspace');
+    agentConfig = makeAgentConfig(workspace);
+    fs.mkdirSync(workspace, { recursive: true });
+    gatewayConfig = makeGatewayConfig();
+    allProcesses.length = 0;
+    (require('child_process').spawn as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    if (runner) await runner.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  function typingDir(): string {
+    return path.join(agentConfig.workspace, '.telegram-state', 'typing');
+  }
+
+  const replyToolUse = (toolUseId: string, text: string) =>
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'tool_use',
+          id: toolUseId,
+          name: 'mcp__gateway__telegram_reply',
+          input: { chat_id: 'x', text },
+        }],
+      },
+    });
+
+  const replyResult = (toolUseId: string, isError: boolean) =>
+    JSON.stringify({
+      type: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: toolUseId, is_error: isError }],
+      },
+    });
+
+  const turnResult = (text: string) =>
+    JSON.stringify({ type: 'result', is_error: false, result: text });
+
+  /**
+   * Start a session and plant the live typing-signal file the receiver writes
+   * for an in-flight turn — that file IS the turn id both `.replied` and
+   * `.forward` markers are stamped with.
+   */
+  async function startTurn(chatId: string, turnId: string): Promise<SessionProcess> {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    await sendChannelPost(getCallbackPort(runner), chatId, 'run the long task');
+    await waitForSession(runner, chatId);
+    fs.mkdirSync(typingDir(), { recursive: true });
+    fs.writeFileSync(path.join(typingDir(), chatId), turnId);
+    return getSessions(runner).get(chatId)!;
+  }
+
+  /** The `.replied` marker the MCP reply tool writes (in its own process). */
+  function writeRepliedMarker(chatId: string, text: string, turnId: string): void {
+    fs.writeFileSync(
+      path.join(typingDir(), `${chatId}.replied`),
+      JSON.stringify({ text, turnId }),
+    );
+  }
+
+  function forwardEntries(chatId: string): Array<{ text: string; format: string; turnId: string | null }> | null {
+    const p = path.join(typingDir(), `${chatId}.forward`);
+    if (!fs.existsSync(p)) return null;
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  }
+
+  // The core regression. Pre-fix there is no `.forward` file at all.
+  it('delivers the final text when the turn\'s second reply call is rejected', async () => {
+    const chatId = 'chat:422-core';
+    const turnId = '1755000000000';
+    const session = await startTurn(chatId, turnId);
+
+    // Interim progress update — succeeds, and leaves a `.replied` marker
+    // stamped with this turn's id (what the guard later trips on).
+    session.emit('output', replyToolUse('toolu_first', 'working on it, this will take a while'));
+    session.emit('output', replyResult('toolu_first', false));
+    writeRepliedMarker(chatId, 'working on it, this will take a while', turnId);
+
+    // Final report — the turn-scoped guard rejects it.
+    session.emit('output', replyToolUse('toolu_second', 'all done, everything is deployed'));
+    session.emit('output', replyResult('toolu_second', true));
+
+    session.emit('output', turnResult('all done, everything is deployed'));
+    await new Promise(r => setTimeout(r, 100));
+
+    const entries = forwardEntries(chatId);
+    expect(entries).not.toBeNull();
+    expect(entries!.map(e => e.text).join('\n')).toContain('all done, everything is deployed');
+    // Null turn id is what keeps the receiver from deduping this entry against
+    // the interim reply's `.replied` marker — `isEntryAlreadyReplied()` never
+    // matches a null on either side.
+    expect(entries![0]!.turnId).toBeNull();
+    expect(entries![0]!.turnId).not.toBe(turnId);
+  }, 15000);
+
+  // Guard against over-correcting: a turn with no reply failure must still stamp
+  // the real turn id, or the receiver loses its dedup against a `.replied` marker.
+  it('keeps the real turn id on a fallback forward when no reply call failed', async () => {
+    const chatId = 'chat:422-normal';
+    const turnId = '1755000000001';
+    const session = await startTurn(chatId, turnId);
+
+    session.emit('output', turnResult('here is the plain answer'));
+    await new Promise(r => setTimeout(r, 100));
+
+    const entries = forwardEntries(chatId);
+    expect(entries).not.toBeNull();
+    expect(entries![0]!.turnId).toBe(turnId);
+  }, 15000);
+
+  // The socket-drop notice deliberately bypasses the `replyCalled` gate. Without
+  // force-delivery an earlier reply's `.replied` marker would dedup it away and
+  // defeat that bypass — the user would never learn the connection dropped.
+  it('force-delivers the socket-drop notice past an earlier reply in the same turn', async () => {
+    const chatId = 'chat:422-socket';
+    const turnId = '1755000000002';
+    const session = await startTurn(chatId, turnId);
+
+    session.emit('output', replyToolUse('toolu_ok', 'starting now'));
+    session.emit('output', replyResult('toolu_ok', false));
+    writeRepliedMarker(chatId, 'starting now', turnId);
+
+    session.emit('output', turnResult('API Error: The socket connection was closed unexpectedly'));
+    await new Promise(r => setTimeout(r, 100));
+
+    const entries = forwardEntries(chatId);
+    expect(entries).not.toBeNull();
+    const notice = entries!.find(e => e.text.includes('Connection to Anthropic API dropped'));
+    expect(notice).toBeDefined();
+    expect(notice!.turnId).toBeNull();
+  }, 15000);
+
+  // Reply tool_use blocks are now deduped by block id rather than by the
+  // `replyCalled` flag, so a re-emitted cumulative snapshot must not double-post.
+  it('writes one history row when the same reply tool_use block is re-emitted', async () => {
+    const chatId = 'chat:422-snapshot';
+    const session = await startTurn(chatId, '1755000000003');
+
+    session.emit('output', replyToolUse('toolu_dup', 'the one and only answer'));
+    session.emit('output', replyToolUse('toolu_dup', 'the one and only answer')); // snapshot repeat
+    await new Promise(r => setTimeout(r, 50));
+
+    const rows = (runner.getHistoryDb().getMessages(`telegram-${chatId}`).messages as Array<{ role: string; content: string }>)
+      .filter(m => m.role === 'assistant' && m.content === 'the one and only answer');
+    expect(rows).toHaveLength(1);
+  }, 15000);
+
+  // Two distinct reply calls that both succeed must each land in history — the
+  // id-based dedup must not collapse them the way the old flag check did.
+  it('writes both history rows when a turn makes two distinct successful reply calls', async () => {
+    const chatId = 'chat:422-two-ok';
+    const session = await startTurn(chatId, '1755000000004');
+
+    session.emit('output', replyToolUse('toolu_a', 'interim update'));
+    session.emit('output', replyResult('toolu_a', false));
+    session.emit('output', replyToolUse('toolu_b', 'final report'));
+    session.emit('output', replyResult('toolu_b', false));
+    await new Promise(r => setTimeout(r, 50));
+
+    const contents = (runner.getHistoryDb().getMessages(`telegram-${chatId}`).messages as Array<{ role: string; content: string }>)
+      .filter(m => m.role === 'assistant')
+      .map(m => m.content);
+    expect(contents).toContain('interim update');
+    expect(contents).toContain('final report');
   }, 15000);
 });


### PR DESCRIPTION
## Problem

A long turn that posts an interim progress update and then a final report loses the final text entirely — the user sees silence and assumes the agent hung.

Observed timeline from a real session (single turn, no turn boundary in between):

| time | event |
|---|---|
| 05:34:48 | inbound message → new turn, turn id `T` |
| 05:36:58 | interim progress reply → sent, writes `.replied` tagged `T` |
| 06:13:40 | final completion report → `telegram_reply failed: already sent a message this turn` |
| 06:13:50 | turn ends — the final text never reaches the channel |

Recovery was luck-dependent: sometimes the model retried with `allow_multiple: true`, sometimes it just emitted plain text, which never left the process.

## Root cause

Three layers had to line up:

1. **`mcp/tools/telegram/module.ts`** — the turn-scoped gate rejects any second `telegram_reply` in a turn without `allow_multiple: true`. This is intentional (PR #419, stops re-announcing the same result) and is **not** changed here.
2. **`src/agent/runner.ts`** — the reply `tool_use` handler was gated on `!replyCalled`, so `replyToolUseId` froze on the turn's **first** reply call. The failing **second** call's `tool_result` never matched it, `replyCalled` stayed `true`, and the result-forwarding fallback (`!replyCalled`) never fired. No `.forward` entry was written at all.
3. **`mcp/tools/telegram/typing.ts`** — even once the fallback fires, the `.forward` entry carries the live turn id, which is the same id in the `.replied` marker the earlier successful reply left. `isEntryAlreadyReplied()` would discard it.

The same layer-3 problem silently defeated a second, unrelated safety net: the Anthropic socket-drop notice deliberately bypasses the `replyCalled` gate, but was deduped away whenever a reply had already succeeded in that turn.

## Fix

Runner-only, `src/agent/runner.ts` (+45/−8):

- Dedupe reply `tool_use` blocks by **block id** (`seenReplyToolIds`) instead of by the `replyCalled` flag — mirroring how `line_image` already handles cumulative assistant snapshots. `replyToolUseId` now tracks the latest reply call, so the error-unblock matches. Blocks with no id fall back to the old flag check.
- Track `replySendFailed` for the turn and pass it to `writeAutoForward` as `forceDeliver`, which stamps a **null** turnId. `isEntryAlreadyReplied()` never matches a null on either side, so the fallback survives the earlier reply's `.replied` marker.
- Apply the same `forceDeliver` to the socket-drop notice, restoring its intended bypass.

### Non-goals

- **Not** relaxing the `module.ts` guard — that would undo PR #419's dedup. The guard keeps rejecting the second reply; the runner just stops losing the text when it does.
- `forceDeliver` defaults to `false`, so every other `writeAutoForward` caller keeps the real turn id and its existing dedup.

## Tests

`tests/unit/agent-runner.test.ts` — new describe block, 5 tests. Verified against the pre-fix `runner.ts`: **3 of the 5 fail**, 2 pass (those two are the guards that the fix does not regress existing behavior).

| test | pre-fix |
|---|---|
| delivers the final text when the turn's second reply call is rejected | ✗ fails (no `.forward` at all) |
| force-delivers the socket-drop notice past an earlier reply in the same turn | ✗ fails (real turn id → deduped) |
| writes both history rows when a turn makes two distinct successful reply calls | ✗ fails (second row dropped) |
| keeps the real turn id on a fallback forward when no reply call failed | ✓ passes (anti-over-correction guard) |
| writes one history row when the same reply tool_use block is re-emitted | ✓ passes (snapshot-dedup guard) |

The US-005 auto-forward spies are updated for the new explicit `format` / `forceDeliver` arguments; their assertions are unchanged in intent.

## Verification

- `npm run typecheck` — clean
- `npm test -- --ci` — **4050 passed / 4050 total**, 225 suites, 0 failures

Fixes #422
