### PR TITLE
[Bug] Accept the Bypass Permissions dialog on both Claude Code TUI renderings

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ Controls the Claude subprocess backend for all non-app agents.
 
 `--dangerously-skip-permissions` is always injected by the gateway automatically — there is no per-agent config field for it.
 
+In PTY mode that flag makes Claude Code open a "Bypass Permissions mode" confirmation dialog at startup, which the wrapper accepts on your behalf. How it is accepted depends on the Claude Code build: releases up to **2.1.247** render numbered options (`1. No, exit` / `2. Yes, I accept`) and are accepted with the digit, while **2.1.248 and newer** drop the numbers, so the wrapper walks the caret onto the accept row and only then presses Enter. If a future release changes the dialog beyond what the wrapper recognises, it deliberately sends **no** keystroke and leaves the dialog on screen rather than risk selecting "No, exit" (which would exit Claude Code) — set `PTY_SHELL_SKIP_DIALOG_DISMISS=1` to turn the auto-accept off entirely.
+
 ```json
 {
   "gateway": {

--- a/src/shell/bypass-dialog.ts
+++ b/src/shell/bypass-dialog.ts
@@ -49,29 +49,80 @@ export const BYPASS_KEY_UP = '\x1b[A';
 export const BYPASS_KEY_ENTER = '\r';
 
 /**
- * Cap on keystrokes sent per dialog — arrow moves plus the accepting key
- * itself. The dialog needs at most two (one move, one Enter), so the budget
- * exists purely so a dialog that renders but never responds cannot draw
- * unbounded key traffic: those keys are not discarded by an unresponsive TUI,
- * they queue, and land in the prompt once it finally opens. Exhausting the
- * budget falls back to 'wait' — the fail-safe visible dialog.
+ * Ceiling on keystrokes sent per dialog — arrow moves plus the accepting key
+ * itself. A healthy dialog needs at most two (one move, one Enter); the
+ * ceiling exists so a dialog that renders but never responds cannot draw
+ * *unbounded* key traffic, because those keys are not discarded by an
+ * unresponsive TUI — they queue and land in the prompt once it opens.
+ *
+ * Sized to the startup window rather than to the happy path. maybeHandleDialog()
+ * only runs while the shell is not ready, so the caller can make at most
+ * STARTUP_TIMEOUT_MS / DIALOG_ACTION_COOLDOWN_MS = 120000/2000 = 60 attempts
+ * before the startup timeout ends the process anyway; a test pins that
+ * arithmetic against the driver's own constants. A tighter ceiling would go
+ * silent partway through that window, so a dialog that merely swallowed its
+ * first keystrokes (still rendering, key handler not yet attached) would never
+ * be retried and would die at the startup timeout into a respawn loop — the
+ * exact #431 symptom. Overspending is cheap by comparison: an unresponsive TUI
+ * only ever collects arrows and digits here (Enter is sent solely after the
+ * caret is *observed* to have moved, which an unresponsive TUI never does), so
+ * the worst case is junk characters in an input draft the driver already
+ * clears, never a submitted line.
+ *
+ * Exhausting the ceiling falls back to 'wait' — the fail-safe visible dialog.
  */
-export const BYPASS_MAX_KEYS = 4;
+export const BYPASS_MAX_KEYS = 60;
+
+/**
+ * Consecutive rounds with no dialog on screen before the keystroke ceiling is
+ * considered spent on a dialog that is gone.
+ *
+ * Not 1: detection needs both TUI_BYPASS_PERMS markers inside the same bottom
+ * region (screen.ts DIALOG_REGION_ROWS), so a repaint that shifts the box by a
+ * row drops the header out of that window for a single read. Resetting on one
+ * miss would zero the counter mid-dialog — precisely the case the ceiling
+ * exists for. Requiring sustained absence costs the next dialog one extra
+ * cooldown round at most.
+ */
+export const BYPASS_RESET_AFTER_MISSES = 2;
 
 export type BypassDialogAction =
   /** Numbered rendering: type this digit, which selects and confirms in one key. */
   | { kind: 'digit'; key: string }
-  /** Un-numbered rendering: caret is elsewhere, walk it toward the accept row. */
+  /**
+   * Un-numbered rendering: the caret is on the decline row, so step it onto
+   * the accept row. Exactly one step — see decideBypassDialogAction(); a caret
+   * anywhere other than the decline row is ambiguous and yields 'wait'.
+   */
   | { kind: 'move'; key: string }
   /** Caret is on the accept row — safe to confirm. */
   | { kind: 'confirm'; key: string }
   /** Nothing safe to do this round; `reason` is for the log. */
   | { kind: 'wait'; reason: string };
 
-/** Per-dialog bookkeeping. Reset once the dialog leaves the screen. */
+/** Per-dialog bookkeeping. Reset once the dialog has left the screen. */
 export interface BypassDialogState {
   /** Keystrokes already sent for the current dialog. */
   keys: number;
+  /** Consecutive rounds the dialog was not detected — see noteDialogAbsent(). */
+  misses: number;
+}
+
+/**
+ * Record a round in which no dialog was detected, clearing the keystroke count
+ * once the dialog has been absent for BYPASS_RESET_AFTER_MISSES consecutive
+ * rounds so the next dialog starts with a full allowance. Tolerating a single
+ * miss keeps a one-round detection flicker (a repaint shifting the header out
+ * of the detection window) from silently refilling the allowance mid-dialog.
+ */
+export function noteDialogAbsent(state: BypassDialogState): void {
+  state.misses++;
+  if (state.misses >= BYPASS_RESET_AFTER_MISSES) state.keys = 0;
+}
+
+/** Record a round in which the dialog *was* detected, restarting the miss run. */
+export function noteDialogPresent(state: BypassDialogState): void {
+  state.misses = 0;
 }
 
 /** One option row of the dialog as it appears on screen. */
@@ -96,9 +147,22 @@ interface OptionRow {
  * The caret is U+276F only — never the ASCII '>' that TUI_MENU_OPTION_RE
  * tolerates for row content — because the real TUI never renders '>' as a
  * caret while prose (markdown blockquotes) renders it constantly.
+ *
+ * The label is escaped before interpolation. These patterns are built at module
+ * load, and the labels above are meant to be edited when the TUI changes: an
+ * unescaped label containing '(' would throw SyntaxError at import time and take
+ * every PTY session down with it, and a '.' would silently become a wildcard
+ * that widens what counts as a selectable row.
  */
-function rowPattern(label: string): RegExp {
-  return new RegExp(`^[\\s│]*(❯)?\\s*(?:(\\d+)\\.)?\\s*${label}[\\s│]*$`);
+function escapeForRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Exported only so a unit test can prove the escaping above. */
+export function rowPattern(label: string): RegExp {
+  return new RegExp(
+    `^[\\s│]*(❯)?\\s*(?:(\\d+)\\.)?\\s*${escapeForRegExp(label)}[\\s│]*$`,
+  );
 }
 
 const ACCEPT_ROW_RE = rowPattern(BYPASS_ACCEPT_LABEL);
@@ -147,11 +211,11 @@ export function decideBypassDialogAction(
   if (!accept) return { kind: 'wait', reason: 'accept row not parseable on screen' };
 
   // Numbered rendering (<= 2.1.247): the digit selects and confirms in one
-  // keystroke — the pre-#431 behavior, preserved. The index comes from the
-  // accept row itself, so a reordered dialog cannot make us type the digit
-  // that means "No, exit". A wider index is not one keystroke, and how such a
-  // dialog responds to arrows has never been observed, so it stops here rather
-  // than guessing its way toward Enter.
+  // keystroke, the same key the pre-#431 code sent — but read off the accept
+  // row rather than hard-coded, so a reordered dialog cannot make us type the
+  // digit that means "No, exit". A wider index is not one keystroke, and how
+  // such a dialog responds to arrows has never been observed, so it stops here
+  // rather than guessing its way toward Enter.
   if (accept.digit !== null) {
     if (accept.digit >= 1 && accept.digit <= 9) {
       return { kind: 'digit', key: String(accept.digit) };
@@ -167,6 +231,12 @@ export function decideBypassDialogAction(
   // decline row: a screen with no caret at all is still rendering (or is not
   // the live dialog), and one with a caret on both rows is not a shape we
   // understand. Guessing either way risks confirming "No, exit".
+  //
+  // So this is a single step between two known rows, not a search: on a dialog
+  // whose caret sits on some third row, every round yields 'wait' and the
+  // operator sees the dialog. Both observed renderings have exactly these two
+  // options, and stepping blindly toward a row we cannot see the caret on is
+  // how Enter ends up on "No, exit".
   if (!decline?.caret || accept.caret) {
     return { kind: 'wait', reason: 'no unambiguous caret on the dialog rows' };
   }

--- a/src/shell/bypass-dialog.ts
+++ b/src/shell/bypass-dialog.ts
@@ -32,9 +32,15 @@
  * Driver.maybeHandleDialog() in claude-pty-shell.ts for where it is wired in.
  */
 
-/** The dialog's two option labels — also the TUI_BYPASS_PERMS detection markers. */
-const ACCEPT_LABEL = 'Yes, I accept';
-const DECLINE_LABEL = 'No, exit';
+/**
+ * The dialog's two option labels. BYPASS_ACCEPT_LABEL is the same string
+ * screen.ts lists in TUI_BYPASS_PERMS as a detection marker; it is repeated
+ * here rather than imported to keep this module dependency-free, and a unit
+ * test asserts the two never drift apart (screen.ts: "all matchers live here
+ * so a UI change requires touching exactly one file").
+ */
+export const BYPASS_ACCEPT_LABEL = 'Yes, I accept';
+export const BYPASS_DECLINE_LABEL = 'No, exit';
 
 /** Arrow keystrokes used to walk the caret onto the accept row. */
 export const BYPASS_KEY_DOWN = '\x1b[B';
@@ -43,12 +49,14 @@ export const BYPASS_KEY_UP = '\x1b[A';
 export const BYPASS_KEY_ENTER = '\r';
 
 /**
- * Cap on arrow keystrokes per dialog. The dialog has two rows, so one move is
- * always enough; the budget exists purely so a dialog that renders but never
- * responds cannot draw unbounded key traffic. Exhausting it falls back to
- * 'wait' — the fail-safe visible dialog, not a guessed Enter.
+ * Cap on keystrokes sent per dialog — arrow moves plus the accepting key
+ * itself. The dialog needs at most two (one move, one Enter), so the budget
+ * exists purely so a dialog that renders but never responds cannot draw
+ * unbounded key traffic: those keys are not discarded by an unresponsive TUI,
+ * they queue, and land in the prompt once it finally opens. Exhausting the
+ * budget falls back to 'wait' — the fail-safe visible dialog.
  */
-export const BYPASS_MAX_MOVES = 4;
+export const BYPASS_MAX_KEYS = 4;
 
 export type BypassDialogAction =
   /** Numbered rendering: type this digit, which selects and confirms in one key. */
@@ -62,8 +70,8 @@ export type BypassDialogAction =
 
 /** Per-dialog bookkeeping. Reset once the dialog leaves the screen. */
 export interface BypassDialogState {
-  /** Arrow keystrokes sent for the current dialog. */
-  moves: number;
+  /** Keystrokes already sent for the current dialog. */
+  keys: number;
 }
 
 /** One option row of the dialog as it appears on screen. */
@@ -93,8 +101,8 @@ function rowPattern(label: string): RegExp {
   return new RegExp(`^[\\s│]*(❯)?\\s*(?:(\\d+)\\.)?\\s*${label}[\\s│]*$`);
 }
 
-const ACCEPT_ROW_RE = rowPattern(ACCEPT_LABEL);
-const DECLINE_ROW_RE = rowPattern(DECLINE_LABEL);
+const ACCEPT_ROW_RE = rowPattern(BYPASS_ACCEPT_LABEL);
+const DECLINE_ROW_RE = rowPattern(BYPASS_DECLINE_LABEL);
 
 /**
  * Find the option row nearest the bottom of the region. A live modal is the
@@ -119,12 +127,21 @@ function findRow(lines: string[], re: RegExp): OptionRow | null {
  * blind key sequence: every keystroke is justified by what is on screen at
  * the moment it is sent.
  *
- * `state.moves` is only read/advanced by the caller for 'move' actions.
+ * `state.keys` is only read here; the caller advances it for every action that
+ * actually sends a key.
  */
 export function decideBypassDialogAction(
   dialogText: string,
   state: BypassDialogState,
 ): BypassDialogAction {
+  // Budget applies to every keystroke, not just the arrows: a dialog still on
+  // screen after this many keys is not responding to us, and the fix for #431
+  // is precisely that repeating a key at a dialog that ignores it is worse
+  // than doing nothing.
+  if (state.keys >= BYPASS_MAX_KEYS) {
+    return { kind: 'wait', reason: `keystroke budget exhausted after ${state.keys} keys` };
+  }
+
   const lines = dialogText.split('\n');
   const accept = findRow(lines, ACCEPT_ROW_RE);
   if (!accept) return { kind: 'wait', reason: 'accept row not parseable on screen' };
@@ -151,9 +168,6 @@ export function decideBypassDialogAction(
   // understand. Guessing either way risks confirming "No, exit".
   if (!decline?.caret || accept.caret) {
     return { kind: 'wait', reason: 'no unambiguous caret on the dialog rows' };
-  }
-  if (state.moves >= BYPASS_MAX_MOVES) {
-    return { kind: 'wait', reason: `move budget exhausted after ${state.moves} keystrokes` };
   }
   return {
     kind: 'move',

--- a/src/shell/bypass-dialog.ts
+++ b/src/shell/bypass-dialog.ts
@@ -1,0 +1,162 @@
+/**
+ * Decision logic for accepting Claude Code's "Bypass Permissions mode" dialog.
+ *
+ * The wrapper always injects --dangerously-skip-permissions, so the resulting
+ * confirmation modal is accepted on the operator's behalf. How to accept it
+ * depends on the Claude Code build, because the dialog's rendering changed:
+ *
+ *   Claude Code <= 2.1.247          Claude Code >= 2.1.248
+ *     ❯ 1. No, exit                   ❯ No, exit
+ *       2. Yes, I accept                Yes, I accept
+ *
+ * The old shape is a numbered select — typing the digit picks *and* confirms
+ * the row in one keystroke. The new shape has no indexes, so a digit selects
+ * nothing at all: the dialog stays up, gets re-detected every
+ * DIALOG_ACTION_COOLDOWN_MS, and the session wedges until the watchdog kills
+ * it (issue #431). Both shapes start with the caret on "No, exit".
+ *
+ * Both renderings are still in the wild, so this decides per screen rather
+ * than per version — there is no version string to read from inside the PTY
+ * anyway, and the screen is the thing that actually has to be driven.
+ *
+ * SAFETY: choosing "No, exit" terminates Claude Code, which is not
+ * recoverable, while leaving the dialog up merely means an operator sees it.
+ * So Enter is only ever sent once the caret is *observed* on the accept row,
+ * the digit is read off the accept row instead of hard-coded (a future
+ * reordering must not send us to "No, exit"), and anything unparseable or
+ * ambiguous produces no keystroke at all.
+ *
+ * This module is the pure decision — kept free of node-pty / screen imports so
+ * it is cheap to unit-test in isolation, same pattern as menu-probe.ts's
+ * decideProbeAttempt and menu-cancel.ts's decideMenuCancel. See
+ * Driver.maybeHandleDialog() in claude-pty-shell.ts for where it is wired in.
+ */
+
+/** The dialog's two option labels — also the TUI_BYPASS_PERMS detection markers. */
+const ACCEPT_LABEL = 'Yes, I accept';
+const DECLINE_LABEL = 'No, exit';
+
+/** Arrow keystrokes used to walk the caret onto the accept row. */
+export const BYPASS_KEY_DOWN = '\x1b[B';
+export const BYPASS_KEY_UP = '\x1b[A';
+/** Confirms the highlighted row ("Enter to confirm" per the dialog's own footer). */
+export const BYPASS_KEY_ENTER = '\r';
+
+/**
+ * Cap on arrow keystrokes per dialog. The dialog has two rows, so one move is
+ * always enough; the budget exists purely so a dialog that renders but never
+ * responds cannot draw unbounded key traffic. Exhausting it falls back to
+ * 'wait' — the fail-safe visible dialog, not a guessed Enter.
+ */
+export const BYPASS_MAX_MOVES = 4;
+
+export type BypassDialogAction =
+  /** Numbered rendering: type this digit, which selects and confirms in one key. */
+  | { kind: 'digit'; key: string }
+  /** Un-numbered rendering: caret is elsewhere, walk it toward the accept row. */
+  | { kind: 'move'; key: string }
+  /** Caret is on the accept row — safe to confirm. */
+  | { kind: 'confirm'; key: string }
+  /** Nothing safe to do this round; `reason` is for the log. */
+  | { kind: 'wait'; reason: string };
+
+/** Per-dialog bookkeeping. Reset once the dialog leaves the screen. */
+export interface BypassDialogState {
+  /** Arrow keystrokes sent for the current dialog. */
+  moves: number;
+}
+
+/** One option row of the dialog as it appears on screen. */
+interface OptionRow {
+  /** Line index within the scanned region — decides Down vs Up. */
+  line: number;
+  /** The ❯ caret is on this row. */
+  caret: boolean;
+  /** The row's `N.` index in the numbered rendering, or null when un-numbered. */
+  digit: number | null;
+}
+
+/**
+ * Match an option row: optional box border, optional ❯ caret, optional `N.`
+ * index, then the label and nothing else.
+ *
+ * Anchored at both ends on purpose. The dialog's own warning prose mentions
+ * accepting responsibility and Bypass Permissions mode, and a chat reply can
+ * quote the labels outright; requiring the label to be the *whole* row keeps
+ * those from being mistaken for a selectable option.
+ *
+ * The caret is U+276F only — never the ASCII '>' that TUI_MENU_OPTION_RE
+ * tolerates for row content — because the real TUI never renders '>' as a
+ * caret while prose (markdown blockquotes) renders it constantly.
+ */
+function rowPattern(label: string): RegExp {
+  return new RegExp(`^[\\s│]*(❯)?\\s*(?:(\\d+)\\.)?\\s*${label}[\\s│]*$`);
+}
+
+const ACCEPT_ROW_RE = rowPattern(ACCEPT_LABEL);
+const DECLINE_ROW_RE = rowPattern(DECLINE_LABEL);
+
+/**
+ * Find the option row nearest the bottom of the region. A live modal is the
+ * bottom-most thing on screen, so scanning upward from the end means quoted
+ * scrollback above it can never be the row we act on.
+ */
+function findRow(lines: string[], re: RegExp): OptionRow | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const m = re.exec(lines[i]);
+    if (m) return { line: i, caret: m[1] === '❯', digit: m[2] ? Number(m[2]) : null };
+  }
+  return null;
+}
+
+/**
+ * Decide the single keystroke to send at a bypass-permissions dialog, given
+ * the screen region the dialog was detected in.
+ *
+ * Callers send at most one key per call and re-read the screen before the
+ * next one (the DIALOG_ACTION_COOLDOWN_MS re-entry in maybeHandleDialog()),
+ * so multi-step acceptance is a screen-driven state machine rather than a
+ * blind key sequence: every keystroke is justified by what is on screen at
+ * the moment it is sent.
+ *
+ * `state.moves` is only read/advanced by the caller for 'move' actions.
+ */
+export function decideBypassDialogAction(
+  dialogText: string,
+  state: BypassDialogState,
+): BypassDialogAction {
+  const lines = dialogText.split('\n');
+  const accept = findRow(lines, ACCEPT_ROW_RE);
+  if (!accept) return { kind: 'wait', reason: 'accept row not parseable on screen' };
+
+  // Numbered rendering (<= 2.1.247): the digit selects and confirms in one
+  // keystroke — the pre-#431 behavior, preserved. The index comes from the
+  // accept row itself, so a reordered dialog cannot make us type the digit
+  // that means "No, exit". Only a single-character index is typable as one
+  // keystroke; a wider index falls through to the arrow path below.
+  if (accept.digit !== null) {
+    if (accept.digit >= 1 && accept.digit <= 9) {
+      return { kind: 'digit', key: String(accept.digit) };
+    }
+    return { kind: 'wait', reason: `accept row index ${accept.digit} is not a single keystroke` };
+  }
+
+  // Un-numbered rendering (>= 2.1.248): navigate, then confirm.
+  const decline = findRow(lines, DECLINE_ROW_RE);
+  if (accept.caret && !decline?.caret) return { kind: 'confirm', key: BYPASS_KEY_ENTER };
+
+  // Not on the accept row. Only move when the caret is unambiguously on the
+  // decline row: a screen with no caret at all is still rendering (or is not
+  // the live dialog), and one with a caret on both rows is not a shape we
+  // understand. Guessing either way risks confirming "No, exit".
+  if (!decline?.caret || accept.caret) {
+    return { kind: 'wait', reason: 'no unambiguous caret on the dialog rows' };
+  }
+  if (state.moves >= BYPASS_MAX_MOVES) {
+    return { kind: 'wait', reason: `move budget exhausted after ${state.moves} keystrokes` };
+  }
+  return {
+    kind: 'move',
+    key: accept.line > decline.line ? BYPASS_KEY_DOWN : BYPASS_KEY_UP,
+  };
+}

--- a/src/shell/bypass-dialog.ts
+++ b/src/shell/bypass-dialog.ts
@@ -149,8 +149,9 @@ export function decideBypassDialogAction(
   // Numbered rendering (<= 2.1.247): the digit selects and confirms in one
   // keystroke — the pre-#431 behavior, preserved. The index comes from the
   // accept row itself, so a reordered dialog cannot make us type the digit
-  // that means "No, exit". Only a single-character index is typable as one
-  // keystroke; a wider index falls through to the arrow path below.
+  // that means "No, exit". A wider index is not one keystroke, and how such a
+  // dialog responds to arrows has never been observed, so it stops here rather
+  // than guessing its way toward Enter.
   if (accept.digit !== null) {
     if (accept.digit >= 1 && accept.digit <= 9) {
       return { kind: 'digit', key: String(accept.digit) };

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -24,7 +24,13 @@ import { classifyPhantomDraft, unsubmittedDraft as discountPhantom } from './dra
 import { shouldAdoptOrphanWake } from './orphan-wake';
 import { parseControlCommand, keystrokesFor, KEY_ENTER, isAcceptablePtyInput, MAX_PTY_INPUT_BYTES } from './control-channel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
-import { decideBypassDialogAction, BypassDialogState, BYPASS_MAX_KEYS } from './bypass-dialog';
+import {
+  decideBypassDialogAction,
+  noteDialogAbsent,
+  noteDialogPresent,
+  BypassDialogState,
+  BYPASS_MAX_KEYS,
+} from './bypass-dialog';
 import { buildSubmitDiag } from './submit-diag';
 
 const POLL_MS = 200;
@@ -52,6 +58,12 @@ const MAX_ENTER_RETRIES = 2;
 const INPUT_CLEAR_MAX_KEYS = 8;
 const INPUT_CLEAR_SETTLE_MS = 60;
 const FALLBACK_IDLE_QUIET_MS = 2000;
+// Together with STARTUP_TIMEOUT_MS below this bounds how many dialog rounds can
+// ever happen: maybeHandleDialog() runs only while the shell is not ready, so at
+// most STARTUP_TIMEOUT_MS / DIALOG_ACTION_COOLDOWN_MS attempts. BYPASS_MAX_KEYS is
+// sized against that, and a unit test reads both numbers back out of this file to
+// keep the two from drifting apart (this module self-starts a Driver on import, so
+// a test cannot import them).
 const DIALOG_ACTION_COOLDOWN_MS = 2000;
 // An interactive select menu must be stable (no PTY output) this long before we
 // bridge it to chat — avoids racing a menu that's still rendering.
@@ -191,7 +203,7 @@ class Driver {
   // send at it — the arrows that walk the caret onto the accept row on builds
   // whose dialog has no row numbers, and the key that accepts (see
   // bypass-dialog.ts). Reset once the dialog leaves the screen.
-  private bypassDialog: BypassDialogState = { keys: 0 };
+  private bypassDialog: BypassDialogState = { keys: 0, misses: 0 };
   // In-flight behavioral probe round, advanced synchronously by tick() at a
   // single chokepoint — the same tick-driven pattern as menuCancel and
   // interrupting (review round 2, finding 6; replaced a detached async
@@ -1026,11 +1038,15 @@ class Driver {
     if (this.screen.quietMs() < 500) return;
     const dialog = this.screen.detectDialog();
     if (!dialog) {
-      // Dialog gone (accepted, or never really there) — the next one starts
-      // with a fresh keystroke budget.
-      this.bypassDialog.keys = 0;
+      // No dialog this round. The keystroke allowance is only refilled once it
+      // has been absent for several consecutive rounds: detectDialog() needs
+      // both markers inside the same bottom region, so a repaint that shifts
+      // the box by a row can hide it for a single read while it is still very
+      // much up, and refilling there would defeat the allowance entirely.
+      noteDialogAbsent(this.bypassDialog);
       return;
     }
+    noteDialogPresent(this.bypassDialog);
     this.lastDialogActionAt = now;
 
     if (dialog === 'bypass-permissions') {

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -24,7 +24,7 @@ import { classifyPhantomDraft, unsubmittedDraft as discountPhantom } from './dra
 import { shouldAdoptOrphanWake } from './orphan-wake';
 import { parseControlCommand, keystrokesFor, KEY_ENTER, isAcceptablePtyInput, MAX_PTY_INPUT_BYTES } from './control-channel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
-import { decideBypassDialogAction, BypassDialogState, BYPASS_MAX_MOVES } from './bypass-dialog';
+import { decideBypassDialogAction, BypassDialogState, BYPASS_MAX_KEYS } from './bypass-dialog';
 import { buildSubmitDiag } from './submit-diag';
 
 const POLL_MS = 200;
@@ -187,11 +187,11 @@ class Driver {
   // re-sent every poll while the error overlay lingers. Reset when a new turn begins.
   private requestTooLargeHandled = false;
   private lastDialogActionAt = 0;
-  // Keystroke budget for the bypass-permissions dialog, spent by the arrow
-  // keys that walk the caret onto the accept row on Claude Code builds whose
-  // dialog has no row numbers (see bypass-dialog.ts). Reset once the dialog
-  // leaves the screen.
-  private bypassDialog: BypassDialogState = { moves: 0 };
+  // Keystroke budget for the bypass-permissions dialog, spent by every key we
+  // send at it — the arrows that walk the caret onto the accept row on builds
+  // whose dialog has no row numbers, and the key that accepts (see
+  // bypass-dialog.ts). Reset once the dialog leaves the screen.
+  private bypassDialog: BypassDialogState = { keys: 0 };
   // In-flight behavioral probe round, advanced synchronously by tick() at a
   // single chokepoint — the same tick-driven pattern as menuCancel and
   // interrupting (review round 2, finding 6; replaced a detached async
@@ -1028,7 +1028,7 @@ class Driver {
     if (!dialog) {
       // Dialog gone (accepted, or never really there) — the next one starts
       // with a fresh keystroke budget.
-      this.bypassDialog.moves = 0;
+      this.bypassDialog.keys = 0;
       return;
     }
     this.lastDialogActionAt = now;
@@ -1040,26 +1040,24 @@ class Driver {
       // renders the dialog (numbered rows vs not — see bypass-dialog.ts), so
       // it is decided from the screen, one key per cooldown round.
       const action = decideBypassDialogAction(this.screen.dialogText(), this.bypassDialog);
-      switch (action.kind) {
-        case 'digit':
-          logWarn('accepting Bypass Permissions dialog (per built-in --dangerously-skip-permissions)');
-          this.host.writeRaw(action.key);
-          break;
-        case 'move':
-          this.bypassDialog.moves++;
-          logWarn(`Bypass Permissions dialog: moving caret to the accept row (${this.bypassDialog.moves}/${BYPASS_MAX_MOVES})`);
-          this.host.writeRaw(action.key);
-          break;
-        case 'confirm':
-          logWarn('accepting Bypass Permissions dialog (per built-in --dangerously-skip-permissions)');
-          this.host.writeRaw(action.key);
-          break;
-        case 'wait':
-          // Deliberately no keystroke: an un-accepted dialog is visible and
-          // recoverable, a mis-aimed Enter picks "No, exit" and is not.
-          logWarn(`Bypass Permissions dialog left alone — ${action.reason}`);
-          break;
+      if (action.kind === 'wait') {
+        // Deliberately no keystroke: an un-accepted dialog is visible and
+        // recoverable, a mis-aimed Enter picks "No, exit" and is not.
+        logWarn(`Bypass Permissions dialog left alone — ${action.reason}`);
+        return;
       }
+      // Every key sent draws down the same per-dialog budget, so a dialog that
+      // ignores us stops attracting keystrokes instead of collecting them.
+      this.bypassDialog.keys++;
+      const spent = `${this.bypassDialog.keys}/${BYPASS_MAX_KEYS}`;
+      if (action.kind === 'move') {
+        logWarn(`Bypass Permissions dialog: moving caret to the accept row (${spent})`);
+      } else {
+        logWarn(
+          `accepting Bypass Permissions dialog (per built-in --dangerously-skip-permissions) (${spent})`,
+        );
+      }
+      this.host.writeRaw(action.key);
     }
   }
 

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -24,6 +24,7 @@ import { classifyPhantomDraft, unsubmittedDraft as discountPhantom } from './dra
 import { shouldAdoptOrphanWake } from './orphan-wake';
 import { parseControlCommand, keystrokesFor, KEY_ENTER, isAcceptablePtyInput, MAX_PTY_INPUT_BYTES } from './control-channel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_KEY_DOWN, PROBE_KEY_UP, PROBE_SETTLE_MS } from './menu-probe';
+import { decideBypassDialogAction, BypassDialogState, BYPASS_MAX_MOVES } from './bypass-dialog';
 import { buildSubmitDiag } from './submit-diag';
 
 const POLL_MS = 200;
@@ -186,6 +187,11 @@ class Driver {
   // re-sent every poll while the error overlay lingers. Reset when a new turn begins.
   private requestTooLargeHandled = false;
   private lastDialogActionAt = 0;
+  // Keystroke budget for the bypass-permissions dialog, spent by the arrow
+  // keys that walk the caret onto the accept row on Claude Code builds whose
+  // dialog has no row numbers (see bypass-dialog.ts). Reset once the dialog
+  // leaves the screen.
+  private bypassDialog: BypassDialogState = { moves: 0 };
   // In-flight behavioral probe round, advanced synchronously by tick() at a
   // single chokepoint — the same tick-driven pattern as menuCancel and
   // interrupting (review round 2, finding 6; replaced a detached async
@@ -1019,14 +1025,41 @@ class Driver {
     if (now - this.lastDialogActionAt < DIALOG_ACTION_COOLDOWN_MS) return;
     if (this.screen.quietMs() < 500) return;
     const dialog = this.screen.detectDialog();
-    if (!dialog) return;
+    if (!dialog) {
+      // Dialog gone (accepted, or never really there) — the next one starts
+      // with a fresh keystroke budget.
+      this.bypassDialog.moves = 0;
+      return;
+    }
     this.lastDialogActionAt = now;
 
     if (dialog === 'bypass-permissions') {
       // --dangerously-skip-permissions is built into the wrapper, so the
       // confirmation dialog is always accepted on the operator's behalf.
-      logWarn('accepting Bypass Permissions dialog (per built-in --dangerously-skip-permissions)');
-      this.host.writeRaw('2');
+      // WHICH keystroke does that depends on how the running Claude Code
+      // renders the dialog (numbered rows vs not — see bypass-dialog.ts), so
+      // it is decided from the screen, one key per cooldown round.
+      const action = decideBypassDialogAction(this.screen.dialogText(), this.bypassDialog);
+      switch (action.kind) {
+        case 'digit':
+          logWarn('accepting Bypass Permissions dialog (per built-in --dangerously-skip-permissions)');
+          this.host.writeRaw(action.key);
+          break;
+        case 'move':
+          this.bypassDialog.moves++;
+          logWarn(`Bypass Permissions dialog: moving caret to the accept row (${this.bypassDialog.moves}/${BYPASS_MAX_MOVES})`);
+          this.host.writeRaw(action.key);
+          break;
+        case 'confirm':
+          logWarn('accepting Bypass Permissions dialog (per built-in --dangerously-skip-permissions)');
+          this.host.writeRaw(action.key);
+          break;
+        case 'wait':
+          // Deliberately no keystroke: an un-accepted dialog is visible and
+          // recoverable, a mis-aimed Enter picks "No, exit" and is not.
+          logWarn(`Bypass Permissions dialog left alone — ${action.reason}`);
+          break;
+      }
     }
   }
 

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -478,13 +478,23 @@ export class ScreenModel {
     return draft;
   }
 
+  /**
+   * The exact screen region {@link detectDialog} matches against. Exposed so a
+   * dialog's follow-up action (see decideBypassDialogAction in bypass-dialog.ts)
+   * reads the same rows the detection was made from — acting on a wider view
+   * could send keystrokes because of text that never triggered the detector.
+   */
+  dialogText(): string {
+    return this.bottomText(DIALOG_REGION_ROWS);
+  }
+
   detectDialog(): DialogKind | null {
     // Scan only the bottom region: a real modal dialog renders there, while a
     // reply/history quoting "Bypass Permissions mode … Yes, I accept" sits in the
     // scrollback above and must not trigger the auto-accept keystroke. The dialog
     // has no transcript signal, so this region guard (plus requiring BOTH markers)
     // is the available defense.
-    const text = this.bottomText(DIALOG_REGION_ROWS);
+    const text = this.dialogText();
     if (TUI_BYPASS_PERMS.every((s) => text.includes(s))) {
       return 'bypass-permissions';
     }

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -18,6 +18,13 @@ import { Writable } from 'stream';
 import { preTrustWorkspace, checkAuthStatus } from '../../src/shell/trust';
 import { decideMenuCancel, MenuCancelState } from '../../src/shell/menu-cancel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_MAX_ROUNDS, PROBE_RETRY_COOLDOWN_MS } from '../../src/shell/menu-probe';
+import {
+  decideBypassDialogAction,
+  BYPASS_KEY_DOWN,
+  BYPASS_KEY_UP,
+  BYPASS_KEY_ENTER,
+  BYPASS_MAX_MOVES,
+} from '../../src/shell/bypass-dialog';
 import { shouldAdoptOrphanWake, OrphanWakeObs } from '../../src/shell/orphan-wake';
 import * as os from 'os';
 import * as fs from 'fs';
@@ -865,6 +872,117 @@ describe('ScreenModel detectDialog (region-restricted)', () => {
   it('requires BOTH markers (one alone never triggers)', async () => {
     const screen = await renderScreen([...FILLER(45), '  Bypass Permissions mode']);
     expect(screen.detectDialog()).toBeNull();
+  });
+});
+
+describe('decideBypassDialogAction (accepting the bypass dialog across Claude Code versions)', () => {
+  // Both fixtures are verbatim captures of the real dialog, taken by driving
+  // `claude --dangerously-skip-permissions` through node-pty + @xterm/headless
+  // and reading the screen with no keys pressed. The ONLY difference between
+  // them is the option rows: Claude Code <= 2.1.247 numbers them, >= 2.1.248
+  // does not (bisected to that exact release — issue #431). Both start with
+  // the caret on "No, exit".
+  const DIALOG_BODY = [
+    '  WARNING: Claude Code running in Bypass Permissions mode',
+    '',
+    '  In Bypass Permissions mode, Claude Code will not ask for your approval before running',
+    '  potentially dangerous commands.',
+    '  This mode should only be used in a sandboxed container/VM that has restricted internet access',
+    '  and can easily be restored if damaged.',
+    '',
+    '  By proceeding, you accept all responsibility for actions taken while running in Bypass',
+    '  Permissions mode.',
+    '',
+    '  https://code.claude.com/docs/en/security',
+    '',
+  ];
+  const DIALOG_FOOTER = ['', '  Enter to confirm · Esc to cancel'];
+  // FILLER pushes the modal down into the bottom-region window detectDialog()
+  // scans, the way a real session's scrollback does.
+  const dialog = (rows: string[]) => [...FILLER(34), ...DIALOG_BODY, ...rows, ...DIALOG_FOOTER];
+
+  /** Claude Code <= 2.1.247 — numbered rows, caret on decline. */
+  const LEGACY_ROWS = ['  ❯ 1. No, exit', '    2. Yes, I accept'];
+  /** Claude Code >= 2.1.248 — no row numbers, caret on decline. */
+  const CURRENT_ROWS = ['  ❯ No, exit', '    Yes, I accept'];
+  /** The same build after one Down: caret has moved onto the accept row. */
+  const CURRENT_ROWS_AFTER_DOWN = ['    No, exit', '  ❯ Yes, I accept'];
+
+  const decide = async (rows: string[], moves = 0) => {
+    const screen = await renderScreen(dialog(rows));
+    // Sanity: every fixture is a screen the detector actually fires on, so the
+    // decision is only ever asked about dialogs that reached this code path.
+    expect(screen.detectDialog()).toBe('bypass-permissions');
+    return decideBypassDialogAction(screen.dialogText(), { moves });
+  };
+
+  it('types the digit on the numbered rendering (<= 2.1.247 behavior, unchanged)', async () => {
+    // Proven live on 2.1.247: the digit alone selects AND confirms — Claude
+    // Code dismissed the dialog and persisted skipDangerousModePermissionPrompt.
+    expect(await decide(LEGACY_ROWS)).toEqual({ kind: 'digit', key: '2' });
+  });
+
+  it('reads the digit off the accept row instead of hard-coding it', async () => {
+    // Same numbered shape with the options ordered the other way. The pre-#431
+    // code sent a hard-coded '2', which here means "No, exit" — i.e. it would
+    // have killed the session rather than accepted.
+    const action = await decide(['  ❯ 1. Yes, I accept', '    2. No, exit']);
+    expect(action).toEqual({ kind: 'digit', key: '1' });
+  });
+
+  it('moves the caret toward the accept row on the un-numbered rendering (>= 2.1.248)', async () => {
+    // Proven live on 2.1.251: '2' leaves the caret untouched, Down moves it.
+    expect(await decide(CURRENT_ROWS)).toEqual({ kind: 'move', key: BYPASS_KEY_DOWN });
+  });
+
+  it('confirms only once the caret is observed on the accept row', async () => {
+    expect(await decide(CURRENT_ROWS_AFTER_DOWN)).toEqual({ kind: 'confirm', key: BYPASS_KEY_ENTER });
+  });
+
+  it('moves up when the accept row is listed above the caret', async () => {
+    const action = await decide(['    Yes, I accept', '  ❯ No, exit']);
+    expect(action).toEqual({ kind: 'move', key: BYPASS_KEY_UP });
+  });
+
+  it('NEVER confirms while the caret is on "No, exit" (that keystroke exits Claude Code)', async () => {
+    for (const rows of [CURRENT_ROWS, ['    Yes, I accept', '  ❯ No, exit']]) {
+      const action = await decide(rows);
+      expect(action.kind).not.toBe('confirm');
+    }
+  });
+
+  it('does nothing when no row is highlighted (still rendering / not the live dialog)', async () => {
+    const action = await decide(['    No, exit', '    Yes, I accept']);
+    expect(action.kind).toBe('wait');
+  });
+
+  it('does nothing when both rows carry a caret (shape we do not understand)', async () => {
+    const action = await decide(['  ❯ No, exit', '  ❯ Yes, I accept']);
+    expect(action.kind).toBe('wait');
+  });
+
+  it('stops moving once the keystroke budget is spent, rather than guessing Enter', async () => {
+    const action = await decide(CURRENT_ROWS, BYPASS_MAX_MOVES);
+    expect(action.kind).toBe('wait');
+    // One below the cap still moves — the budget bounds key traffic, it does
+    // not disable the fix.
+    expect(await decide(CURRENT_ROWS, BYPASS_MAX_MOVES - 1)).toEqual({ kind: 'move', key: BYPASS_KEY_DOWN });
+  });
+
+  it('ignores prose that merely quotes the labels mid-sentence', async () => {
+    const action = await decide([
+      '  ❯ No, exit',
+      '  You will be asked to pick Yes, I accept before the session starts.',
+    ]);
+    expect(action.kind).toBe('wait');
+  });
+
+  it('acts only on the region the detector fired for (quoted dialog in scrollback)', async () => {
+    // Same guard detectDialog() has: rows sitting in the upper scrollback are
+    // not a live modal, and must not attract a keystroke.
+    const screen = await renderScreen([...dialog(CURRENT_ROWS_AFTER_DOWN), ...FILLER(44), '❯ ']);
+    expect(screen.detectDialog()).toBeNull();
+    expect(decideBypassDialogAction(screen.dialogText(), { moves: 0 }).kind).toBe('wait');
   });
 });
 

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -20,10 +20,14 @@ import { decideMenuCancel, MenuCancelState } from '../../src/shell/menu-cancel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_MAX_ROUNDS, PROBE_RETRY_COOLDOWN_MS } from '../../src/shell/menu-probe';
 import {
   decideBypassDialogAction,
+  noteDialogAbsent,
+  noteDialogPresent,
+  rowPattern,
   BYPASS_KEY_DOWN,
   BYPASS_KEY_UP,
   BYPASS_KEY_ENTER,
   BYPASS_MAX_KEYS,
+  BYPASS_RESET_AFTER_MISSES,
   BYPASS_ACCEPT_LABEL,
   BYPASS_DECLINE_LABEL,
 } from '../../src/shell/bypass-dialog';
@@ -915,7 +919,7 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
     // Sanity: every fixture is a screen the detector actually fires on, so the
     // decision is only ever asked about dialogs that reached this code path.
     expect(screen.detectDialog()).toBe('bypass-permissions');
-    return decideBypassDialogAction(screen.dialogText(), { keys });
+    return decideBypassDialogAction(screen.dialogText(), { keys, misses: 0 });
   };
 
   it('types the digit on the numbered rendering (<= 2.1.247 behavior, unchanged)', async () => {
@@ -976,6 +980,67 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
     expect(await decide(CURRENT_ROWS, BYPASS_MAX_KEYS - 1)).toEqual({ kind: 'move', key: BYPASS_KEY_DOWN });
   });
 
+  it('keeps retrying for the whole startup window, not a fraction of it', () => {
+    // The pre-#431 code retried every DIALOG_ACTION_COOLDOWN_MS until the
+    // startup timeout. A ceiling below that many rounds would go silent while
+    // the shell is still starting, so a dialog that merely swallowed its first
+    // keystrokes would never be retried and would die at the startup timeout
+    // into a respawn loop — the very symptom #431 is about.
+    //
+    // claude-pty-shell.ts self-starts a Driver at import, so the two constants
+    // are read back out of its source instead of imported.
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../src/shell/claude-pty-shell.ts'),
+      'utf8',
+    );
+    const numberOf = (name: string): number => {
+      const m = new RegExp(`const ${name} = ([\\d_]+);`).exec(src);
+      if (!m) throw new Error(`${name} not found in claude-pty-shell.ts — update this test`);
+      return Number(m[1].replace(/_/g, ''));
+    };
+    const rounds = numberOf('STARTUP_TIMEOUT_MS') / numberOf('DIALOG_ACTION_COOLDOWN_MS');
+    expect(rounds).toBeGreaterThan(0);
+    expect(BYPASS_MAX_KEYS).toBeGreaterThanOrEqual(rounds);
+  });
+
+  it('does not refill the budget on a single missed detection', () => {
+    // detectDialog() needs both markers inside the same bottom region, so a
+    // repaint that shifts the box by one row hides a dialog that is still up.
+    // Refilling there would defeat the ceiling exactly when it is needed.
+    const state = { keys: 5, misses: 0 };
+    noteDialogAbsent(state);
+    expect(state.keys).toBe(5);
+  });
+
+  it('refills the budget once the dialog has been gone for several rounds', () => {
+    const state = { keys: 5, misses: 0 };
+    for (let i = 0; i < BYPASS_RESET_AFTER_MISSES; i++) noteDialogAbsent(state);
+    expect(state.keys).toBe(0);
+  });
+
+  it('restarts the miss run whenever the dialog is seen again', () => {
+    // A flicker (seen, missed, seen, missed, …) must never accumulate its way
+    // to a refill while the dialog is still on screen.
+    const state = { keys: 5, misses: 0 };
+    for (let i = 0; i < 10; i++) {
+      noteDialogAbsent(state);
+      noteDialogPresent(state);
+    }
+    expect(state.keys).toBe(5);
+  });
+
+  it('matches the option labels literally, so a label edit cannot widen the pattern', () => {
+    // rowPattern() interpolates the label into a RegExp built at module load,
+    // and the labels are meant to be edited when the TUI changes. Unescaped,
+    // '.' would silently become a wildcard...
+    expect(rowPattern('a.c').test('  abc')).toBe(false);
+    expect(rowPattern('a.c').test('  a.c')).toBe(true);
+    // ...and an unbalanced group would throw at import time, taking down every
+    // PTY session rather than one dialog.
+    expect(() => rowPattern('Yes (really)')).not.toThrow();
+    expect(rowPattern('Yes (really)').test('  ❯ Yes (really)')).toBe(true);
+  });
+
   it('bounds the digit path too — an unresponsive numbered dialog is #431 all over again', async () => {
     // Keys sent at a dialog that ignores them are not discarded, they queue and
     // land in the prompt later, so the digit gets the same budget as the arrows.
@@ -1010,7 +1075,7 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
     // not a live modal, and must not attract a keystroke.
     const screen = await renderScreen([...dialog(CURRENT_ROWS_AFTER_DOWN), ...FILLER(44), '❯ ']);
     expect(screen.detectDialog()).toBeNull();
-    expect(decideBypassDialogAction(screen.dialogText(), { keys: 0 }).kind).toBe('wait');
+    expect(decideBypassDialogAction(screen.dialogText(), { keys: 0, misses: 0 }).kind).toBe('wait');
   });
 });
 

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -932,6 +932,11 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
     expect(action).toEqual({ kind: 'digit', key: '1' });
   });
 
+  it('does nothing for a multi-digit index — that is not one keystroke', async () => {
+    const action = await decide(['  ❯ 10. No, exit', '    11. Yes, I accept']);
+    expect(action.kind).toBe('wait');
+  });
+
   it('moves the caret toward the accept row on the un-numbered rendering (>= 2.1.248)', async () => {
     // Proven live on 2.1.251: '2' leaves the caret untouched, Down moves it.
     expect(await decide(CURRENT_ROWS)).toEqual({ kind: 'move', key: BYPASS_KEY_DOWN });

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -23,7 +23,9 @@ import {
   BYPASS_KEY_DOWN,
   BYPASS_KEY_UP,
   BYPASS_KEY_ENTER,
-  BYPASS_MAX_MOVES,
+  BYPASS_MAX_KEYS,
+  BYPASS_ACCEPT_LABEL,
+  BYPASS_DECLINE_LABEL,
 } from '../../src/shell/bypass-dialog';
 import { shouldAdoptOrphanWake, OrphanWakeObs } from '../../src/shell/orphan-wake';
 import * as os from 'os';
@@ -908,12 +910,12 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
   /** The same build after one Down: caret has moved onto the accept row. */
   const CURRENT_ROWS_AFTER_DOWN = ['    No, exit', '  ❯ Yes, I accept'];
 
-  const decide = async (rows: string[], moves = 0) => {
+  const decide = async (rows: string[], keys = 0) => {
     const screen = await renderScreen(dialog(rows));
     // Sanity: every fixture is a screen the detector actually fires on, so the
     // decision is only ever asked about dialogs that reached this code path.
     expect(screen.detectDialog()).toBe('bypass-permissions');
-    return decideBypassDialogAction(screen.dialogText(), { moves });
+    return decideBypassDialogAction(screen.dialogText(), { keys });
   };
 
   it('types the digit on the numbered rendering (<= 2.1.247 behavior, unchanged)', async () => {
@@ -961,12 +963,33 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
     expect(action.kind).toBe('wait');
   });
 
-  it('stops moving once the keystroke budget is spent, rather than guessing Enter', async () => {
-    const action = await decide(CURRENT_ROWS, BYPASS_MAX_MOVES);
+  it('stops sending keys once the budget is spent, rather than guessing Enter', async () => {
+    const action = await decide(CURRENT_ROWS, BYPASS_MAX_KEYS);
     expect(action.kind).toBe('wait');
     // One below the cap still moves — the budget bounds key traffic, it does
     // not disable the fix.
-    expect(await decide(CURRENT_ROWS, BYPASS_MAX_MOVES - 1)).toEqual({ kind: 'move', key: BYPASS_KEY_DOWN });
+    expect(await decide(CURRENT_ROWS, BYPASS_MAX_KEYS - 1)).toEqual({ kind: 'move', key: BYPASS_KEY_DOWN });
+  });
+
+  it('bounds the digit path too — an unresponsive numbered dialog is #431 all over again', async () => {
+    // Keys sent at a dialog that ignores them are not discarded, they queue and
+    // land in the prompt later, so the digit gets the same budget as the arrows.
+    expect((await decide(LEGACY_ROWS, BYPASS_MAX_KEYS)).kind).toBe('wait');
+    expect(await decide(LEGACY_ROWS, BYPASS_MAX_KEYS - 1)).toEqual({ kind: 'digit', key: '2' });
+  });
+
+  it('bounds repeated Enter at a dialog that will not dismiss', async () => {
+    expect((await decide(CURRENT_ROWS_AFTER_DOWN, BYPASS_MAX_KEYS)).kind).toBe('wait');
+  });
+
+  it('keeps the accept label in sync with the detection marker in screen.ts', async () => {
+    // The label is duplicated (this module stays dependency-free), so drift
+    // would mean detectDialog() fires on a dialog whose rows we cannot parse.
+    expect(TUI_BYPASS_PERMS).toContain(BYPASS_ACCEPT_LABEL);
+    expect(await decide([`  ❯ ${BYPASS_DECLINE_LABEL}`, `    ${BYPASS_ACCEPT_LABEL}`])).toEqual({
+      kind: 'move',
+      key: BYPASS_KEY_DOWN,
+    });
   });
 
   it('ignores prose that merely quotes the labels mid-sentence', async () => {
@@ -982,7 +1005,7 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
     // not a live modal, and must not attract a keystroke.
     const screen = await renderScreen([...dialog(CURRENT_ROWS_AFTER_DOWN), ...FILLER(44), '❯ ']);
     expect(screen.detectDialog()).toBeNull();
-    expect(decideBypassDialogAction(screen.dialogText(), { moves: 0 }).kind).toBe('wait');
+    expect(decideBypassDialogAction(screen.dialogText(), { keys: 0 }).kind).toBe('wait');
   });
 });
 


### PR DESCRIPTION
## Summary
With `gateway.headless: false`, the PTY backend accepted Claude Code's "Bypass Permissions mode" modal by sending the digit `2`. Claude Code 2.1.248 dropped the row numbers from that dialog, so the digit selects nothing and the session wedges: the modal is re-detected every cooldown, the prompt is never reached, and the watchdog kills and respawns straight back into the same dialog. Releases up to 2.1.247 still number the rows, so the keystroke is now decided from the screen instead of hard-coded, and both renderings work.

## Related Issue
Closes #431

## Changes Made
- `src/shell/bypass-dialog.ts` (new): pure decision module — same shape as `menu-probe.ts` / `menu-cancel.ts` — returning one action per cooldown round: `digit` (numbered rendering, read off the accept row itself so a reordered dialog cannot make us type the one that means "No, exit"), `move` (arrow the caret toward the accept row), `confirm` (Enter, only once the caret is observed on the accept row), or `wait` (send nothing, log why).
- `src/shell/claude-pty-shell.ts`: `maybeHandleDialog()` now runs that decision instead of writing a literal `'2'`, tracks a per-dialog arrow-key budget, and resets it when the dialog leaves the screen.
- `src/shell/screen.ts`: added `ScreenModel.dialogText()` — the exact region `detectDialog()` matches on — so the follow-up action can never be driven by text that did not trigger the detector.
- `tests/unit/pty-shell.test.ts`: 11 unit tests over both renderings, using screens captured verbatim from live sessions.
- `README.md`: documented the version split and the fallback behaviour under `gateway.headless`.

## Safety
Choosing "No, exit" terminates Claude Code and is unrecoverable, while an un-accepted dialog is merely visible to the operator. Every ambiguous case therefore resolves to no keystroke at all: no caret on either row, a caret on both, an unparseable accept row, a multi-digit index, or an exhausted move budget. Enter is only ever sent after the caret is observed on the accept row.

## Verification
The version boundary and per-version keystroke behaviour were established empirically, by driving 12 sampled releases across the range through `node-pty` with no keys pressed and bisecting to the exact boundary:

| Claude Code | Dialog rows | Digit `2` | Down + Enter |
|---|---|---|---|
| 1.0.0 – 2.1.247 | `1. No, exit` / `2. Yes, I accept` | accepts | n/a |
| 2.1.248 – 2.1.252 | `No, exit` / `Yes, I accept` | no effect | accepts |

Both captured screens are used verbatim as the test fixtures. The new tests were confirmed to fail against the pre-fix hard-coded `'2'` before the fix was restored.

## Testing
- `npx tsc --noEmit`: pass
- `npm run build`: pass
- `npx jest --ci`: 230 suites / 4189 tests pass (baseline 230 / 4174; +15 new)

## Review follow-ups (already pushed on this branch)
- The keystroke budget now covers **every** key sent at the dialog, not just the arrows. The digit and the confirming Enter were exempt, and the digit is exactly the path that spun in #431 — keys sent at an unresponsive TUI queue rather than vanish, and land in the prompt once it opens.
- The accept label is exported and a test asserts it never drifts from the `TUI_BYPASS_PERMS` detection marker in `screen.ts`. Drift would mean `detectDialog()` fires on a dialog whose rows cannot be parsed.
- Corrected a comment that claimed a multi-digit row index falls through to the arrow path; it returns `wait` and sends nothing, which is deliberate — added the test that pins it.
