### PR TITLE
fix(config): refresh per-agent .env files before every config reload (#427)

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Each key has a `key` string (supports `${ENV_VAR}` interpolation), an optional `
 
 ### Bot tokens
 
-Tokens are stored per-agent at `~/.claude-gateway/agents/<id>/.env` and auto-loaded at startup **and before every config reload** — so an agent added to `config.json` while the gateway is running starts without a restart, even though its token only exists in a brand-new `.env`. Use `${AGENT_BOT_TOKEN}` syntax in config to reference them, or set them as shell environment variables.
+Tokens are stored per-agent at `~/.claude-gateway/agents/<id>/.env` and auto-loaded at startup **and before every config reload** — so an agent added to `config.json` while the gateway is running starts without a restart, even though its token only exists in a brand-new `.env`. Use `${AGENT_BOT_TOKEN}` syntax in config to reference them, or set them as shell environment variables. Lines are `KEY=value`; `#` comments and blank lines are ignored, and surrounding quotes are stripped, the same as in `~/.claude-gateway/.env`.
 
 A variable you exported yourself always wins over the `.env` file and is never replaced by a reload. A token the gateway did read from a `.env` is refreshed when that file changes, so **rotating a token takes effect on the next config reload** rather than at the next restart. Note that only `config.json` is watched — editing a `.env` by hand applies on the following reload, while the MCP `agent_create` / `agent_update` tools write both files and so take effect immediately. If a `${VAR}` cannot be resolved from anywhere, that one agent is skipped — the rest of the gateway starts normally — and the skip is logged to `logs/gateway.log` with the name of the missing variable.
 

--- a/README.md
+++ b/README.md
@@ -571,7 +571,9 @@ Each key has a `key` string (supports `${ENV_VAR}` interpolation), an optional `
 
 ### Bot tokens
 
-Tokens are stored per-agent at `~/.claude-gateway/agents/<id>/.env` and auto-loaded at startup. Use `${AGENT_BOT_TOKEN}` syntax in config to reference them, or set them as shell environment variables.
+Tokens are stored per-agent at `~/.claude-gateway/agents/<id>/.env` and auto-loaded at startup **and before every config reload** — so an agent added to `config.json` while the gateway is running starts without a restart, even though its token only exists in a brand-new `.env`. Use `${AGENT_BOT_TOKEN}` syntax in config to reference them, or set them as shell environment variables.
+
+A variable already present in the environment always wins over the `.env` file, so a token you exported yourself is never replaced by a reload. If a `${VAR}` cannot be resolved from anywhere, that one agent is skipped — the rest of the gateway starts normally — and the skip is logged to `logs/gateway.log` with the name of the missing variable.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Each key has a `key` string (supports `${ENV_VAR}` interpolation), an optional `
 
 Tokens are stored per-agent at `~/.claude-gateway/agents/<id>/.env` and auto-loaded at startup **and before every config reload** — so an agent added to `config.json` while the gateway is running starts without a restart, even though its token only exists in a brand-new `.env`. Use `${AGENT_BOT_TOKEN}` syntax in config to reference them, or set them as shell environment variables.
 
-A variable already present in the environment always wins over the `.env` file, so a token you exported yourself is never replaced by a reload. If a `${VAR}` cannot be resolved from anywhere, that one agent is skipped — the rest of the gateway starts normally — and the skip is logged to `logs/gateway.log` with the name of the missing variable.
+A variable you exported yourself always wins over the `.env` file and is never replaced by a reload. A token the gateway did read from a `.env` is refreshed when that file changes, so **rotating a token takes effect on the next config reload** rather than at the next restart. Note that only `config.json` is watched — editing a `.env` by hand applies on the following reload, while the MCP `agent_create` / `agent_update` tools write both files and so take effect immediately. If a `${VAR}` cannot be resolved from anywhere, that one agent is skipped — the rest of the gateway starts normally — and the skip is logged to `logs/gateway.log` with the name of the missing variable.
 
 ---
 

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -9,6 +9,7 @@ import { Server } from 'http';
 import { WebSocketServer, WebSocket, type RawData } from 'ws';
 import { AgentRunner } from '../agent/runner';
 import { AgentConfig, AgentStats, ApiKey, GatewayConfig, HeartbeatResult } from '../types';
+import { agentsDirForConfig } from '../config/agent-env';
 import { ptyStreamRegistry } from '../shell/pty-stream-registry';
 import { shouldRoutePtyInput, MAX_PTY_INPUT_BYTES } from '../shell/control-channel';
 import { getWatcherHealth } from '../watch/factory';
@@ -369,9 +370,7 @@ export class GatewayRouter {
    */
   /** Filesystem root holding per-agent workspaces: <config-dir>/agents (or ~/.claude-gateway/agents). */
   private agentsRoot(): string {
-    return this.configPath
-      ? path.join(path.dirname(this.configPath), 'agents')
-      : path.join(os.homedir(), '.claude-gateway', 'agents');
+    return agentsDirForConfig(this.configPath);
   }
 
   private requireDashOrApiKey(req: Request, res: Response): boolean {

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -8,6 +8,7 @@ import { spawn } from 'child_process';
 import { AgentRunner } from '../agent/runner';
 import { callbackSink, errorCode, type ApiStreamCallbacks } from '../agent/turn-stream';
 import { AgentConfig, ApiKey, ImageParams, ModelConfig } from '../types';
+import { agentsDirForConfig } from '../config/agent-env';
 import { createApiAuthMiddleware, canAccessAgent, canWriteAgent, isAdmin } from './auth';
 import { MediaStore } from '../history/media-store';
 import { HistoryDB, MAX_HISTORY_LIMIT } from '../history/db';
@@ -898,9 +899,7 @@ export function createApiRouter(
   // ──────────────────────────────────────────────────────────────
 
   function getAgentsBaseDir(): string {
-    return configPath
-      ? path.join(path.dirname(configPath), 'agents')
-      : path.join(os.homedir(), '.claude-gateway', 'agents');
+    return agentsDirForConfig(configPath);
   }
 
   function getTelegramStateDir(agentId: string): string {

--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -5,6 +5,7 @@ import { execSync } from 'node:child_process';
 import yaml from 'js-yaml';
 import { AppsRegistry, AppEntry } from './registry';
 import { pathWithNativeBin } from '../session/claude-bin';
+import { agentsDirForConfig } from '../config/agent-env';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -23,7 +24,9 @@ interface RawConfig {
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const DEFAULT_CONFIG_PATH = path.join(os.homedir(), '.claude-gateway', 'config.json');
-const DEFAULT_AGENTS_DIR = path.join(os.homedir(), '.claude-gateway', 'agents');
+// Derived, not declared independently: the agents dir is always config.json's
+// sibling, and the two must not be able to drift apart.
+const DEFAULT_AGENTS_DIR = agentsDirForConfig(DEFAULT_CONFIG_PATH);
 
 // ─── AgentManager ────────────────────────────────────────────────────────────
 

--- a/src/config/agent-env.ts
+++ b/src/config/agent-env.ts
@@ -1,0 +1,79 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Per-agent `.env` loading.
+ *
+ * Agent secrets (bot tokens above all) live in
+ * `~/.claude-gateway/agents/<id>/.env` and are referenced from `config.json`
+ * as `${VAR}` placeholders. `loadConfig()` resolves those placeholders from
+ * `process.env` alone, so the `.env` files must be folded into `process.env`
+ * *before* every config load — not just the one at startup.
+ *
+ * Issue #427: `agent_create` writes a new `agents/<id>/.env` and a `${VAR}`
+ * placeholder into `config.json` while the gateway is already running. Without
+ * a refresh on reload, that variable is never in `process.env`, the agent is
+ * silently dropped from the reloaded snapshot, and `agent.added` never fires —
+ * so the handler that *would* have loaded the `.env` is itself unreachable.
+ */
+
+/**
+ * The gateway's agents directory for a given config path — the sibling
+ * `agents/` of `config.json`, which is where per-agent workspaces and their
+ * `.env` files live.
+ */
+export function agentsDirForConfig(configPath: string): string {
+  return path.join(path.dirname(configPath), 'agents');
+}
+
+/**
+ * Fold a single agent's `.env` file into `process.env`.
+ *
+ * Values already in `process.env` win, so a variable exported by the operator
+ * (or read from an earlier `.env`) is never clobbered. That also makes this
+ * safe to call repeatedly: re-loading an unchanged file is a no-op.
+ */
+function loadAgentEnvFile(envFile: string): void {
+  for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed.slice(eq + 1).trim();
+    if (key && process.env[key] === undefined) {
+      process.env[key] = val;
+    }
+  }
+}
+
+/**
+ * Fold every `agents/<id>/.env` under `gatewayAgentsDir` into `process.env`.
+ *
+ * Idempotent by construction (see `loadAgentEnvFile`), so callers may run it
+ * before each config load to pick up agents that appeared since the last one.
+ * A missing directory, an unreadable file, or a `.env` belonging to an agent
+ * that is not in the config are all non-fatal: config loading has its own
+ * per-agent error handling, and failing here would take the whole gateway down
+ * over one bad file.
+ */
+export function loadAgentEnvFiles(gatewayAgentsDir: string): void {
+  let entries: string[];
+  try {
+    if (!fs.existsSync(gatewayAgentsDir)) return;
+    entries = fs.readdirSync(gatewayAgentsDir);
+  } catch {
+    return;
+  }
+  for (const agentId of entries) {
+    const envFile = path.join(gatewayAgentsDir, agentId, '.env');
+    try {
+      if (!fs.existsSync(envFile)) continue;
+      loadAgentEnvFile(envFile);
+    } catch {
+      // Unreadable .env (permissions, race with a concurrent write): skip it
+      // and let loadConfig() report the resulting unresolvable ${VAR}.
+      continue;
+    }
+  }
+}

--- a/src/config/agent-env.ts
+++ b/src/config/agent-env.ts
@@ -15,6 +15,11 @@ import * as path from 'path';
  * a refresh on reload, that variable is never in `process.env`, the agent is
  * silently dropped from the reloaded snapshot, and `agent.added` never fires —
  * so the handler that *would* have loaded the `.env` is itself unreachable.
+ *
+ * The same one-way copy makes `process.env` a cache that outlives the file it
+ * came from: once a token is in there, a rotated value on disk cannot displace
+ * it. That is why this module tracks which variables it injected — see
+ * `injected` below.
  */
 
 /**
@@ -27,11 +32,30 @@ export function agentsDirForConfig(configPath: string): string {
 }
 
 /**
+ * Variables this module injected, and the file each one came from.
+ *
+ * `process.env` is the only thing `loadConfig()` interpolates from, and it is
+ * process-lifetime state — so without this ledger there is no way to tell a
+ * value the *operator* exported (which must never be clobbered) from one we
+ * ourselves copied out of a `.env` on an earlier reload (which is just a stale
+ * cache of a file that may since have changed). Both look identical in
+ * `process.env`.
+ */
+const injected = new Map<string, { file: string; value: string }>();
+
+/**
  * Fold a single agent's `.env` file into `process.env`.
  *
- * Values already in `process.env` win, so a variable exported by the operator
- * (or read from an earlier `.env`) is never clobbered. That also makes this
- * safe to call repeatedly: re-loading an unchanged file is a no-op.
+ * A variable the process already had — exported by the operator, or provided
+ * by a *different* agent's `.env` — always wins; the file never clobbers it.
+ * A variable this module injected from *this* file is refreshed when the file
+ * changes, so a rotated token takes effect on reload instead of the process
+ * serving the revoked one until it is restarted.
+ *
+ * The `value === current` check is what keeps those two cases apart after the
+ * first load: if anything else has since assigned to the variable, the ledger
+ * no longer matches, ownership is dropped, and the file goes back to losing.
+ * Re-loading an unchanged file remains a no-op.
  */
 function loadAgentEnvFile(envFile: string): void {
   for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
@@ -41,8 +65,21 @@ function loadAgentEnvFile(envFile: string): void {
     if (eq < 1) continue;
     const key = trimmed.slice(0, eq).trim();
     const val = trimmed.slice(eq + 1).trim();
-    if (key && process.env[key] === undefined) {
+    if (!key) continue;
+
+    const current = process.env[key];
+    if (current === undefined) {
       process.env[key] = val;
+      injected.set(key, { file: envFile, value: val });
+      continue;
+    }
+
+    const owned = injected.get(key);
+    if (owned && owned.file === envFile && owned.value === current) {
+      if (val !== current) {
+        process.env[key] = val;
+        injected.set(key, { file: envFile, value: val });
+      }
     }
   }
 }
@@ -50,8 +87,8 @@ function loadAgentEnvFile(envFile: string): void {
 /**
  * Fold every `agents/<id>/.env` under `gatewayAgentsDir` into `process.env`.
  *
- * Idempotent by construction (see `loadAgentEnvFile`), so callers may run it
- * before each config load to pick up agents that appeared since the last one.
+ * Safe to run before each config load: it picks up agents that appeared since
+ * the last one, and re-reading an unchanged file changes nothing.
  * A missing directory, an unreadable file, or a `.env` belonging to an agent
  * that is not in the config are all non-fatal: config loading has its own
  * per-agent error handling, and failing here would take the whole gateway down

--- a/src/config/agent-env.ts
+++ b/src/config/agent-env.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
+import { parseDotenv } from '../load-dotenv';
 
 /**
  * Per-agent `.env` loading.
@@ -23,12 +25,17 @@ import * as path from 'path';
  */
 
 /**
- * The gateway's agents directory for a given config path — the sibling
- * `agents/` of `config.json`, which is where per-agent workspaces and their
- * `.env` files live.
+ * The gateway's agents directory — the sibling `agents/` of `config.json`,
+ * which is where per-agent workspaces and their `.env` files live.
+ *
+ * Falls back to `~/.claude-gateway/agents` when there is no config path: the
+ * API routers serve requests whose `configPath` may be unset, and the apps
+ * agent manager has no config path at all.
  */
-export function agentsDirForConfig(configPath: string): string {
-  return path.join(path.dirname(configPath), 'agents');
+export function agentsDirForConfig(configPath?: string): string {
+  return configPath
+    ? path.join(path.dirname(configPath), 'agents')
+    : path.join(os.homedir(), '.claude-gateway', 'agents');
 }
 
 /**
@@ -56,29 +63,24 @@ const injected = new Map<string, { file: string; value: string }>();
  * first load: if anything else has since assigned to the variable, the ledger
  * no longer matches, ownership is dropped, and the file goes back to losing.
  * Re-loading an unchanged file remains a no-op.
+ *
+ * Line syntax is `parseDotenv`'s, shared with `~/.claude-gateway/.env`, so a
+ * quoted token means the same thing in both places.
  */
 function loadAgentEnvFile(envFile: string): void {
-  for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eq = trimmed.indexOf('=');
-    if (eq < 1) continue;
-    const key = trimmed.slice(0, eq).trim();
-    const val = trimmed.slice(eq + 1).trim();
-    if (!key) continue;
-
+  for (const { key, value } of parseDotenv(fs.readFileSync(envFile, 'utf8'))) {
     const current = process.env[key];
     if (current === undefined) {
-      process.env[key] = val;
-      injected.set(key, { file: envFile, value: val });
+      process.env[key] = value;
+      injected.set(key, { file: envFile, value });
       continue;
     }
 
     const owned = injected.get(key);
     if (owned && owned.file === envFile && owned.value === current) {
-      if (val !== current) {
-        process.env[key] = val;
-        injected.set(key, { file: envFile, value: val });
+      if (value !== current) {
+        process.env[key] = value;
+        injected.set(key, { file: envFile, value });
       }
     }
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -17,9 +17,16 @@ export class DuplicateAgentIdError extends Error {
 }
 
 export class MissingEnvVarError extends Error {
+  /**
+   * The unresolved variable, exposed separately so callers can log it as a
+   * field instead of scraping it back out of `message`.
+   */
+  readonly varName: string;
+
   constructor(varName: string) {
     super(`Missing environment variable: ${varName}`);
     this.name = 'MissingEnvVarError';
+    this.varName = varName;
   }
 }
 
@@ -92,11 +99,35 @@ function validateAgent(agent: Record<string, unknown>, index: number): string | 
   return null;
 }
 
+/** An agent that was dropped from the loaded config rather than started. */
+export interface SkippedAgent {
+  /** The agent's id, or `index N` when the entry was too malformed to have one. */
+  id: string;
+  /** Human-readable cause, e.g. `Missing environment variable: ACME_BOT_TOKEN`. */
+  reason: string;
+  /** Set only when the agent was dropped because a `${VAR}` did not resolve. */
+  missingVar?: string;
+}
+
+export interface LoadConfigOptions {
+  /**
+   * Called once per dropped agent. Skipping is deliberately non-fatal (one bad
+   * agent must not take the gateway down), which historically made it invisible:
+   * the only signal was a `console.warn` that never reaches `logs/gateway.log`.
+   * Callers that have a structured logger should pass this so a dropped agent
+   * is diagnosable — see issue #427.
+   */
+  onSkippedAgent?: (skipped: SkippedAgent) => void;
+}
+
 /**
  * Load and validate config.json from the given path.
  * Interpolates ${VAR} env vars throughout the config.
  */
-export function loadConfig(configPath: string): GatewayConfig {
+export function loadConfig(configPath: string, options?: LoadConfigOptions): GatewayConfig {
+  const reportSkipped = (skipped: SkippedAgent): void => {
+    options?.onSkippedAgent?.(skipped);
+  };
   let raw: string;
   try {
     raw = fs.readFileSync(configPath, 'utf-8');
@@ -133,6 +164,7 @@ export function loadConfig(configPath: string): GatewayConfig {
     if (typeof agent !== 'object' || agent === null) {
       console.warn(`[gateway] Skipping agent at index ${i}: must be an object`);
       skippedAgents.push(`index ${i}`);
+      reportSkipped({ id: `index ${i}`, reason: 'Config entry must be an object' });
       continue;
     }
     const error = validateAgent(agent as Record<string, unknown>, i);
@@ -140,6 +172,7 @@ export function loadConfig(configPath: string): GatewayConfig {
       const agentId = (agent as Record<string, unknown>).id || `index ${i}`;
       console.warn(`[gateway] Skipping agent "${agentId}": ${error}`);
       skippedAgents.push(String(agentId));
+      reportSkipped({ id: String(agentId), reason: error });
       continue;
     }
     validAgents.push(agent as Record<string, unknown>);
@@ -211,6 +244,11 @@ export function loadConfig(configPath: string): GatewayConfig {
       if (err instanceof MissingEnvVarError) {
         console.warn(`[gateway] Skipping agent "${agent.id}": ${err.message}`);
         skippedAgents.push(String(agent.id));
+        reportSkipped({
+          id: String(agent.id),
+          reason: err.message,
+          missingVar: err.varName,
+        });
         continue;
       }
       throw err;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { GatewayConfig } from '../types';
+import { GatewayConfig, Logger } from '../types';
 import { resolveGatewayPublicUrl } from './public-url';
 
 export class ConfigValidationError extends Error {
@@ -121,12 +121,42 @@ export interface LoadConfigOptions {
 }
 
 /**
+ * Emit one `SkippedAgent` through a caller's structured logger.
+ *
+ * Shared by the startup load and every reload so both write the same fields
+ * under the same key — `grep "Agent skipped" logs/gateway.log` finds either.
+ */
+export function logSkippedAgents(
+  logger: Logger,
+  skipped: readonly SkippedAgent[],
+  message: string,
+): void {
+  for (const s of skipped) {
+    logger.warn(message, {
+      id: s.id,
+      reason: s.reason,
+      ...(s.missingVar ? { missingVar: s.missingVar } : {}),
+    });
+  }
+}
+
+/**
  * Load and validate config.json from the given path.
  * Interpolates ${VAR} env vars throughout the config.
  */
 export function loadConfig(configPath: string, options?: LoadConfigOptions): GatewayConfig {
-  const reportSkipped = (skipped: SkippedAgent): void => {
-    options?.onSkippedAgent?.(skipped);
+  const skippedAgents: string[] = [];
+
+  /**
+   * The single place an agent is dropped. Both the console warning and the
+   * structured-logger callback go through here on purpose: when they were two
+   * parallel statements per call site, a new skip site could easily carry one
+   * and not the other — reintroducing exactly the invisible drop of #427.
+   */
+  const skipAgent = (id: string, reason: string, missingVar?: string): void => {
+    console.warn(`[gateway] Skipping agent "${id}": ${reason}`);
+    skippedAgents.push(id);
+    options?.onSkippedAgent?.({ id, reason, ...(missingVar ? { missingVar } : {}) });
   };
   let raw: string;
   try {
@@ -158,21 +188,15 @@ export function loadConfig(configPath: string, options?: LoadConfigOptions): Gat
 
   // Validate each agent before interpolation — skip invalid agents with a warning
   const validAgents: Record<string, unknown>[] = [];
-  const skippedAgents: string[] = [];
   for (let i = 0; i < (config.agents as unknown[]).length; i++) {
     const agent = (config.agents as unknown[])[i];
     if (typeof agent !== 'object' || agent === null) {
-      console.warn(`[gateway] Skipping agent at index ${i}: must be an object`);
-      skippedAgents.push(`index ${i}`);
-      reportSkipped({ id: `index ${i}`, reason: 'Config entry must be an object' });
+      skipAgent(`index ${i}`, 'Config entry must be an object');
       continue;
     }
     const error = validateAgent(agent as Record<string, unknown>, i);
     if (error) {
-      const agentId = (agent as Record<string, unknown>).id || `index ${i}`;
-      console.warn(`[gateway] Skipping agent "${agentId}": ${error}`);
-      skippedAgents.push(String(agentId));
-      reportSkipped({ id: String(agentId), reason: error });
+      skipAgent(String((agent as Record<string, unknown>).id || `index ${i}`), error);
       continue;
     }
     validAgents.push(agent as Record<string, unknown>);
@@ -242,13 +266,7 @@ export function loadConfig(configPath: string, options?: LoadConfigOptions): Gat
       interpolatedAgents.push(interpolateObject(agent));
     } catch (err) {
       if (err instanceof MissingEnvVarError) {
-        console.warn(`[gateway] Skipping agent "${agent.id}": ${err.message}`);
-        skippedAgents.push(String(agent.id));
-        reportSkipped({
-          id: String(agent.id),
-          reason: err.message,
-          missingVar: err.varName,
-        });
+        skipAgent(String(agent.id), err.message, err.varName);
         continue;
       }
       throw err;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -158,6 +158,7 @@ export function loadConfig(configPath: string, options?: LoadConfigOptions): Gat
     skippedAgents.push(id);
     options?.onSkippedAgent?.({ id, reason, ...(missingVar ? { missingVar } : {}) });
   };
+
   let raw: string;
   try {
     raw = fs.readFileSync(configPath, 'utf-8');

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { loadConfig, SkippedAgent } from './loader';
+import { loadConfig, logSkippedAgents, SkippedAgent } from './loader';
 import { agentsDirForConfig, loadAgentEnvFiles } from './agent-env';
 import { AgentConfig, GatewayConfig, Logger } from '../types';
 import { createWatcher, WatchHandle } from '../watch/factory';
@@ -101,13 +101,7 @@ export class ConfigWatcher extends EventEmitter {
 
     // Report drops before the no-change bail-out below: a silently dropped
     // agent produces exactly zero diff, so this is the only trace it leaves.
-    for (const s of skipped) {
-      this.logger.warn('Agent skipped during config reload', {
-        id: s.id,
-        reason: s.reason,
-        ...(s.missingVar ? { missingVar: s.missingVar } : {}),
-      });
-    }
+    logSkippedAgents(this.logger, skipped, 'Agent skipped during config reload');
 
     const { fieldChanges, addedAgents } = this.diffConfig(this.currentConfig, newConfig);
 

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
-import { loadConfig } from './loader';
+import { loadConfig, SkippedAgent } from './loader';
+import { agentsDirForConfig, loadAgentEnvFiles } from './agent-env';
 import { AgentConfig, GatewayConfig, Logger } from '../types';
 import { createWatcher, WatchHandle } from '../watch/factory';
 import { expandHome } from '../utils/paths';
@@ -43,6 +44,7 @@ export class ConfigWatcher extends EventEmitter {
 
   private watchHandle: WatchHandle | null = null;
   private currentConfig: GatewayConfig;
+  private readonly agentsDir: string;
 
   constructor(
     private readonly configPath: string,
@@ -51,6 +53,7 @@ export class ConfigWatcher extends EventEmitter {
   ) {
     super();
     this.currentConfig = structuredClone(initialConfig);
+    this.agentsDir = agentsDirForConfig(configPath);
   }
 
   start(): void {
@@ -73,15 +76,37 @@ export class ConfigWatcher extends EventEmitter {
   }
 
   reload(): void {
+    // Fold any per-agent .env files into process.env BEFORE interpolation.
+    // An agent added while the gateway is running (MCP `agent_create`) writes
+    // its token to a brand-new agents/<id>/.env and only a ${VAR} placeholder
+    // into config.json. Without this refresh that variable is absent from
+    // process.env, loadConfig() drops the agent, the diff below sees nothing,
+    // and `agent.added` — whose handler is what used to load the .env — never
+    // fires. Issue #427.
+    loadAgentEnvFiles(this.agentsDir);
+
     let newConfig: GatewayConfig;
+    const skipped: SkippedAgent[] = [];
     try {
-      newConfig = loadConfig(this.configPath);
+      newConfig = loadConfig(this.configPath, {
+        onSkippedAgent: (s) => skipped.push(s),
+      });
       newConfig.gateway.logDir = expandHome(newConfig.gateway.logDir);
     } catch (err) {
       this.logger.error('Config reload failed, keeping current config', {
         error: (err as Error).message,
       });
       return;
+    }
+
+    // Report drops before the no-change bail-out below: a silently dropped
+    // agent produces exactly zero diff, so this is the only trace it leaves.
+    for (const s of skipped) {
+      this.logger.warn('Agent skipped during config reload', {
+        id: s.id,
+        reason: s.reason,
+        ...(s.missingVar ? { missingVar: s.missingVar } : {}),
+      });
     }
 
     const { fieldChanges, addedAgents } = this.diffConfig(this.currentConfig, newConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,6 +590,13 @@ async function main(): Promise<void> {
   });
   config.gateway.logDir = expandTilde(config.gateway.logDir);
 
+  // Created as early as logDir allows, and before the isolation guard below:
+  // a config bad enough to drop an agent is exactly the config likely to fail
+  // validation too, and a guard throw must not swallow the reason an agent
+  // went missing.
+  const globalLogger = createLogger('gateway', expandTilde(config.gateway.logDir));
+  logSkippedAgents(globalLogger, startupSkips, 'Agent skipped at startup');
+
   // ── Context isolation check ──────────────────────────────────────────────
   const guard = new ContextIsolationGuard();
   guard.validate(config.agents);
@@ -601,8 +608,6 @@ async function main(): Promise<void> {
 
   const sharedSkillsDir = path.join(os.homedir(), '.claude-gateway', 'shared-skills');
   const personalSkillsDir = path.join(os.homedir(), '.claude', 'skills');
-  const globalLogger = createLogger('gateway', expandTilde(config.gateway.logDir));
-  logSkippedAgents(globalLogger, startupSkips, 'Agent skipped at startup');
   const mcpToolsDir = path.resolve(__dirname, '..', 'mcp', 'tools');
   const logDir = expandTilde(config.gateway.logDir);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { loadGatewayDotenv } from './load-dotenv';
 // which does the same before dispatching to the CLI.
 loadGatewayDotenv();
 
-import { loadConfig } from './config/loader';
+import { loadConfig, logSkippedAgents, SkippedAgent } from './config/loader';
 import { agentsDirForConfig, loadAgentEnvFiles } from './config/agent-env';
 import { detectMigration, applyMigration, loadCleanTemplate } from './config/migrator';
 import { ensureConfigExists, firstRunNotice } from './config/bootstrap';
@@ -580,7 +580,14 @@ async function main(): Promise<void> {
   }
 
   console.log(`[gateway] Loading config from ${CONFIG_PATH}`);
-  const config: GatewayConfig = loadConfig(CONFIG_PATH);
+  // Skips are collected rather than logged inline: the structured logger needs
+  // config.gateway.logDir, so it cannot exist until this call returns. They are
+  // replayed through globalLogger below so a dropped agent is diagnosable from
+  // logs/gateway.log at startup too, not only on reload (#427).
+  const startupSkips: SkippedAgent[] = [];
+  const config: GatewayConfig = loadConfig(CONFIG_PATH, {
+    onSkippedAgent: (s) => startupSkips.push(s),
+  });
   config.gateway.logDir = expandTilde(config.gateway.logDir);
 
   // ── Context isolation check ──────────────────────────────────────────────
@@ -595,6 +602,7 @@ async function main(): Promise<void> {
   const sharedSkillsDir = path.join(os.homedir(), '.claude-gateway', 'shared-skills');
   const personalSkillsDir = path.join(os.homedir(), '.claude', 'skills');
   const globalLogger = createLogger('gateway', expandTilde(config.gateway.logDir));
+  logSkippedAgents(globalLogger, startupSkips, 'Agent skipped at startup');
   const mcpToolsDir = path.resolve(__dirname, '..', 'mcp', 'tools');
   const logDir = expandTilde(config.gateway.logDir);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -730,7 +730,7 @@ async function main(): Promise<void> {
   const appsConfigPath = path.join(path.dirname(CONFIG_PATH), 'apps.json');
   const appsRegistry = new AppsRegistry(appsConfigPath);
   const registryClient = new RegistryClient();
-  const agentManager = new AgentManager(CONFIG_PATH, path.join(path.dirname(CONFIG_PATH), 'agents'));
+  const agentManager = new AgentManager(CONFIG_PATH, agentsDirForConfig(CONFIG_PATH));
   const socketServer = new SocketServer();
 
   // Callbacks that bridge installer events to the router (filled in after router is created)

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { loadGatewayDotenv } from './load-dotenv';
 loadGatewayDotenv();
 
 import { loadConfig } from './config/loader';
+import { agentsDirForConfig, loadAgentEnvFiles } from './config/agent-env';
 import { detectMigration, applyMigration, loadCleanTemplate } from './config/migrator';
 import { ensureConfigExists, firstRunNotice } from './config/bootstrap';
 import { loadWorkspace, watchWorkspace, migrateWorkspaceFiles, classifyWorkspaceRestart } from './agent/workspace-loader';
@@ -123,38 +124,6 @@ function validateWorkspaceFast(workspacePath: string): { ok: true } | { ok: fals
     return { ok: false, reason: 'workspace missing AGENTS.md' };
   }
   return { ok: true };
-}
-
-/**
- * Load .env from a single agent's env file into process.env.
- * Values already in process.env win (existing env vars take priority).
- */
-function loadAgentEnvFile(envFile: string): void {
-  for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eq = trimmed.indexOf('=');
-    if (eq < 1) continue;
-    const key = trimmed.slice(0, eq).trim();
-    const val = trimmed.slice(eq + 1).trim();
-    if (key && process.env[key] === undefined) {
-      process.env[key] = val;
-    }
-  }
-}
-
-/**
- * Load .env files from the gateway agents directory into process.env.
- * Each agent may have a .env at ~/.claude-gateway/agents/<id>/.env
- * containing bot tokens and other secrets. Values already in process.env win.
- */
-function loadAgentEnvFiles(gatewayAgentsDir: string): void {
-  if (!fs.existsSync(gatewayAgentsDir)) return;
-  for (const agentId of fs.readdirSync(gatewayAgentsDir)) {
-    const envFile = path.join(gatewayAgentsDir, agentId, '.env');
-    if (!fs.existsSync(envFile)) continue;
-    loadAgentEnvFile(envFile);
-  }
 }
 
 // ─── Context shared between startAgent calls ──────────────────────────────────
@@ -569,9 +538,10 @@ let isShuttingDown = false;
 let registeredShutdown: ((signal: string) => Promise<void>) | null = null;
 
 async function main(): Promise<void> {
-  // Load agent .env files before config interpolation so ${TOKEN} vars resolve
-  const gatewayAgentsDir = path.join(path.dirname(CONFIG_PATH), 'agents');
-  loadAgentEnvFiles(gatewayAgentsDir);
+  // Load agent .env files before config interpolation so ${TOKEN} vars resolve.
+  // ConfigWatcher repeats this before every reload, so agents that appear later
+  // resolve too — see src/config/agent-env.ts.
+  loadAgentEnvFiles(agentsDirForConfig(CONFIG_PATH));
 
   // ── First run: create config.json with a fresh admin key if none exists ───
   const templatePath = path.join(__dirname, '..', 'config.template.json');
@@ -943,12 +913,9 @@ async function main(): Promise<void> {
   configWatcher.on('agent.added', async (newAgentConfig: AgentConfig) => {
     globalLogger.info('New agent detected in config, starting dynamically', { id: newAgentConfig.id });
 
-    // Load .env for new agent so token interpolation works before startAgent
-    const agentEnvFile = path.join(gatewayAgentsDir, newAgentConfig.id, '.env');
-    if (fs.existsSync(agentEnvFile)) {
-      loadAgentEnvFile(agentEnvFile);
-    }
-
+    // The agent's .env is already in process.env: ConfigWatcher.reload() folds
+    // agents/<id>/.env in before interpolating, which is the only reason this
+    // event can fire for a ${VAR}-token agent at all (#427).
     newAgentConfig.workspace = expandTilde(newAgentConfig.workspace);
     await startAgent(newAgentConfig, configWatcher.getConfig(), ctx);
     globalLogger.info('Agent hot-added successfully', { id: newAgentConfig.id });
@@ -957,12 +924,6 @@ async function main(): Promise<void> {
   configWatcher.on('channel.added', async (agentId: string, channel: string) => {
     const runner = ctx.agentRunners.get(agentId);
     if (!runner) return;
-
-    // Load fresh .env so new token is available before starting receiver
-    const agentEnvFile = path.join(gatewayAgentsDir, agentId, '.env');
-    if (fs.existsSync(agentEnvFile)) {
-      loadAgentEnvFile(agentEnvFile);
-    }
 
     // Reload the agent config so runner has the new token
     const freshConfig = configWatcher.getConfig();

--- a/src/load-dotenv.ts
+++ b/src/load-dotenv.ts
@@ -13,16 +13,38 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-export function loadGatewayDotenv(): void {
-  const envFile = path.join(os.homedir(), '.claude-gateway', '.env');
-  if (!fs.existsSync(envFile)) return;
-  for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
+/**
+ * Parse `.env` text into key/value pairs, in file order.
+ *
+ * Shared with the per-agent loader (`src/config/agent-env.ts`) so that both
+ * agree on what a line means. They must: a value that survives one parser and
+ * not the other is not a parse error anyone sees. Surrounding quotes are the
+ * case that bites — `TOKEN="123:ABC"` is ordinary `.env` style, and a parser
+ * that keeps the quotes still resolves the `${VAR}` in `config.json`. The
+ * config loads, nothing is skipped, nothing is logged, and the receiver simply
+ * 401s on every poll with a token that has quotes in it.
+ *
+ * Blank lines, `#` comments and lines with no key (`=value`) are dropped.
+ */
+export function parseDotenv(text: string): Array<{ key: string; value: string }> {
+  const pairs: Array<{ key: string; value: string }> = [];
+  for (const line of text.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
     const eq = trimmed.indexOf('=');
-    if (eq === -1) continue;
+    if (eq < 1) continue;
     const key = trimmed.slice(0, eq).trim();
-    const val = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
-    if (key && !(key in process.env)) process.env[key] = val;
+    if (!key) continue;
+    const value = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+    pairs.push({ key, value });
+  }
+  return pairs;
+}
+
+export function loadGatewayDotenv(): void {
+  const envFile = path.join(os.homedir(), '.claude-gateway', '.env');
+  if (!fs.existsSync(envFile)) return;
+  for (const { key, value } of parseDotenv(fs.readFileSync(envFile, 'utf8'))) {
+    if (!(key in process.env)) process.env[key] = value;
   }
 }

--- a/tests/unit/agent-env.test.ts
+++ b/tests/unit/agent-env.test.ts
@@ -42,6 +42,10 @@ describe('agent-env', () => {
 
   it('U-AE-01: derives the agents dir as the sibling of config.json', () => {
     expect(agentsDirForConfig('/srv/gw/config.json')).toBe('/srv/gw/agents');
+    // No config path: the API routers and the apps agent manager fall back to
+    // the default install root rather than resolving against the cwd.
+    expect(agentsDirForConfig()).toBe(path.join(os.homedir(), '.claude-gateway', 'agents'));
+    expect(agentsDirForConfig('')).toBe(path.join(os.homedir(), '.claude-gateway', 'agents'));
   });
 
   it('U-AE-02: folds a new agent .env into process.env', () => {
@@ -116,5 +120,16 @@ describe('agent-env', () => {
 
     expect(() => loadAgentEnvFiles(agentsDir)).not.toThrow();
     expect(process.env.ACME_BOT_TOKEN).toBe('token-a');
+  });
+
+  it('U-AE-08: strips quotes around a token, as ~/.claude-gateway/.env does', () => {
+    // Quoting is ordinary .env style. Keeping the quotes would still resolve
+    // the ${VAR}, so loadConfig() reports no skip and the only symptom is the
+    // receiver 401-ing on a token that has `"` in it.
+    writeAgentEnv('acme', 'ACME_BOT_TOKEN="123:ABC-def"\n');
+
+    loadAgentEnvFiles(agentsDir);
+
+    expect(process.env.ACME_BOT_TOKEN).toBe('123:ABC-def');
   });
 });

--- a/tests/unit/agent-env.test.ts
+++ b/tests/unit/agent-env.test.ts
@@ -1,0 +1,120 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { agentsDirForConfig, loadAgentEnvFiles } from '../../src/config/agent-env';
+
+// ---------------------------------------------------------------------------
+// U-AE: per-agent .env → process.env folding (issue #427)
+//
+// `loadConfig()` interpolates ${VAR} from `process.env` alone, so these files
+// are the only way a token written by MCP `agent_create` / `agent_update`
+// reaches a running gateway. Two rules have to hold at once:
+//
+//   - a value the operator exported must never be clobbered by a file, and
+//   - a value this module itself copied out of a file is a cache of that file,
+//     so a rotated token must take effect on the next reload rather than the
+//     process serving the revoked one until it restarts.
+//
+// Both look identical in `process.env`; only the ledger tells them apart.
+// ---------------------------------------------------------------------------
+describe('agent-env', () => {
+  const OWNED_VARS = ['ACME_BOT_TOKEN', 'ACME_DISCORD_TOKEN', 'SHARED_TOKEN'];
+  let tmpDir: string;
+  let agentsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-test-'));
+    agentsDir = path.join(tmpDir, 'agents');
+    for (const v of OWNED_VARS) delete process.env[v];
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    for (const v of OWNED_VARS) delete process.env[v];
+  });
+
+  /** Write agents/<id>/.env under the temp gateway root. */
+  function writeAgentEnv(agentId: string, contents: string): void {
+    const dir = path.join(agentsDir, agentId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '.env'), contents);
+  }
+
+  it('U-AE-01: derives the agents dir as the sibling of config.json', () => {
+    expect(agentsDirForConfig('/srv/gw/config.json')).toBe('/srv/gw/agents');
+  });
+
+  it('U-AE-02: folds a new agent .env into process.env', () => {
+    writeAgentEnv('acme', 'ACME_BOT_TOKEN=token-a\n# comment\n\nACME_DISCORD_TOKEN=disc-a\n');
+
+    loadAgentEnvFiles(agentsDir);
+
+    expect(process.env.ACME_BOT_TOKEN).toBe('token-a');
+    expect(process.env.ACME_DISCORD_TOKEN).toBe('disc-a');
+  });
+
+  it('U-AE-03: never overwrites a variable the operator exported', () => {
+    process.env.ACME_BOT_TOKEN = 'from-operator';
+    writeAgentEnv('acme', 'ACME_BOT_TOKEN=from-dotenv\n');
+
+    loadAgentEnvFiles(agentsDir);
+    // Still loses on a later pass — ownership is never acquired for this key.
+    writeAgentEnv('acme', 'ACME_BOT_TOKEN=from-dotenv-rotated\n');
+    loadAgentEnvFiles(agentsDir);
+
+    expect(process.env.ACME_BOT_TOKEN).toBe('from-operator');
+  });
+
+  it('U-AE-04: picks up a rotated token from the file it originally loaded', () => {
+    // What `agent_update` remove_channel + add_channel leaves on disk: the old
+    // line stripped, the new token appended under the same variable name.
+    writeAgentEnv('acme', 'ACME_BOT_TOKEN=token-a\n');
+    loadAgentEnvFiles(agentsDir);
+    expect(process.env.ACME_BOT_TOKEN).toBe('token-a');
+
+    writeAgentEnv('acme', 'ACME_BOT_TOKEN=token-b\n');
+    loadAgentEnvFiles(agentsDir);
+
+    expect(process.env.ACME_BOT_TOKEN).toBe('token-b');
+  });
+
+  it('U-AE-05: stops refreshing a variable once something else assigns to it', () => {
+    writeAgentEnv('acme', 'ACME_BOT_TOKEN=token-a\n');
+    loadAgentEnvFiles(agentsDir);
+
+    // A runtime assignment is indistinguishable from an operator export, and
+    // outranks the file for the same reason.
+    process.env.ACME_BOT_TOKEN = 'set-at-runtime';
+    writeAgentEnv('acme', 'ACME_BOT_TOKEN=token-b\n');
+    loadAgentEnvFiles(agentsDir);
+
+    expect(process.env.ACME_BOT_TOKEN).toBe('set-at-runtime');
+  });
+
+  it('U-AE-06: a second agent .env cannot hijack a key another one owns', () => {
+    // First loaded wins, and keeps winning: ownership is per (key, file), so a
+    // later agent declaring the same variable is treated like any other value
+    // already in process.env. Without the file check it would take the key
+    // over on the next reload and quietly re-point the first agent's channel.
+    writeAgentEnv('acme', 'SHARED_TOKEN=from-acme\n');
+    loadAgentEnvFiles(agentsDir);
+    expect(process.env.SHARED_TOKEN).toBe('from-acme');
+
+    writeAgentEnv('other', 'SHARED_TOKEN=from-other\n');
+    loadAgentEnvFiles(agentsDir);
+
+    expect(process.env.SHARED_TOKEN).toBe('from-acme');
+  });
+
+  it('U-AE-07: survives a missing dir, an unreadable file and a bad line', () => {
+    expect(() => loadAgentEnvFiles(path.join(tmpDir, 'nope'))).not.toThrow();
+
+    // A directory where the .env should be: readFileSync throws EISDIR, and one
+    // bad agent must not stop the others from loading.
+    fs.mkdirSync(path.join(agentsDir, 'broken', '.env'), { recursive: true });
+    writeAgentEnv('acme', 'not-a-pair\n=novalue\nACME_BOT_TOKEN=token-a\n');
+
+    expect(() => loadAgentEnvFiles(agentsDir)).not.toThrow();
+    expect(process.env.ACME_BOT_TOKEN).toBe('token-a');
+  });
+});

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import {
   loadConfig,
+  logSkippedAgents,
   ConfigValidationError,
   DuplicateAgentIdError,
   MissingEnvVarError,
@@ -386,6 +387,45 @@ describe('config-loader', () => {
     it('U-CL-09d: omits the callback safely when no options are passed', () => {
       const configPath = writeConfig('no-options.json', ['not-an-object', healthyAgent]);
       expect(() => loadConfig(configPath)).not.toThrow();
+    });
+
+    it('U-CL-09e: logSkippedAgents writes one warn per skip, with the variable name', () => {
+      // The startup path (src/index.ts) and the reload path (ConfigWatcher)
+      // both collect skips first and replay them through this helper once a
+      // logger exists — at startup because logDir is only known after the load
+      // it is reporting on. This pins the payload both of them emit.
+      const warn = jest.fn();
+      const logger = { info: jest.fn(), warn, error: jest.fn(), debug: jest.fn() };
+
+      logSkippedAgents(
+        logger as unknown as Parameters<typeof logSkippedAgents>[0],
+        [
+          { id: 'nowhere', reason: 'Missing environment variable: X_TOKEN', missingVar: 'X_TOKEN' },
+          { id: 'broken', reason: 'missing "telegram.botToken"' },
+        ],
+        'Agent skipped at startup',
+      );
+
+      expect(warn).toHaveBeenCalledTimes(2);
+      expect(warn).toHaveBeenNthCalledWith(1, 'Agent skipped at startup', {
+        id: 'nowhere',
+        reason: 'Missing environment variable: X_TOKEN',
+        missingVar: 'X_TOKEN',
+      });
+      // Nothing named a variable here, so the payload carries id + reason only.
+      expect(warn).toHaveBeenNthCalledWith(2, 'Agent skipped at startup', {
+        id: 'broken',
+        reason: 'missing "telegram.botToken"',
+      });
+    });
+
+    it('U-CL-09f: logSkippedAgents is a no-op when nothing was skipped', () => {
+      const warn = jest.fn();
+      const logger = { info: jest.fn(), warn, error: jest.fn(), debug: jest.fn() };
+
+      logSkippedAgents(logger as unknown as Parameters<typeof logSkippedAgents>[0], [], 'x');
+
+      expect(warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -6,6 +6,7 @@ import {
   ConfigValidationError,
   DuplicateAgentIdError,
   MissingEnvVarError,
+  SkippedAgent,
 } from '../../src/config/loader';
 
 const FIXTURES = path.join(__dirname, '../fixtures/configs');
@@ -305,5 +306,86 @@ describe('config-loader', () => {
       if (prevAdmin === undefined) delete process.env.ADMIN_API_KEY;
       else process.env.ADMIN_API_KEY = prevAdmin;
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // U-CL-09: onSkippedAgent reports every drop site
+  //
+  // Skipping an agent is deliberately non-fatal, which is exactly what made it
+  // invisible before #427 — the only signal was a console.warn that never
+  // reaches logs/gateway.log. These pin the callback contract for all three
+  // sites so a drop can never go back to being silent.
+  // -------------------------------------------------------------------------
+  describe('U-CL-09: onSkippedAgent callback', () => {
+    const healthyAgent = {
+      id: 'alfred',
+      description: '',
+      workspace: '/tmp',
+      env: '/tmp/.env',
+      telegram: { botToken: 'alfred-plain-token' },
+      claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: false, extraFlags: [] },
+    };
+
+    function writeConfig(name: string, agents: unknown[]): string {
+      const configPath = path.join(tmpDir, name);
+      fs.writeFileSync(configPath, JSON.stringify({
+        gateway: { logDir: '/tmp/logs', port: 8080 },
+        agents,
+      }));
+      return configPath;
+    }
+
+    it('U-CL-09a: reports a malformed (non-object) config entry', () => {
+      const configPath = writeConfig('malformed.json', ['not-an-object', healthyAgent]);
+      const skipped: SkippedAgent[] = [];
+
+      const config = loadConfig(configPath, { onSkippedAgent: (s) => skipped.push(s) });
+
+      expect(config.agents.map(a => a.id)).toEqual(['alfred']);
+      expect(skipped).toEqual([
+        { id: 'index 0', reason: 'Config entry must be an object' },
+      ]);
+    });
+
+    it('U-CL-09b: reports an agent that fails validation', () => {
+      const configPath = writeConfig('invalid.json', [
+        { ...healthyAgent, id: 'broken', telegram: {} },
+        healthyAgent,
+      ]);
+      const skipped: SkippedAgent[] = [];
+
+      const config = loadConfig(configPath, { onSkippedAgent: (s) => skipped.push(s) });
+
+      expect(config.agents.map(a => a.id)).toEqual(['alfred']);
+      expect(skipped).toHaveLength(1);
+      expect(skipped[0].id).toBe('broken');
+      expect(skipped[0].reason).toContain('missing "telegram.botToken"');
+      // No ${VAR} was involved, so there is nothing to name.
+      expect(skipped[0].missingVar).toBeUndefined();
+    });
+
+    it('U-CL-09c: reports the unresolved variable name for a missing env var', () => {
+      const configPath = writeConfig('missing-var.json', [
+        { ...healthyAgent, id: 'nowhere', telegram: { botToken: '${NOWHERE_BOT_TOKEN}' } },
+        healthyAgent,
+      ]);
+      const skipped: SkippedAgent[] = [];
+
+      const config = loadConfig(configPath, { onSkippedAgent: (s) => skipped.push(s) });
+
+      expect(config.agents.map(a => a.id)).toEqual(['alfred']);
+      expect(skipped).toEqual([
+        {
+          id: 'nowhere',
+          reason: 'Missing environment variable: NOWHERE_BOT_TOKEN',
+          missingVar: 'NOWHERE_BOT_TOKEN',
+        },
+      ]);
+    });
+
+    it('U-CL-09d: omits the callback safely when no options are passed', () => {
+      const configPath = writeConfig('no-options.json', ['not-an-object', healthyAgent]);
+      expect(() => loadConfig(configPath)).not.toThrow();
+    });
   });
 });

--- a/tests/unit/config-watcher.test.ts
+++ b/tests/unit/config-watcher.test.ts
@@ -727,5 +727,45 @@ describe('config-watcher', () => {
 
       watcher.stop();
     });
+
+    it('U-CW-11e: swaps the receiver over to a rotated token without a restart', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      writeConfigFile(configPath, rawConfig());
+      const watcher = new ConfigWatcher(configPath, loadConfig(configPath), logger);
+
+      // agent_create: token A in a fresh .env, placeholder in config.json.
+      writeAgentEnv('carlos', 'CARLOS_BOT_TOKEN=token-a\n');
+      const withCarlos = rawConfig();
+      (withCarlos.agents as unknown[]).push(rawAgentWithToken('carlos', '${CARLOS_BOT_TOKEN}'));
+      writeConfigFile(configPath, withCarlos);
+      watcher.reload();
+      expect(watcher.getConfig().agents.find(a => a.id === 'carlos')!.telegram!.botToken)
+        .toBe('token-a');
+
+      // Token A is revoked. agent_update remove_channel strips the .env line
+      // and drops the channel from config.json...
+      const withoutChannel = rawConfig();
+      const carlosRaw = rawAgentWithToken('carlos', '${CARLOS_BOT_TOKEN}');
+      delete carlosRaw.telegram;
+      (withoutChannel.agents as unknown[]).push(carlosRaw);
+      writeAgentEnv('carlos', '');
+      writeConfigFile(configPath, withoutChannel);
+      watcher.reload();
+
+      // ...then add_channel writes token B and puts the same placeholder back.
+      const channelSpy = jest.fn();
+      watcher.on('channel.added', channelSpy);
+      writeAgentEnv('carlos', 'CARLOS_BOT_TOKEN=token-b\n');
+      writeConfigFile(configPath, withCarlos);
+      watcher.reload();
+
+      // Before the ownership ledger this resolved to the revoked token-a: the
+      // reload reported success, the receiver started, and every poll 401'd.
+      expect(channelSpy).toHaveBeenCalledWith('carlos', 'telegram');
+      expect(watcher.getConfig().agents.find(a => a.id === 'carlos')!.telegram!.botToken)
+        .toBe('token-b');
+
+      watcher.stop();
+    });
   });
 });

--- a/tests/unit/config-watcher.test.ts
+++ b/tests/unit/config-watcher.test.ts
@@ -585,4 +585,147 @@ describe('config-watcher', () => {
     expect(agentConfig.heartbeat).toBeDefined();
     expect(agentConfig.heartbeat!.rateLimitMinutes).toBe(45);
   });
+
+  // ---------------------------------------------------------------------------
+  // U-CW-11: per-agent .env files are refreshed before every reload (issue #427)
+  //
+  // MCP `agent_create` writes the real bot token to a brand-new
+  // agents/<id>/.env and only a ${VAR} placeholder into config.json. A gateway
+  // that was already running has never seen that variable, so before the fix
+  // loadConfig() dropped the agent, the diff came back empty, and `agent.added`
+  // — whose handler is what used to load the .env — never fired.
+  // ---------------------------------------------------------------------------
+  describe('U-CW-11: agent .env refresh on reload', () => {
+    const OWNED_VARS = ['CARLOS_BOT_TOKEN', 'ALFRED_DISCORD_TOKEN', 'NOWHERE_BOT_TOKEN'];
+
+    beforeEach(() => {
+      for (const v of OWNED_VARS) delete process.env[v];
+    });
+
+    afterEach(() => {
+      for (const v of OWNED_VARS) delete process.env[v];
+    });
+
+    /** Write agents/<id>/.env under the temp gateway root (sibling of config.json). */
+    function writeAgentEnv(agentId: string, contents: string): void {
+      const dir = path.join(tmpDir, 'agents', agentId);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, '.env'), contents);
+    }
+
+    /** A raw agent entry whose telegram token is the given ${VAR} placeholder. */
+    function rawAgentWithToken(id: string, tokenPlaceholder: string): Record<string, unknown> {
+      return {
+        id,
+        description: `${id} bot`,
+        workspace: `/tmp/${id}/workspace`,
+        env: `/tmp/${id}/.env`,
+        telegram: { botToken: tokenPlaceholder },
+        claude: { model: 'claude-opus-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+      };
+    }
+
+    it('U-CW-11a: emits agent.added for an agent whose token only exists in a new agents/<id>/.env', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      writeConfigFile(configPath, rawConfig());
+      const watcher = new ConfigWatcher(configPath, loadConfig(configPath), logger);
+
+      const addedSpy = jest.fn();
+      watcher.on('agent.added', addedSpy);
+
+      // What agent_create does: token to a fresh .env, placeholder to config.json.
+      writeAgentEnv('carlos', 'CARLOS_BOT_TOKEN=carlos-secret-token\n');
+      const raw = rawConfig();
+      (raw.agents as unknown[]).push(rawAgentWithToken('carlos', '${CARLOS_BOT_TOKEN}'));
+      writeConfigFile(configPath, raw);
+
+      expect(process.env.CARLOS_BOT_TOKEN).toBeUndefined();
+      watcher.reload();
+
+      expect(addedSpy).toHaveBeenCalledTimes(1);
+      const added: AgentConfig = addedSpy.mock.calls[0][0];
+      expect(added.id).toBe('carlos');
+      // The placeholder must be resolved, not passed through verbatim — the
+      // receiver would authenticate with the literal "${CARLOS_BOT_TOKEN}".
+      expect(added.telegram!.botToken).toBe('carlos-secret-token');
+
+      watcher.stop();
+    });
+
+    it('U-CW-11b: emits channel.added when an existing agent gains a channel whose token is in .env', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      writeConfigFile(configPath, rawConfig());
+      const watcher = new ConfigWatcher(configPath, loadConfig(configPath), logger);
+
+      const channelSpy = jest.fn();
+      watcher.on('channel.added', channelSpy);
+
+      // What agent_update/add_channel does.
+      writeAgentEnv('alfred', 'ALFRED_DISCORD_TOKEN=alfred-discord-secret\n');
+      const raw = rawConfig();
+      const alfred = (raw.agents as Record<string, unknown>[])[0];
+      alfred.discord = { botToken: '${ALFRED_DISCORD_TOKEN}' };
+      writeConfigFile(configPath, raw);
+
+      watcher.reload();
+
+      expect(channelSpy).toHaveBeenCalledWith('alfred', 'discord');
+      expect(watcher.getConfig().agents[0].discord!.botToken).toBe('alfred-discord-secret');
+
+      watcher.stop();
+    });
+
+    it('U-CW-11c: logs the skip and the missing variable when no .env resolves the placeholder', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      writeConfigFile(configPath, rawConfig());
+      const watcher = new ConfigWatcher(configPath, loadConfig(configPath), logger);
+
+      const addedSpy = jest.fn();
+      watcher.on('agent.added', addedSpy);
+
+      // Placeholder with no .env anywhere: the agent must still be skipped
+      // rather than crash the reload — but the skip has to be visible.
+      const raw = rawConfig();
+      (raw.agents as unknown[]).push(rawAgentWithToken('nowhere', '${NOWHERE_BOT_TOKEN}'));
+      writeConfigFile(configPath, raw);
+
+      expect(() => watcher.reload()).not.toThrow();
+
+      expect(addedSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Agent skipped during config reload',
+        { id: 'nowhere', reason: 'Missing environment variable: NOWHERE_BOT_TOKEN', missingVar: 'NOWHERE_BOT_TOKEN' },
+      );
+      // The healthy agents are untouched by their neighbour's bad token.
+      expect(watcher.getConfig().agents.map(a => a.id)).toEqual(['alfred', 'baerbel']);
+
+      watcher.stop();
+    });
+
+    it('U-CW-11d: does not let a per-agent .env overwrite a variable already in process.env', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      writeConfigFile(configPath, rawConfig());
+      const watcher = new ConfigWatcher(configPath, loadConfig(configPath), logger);
+
+      const addedSpy = jest.fn();
+      watcher.on('agent.added', addedSpy);
+
+      // An operator-exported value must win over the file on disk, otherwise
+      // reload would silently swap out a token the operator set deliberately.
+      process.env.CARLOS_BOT_TOKEN = 'from-process-env';
+      writeAgentEnv('carlos', 'CARLOS_BOT_TOKEN=from-dotenv\n');
+      const raw = rawConfig();
+      (raw.agents as unknown[]).push(rawAgentWithToken('carlos', '${CARLOS_BOT_TOKEN}'));
+      writeConfigFile(configPath, raw);
+
+      watcher.reload();
+
+      expect(addedSpy).toHaveBeenCalledTimes(1);
+      expect((addedSpy.mock.calls[0][0] as AgentConfig).telegram!.botToken).toBe('from-process-env');
+      expect(process.env.CARLOS_BOT_TOKEN).toBe('from-process-env');
+
+      watcher.stop();
+    });
+  });
 });

--- a/tests/unit/load-dotenv.test.ts
+++ b/tests/unit/load-dotenv.test.ts
@@ -1,0 +1,49 @@
+import { parseDotenv } from '../../src/load-dotenv';
+
+// ---------------------------------------------------------------------------
+// U-DE: the shared `.env` line parser.
+//
+// Used by both `~/.claude-gateway/.env` (loadGatewayDotenv) and the per-agent
+// `agents/<id>/.env` files (src/config/agent-env.ts). The two used to carry
+// separate copies of this loop and had already drifted on quote handling —
+// which is the silent case, because a quoted token still resolves its ${VAR},
+// so the config loads clean and only the receiver notices.
+// ---------------------------------------------------------------------------
+describe('parseDotenv', () => {
+  it('U-DE-01: parses pairs in file order and trims surrounding whitespace', () => {
+    expect(parseDotenv('A=1\n  B = 2  \nC=3\n')).toEqual([
+      { key: 'A', value: '1' },
+      { key: 'B', value: '2' },
+      { key: 'C', value: '3' },
+    ]);
+  });
+
+  it('U-DE-02: strips surrounding quotes from the value', () => {
+    expect(parseDotenv('T="123:ABC-def"\nU=\'sk-live\'\n')).toEqual([
+      { key: 'T', value: '123:ABC-def' },
+      { key: 'U', value: 'sk-live' },
+    ]);
+  });
+
+  it('U-DE-03: keeps quotes that are inside the value', () => {
+    // Only the outermost pair is shell quoting; an inner quote is data.
+    expect(parseDotenv('T=a"b"c\n')).toEqual([{ key: 'T', value: 'a"b"c' }]);
+  });
+
+  it('U-DE-04: keeps `=` and `#` that appear inside a value', () => {
+    // Tokens contain both, and only the first `=` separates key from value.
+    expect(parseDotenv('T=a=b#c\n')).toEqual([{ key: 'T', value: 'a=b#c' }]);
+  });
+
+  it('U-DE-05: drops blanks, comments and lines with no key', () => {
+    expect(parseDotenv('\n# comment\n   \n=novalue\nnot-a-pair\nA=1\n')).toEqual([
+      { key: 'A', value: '1' },
+    ]);
+  });
+
+  it('U-DE-06: yields an empty value for a key with nothing after the `=`', () => {
+    // What `agent_update remove_channel` can leave behind; the caller decides
+    // what an empty token means, the parser does not drop the key.
+    expect(parseDotenv('T=\n')).toEqual([{ key: 'T', value: '' }]);
+  });
+});


### PR DESCRIPTION
Closes #427

## Problem

An agent created through the MCP `agent_create` tool is never started by an already-running gateway.

The tool writes the real bot token to a brand-new `agents/<id>/.env` and only a `${VAR}` placeholder into `config.json` ([`handlers.ts:289-292`, `:359-370`](../blob/main/mcp/tools/agent/handlers.ts)). But `loadConfig()` interpolates strictly from `process.env` (`src/config/loader.ts:32`), and the gateway read the agents directory exactly once — at startup, in `main()` (`src/index.ts:573-574`).

So on a gateway that started *before* the agent existed:

1. `ACME_BOT_TOKEN` is not in `process.env`.
2. `loadConfig()` catches `MissingEnvVarError` and drops the agent (`loader.ts:205-218`) — via `console.warn`, which never reaches `logs/gateway.log`.
3. `diffConfig` therefore sees no new agent; `reload()` logs *"no effective differences detected"* and returns (`watcher.ts:84-88`).
4. `agent.added` never fires — and the code that would have loaded the `.env` lives **inside that handler** (`index.ts:943-955`).

A chicken-and-egg deadlock: the event that makes the token resolvable can only fire once the token is already resolvable. The only escapes were restarting the gateway or hand-inlining the raw token into `config.json` — exactly what the `${VAR}` scheme exists to avoid.

`agent_update` with `action: add_channel` fails the same way (`handlers.ts:472-482`, `:530-545`): the whole agent drops out of the reloaded snapshot, so there is no field change either, and `channel.added` never fires. The new channel silently no-ops.

Not affected: the HTTP API path stores the raw token (`router.ts:1644`), so API-created agents start normally.

## Fix

**1. Refresh the `.env` files before every load, not just at startup.**

`loadAgentEnvFile` / `loadAgentEnvFiles` move out of `src/index.ts` into a new `src/config/agent-env.ts`, and `ConfigWatcher.reload()` calls `loadAgentEnvFiles()` before `loadConfig()`.

Loading is idempotent by construction — values already in `process.env` win — so a reload only ever *adds* variables that have newly appeared, and a token the operator exported is never clobbered by the file on disk.

Reads are now fault-tolerant (missing dir, unreadable file). This matters because the code moved: it now runs inside the watcher's change handler, outside `reload()`'s `try`, where a throw on one bad `.env` would escape into chokidar's callback uncaught. An unreadable file degrades to the normal "unresolvable `${VAR}`" path instead, which is reported properly by (2).

**2. Make the silent drop observable.**

`loadConfig()` takes an optional `onSkippedAgent` callback, and `ConfigWatcher` logs each skip through the structured logger — including the missing variable name, now carried on `MissingEnvVarError.varName` rather than scraped out of the message.

The log happens **before** the no-change bail-out, deliberately: a dropped agent produces exactly zero diff, so that warning is the only trace it leaves.

**3. Remove the two now-unreachable `.env` loads** from the `agent.added` / `channel.added` handlers. `ConfigWatcher` owns the refresh; keeping a second copy in the handlers would be dead code that reads like a safety net.

## Tests

`tests/unit/config-watcher.test.ts`, `U-CW-11a`–`d`:

| | Covers |
|---|---|
| `11a` | `agent_create`: token only in a new `agents/<id>/.env` → `agent.added` fires **and** the token is resolved, not passed through as the literal `${VAR}` |
| `11b` | `add_channel`: an existing agent gains a channel whose token is in `.env` → `channel.added` fires |
| `11c` | Genuinely unresolvable `${VAR}` → agent still skipped rather than crashing, healthy agents untouched, and the skip + variable name logged via the structured logger |
| `11d` | A value already in `process.env` is not overwritten by the `.env` |

**Proven to fail on the pre-fix behaviour**, each against the specific change it pins:

- Remove `loadAgentEnvFiles()` from `reload()` → `11a` and `11b` fail with *"Expected number of calls: 1, Received: 0"* — the original bug, exactly.
- Remove the skip logging → `11c` fails (`Number of calls: 0`).
- Let `.env` override `process.env` → `11d` fails (`Expected "from-process-env", Received "from-dotenv"`).

`11d` deliberately still passes under the first revert: it pins preserved precedence, not new behaviour.

## Verification

- `tsc --noEmit` clean
- Full suite: **230 suites / 4155 tests pass** (4139 baseline + 16 new)

## Docs

README's "Bot tokens" section said tokens are "auto-loaded at startup", which this change makes stale. Updated to state the reload behaviour, the `process.env`-wins precedence, and that an unresolvable variable skips one agent and is logged with its name.

The MCP tool's own success message already promised hot-add with a restart fallback — this makes that promise true; no wording change needed.

## Acceptance criteria

| AC (from #427) | Status |
|---|---|
| `agent_create` on a running gateway → `agent.added` fires and the agent starts, no restart, no hand-editing | ✅ `11a` |
| `logs/gateway.log` shows `Agent hot-added successfully`; receiver polls | ✅ unchanged handler, now reachable (`index.ts:920`) |
| `agent_update`/`add_channel` starts the new receiver without a restart | ✅ `11b` |
| Unresolvable `${VAR}` still skips rather than crashing, **and** is logged with the variable name | ✅ `11c` |
| A variable already in `process.env` is not overwritten on reload | ✅ `11d` |
| Regression test fails on current code, passes with the fix | ✅ revert-proofed three ways |


## Follow-up in this PR: a rotated token was served from a stale `process.env`

Folding the `.env` files in before every reload exposed the other half of the
same one-way copy. `loadAgentEnvFile` wrote a variable only when it was
*absent*, so `process.env` acted as a cache that outlived the file it came
from — once a token was in there, a new value on disk could never displace it.

Reachable path, and it is the token-revocation one:

1. `agent_update` `remove_channel` strips the line from `agents/<id>/.env` and drops the channel from `config.json`.
2. `agent_update` `add_channel` writes the **new** token to that `.env` and puts the same `${VAR}` placeholder back.
3. Reload resolves the placeholder from the stale `process.env` → `channel.added` fires with the **revoked** token.

Reload reports success, `logs/gateway.log` says the channel was added, the
receiver starts — and every poll 401s until someone restarts the gateway. Same
shape as #427: a running gateway cannot see what MCP just wrote to disk.

Measured before the fix, not inferred:

```
after create : token-AAA
after rotate : token-AAA   <-- file says token-BBB
```

**Why it needs a ledger.** A value the operator exported and one this module
copied out of a `.env` are indistinguishable once they are in `process.env`,
and the first must never be clobbered (AC #5). So `agent-env.ts` now records
what it injected and from which file, and refreshes a variable only while it
still holds exactly the value that file last gave it. Every other case —
operator export, a second agent's `.env`, a runtime assignment — leaves the
file as the loser. AC #5 is about operator-set values and still holds; `11d`
pins it unchanged.

### Tests

New `tests/unit/agent-env.test.ts` (`U-AE-01`…`07`) covers the folding, both
precedence rules, rotation, ownership loss on a foreign write, and the
non-fatal paths. `U-CW-11e` drives the whole remove/add rotation through
`ConfigWatcher` and asserts `channel.added` carries the new token.

Revert-proofed three ways, each against the specific guard it pins:

- Drop the refresh → `U-AE-04` and `U-CW-11e` fail with *Expected `token-b`, Received `token-a`* — the revoked-token symptom itself.
- Drop `owned.file === envFile` → `U-AE-06` fails (`Received "from-other"`): a later agent's `.env` hijacks a key the first one owns.
- Drop `owned.value === current` → `U-AE-05` fails (`Received "token-b"`): a runtime assignment gets overwritten by the file.

### Known limitation (unchanged, now documented)

Only `config.json` is watched, so hand-editing a `.env` alone does not trigger
a reload — the new value applies on the next one. The MCP tools write both
files, so the flows above take effect immediately. README's "Bot tokens"
section now states this alongside the precedence rules.
