### PR TITLE
fix(ci): honour the workflow_dispatch tag input in release.yml (#433)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # `github.event.inputs` is null on a tag push, so the fallback keeps the
+      # push path identical; on workflow_dispatch it pins the checkout to the
+      # tag the operator typed instead of the branch chosen in the UI.
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -46,7 +51,9 @@ jobs:
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           generate_release_notes: true
-          tag_name: ${{ github.ref_name }}
+          # On workflow_dispatch `github.ref_name` is the branch name, which
+          # would tag the Release `main` and create refs/tags/main.
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Publish to npm
         run: npm publish --access public --provenance


### PR DESCRIPTION
Closes #433.

## Problem

`release.yml` declared a required `tag` input for `workflow_dispatch` and then never read it. A manual run built whatever branch was selected in the UI and tagged the GitHub Release with the **branch** name — creating `refs/tags/main` alongside `refs/heads/main`.

The tag-push path (`on.push.tags: v*.*.*`, driven by `make release`) was never affected.

This is latent today — no dispatch has been run, and `main` HEAD equals `v1.8.3`. It is worth closing because the situation that invites an operator to press **Run workflow** is a failed publish step, which is exactly what happened during v1.8.3 (npm token expiry). That release was recovered with `gh run rerun --failed`, which reuses the original tag ref; the next person may reach for the dispatch button instead.

## Change

Two consumers now read the input, each with a fallback to the push-event value:

```yaml
ref:      ${{ github.event.inputs.tag || github.ref }}
tag_name: ${{ github.event.inputs.tag || github.ref_name }}
```

`github.event.inputs` is used in preference to the `inputs` context because `github.event` is defined on every event, making the fallback unambiguous on a tag push.

## Verification

The half of this change that could regress the *working* release path is the fallback on a non-dispatch event, so it was proven rather than assumed. A throwaway branch (`tmp/expr-probe`, pushed, run, then deleted along with its remote ref) echoed the two expressions from a plain `push` event:

```
raw_input=[]
checkout_ref=[refs/heads/tmp/expr-probe]
tag_name=[tmp/expr-probe]
```

So on a non-dispatch event the input renders as the empty string and `||` falls through to the push-event value — the tag-push path is byte-for-byte unchanged in behaviour. The same output independently confirms the bug's mechanism: `github.ref_name` really is the branch name outside a tag push.

The workflow YAML was also re-parsed after editing to confirm both `with:` blocks land on the intended steps.

**Not verified:** the dispatch path itself. Exercising it would require merging this to the default branch (`workflow_dispatch` only appears for workflows present there) and then running a real release job, which creates a GitHub Release and attempts an npm publish. That was deliberately not done. The affected path is already broken, so the risk of the change is confined to the push path, which is covered above.

No source, tests, or docs are touched — this is CI configuration only. The repo runs no CI checks on pull requests, so there is nothing for this PR to report.