### PR TITLE
feat(logs): add `gateway logs` and bound the log directory (#435)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ only the level bounds what is *written*.
 Retention is age-based because each session writes its own `<agent>:session:<uuid>.log` and never
 returns to it — `maxFiles` prunes generations of one stream, so it can never reach them.
 
+This block is **hot-reloaded**: edit it in `config.json` and it applies on the next config reload,
+no restart. That matters because turning the level up is something you do while chasing a live
+problem, and a restart would kill the sessions you are trying to observe.
+
 ### `session`
 
 | Field | Default | Description |

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Once installed, drive it through the CLI — it detects whichever manager owns t
 claude-gateway gateway status   # manager, URL, health
 claude-gateway gateway restart
 claude-gateway gateway stop
+claude-gateway gateway logs     # tail the gateway's own log (works even when it is dead)
 ```
 
 Managing PM2 directly still works too:
@@ -214,6 +215,12 @@ Config lives at `~/.claude-gateway/config.json` (or set `GATEWAY_CONFIG` env var
   "configVersion": "1.0.0",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
+    "logs": {
+      "level": "info",
+      "maxFileBytes": 16777216,
+      "maxFiles": 3,
+      "retentionDays": 14
+    },
     "timezone": "Asia/Bangkok",
     "api": {
       "keys": [
@@ -276,6 +283,27 @@ returns the `token` (the share endpoint stays enabled) and callers with their ow
 public base — e.g. LINE, which derives its host from the inbound webhook — build
 `<base>/shared/<token>` themselves. HTTP is accepted only for local development
 hosts such as `http://host.docker.internal:10850/gateway`.
+
+### `gateway.logs` (optional)
+
+Verbosity, rotation and retention for the files in `logDir`. The whole block is optional —
+omit it and the defaults below apply.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `level` | `"info"` | Minimum level written, to both the file and stdout. One of `debug`, `info`, `warn`, `error` |
+| `maxFileBytes` | `16777216` (16 MiB) | Rotate `<name>.log` to `<name>.log.1` once an append would carry it past this size |
+| `maxFiles` | `3` | Rotated generations kept per stream; the oldest is deleted. Lowering it collects the generations it orphans at the next rotation. `0` = keep none |
+| `retentionDays` | `14` | Delete logs (live and rotated) older than this, at boot and once a day. `0` = keep forever |
+
+`level` is the one that governs disk usage. Session processes log every stream event at `debug`,
+which on a live host measured 19,995 `debug` lines to 5 `info` lines inside a single 217 MB file —
+so `debug` is off by default. Set `"level": "debug"` when you are actually chasing something, and
+expect the directory to grow quickly while it is on. Rotation and retention bound what is *kept*;
+only the level bounds what is *written*.
+
+Retention is age-based because each session writes its own `<agent>:session:<uuid>.log` and never
+returns to it — `maxFiles` prunes generations of one stream, so it can never reach them.
 
 ### `session`
 
@@ -715,6 +743,7 @@ The `claude-gateway` binary doubles as a command-line client for a running gatew
 claude-gateway                             # help (never starts a server)
 claude-gateway gateway start               # run the gateway in the foreground
 claude-gateway gateway status              # is it running? which manager owns it?
+claude-gateway gateway logs --follow       # stream the gateway log (reads files, needs no server)
 claude-gateway service install             # run it as a systemd-user (or --manager pm2) service
 claude-gateway update check                # newer claude-gateway published?
 claude-gateway claude update               # update Claude Code via its own updater
@@ -726,6 +755,28 @@ claude-gateway crons run <jobId>
 claude-gateway debug-bundle                # small redacted bundle for a stuck session (works even if the server is down)
 claude-gateway api GET /v1/agents          # escape hatch: call any endpoint directly
 ```
+
+### Reading the logs
+
+`gateway logs` reads the log files directly, so it answers whether or not the gateway is
+running — which is usually exactly when you need it.
+
+```bash
+claude-gateway gateway logs                       # last 50 lines of logs/gateway.log
+claude-gateway gateway logs --lines 200 --follow  # more history, then stream
+claude-gateway gateway logs --agent alfred        # that agent's stream instead
+claude-gateway gateway logs --json                # the stored JSON lines, verbatim
+```
+
+Each line is stored as one JSON object and rendered as `<ts> <LEVEL> <message>` with `data`
+appended; `--json` prints the stored line unchanged, for piping into `jq`. `--agent <id>` takes
+any stream id in the log directory — agents (`alfred`), receivers (`alfred:receiver`), and
+sessions (`alfred:session:<uuid>`) each get their own file — and an unknown id lists the ids that
+do exist rather than reporting an empty result. `--follow` survives a rotation: when the file it
+is watching is renamed away it reopens the new one instead of going quiet.
+
+Unlike `debug-bundle`, this output is **not redacted** — it is the local file you could already
+`cat`. Skim before pasting it anywhere.
 
 > **Upgrading from < 1.8:** a service unit that runs the binary with no command still starts the
 > gateway, with a deprecation warning. Point `ExecStart` at `claude-gateway gateway start`, or
@@ -961,6 +1012,7 @@ claude-gateway/
 ├── config.json                         ← gateway config
 ├── logs/
 │   ├── alfred.log
+│   ├── alfred.log.1                    ← rotated generation (see `gateway.logs`)
 │   └── warrior.log
 ├── shared-skills/                      ← shared skills (synced to ~/.claude/skills/ on boot and on change)
 │   └── <skill-name>/

--- a/src/cli/commands/debug-bundle.ts
+++ b/src/cli/commands/debug-bundle.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { expandHome, loadCliConfig } from '../http-client';
+import { listSessionLogs, resolveLogDir } from '../logs-dir';
 import { redactLine } from '../redact';
 import { writeCommandHelp } from '../output';
 
@@ -39,51 +39,6 @@ export function selectDiagnosticLines(content: string, maxLines = MAX_DIAG_LINES
     }
   }
   return picked.length > maxLines ? picked.slice(picked.length - maxLines) : picked;
-}
-
-/** The config file stores `logDir` exactly as written, and the shipped template
- *  writes `~/.claude-gateway/logs`. The server expands that itself on boot, so
- *  the literal tilde survives on disk and only bites a reader that forgets to
- *  expand it — `readdirSync('~/...')` throws ENOENT and looks like "no logs". */
-function resolveLogDir(flags: Record<string, string | boolean>): string {
-  if (typeof flags.logDir === 'string') return expandHome(flags.logDir);
-  const cfg = loadCliConfig(typeof flags.config === 'string' ? flags.config : undefined);
-  if (cfg.logDir) return expandHome(cfg.logDir);
-  return path.join(os.homedir(), '.claude-gateway', 'logs');
-}
-
-/**
- * Session logs in `dir`, or the reason the directory could not be read.
- *
- * The read used to be wrapped in a bare `catch { return [] }`, which reported
- * every failure as "no session logs found". That is how the unexpanded `~`
- * stayed invisible: an ENOENT on a path that was never resolved looked exactly
- * like an empty directory, and a permission problem still would. The caller
- * needs the errno to say anything useful, so it is returned rather than eaten.
- */
-function listSessionLogs(dir: string): { logs: Array<{ file: string; mtimeMs: number }>; error?: string } {
-  let names: string[];
-  try {
-    names = fs.readdirSync(dir);
-  } catch (err) {
-    const e = err as NodeJS.ErrnoException;
-    if (e.code === 'ENOENT') return { logs: [], error: `${dir} does not exist` };
-    if (e.code === 'ENOTDIR') return { logs: [], error: `${dir} is not a directory` };
-    return { logs: [], error: `${dir} could not be read (${e.code ?? e.message})` };
-  }
-  const logs = names
-    .filter((n) => n.endsWith('.log') && /session/i.test(n))
-    .map((n) => {
-      const file = path.join(dir, n);
-      let mtimeMs = 0;
-      try {
-        mtimeMs = fs.statSync(file).mtimeMs;
-      } catch {
-        /* ignore */
-      }
-      return { file, mtimeMs };
-    });
-  return { logs };
 }
 
 function claudeCodeVersion(): string {

--- a/src/cli/commands/debug-bundle.ts
+++ b/src/cli/commands/debug-bundle.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { listSessionLogs, resolveLogDir } from '../logs-dir';
+import { explicitConfigWarning, listSessionLogs, resolveLogDir } from '../logs-dir';
 import { redactLine } from '../redact';
 import { writeCommandHelp } from '../output';
 
@@ -82,6 +82,11 @@ export async function runDebugBundle(flags: Record<string, string | boolean>): P
     return 0;
   }
   const logDir = resolveLogDir(flags);
+  // A `--config` that could not be read leaves this pointing at the default
+  // directory, which would otherwise be reported as though it were the one
+  // asked for.
+  const configWarning = explicitConfigWarning(flags);
+  if (configWarning) process.stderr.write(`${configWarning}\n`);
   const sessionFilter = typeof flags.session === 'string' ? flags.session : undefined;
 
   const found = listSessionLogs(logDir);

--- a/src/cli/commands/gateway.ts
+++ b/src/cli/commands/gateway.ts
@@ -5,15 +5,21 @@ import { probeHealth } from '../health';
 import { detectManager, defaultPidfilePath, pidLooksLikeGateway } from '../manager';
 import { printJson } from '../output';
 import { writeCommandHelp } from '../output';
+import { runGatewayLogs } from './logs';
 
 /**
- * `gateway start|status|restart|stop` — whole-process lifecycle.
+ * `gateway start|status|restart|stop|logs` — whole-process lifecycle.
  *
  * `start` is handled by the boot entry point (src/index.ts), which recognises
  * it before the CLI is ever imported; it is listed here only so the usage text
  * and an unknown-verb error stay honest. Restart/stop must be performed by
  * whatever manager owns the process (it has to stop the very process serving
  * HTTP), so detection resolves the manager and the action is delegated to it.
+ *
+ * `logs` is the odd one out: it touches no process at all, reading the log
+ * files directly so it still answers when the gateway is wedged or dead. It
+ * lives here because the logs are the gateway's, and an operator looking for
+ * them looks under the noun they already know.
  */
 export async function runGatewayLifecycle(
   positionals: string[],
@@ -27,8 +33,11 @@ export async function runGatewayLifecycle(
       flags.help === true,
       'gateway',
       'manage the gateway process on this host',
-      'claude-gateway gateway <start|status|restart|stop>',
-      ['  start is the only command that boots a server; the rest are manager-aware.'],
+      'claude-gateway gateway <start|status|restart|stop|logs>',
+      [
+        '  start is the only command that boots a server; status/restart/stop are manager-aware.',
+        '  logs reads the log files directly and works even when the gateway is dead.',
+      ],
     );
     return flags.help === true ? 0 : 1;
   }
@@ -45,8 +54,10 @@ export async function runGatewayLifecycle(
       return gatewayAction('restart');
     case 'stop':
       return gatewayAction('stop');
+    case 'logs':
+      return runGatewayLogs(flags);
     default:
-      process.stderr.write(`Unknown: gateway ${verb} (expected start|status|restart|stop)\n`);
+      process.stderr.write(`Unknown: gateway ${verb} (expected start|status|restart|stop|logs)\n`);
       return 1;
   }
 }

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -67,12 +67,20 @@ export function formatLogLine(line: string): string {
 }
 
 /**
- * The last `count` lines of `file`, oldest first.
+ * The last `count` lines of `file`, oldest first, with the offset they were
+ * read to.
  *
  * Reads backwards in chunks so the cost is bounded by what is asked for rather
  * than by the size of the file.
+ *
+ * `endPos` is what `--follow` must resume from. Following from a *later*
+ * `statSync` would skip whatever the gateway appended in between: those bytes
+ * are past the tail's read and before the follower's start, so nothing would
+ * ever print them. Nothing can interleave here within this process — the read
+ * is synchronous — but the writer is a different process, which is the whole
+ * reason the command exists.
  */
-export function tailLines(file: string, count: number): string[] {
+export function tailFrom(file: string, count: number): { lines: string[]; endPos: number } {
   const fd = fs.openSync(file, 'r');
   try {
     const size = fs.fstatSync(fd).size;
@@ -92,13 +100,21 @@ export function tailLines(file: string, count: number): string[] {
     }
     const lines = text.split('\n');
     // A leading fragment from a chunk boundary is not a whole line. It only
-    // exists when the scan stopped short of the start of the file.
+    // exists when the scan stopped short of the start of the file. Dropping it
+    // is safe even when the boundary happens to land exactly on a newline: the
+    // loop only stops with more than `count` lines in hand, so the one dropped
+    // is always older than the newest `count`.
     if (pos > 0 && lines.length > 0) lines.shift();
     while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
-    return lines.length > count ? lines.slice(lines.length - count) : lines;
+    return { lines: lines.length > count ? lines.slice(lines.length - count) : lines, endPos: size };
   } finally {
     fs.closeSync(fd);
   }
+}
+
+/** The last `count` lines of `file`, oldest first. */
+export function tailLines(file: string, count: number): string[] {
+  return tailFrom(file, count).lines;
 }
 
 function countNewlines(s: string): number {
@@ -197,8 +213,11 @@ export async function runGatewayLogs(
 
   let startPos: number;
   try {
-    for (const line of tailLines(file, parsed.lines)) emit(line);
-    startPos = fs.statSync(file).size;
+    // Resume from where the tail stopped, not from a fresh stat: the gateway is
+    // a different process and may have appended in between.
+    const tail = tailFrom(file, parsed.lines);
+    for (const line of tail.lines) emit(line);
+    startPos = tail.endPos;
   } catch (err) {
     const e = err as NodeJS.ErrnoException;
     process.stderr.write(`Cannot read ${file} (${e.code ?? e.message})\n`);

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -1,0 +1,306 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { listLogStreamIds, resolveLogDir } from '../logs-dir';
+import { writeCommandHelp } from '../output';
+
+/**
+ * `gateway logs` — read the gateway's own logs without knowing where they live.
+ *
+ * The data was always well structured (one JSON object per line, written by
+ * src/logger.ts); what was missing was any way to reach it from the CLI, so
+ * operators had to know the on-disk layout and reach for `tail` by hand. A
+ * `logs` command was in scope for #374 and dropped in #375 rather than shipped
+ * as an always-failing stub; this is the version that works (#435).
+ *
+ * Every failure here is explicit — a missing directory, an unknown agent, a bad
+ * `--lines` — because the one thing a log reader must never do is answer "no
+ * logs" when the real answer is "I looked in the wrong place".
+ */
+
+/** Default tail length, matching what `tail` gives you for free minus the guesswork. */
+const DEFAULT_LINES = 50;
+/** Chunk size for the reverse read. */
+const TAIL_CHUNK = 64 * 1024;
+/** Ceiling on how much of a file the tail will scan backwards. A session log can
+ *  be hundreds of MB; reading it whole to show 50 lines would be the same
+ *  mistake `debug-bundle` exists to avoid. A tail that hits this stops early and
+ *  returns what it has, which is still the newest content. */
+const TAIL_MAX_SCAN = 8 * 1024 * 1024;
+/** How often `--follow` re-stats the file. */
+const DEFAULT_POLL_MS = 300;
+
+interface LogRecord {
+  ts?: unknown;
+  level?: unknown;
+  message?: unknown;
+  data?: unknown;
+}
+
+/**
+ * Render one stored line as `<ts> <level> <message>` with `data` appended
+ * compactly.
+ *
+ * A line that is not a gateway log record is passed through verbatim rather
+ * than dropped or replaced with a placeholder: anything already in the file is
+ * something the operator may need to see, and a reader that silently discards
+ * what it does not recognise is how a corrupt tail looks like an idle gateway.
+ */
+export function formatLogLine(line: string): string {
+  let rec: LogRecord;
+  try {
+    rec = JSON.parse(line) as LogRecord;
+  } catch {
+    return line;
+  }
+  if (rec === null || typeof rec !== 'object' || typeof rec.message !== 'string') return line;
+  const ts = typeof rec.ts === 'string' ? rec.ts : '-';
+  const level = typeof rec.level === 'string' ? rec.level.toUpperCase().padEnd(5) : '-    ';
+  const head = `${ts} ${level} ${rec.message}`;
+  if (rec.data === undefined) return head;
+  let data: string;
+  try {
+    data = JSON.stringify(rec.data);
+  } catch {
+    return head; // circular/unserialisable — the message alone is still useful
+  }
+  return `${head} ${data}`;
+}
+
+/**
+ * The last `count` lines of `file`, oldest first.
+ *
+ * Reads backwards in chunks so the cost is bounded by what is asked for rather
+ * than by the size of the file.
+ */
+export function tailLines(file: string, count: number): string[] {
+  const fd = fs.openSync(file, 'r');
+  try {
+    const size = fs.fstatSync(fd).size;
+    let pos = size;
+    let scanned = 0;
+    let text = '';
+    while (pos > 0 && scanned < TAIL_MAX_SCAN) {
+      const len = Math.min(TAIL_CHUNK, pos);
+      pos -= len;
+      scanned += len;
+      const buf = Buffer.alloc(len);
+      fs.readSync(fd, buf, 0, len, pos);
+      text = buf.toString('utf-8') + text;
+      // +1 because the newline that ends the (count)th-from-last line belongs to
+      // the line before it — stopping at `count` can return one line short.
+      if (countNewlines(text) > count) break;
+    }
+    const lines = text.split('\n');
+    // A leading fragment from a chunk boundary is not a whole line. It only
+    // exists when the scan stopped short of the start of the file.
+    if (pos > 0 && lines.length > 0) lines.shift();
+    while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+    return lines.length > count ? lines.slice(lines.length - count) : lines;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function countNewlines(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) === 10) n++;
+  return n;
+}
+
+export interface LogsRunOptions {
+  /** Stops `--follow`. Tests pass one; the CLI wires it to SIGINT. */
+  signal?: AbortSignal;
+  pollMs?: number;
+}
+
+/** Positive integer, or the reason it is not one. */
+function parseLines(raw: string | boolean | undefined): { lines: number } | { error: string } {
+  if (raw === undefined) return { lines: DEFAULT_LINES };
+  if (typeof raw !== 'string') return { error: '--lines requires a value (a positive integer)' };
+  if (!/^\d+$/.test(raw)) return { error: `--lines must be a positive integer, got "${raw}"` };
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n) || n < 1) return { error: `--lines must be a positive integer, got "${raw}"` };
+  return { lines: n };
+}
+
+function printHelp(requested: boolean): void {
+  writeCommandHelp(
+    requested,
+    'gateway logs',
+    'read the gateway log files on this host',
+    'claude-gateway gateway logs [--follow] [--lines <n>] [--agent <id>] [--json] [--logDir <path>] [--config <path>]',
+    [
+      '  --follow         Stream new lines until interrupted (Ctrl-C)',
+      `  --lines <n>      How many lines to show (default ${DEFAULT_LINES})`,
+      '  --agent <id>     Read <id>.log instead of the process-wide gateway.log',
+      '  --json           Print the stored lines verbatim, one JSON object per line',
+      '  --logDir <path>  Read logs from here instead of the configured directory',
+      '  --config <path>  Read logDir from this config file',
+      '',
+      '  Reads files directly, so it works even when the gateway is wedged or dead.',
+    ],
+  );
+}
+
+export async function runGatewayLogs(
+  flags: Record<string, string | boolean>,
+  opts: LogsRunOptions = {},
+): Promise<number> {
+  if (flags.help === true) {
+    printHelp(true);
+    return 0;
+  }
+
+  const parsed = parseLines(flags.lines);
+  if ('error' in parsed) {
+    process.stderr.write(`${parsed.error}\n`);
+    return 1;
+  }
+
+  if (flags.agent !== undefined && typeof flags.agent !== 'string') {
+    process.stderr.write('--agent requires a value (a log stream id)\n');
+    return 1;
+  }
+
+  const logDir = resolveLogDir(flags);
+  const streamId = typeof flags.agent === 'string' ? flags.agent : 'gateway';
+
+  // A stream id reaches the filesystem, so it must not be able to leave the log
+  // directory. Session streams legitimately contain ':' (`<agent>:session:<id>`),
+  // so this rejects traversal rather than restricting the charset.
+  if (streamId.includes('/') || streamId.includes('\\') || streamId.split(path.sep).includes('..')) {
+    process.stderr.write(`Invalid --agent "${streamId}": a log stream id cannot contain a path separator\n`);
+    return 1;
+  }
+
+  const file = path.join(logDir, `${streamId}.log`);
+  if (!fs.existsSync(file)) {
+    // Never "no logs found": say which path was tried, and — since an unknown
+    // id is usually a typo — what could have been meant instead.
+    const { ids, error } = listLogStreamIds(logDir);
+    process.stderr.write(`No log file at ${file}\n`);
+    if (error) {
+      process.stderr.write(`${error}\n`);
+    } else if (ids.length > 0) {
+      process.stderr.write(`Available streams (--agent <id>): ${ids.join(', ')}\n`);
+    } else {
+      process.stderr.write(`${logDir} holds no log files yet\n`);
+    }
+    return 1;
+  }
+
+  const asJson = flags.json === true;
+  const emit = (line: string): void => {
+    if (line === '') return;
+    process.stdout.write(`${asJson ? line : formatLogLine(line)}\n`);
+  };
+
+  let startPos: number;
+  try {
+    for (const line of tailLines(file, parsed.lines)) emit(line);
+    startPos = fs.statSync(file).size;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    process.stderr.write(`Cannot read ${file} (${e.code ?? e.message})\n`);
+    return 1;
+  }
+
+  if (flags.follow !== true) return 0;
+  return await followFile(file, startPos, emit, opts);
+}
+
+/**
+ * Stream lines appended to `file` until aborted.
+ *
+ * Polls rather than using `fs.watch` because the file it is following can be
+ * rotated out from under it (src/logger.ts renames `<name>.log` to
+ * `<name>.log.1`): a watcher holds the old inode and would go quiet forever
+ * while the gateway writes happily into the new file. Comparing the inode on
+ * every poll turns that into a reopen.
+ */
+async function followFile(
+  file: string,
+  fromPos: number,
+  emit: (line: string) => void,
+  opts: LogsRunOptions,
+): Promise<number> {
+  const pollMs = opts.pollMs ?? DEFAULT_POLL_MS;
+  let pos = fromPos;
+  let inode: number | undefined;
+  let carry = '';
+  try {
+    inode = fs.statSync(file).ino;
+  } catch {
+    /* the file was there a moment ago; treat it as rotated on the next poll */
+  }
+
+  const drain = (): void => {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(file);
+    } catch {
+      return; // mid-rotation: the rename has happened, the new file has not appeared
+    }
+    if (inode !== undefined && stat.ino !== inode) {
+      // Rotated: a different file now answers to this name. Start at its
+      // beginning — the bytes between the old position and the rotation are in
+      // `<name>.log.1`, which the operator can read directly.
+      inode = stat.ino;
+      pos = 0;
+      carry = '';
+    } else if (stat.size < pos) {
+      // Truncated in place (maxFiles = 0 unlinks rather than renames).
+      pos = 0;
+      carry = '';
+    }
+    if (inode === undefined) inode = stat.ino;
+    if (stat.size <= pos) return;
+
+    const len = stat.size - pos;
+    const buf = Buffer.alloc(len);
+    let read = 0;
+    const fd = fs.openSync(file, 'r');
+    try {
+      read = fs.readSync(fd, buf, 0, len, pos);
+    } finally {
+      fs.closeSync(fd);
+    }
+    pos += read;
+    // A tail can land mid-line; hold the fragment until its newline arrives so
+    // a line is never emitted in two halves.
+    const chunk = carry + buf.subarray(0, read).toString('utf-8');
+    const parts = chunk.split('\n');
+    carry = parts.pop() ?? '';
+    for (const line of parts) emit(line);
+  };
+
+  await new Promise<void>((resolve) => {
+    const timer = setInterval(() => {
+      try {
+        drain();
+      } catch {
+        /* transient (rotation race, permissions) — the next poll retries */
+      }
+    }, pollMs);
+    if (typeof timer.unref === 'function') timer.unref();
+    const stop = (): void => {
+      clearInterval(timer);
+      resolve();
+    };
+    if (opts.signal) {
+      if (opts.signal.aborted) return stop();
+      opts.signal.addEventListener('abort', stop, { once: true });
+    } else {
+      process.once('SIGINT', stop);
+    }
+  });
+  // One last pass so lines written between the final poll and the interrupt are
+  // not lost, then flush any line the file never terminated.
+  try {
+    drain();
+  } catch {
+    /* best-effort */
+  }
+  if (carry !== '') emit(carry);
+  return 0;
+}

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { listLogStreamIds, resolveLogDir } from '../logs-dir';
+import { explicitConfigWarning, listLogStreamIds, resolveLogDir } from '../logs-dir';
 import { writeCommandHelp } from '../output';
 
 /**
@@ -179,6 +179,11 @@ export async function runGatewayLogs(
   }
 
   const logDir = resolveLogDir(flags);
+  // Before anything else reads a path: if `--config` named a file we could not
+  // use, say so now. Otherwise the "no log file at …" below names the default
+  // directory and reads like an answer rather than a misdirection.
+  const configWarning = explicitConfigWarning(flags);
+  if (configWarning) process.stderr.write(`${configWarning}\n`);
   const streamId = typeof flags.agent === 'string' ? flags.agent : 'gateway';
 
   // A stream id reaches the filesystem, so it must not be able to leave the log

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,9 +23,17 @@ const GLOBAL_BOOLEAN_FLAGS = new Set(['help', 'json', 'yes', 'print', 'follow'])
  *  declares for that command. Anything outside this set and the command's own
  *  flags is a typo, and is reported rather than dropped: a resource command
  *  builds its query/body from `cmd.flags` alone, so an unrecognised flag would
- *  otherwise be parsed, ignored, and reported as success. */
+ *  otherwise be parsed, ignored, and reported as success.
+ *
+ *  Not simply `GLOBAL_BOOLEAN_FLAGS` spread in: the two sets answer different
+ *  questions. `follow` has to parse as a boolean everywhere so the gateway verb
+ *  survives, but it means nothing to a resource command, and accepting it there
+ *  would quietly re-open the hole this check exists to close. */
 const GLOBAL_FLAG_NAMES: ReadonlySet<string> = new Set([
-  ...GLOBAL_BOOLEAN_FLAGS,
+  'help',
+  'json',
+  'yes',
+  'print',
   'url',
   'key',
   'config',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,8 +14,11 @@ import { runAgents } from './commands/agents';
 import { runChannels } from './commands/channels';
 
 /** Flags that are always boolean regardless of command — never consume the next
- *  token as a value (see parseCliArgs). */
-const GLOBAL_BOOLEAN_FLAGS = new Set(['help', 'json', 'yes', 'print']);
+ *  token as a value (see parseCliArgs). `follow` is here rather than in the
+ *  gateway command because the verb is a positional: `gateway --follow logs`
+ *  would otherwise parse `logs` as the flag's value and leave no command at all.
+ *  No generated resource command declares a `--follow` value flag. */
+const GLOBAL_BOOLEAN_FLAGS = new Set(['help', 'json', 'yes', 'print', 'follow']);
 /** Flags every command accepts, on top of whatever the generated manifest
  *  declares for that command. Anything outside this set and the command's own
  *  flags is a typo, and is reported rather than dropped: a resource command
@@ -281,7 +284,7 @@ export const NAME_W = 36;
 export const NOUN_NAME_W = 48;
 
 export const CORE_HELP: ReadonlyArray<readonly [string, string]> = [
-  ['gateway status|restart|stop', 'Manage the gateway process (manager-aware)'],
+  ['gateway status|restart|stop|logs', 'Manage the gateway process (manager-aware)'],
   ['service install|status|uninstall', 'Run the gateway as a systemd-user or PM2 service'],
   ['update [check]', 'Check for / install a newer claude-gateway'],
   ['claude version|update [check]', 'Inspect / update the Claude Code binary'],

--- a/src/cli/logs-dir.ts
+++ b/src/cli/logs-dir.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { expandHome, loadCliConfig } from './http-client';
+
+/**
+ * Locating and listing the gateway's log directory, shared by every reader.
+ *
+ * `debug-bundle` owned this privately and `gateway logs` needs the same three
+ * behaviours — the `--logDir` → config → default precedence, the literal `~`
+ * the shipped config template writes, and an errno instead of a silent empty
+ * listing. Two copies of that would drift, and the tilde bug is what a drifted
+ * copy looks like: `readdirSync('~/…')` throws ENOENT, which reads exactly like
+ * "the directory is empty".
+ */
+
+/** The config file stores `logDir` exactly as written, and the shipped template
+ *  writes `~/.claude-gateway/logs`. The server expands that itself on boot, so
+ *  the literal tilde survives on disk and only bites a reader that forgets to
+ *  expand it. */
+export function resolveLogDir(flags: Record<string, string | boolean>): string {
+  if (typeof flags.logDir === 'string') return expandHome(flags.logDir);
+  const cfg = loadCliConfig(typeof flags.config === 'string' ? flags.config : undefined);
+  if (cfg.logDir) return expandHome(cfg.logDir);
+  return path.join(os.homedir(), '.claude-gateway', 'logs');
+}
+
+export interface LogDirListing {
+  names: string[];
+  /** Set when the directory could not be read at all — never "no logs found". */
+  error?: string;
+}
+
+/**
+ * Every entry in `dir`, or the reason it could not be read.
+ *
+ * The read used to be wrapped in a bare `catch { return [] }`, which reported
+ * every failure as "no logs found". That is how the unexpanded `~` stayed
+ * invisible: an ENOENT on a path that was never resolved looked exactly like an
+ * empty directory, and a permission problem still would. The caller needs the
+ * errno to say anything useful, so it is returned rather than eaten.
+ */
+export function readLogDir(dir: string): LogDirListing {
+  try {
+    return { names: fs.readdirSync(dir) };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === 'ENOENT') return { names: [], error: `${dir} does not exist` };
+    if (e.code === 'ENOTDIR') return { names: [], error: `${dir} is not a directory` };
+    return { names: [], error: `${dir} could not be read (${e.code ?? e.message})` };
+  }
+}
+
+/** Session logs in `dir` with their mtimes, or the reason the directory could
+ *  not be read. Session loggers are created as `<agent>:session:<uuid>`, so the
+ *  name carries the marker this filters on. */
+export function listSessionLogs(dir: string): { logs: Array<{ file: string; mtimeMs: number }>; error?: string } {
+  const listing = readLogDir(dir);
+  if (listing.error) return { logs: [], error: listing.error };
+  const logs = listing.names
+    .filter((n) => n.endsWith('.log') && /session/i.test(n))
+    .map((n) => {
+      const file = path.join(dir, n);
+      let mtimeMs = 0;
+      try {
+        mtimeMs = fs.statSync(file).mtimeMs;
+      } catch {
+        /* ignore */
+      }
+      return { file, mtimeMs };
+    });
+  return { logs };
+}
+
+/**
+ * Stream ids that have a live `<id>.log` in `dir`, sorted.
+ *
+ * Rotated generations (`<id>.log.1`) are deliberately excluded: they are not
+ * separate streams, and offering one as an `--agent` value would name a target
+ * that rotation can rename out from under the reader at any moment.
+ */
+export function listLogStreamIds(dir: string): { ids: string[]; error?: string } {
+  const listing = readLogDir(dir);
+  if (listing.error) return { ids: [], error: listing.error };
+  const ids = listing.names
+    .filter((n) => n.endsWith('.log'))
+    .map((n) => n.slice(0, -'.log'.length))
+    .sort();
+  return { ids };
+}

--- a/src/cli/logs-dir.ts
+++ b/src/cli/logs-dir.ts
@@ -25,6 +25,41 @@ export function resolveLogDir(flags: Record<string, string | boolean>): string {
   return path.join(os.homedir(), '.claude-gateway', 'logs');
 }
 
+/**
+ * The reason an explicitly passed `--config` did not contribute a `logDir`, or
+ * undefined when there is nothing to say.
+ *
+ * `loadCliConfig` answers `{}` for a file that is missing, unreadable or
+ * malformed — it cannot distinguish them, and for most commands that is the
+ * right shape. Here it is not: the caller then silently resolves the *default*
+ * log directory and reports "no log file at <default path>", naming a directory
+ * the operator never asked about while the typo in `--config` goes unmentioned.
+ * That is the same class of failure as the unexpanded `~`, arriving by a
+ * different route.
+ *
+ * Only an explicit `--config` is worth complaining about. The default config
+ * being absent is ordinary — a fresh install has no config yet, and the default
+ * log directory is the correct answer for it.
+ */
+export function explicitConfigWarning(flags: Record<string, string | boolean>): string | undefined {
+  if (typeof flags.logDir === 'string') return undefined; // --logDir wins; config was never consulted
+  if (typeof flags.config !== 'string') return undefined;
+  const file = expandHome(flags.config);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    return `Warning: --config ${file} could not be read (${e.code ?? e.message}); falling back to the default log directory`;
+  }
+  try {
+    JSON.parse(raw);
+  } catch (err) {
+    return `Warning: --config ${file} is not valid JSON (${(err as Error).message}); falling back to the default log directory`;
+  }
+  return undefined;
+}
+
 export interface LogDirListing {
   names: string[];
   /** Set when the directory could not be read at all — never "no logs found". */

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -17,6 +17,10 @@ const HOT_RELOADABLE_AGENT_FIELDS: string[] = [
 // Gateway-level (non-agent) fields that can be hot-reloaded; agentId will be '' in ConfigChange
 const HOT_RELOADABLE_GATEWAY_FIELDS: string[] = [
   'gateway.headless',
+  // Logging policy is process-wide module state, so re-installing it is just a
+  // call — and turning the level up to chase a live problem is precisely when a
+  // restart is unaffordable, since it kills the sessions being investigated.
+  'gateway.logs',
 ];
 
 export interface ConfigChange {
@@ -224,6 +228,7 @@ export class ConfigWatcher extends EventEmitter {
     const gatewayFieldPairs: Array<{ field: string; oldVal: unknown; newVal: unknown }> = [
       { field: 'gateway.headless', oldVal: oldCfg.gateway.headless, newVal: newCfg.gateway.headless },
       { field: 'gateway.publicUrl', oldVal: oldCfg.gateway.publicUrl, newVal: newCfg.gateway.publicUrl },
+      { field: 'gateway.logs', oldVal: oldCfg.gateway.logs, newVal: newCfg.gateway.logs },
     ];
     for (const { field, oldVal, newVal } of gatewayFieldPairs) {
       if (!deepEqual(oldVal, newVal)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { CronScheduler } from './cron/scheduler';
 import { CronManager } from './cron/manager';
 import { GatewayRouter } from './api/gateway-router';
 import { ContextIsolationGuard } from './agent/context-isolation';
-import { createLogger, configureLogging, startLogRetentionSweep } from './logger';
+import { createLogger, configureLogging, loggingConfig, startLogRetentionSweep } from './logger';
 import { ConfigWatcher, ConfigChange } from './config/watcher';
 import { AgentConfig, GatewayConfig, LogsConfig } from './types';
 import { AppsRegistry } from './apps/registry';
@@ -593,7 +593,7 @@ async function main(): Promise<void> {
   // Must precede the first createLogger() call: the level gate and the rotation
   // thresholds are process-wide policy, and a logger created before the policy
   // is installed would run the whole boot on defaults.
-  const logsPolicy = configureLogging(config.gateway.logs);
+  configureLogging(config.gateway.logs);
 
   // Created as early as logDir allows, and before the isolation guard below:
   // a config bad enough to drop an agent is exactly the config likely to fail
@@ -810,7 +810,10 @@ async function main(): Promise<void> {
   startLogRetentionSweep(logDir, (removed) => {
     globalLogger.info('Swept expired log files', {
       count: removed.length,
-      retentionDays: logsPolicy.retentionDays,
+      // Read live rather than closing over the boot-time policy: `gateway.logs`
+      // is hot-reloadable, so a captured value would report the threshold that
+      // was in force at boot while the sweep used the current one.
+      retentionDays: loggingConfig().retentionDays,
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { CronScheduler } from './cron/scheduler';
 import { CronManager } from './cron/manager';
 import { GatewayRouter } from './api/gateway-router';
 import { ContextIsolationGuard } from './agent/context-isolation';
-import { createLogger } from './logger';
+import { createLogger, configureLogging, startLogRetentionSweep } from './logger';
 import { ConfigWatcher, ConfigChange } from './config/watcher';
 import { AgentConfig, GatewayConfig } from './types';
 import { AppsRegistry } from './apps/registry';
@@ -590,6 +590,11 @@ async function main(): Promise<void> {
   });
   config.gateway.logDir = expandTilde(config.gateway.logDir);
 
+  // Must precede the first createLogger() call: the level gate and the rotation
+  // thresholds are process-wide policy, and a logger created before the policy
+  // is installed would run the whole boot on defaults.
+  const logsPolicy = configureLogging(config.gateway.logs);
+
   // Created as early as logDir allows, and before the isolation guard below:
   // a config bad enough to drop an agent is exactly the config likely to fail
   // validation too, and a guard throw must not swallow the reason an agent
@@ -798,6 +803,16 @@ async function main(): Promise<void> {
   // the retention-count + max-age union policy. Timer is unref'd, so it never
   // keeps the process alive.
   appInstaller.startBackupCleanup();
+
+  // Log retention (issue #435): sweeps once now and daily thereafter. Session
+  // logs are the reason this is age-based — each session writes its own file
+  // and never returns to it, so the per-stream generation cap cannot reach them.
+  startLogRetentionSweep(logDir, (removed) => {
+    globalLogger.info('Swept expired log files', {
+      count: removed.length,
+      retentionDays: logsPolicy.retentionDays,
+    });
+  });
 
   // Start gateway router
   const router = new GatewayRouter(agentRunners, agentConfigs, undefined, config, cronManager, CONFIG_PATH, appsRegistry, appInstaller, registryClient);

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import { GatewayRouter } from './api/gateway-router';
 import { ContextIsolationGuard } from './agent/context-isolation';
 import { createLogger, configureLogging, startLogRetentionSweep } from './logger';
 import { ConfigWatcher, ConfigChange } from './config/watcher';
-import { AgentConfig, GatewayConfig } from './types';
+import { AgentConfig, GatewayConfig, LogsConfig } from './types';
 import { AppsRegistry } from './apps/registry';
 import { sweepOrphanedReceivers } from './utils/orphan-receivers';
 import { registerShutdownSignals } from './shutdown-signals';
@@ -908,6 +908,16 @@ async function main(): Promise<void> {
         if (change.field === 'gateway.headless') {
           // Applies to sessions spawned after the change; running sessions keep their backend.
           config.gateway.headless = change.newValue as boolean | undefined;
+        }
+        if (change.field === 'gateway.logs') {
+          // Re-installing the policy is enough: every logger reads it per call,
+          // and the retention sweep reads `retentionDays` on each run.
+          config.gateway.logs = change.newValue as LogsConfig | undefined;
+          const applied = configureLogging(config.gateway.logs);
+          // warn, not info: raising the level to `warn` would swallow an `info`
+          // confirmation under the very policy just installed, leaving the
+          // operator with no evidence the edit took.
+          globalLogger.warn('Logging policy reloaded', { ...applied });
         }
         continue;
       }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -81,6 +81,13 @@ function nonNegativeOrDefault(value: number | undefined, fallback: number): numb
  * would each see only their own share of the file and rotate late. Seeded from
  * `statSync` once per file, then maintained by arithmetic so the common path
  * costs no syscall.
+ *
+ * One entry per log file, and session logs create a new file each. The
+ * retention sweep deletes its entry along with the file, which bounds the map
+ * for any configuration that keeps retention on; with `retentionDays: 0` it
+ * grows with the session count, at roughly a path string per session. That is
+ * small enough not to be worth a second eviction mechanism whose only job would
+ * be to duplicate the sweep.
  */
 const fileSizes = new Map<string, number>();
 
@@ -293,6 +300,12 @@ export function sweepOldLogs(logDir: string, retentionDays: number, now = Date.n
  * Modelled on `AppInstaller.startBackupCleanup()`: the timer is unref'd so it
  * never keeps the process alive, and a failing sweep is swallowed rather than
  * escalated — retention is housekeeping, not a reason to take the gateway down.
+ *
+ * The timer is created unconditionally, including when retention is currently
+ * off. `retentionDays` is read on each run rather than captured, so a policy
+ * reloaded from `gateway.logs` takes effect at the next sweep — and a timer
+ * that was never started because retention happened to be 0 at boot could not
+ * do that. A disabled sweep costs one no-op call a day.
  */
 export function startLogRetentionSweep(
   logDir: string,
@@ -307,7 +320,6 @@ export function startLogRetentionSweep(
     }
   };
   run();
-  if (!(active.retentionDays > 0)) return () => {};
   const timer = setInterval(run, 24 * 60 * 60 * 1000);
   if (typeof timer.unref === 'function') timer.unref();
   return () => clearInterval(timer);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,109 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Logger } from './types';
+import { Logger, LogsConfig } from './types';
 
-type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/** Ordering for the level gate. Only the relative order matters. */
+const LEVEL_RANK: Readonly<Record<LogLevel, number>> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+export function isLogLevel(value: unknown): value is LogLevel {
+  return typeof value === 'string' && value in LEVEL_RANK;
+}
+
+/**
+ * Defaults applied when `gateway.logs` is absent or partial.
+ *
+ * `level: 'info'` is the load-bearing one. Session processes log every stream
+ * event at debug (src/session/process.ts), which on a live host measured as
+ * 19,995 debug lines to 5 info lines in a single 217 MB file — so `debug`
+ * on-by-default was, in practice, the whole log directory. Rotation alone would
+ * not have helped: it bounds what is *kept*, not what is *written*.
+ */
+export const LOGS_DEFAULTS: Required<LogsConfig> = {
+  level: 'info',
+  maxFileBytes: 16 * 1024 * 1024,
+  maxFiles: 3,
+  retentionDays: 14,
+};
+
+let active: Required<LogsConfig> = { ...LOGS_DEFAULTS };
+
+/**
+ * Install the process-wide logging policy. Called once at boot, before the
+ * first logger exists.
+ *
+ * Policy is module state rather than a per-logger argument because there is one
+ * of it per process, and `createLogger()` has 13 call sites — several of which
+ * (routers, the session process) have no access to the gateway config. Threading
+ * an options bag through all of them would put the same value in 13 places and
+ * let them drift.
+ */
+export function configureLogging(cfg: LogsConfig | undefined): Required<LogsConfig> {
+  const level = isLogLevel(cfg?.level) ? cfg.level : LOGS_DEFAULTS.level;
+  active = {
+    level,
+    maxFileBytes: positiveOrDefault(cfg?.maxFileBytes, LOGS_DEFAULTS.maxFileBytes),
+    maxFiles: nonNegativeOrDefault(cfg?.maxFiles, LOGS_DEFAULTS.maxFiles),
+    retentionDays: nonNegativeOrDefault(cfg?.retentionDays, LOGS_DEFAULTS.retentionDays),
+  };
+  return { ...active };
+}
+
+/** The policy currently in force (a copy — callers must not mutate it). */
+export function loggingConfig(): Required<LogsConfig> {
+  return { ...active };
+}
+
+/** Test hook: restore defaults and forget per-file state. */
+export function resetLoggingForTests(): void {
+  active = { ...LOGS_DEFAULTS };
+  fileSizes.clear();
+  writeFailureReported = false;
+}
+
+/** 0 is meaningful for `maxFiles`/`retentionDays` (= disabled) but not for a
+ *  size threshold, where it would rotate on every line. */
+function positiveOrDefault(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function nonNegativeOrDefault(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? Math.floor(value) : fallback;
+}
+
+/**
+ * Live size per log file, keyed by absolute path.
+ *
+ * Kept at module scope rather than on the instance because one file can have
+ * several loggers writing to it — `createLogger(agentConfig.id, …)` is called
+ * from both the boot path and the runner constructor. Per-instance counters
+ * would each see only their own share of the file and rotate late. Seeded from
+ * `statSync` once per file, then maintained by arithmetic so the common path
+ * costs no syscall.
+ */
+const fileSizes = new Map<string, number>();
+
+/**
+ * A failed append is latched and reported once per process.
+ *
+ * This used to be a bare `catch {}` — a full disk or a permission change
+ * silently stopped all file logging, which is precisely the failure that makes
+ * the next incident undiagnosable. Reporting every occurrence would be its own
+ * denial of service (the failing call is in the logger), so it is reported once
+ * and then suppressed.
+ */
+let writeFailureReported = false;
+
+function reportWriteFailure(file: string, err: unknown): void {
+  if (writeFailureReported) return;
+  writeFailureReported = true;
+  const reason = (err as NodeJS.ErrnoException)?.code ?? (err as Error)?.message ?? String(err);
+  process.stderr.write(
+    `[logger] cannot write to ${file} (${reason}) — file logging is degraded for the rest of this process. ` +
+      'Further write failures will not be reported.\n',
+  );
+}
 
 interface LogEntry {
   ts: string;
@@ -10,6 +111,68 @@ interface LogEntry {
   level: LogLevel;
   message: string;
   data?: Record<string, unknown>;
+}
+
+/**
+ * Remove every rotated generation at or above `maxFiles`.
+ *
+ * Deleting only `<file>.<maxFiles>` would be dead code: `renameSync` clobbers
+ * its destination, so the top generation is overwritten by the shift below
+ * anyway — but only while `maxFiles` stays where it was. Lower it in the config
+ * (5 → 2) and generations 2..5 are orphaned: nothing renames onto them, and the
+ * age sweep is the only thing that would ever collect them. A rotation happens
+ * once per `maxFileBytes`, so it can afford one readdir to stay bounded.
+ */
+function pruneGenerations(file: string, maxFiles: number): void {
+  const dir = path.dirname(file);
+  const prefix = `${path.basename(file)}.`;
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return; // best-effort
+  }
+  for (const name of names) {
+    if (!name.startsWith(prefix)) continue;
+    const gen = Number(name.slice(prefix.length));
+    if (!Number.isInteger(gen) || gen < maxFiles) continue;
+    try {
+      fs.rmSync(path.join(dir, name), { force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/** `<name>.log` → `<name>.log.1`, dropping generations past `maxFiles`.
+ *
+ *  Synchronous and best-effort by design: it runs inside a logging call, so it
+ *  must neither block on I/O the caller did not ask for nor throw into code
+ *  that was only trying to log. A rotation that fails leaves the live file in
+ *  place and logging simply continues into it. */
+function rotate(file: string, maxFiles: number): void {
+  if (maxFiles <= 0) {
+    // No generations kept: the live file is the only file, so start it over.
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      /* best-effort */
+    }
+    return;
+  }
+  pruneGenerations(file, maxFiles);
+  for (let gen = maxFiles - 1; gen >= 1; gen--) {
+    try {
+      fs.renameSync(`${file}.${gen}`, `${file}.${gen + 1}`);
+    } catch {
+      /* a generation that does not exist yet is the normal case */
+    }
+  }
+  try {
+    fs.renameSync(file, `${file}.1`);
+  } catch {
+    /* best-effort */
+  }
 }
 
 class AgentLogger implements Logger {
@@ -22,7 +185,22 @@ class AgentLogger implements Logger {
     this.logFilePath = path.join(logDir, `${agentId}.log`);
   }
 
+  private currentSize(): number {
+    const known = fileSizes.get(this.logFilePath);
+    if (known !== undefined) return known;
+    let size = 0;
+    try {
+      size = fs.statSync(this.logFilePath).size;
+    } catch {
+      size = 0; // not created yet
+    }
+    fileSizes.set(this.logFilePath, size);
+    return size;
+  }
+
   private log(level: LogLevel, message: string, data?: Record<string, unknown>): void {
+    if (LEVEL_RANK[level] < LEVEL_RANK[active.level]) return;
+
     const entry: LogEntry = {
       ts: new Date().toISOString(),
       agentId: this.agentId,
@@ -38,10 +216,17 @@ class AgentLogger implements Logger {
     process.stdout.write(pretty + '\n');
 
     // Write to log file (compact, one entry per line)
+    const bytes = Buffer.byteLength(line, 'utf-8') + 1;
     try {
+      if (active.maxFileBytes > 0 && this.currentSize() + bytes > active.maxFileBytes) {
+        rotate(this.logFilePath, active.maxFiles);
+        fileSizes.set(this.logFilePath, 0);
+      }
       fs.appendFileSync(this.logFilePath, line + '\n', 'utf-8');
-    } catch {
-      // If we can't write to the log file, just continue
+      fileSizes.set(this.logFilePath, this.currentSize() + bytes);
+    } catch (err) {
+      // Logging must never throw into a caller, but it must not vanish either.
+      reportWriteFailure(this.logFilePath, err);
     }
   }
 
@@ -64,4 +249,66 @@ class AgentLogger implements Logger {
 
 export function createLogger(agentId: string, logDir: string): Logger {
   return new AgentLogger(agentId, logDir);
+}
+
+/**
+ * Delete log files (live and rotated generations) last modified more than
+ * `retentionDays` ago. Returns the paths removed.
+ *
+ * Age, not count, is what bounds a directory of *session* logs: each session
+ * gets its own `<agent>:session:<uuid>.log` that is never written again once the
+ * session ends, so `maxFiles` — which only prunes generations of one stream —
+ * never touches them.
+ */
+export function sweepOldLogs(logDir: string, retentionDays: number, now = Date.now()): string[] {
+  const removed: string[] = [];
+  if (!(retentionDays > 0)) return removed; // 0 = keep forever
+  const cutoff = now - retentionDays * 24 * 60 * 60 * 1000;
+  let names: string[];
+  try {
+    names = fs.readdirSync(logDir);
+  } catch {
+    return removed; // no directory yet, or unreadable — nothing to sweep
+  }
+  for (const name of names) {
+    // `.log` and its rotated generations (`.log.1`), and nothing else: the
+    // directory is not exclusively ours to delete from.
+    if (!/\.log(\.\d+)?$/.test(name)) continue;
+    const full = path.join(logDir, name);
+    try {
+      if (fs.statSync(full).mtimeMs >= cutoff) continue;
+      fs.rmSync(full, { force: true });
+      fileSizes.delete(full);
+      removed.push(full);
+    } catch {
+      /* best-effort — a file that vanished or cannot be read is not fatal */
+    }
+  }
+  return removed;
+}
+
+/**
+ * Sweep now, then once a day. Returns a stop function.
+ *
+ * Modelled on `AppInstaller.startBackupCleanup()`: the timer is unref'd so it
+ * never keeps the process alive, and a failing sweep is swallowed rather than
+ * escalated — retention is housekeeping, not a reason to take the gateway down.
+ */
+export function startLogRetentionSweep(
+  logDir: string,
+  onSwept?: (removed: string[]) => void,
+): () => void {
+  const run = (): void => {
+    try {
+      const removed = sweepOldLogs(logDir, active.retentionDays);
+      if (removed.length > 0) onSwept?.(removed);
+    } catch {
+      /* best-effort */
+    }
+  };
+  run();
+  if (!(active.retentionDays > 0)) return () => {};
+  const timer = setInterval(run, 24 * 60 * 60 * 1000);
+  if (typeof timer.unref === 'function') timer.unref();
+  return () => clearInterval(timer);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,9 +188,30 @@ export interface ModelConfig {
   multiplier?: number;
 }
 
+/**
+ * Log verbosity, rotation and retention (issue #435). Every field is optional
+ * and falls back to `LOGS_DEFAULTS` in src/logger.ts, so a config with no
+ * `gateway.logs` block keeps working.
+ *
+ * Named to match the history-retention settings above (`retentionDays`, with
+ * 0 = keep forever) rather than inventing a second vocabulary for the same idea.
+ */
+export interface LogsConfig {
+  /** Minimum level written to file and stdout. Default "info" — see LOGS_DEFAULTS. */
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  /** Rotate a log once an append would carry it past this size. Default 16 MiB. */
+  maxFileBytes?: number;
+  /** Rotated generations kept per stream (`<name>.log.1` …). 0 = keep none. Default 3. */
+  maxFiles?: number;
+  /** Delete logs older than this at boot and daily. 0 = keep forever. Default 14. */
+  retentionDays?: number;
+}
+
 export interface GatewayConfig {
   gateway: {
     logDir: string;
+    /** Log verbosity, rotation and retention. Absent = LOGS_DEFAULTS. */
+    logs?: LogsConfig;
     timezone: string;
     /**
      * Network interface the HTTP/WebSocket server binds to. Defaults to

--- a/tests/unit/cli-logs-dir.test.ts
+++ b/tests/unit/cli-logs-dir.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { listLogStreamIds, readLogDir, resolveLogDir } from '../../src/cli/logs-dir';
+import { explicitConfigWarning, listLogStreamIds, readLogDir, resolveLogDir } from '../../src/cli/logs-dir';
 
 /**
  * The shared log-directory helper (issue #435).
@@ -85,5 +85,40 @@ describe('cli logs-dir', () => {
 
     expect(ids).toEqual([]);
     expect(error).toBe(`${missing} does not exist`);
+  });
+
+  // `loadCliConfig` cannot distinguish "missing", "unreadable" and "malformed" —
+  // all three come back as `{}` — so resolveLogDir silently answers with the
+  // default directory. Without a warning the caller then reports "no log file
+  // at <default>", naming a directory the operator never asked about while the
+  // typo in --config goes unmentioned.
+  it('U-LD-10: an explicit --config that does not exist is reported, not silently defaulted', () => {
+    const missing = path.join(dir, 'nope.json');
+
+    const warning = explicitConfigWarning({ config: missing });
+
+    expect(warning).toContain(missing);
+    expect(warning).toContain('ENOENT');
+    // The fallback itself still happens — the warning is what makes it legible.
+    expect(resolveLogDir({ config: missing })).toBe(path.join(os.homedir(), '.claude-gateway', 'logs'));
+  });
+
+  it('U-LD-11: an explicit --config that is not valid JSON is reported', () => {
+    const broken = path.join(dir, 'broken.json');
+    fs.writeFileSync(broken, '{ "gateway": ');
+
+    expect(explicitConfigWarning({ config: broken })).toContain('not valid JSON');
+  });
+
+  it('U-LD-12: a readable config, no --config at all, or --logDir winning are all silent', () => {
+    const good = path.join(dir, 'config.json');
+    fs.writeFileSync(good, JSON.stringify({ gateway: { logDir: dir } }));
+
+    expect(explicitConfigWarning({ config: good })).toBeUndefined();
+    // No --config: a fresh install has no config file and the default log
+    // directory is the right answer for it, so there is nothing to warn about.
+    expect(explicitConfigWarning({})).toBeUndefined();
+    // --logDir wins outright, so a bad --config alongside it was never consulted.
+    expect(explicitConfigWarning({ logDir: dir, config: path.join(dir, 'nope.json') })).toBeUndefined();
   });
 });

--- a/tests/unit/cli-logs-dir.test.ts
+++ b/tests/unit/cli-logs-dir.test.ts
@@ -1,0 +1,89 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { listLogStreamIds, readLogDir, resolveLogDir } from '../../src/cli/logs-dir';
+
+/**
+ * The shared log-directory helper (issue #435).
+ *
+ * `debug-bundle` owned this privately; `gateway logs` needs exactly the same
+ * three behaviours, and a second copy is how they drift. The tilde case is not
+ * hypothetical — the shipped config template writes `~/.claude-gateway/logs`
+ * literally, and a reader that forgets to expand it gets an ENOENT that reads
+ * like "the directory is empty".
+ */
+describe('cli logs-dir', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-logs-dir-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    delete process.env.GATEWAY_CONFIG;
+  });
+
+  it('U-LD-01: --logDir wins and its leading ~ is expanded', () => {
+    expect(resolveLogDir({ logDir: '~/somewhere/logs' })).toBe(
+      path.join(os.homedir(), 'somewhere', 'logs'),
+    );
+  });
+
+  it('U-LD-02: a ~ in the config file gateway.logDir is expanded too', () => {
+    const cfg = path.join(dir, 'config.json');
+    fs.writeFileSync(cfg, JSON.stringify({ gateway: { logDir: '~/.claude-gateway/logs' } }));
+
+    expect(resolveLogDir({ config: cfg })).toBe(
+      path.join(os.homedir(), '.claude-gateway', 'logs'),
+    );
+  });
+
+  it('U-LD-03: --logDir takes precedence over the config file', () => {
+    const cfg = path.join(dir, 'config.json');
+    fs.writeFileSync(cfg, JSON.stringify({ gateway: { logDir: '/from/config' } }));
+
+    expect(resolveLogDir({ config: cfg, logDir: '/from/flag' })).toBe('/from/flag');
+  });
+
+  it('U-LD-04: with neither, it falls back to the default location', () => {
+    process.env.GATEWAY_CONFIG = path.join(dir, 'no-such-config.json');
+
+    expect(resolveLogDir({})).toBe(path.join(os.homedir(), '.claude-gateway', 'logs'));
+  });
+
+  it('U-LD-05: a missing directory reports the reason, not an empty listing', () => {
+    const missing = path.join(dir, 'gone');
+    const listing = readLogDir(missing);
+
+    expect(listing.names).toEqual([]);
+    expect(listing.error).toBe(`${missing} does not exist`);
+  });
+
+  it('U-LD-06: a path that is a file reports ENOTDIR distinctly', () => {
+    const file = path.join(dir, 'a-file');
+    fs.writeFileSync(file, 'x');
+
+    expect(readLogDir(file).error).toBe(`${file} is not a directory`);
+  });
+
+  it('U-LD-07: an empty but readable directory is not an error', () => {
+    expect(readLogDir(dir)).toEqual({ names: [] });
+  });
+
+  it('U-LD-08: stream ids exclude rotated generations and non-log files', () => {
+    for (const n of ['gateway.log', 'gateway.log.1', 'gateway.log.2', 'aika:receiver.log', 'notes.txt']) {
+      fs.writeFileSync(path.join(dir, n), 'x');
+    }
+
+    expect(listLogStreamIds(dir).ids).toEqual(['aika:receiver', 'gateway']);
+  });
+
+  it('U-LD-09: listing ids surfaces the directory error instead of claiming none exist', () => {
+    const missing = path.join(dir, 'gone');
+    const { ids, error } = listLogStreamIds(missing);
+
+    expect(ids).toEqual([]);
+    expect(error).toBe(`${missing} does not exist`);
+  });
+});

--- a/tests/unit/cli-logs.test.ts
+++ b/tests/unit/cli-logs.test.ts
@@ -1,0 +1,262 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { formatLogLine, runGatewayLogs, tailLines } from '../../src/cli/commands/logs';
+import { runGatewayLifecycle } from '../../src/cli/commands/gateway';
+import type { CliConfigView } from '../../src/cli/http-client';
+
+/**
+ * `gateway logs` (issue #435) — reads the log files directly, so every test
+ * here writes real files and runs the real command. There is no gateway
+ * process: that is the point of the command, and of testing it this way.
+ */
+describe('cli gateway logs', () => {
+  let dir: string;
+  let stdout: string[];
+  let stderr: string[];
+  let outSpy: jest.SpyInstance;
+  let errSpy: jest.SpyInstance;
+
+  const entry = (level: string, message: string, data?: Record<string, unknown>): string =>
+    JSON.stringify({ ts: '2026-09-02T00:00:00.000Z', agentId: 'gateway', level, message, ...(data ? { data } : {}) });
+
+  const write = (name: string, lines: string[]): string => {
+    const file = path.join(dir, name);
+    fs.writeFileSync(file, lines.length ? lines.join('\n') + '\n' : '');
+    return file;
+  };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-cli-logs-'));
+    stdout = [];
+    stderr = [];
+    outSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stdout.push(chunk.toString());
+      return true;
+    });
+    errSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stderr.push(chunk.toString());
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    outSpy.mockRestore();
+    errSpy.mockRestore();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ── U-LOGS-01..04: the default read ───────────────────────────────────────
+
+  it('U-LOGS-01: prints the tail of gateway.log and exits 0', async () => {
+    write('gateway.log', [entry('info', 'booted'), entry('warn', 'slow start')]);
+
+    const code = await runGatewayLogs({ logDir: dir });
+
+    expect(code).toBe(0);
+    expect(stdout.join('')).toBe(
+      '2026-09-02T00:00:00.000Z INFO  booted\n2026-09-02T00:00:00.000Z WARN  slow start\n',
+    );
+  });
+
+  it('U-LOGS-02: renders data compactly beside the message', async () => {
+    write('gateway.log', [entry('error', 'agent skipped', { agentId: 'aika', varName: 'AIKA_TOKEN' })]);
+
+    await runGatewayLogs({ logDir: dir });
+
+    expect(stdout.join('')).toContain('ERROR agent skipped {"agentId":"aika","varName":"AIKA_TOKEN"}');
+  });
+
+  it('U-LOGS-03: --json output is byte-identical to the stored lines', async () => {
+    const lines = [entry('info', 'one', { a: 1 }), entry('debug', 'two')];
+    write('gateway.log', lines);
+
+    const code = await runGatewayLogs({ logDir: dir, json: true });
+
+    expect(code).toBe(0);
+    expect(stdout.join('')).toBe(lines.join('\n') + '\n');
+  });
+
+  it('U-LOGS-04: --lines caps the tail at the newest n lines', async () => {
+    write('gateway.log', Array.from({ length: 20 }, (_, i) => entry('info', `m${i}`)));
+
+    await runGatewayLogs({ logDir: dir, lines: '3' });
+
+    const printed = stdout.join('').trim().split('\n');
+    expect(printed).toHaveLength(3);
+    expect(printed[0]).toContain('m17');
+    expect(printed[2]).toContain('m19');
+  });
+
+  // ── U-LOGS-05..08: explicit failures, never a silent empty result ─────────
+
+  it('U-LOGS-05: an unknown --agent exits non-zero, naming the path tried and the ids available', async () => {
+    write('gateway.log', [entry('info', 'x')]);
+    write('aika:receiver.log', [entry('info', 'x')]);
+
+    const code = await runGatewayLogs({ logDir: dir, agent: 'nope' });
+
+    expect(code).toBe(1);
+    expect(stderr.join('')).toContain(path.join(dir, 'nope.log'));
+    expect(stderr.join('')).toContain('aika:receiver');
+    expect(stderr.join('')).toContain('gateway');
+    expect(stdout.join('')).toBe('');
+  });
+
+  it('U-LOGS-06: an unreadable directory reports the errno rather than an empty listing', async () => {
+    const missing = path.join(dir, 'not-here');
+
+    const code = await runGatewayLogs({ logDir: missing });
+
+    expect(code).toBe(1);
+    expect(stderr.join('')).toContain(`${missing} does not exist`);
+  });
+
+  it('U-LOGS-07: --lines is validated as a positive integer', async () => {
+    write('gateway.log', [entry('info', 'x')]);
+
+    for (const bad of ['abc', '0', '-5', '2.5', '']) {
+      stderr.length = 0;
+      const code = await runGatewayLogs({ logDir: dir, lines: bad });
+      expect(code).toBe(1);
+      expect(stderr.join('')).toContain('--lines must be a positive integer');
+    }
+    // `--lines` with no value parses as boolean true, which is its own message.
+    stderr.length = 0;
+    expect(await runGatewayLogs({ logDir: dir, lines: true })).toBe(1);
+    expect(stderr.join('')).toContain('--lines requires a value');
+  });
+
+  it('U-LOGS-08: a stream id cannot escape the log directory', async () => {
+    const code = await runGatewayLogs({ logDir: dir, agent: '../../etc/passwd' });
+
+    expect(code).toBe(1);
+    expect(stderr.join('')).toContain('cannot contain a path separator');
+  });
+
+  // ── U-LOGS-09: --agent reads that stream ─────────────────────────────────
+
+  it('U-LOGS-09: --agent <id> reads <id>.log, including a session id with colons', async () => {
+    write('gateway.log', [entry('info', 'wrong file')]);
+    write('meguri:session:abc-123.log', [entry('info', 'right file')]);
+
+    const code = await runGatewayLogs({ logDir: dir, agent: 'meguri:session:abc-123' });
+
+    expect(code).toBe(0);
+    expect(stdout.join('')).toContain('right file');
+    expect(stdout.join('')).not.toContain('wrong file');
+  });
+
+  // ── U-LOGS-10..12: --follow ───────────────────────────────────────────────
+
+  it('U-LOGS-10: --follow streams appended lines and exits 0 when interrupted', async () => {
+    const file = write('gateway.log', [entry('info', 'before')]);
+    const ctl = new AbortController();
+
+    const run = runGatewayLogs({ logDir: dir, follow: true }, { signal: ctl.signal, pollMs: 10 });
+    await new Promise((r) => setTimeout(r, 40));
+    fs.appendFileSync(file, entry('info', 'after') + '\n');
+    await new Promise((r) => setTimeout(r, 60));
+    ctl.abort();
+
+    expect(await run).toBe(0);
+    expect(stdout.join('')).toContain('before');
+    expect(stdout.join('')).toContain('after');
+  });
+
+  it('U-LOGS-11: --follow reopens the file across a rotation instead of following the old inode', async () => {
+    // This is where the two halves of #435 meet: the reader holds a file the
+    // writer is free to rename out from under it.
+    const file = write('gateway.log', [entry('info', 'first')]);
+    const ctl = new AbortController();
+
+    const run = runGatewayLogs({ logDir: dir, follow: true }, { signal: ctl.signal, pollMs: 10 });
+    await new Promise((r) => setTimeout(r, 40));
+
+    fs.renameSync(file, `${file}.1`);
+    fs.writeFileSync(file, entry('info', 'after rotation') + '\n');
+    await new Promise((r) => setTimeout(r, 80));
+    ctl.abort();
+
+    expect(await run).toBe(0);
+    expect(stdout.join('')).toContain('after rotation');
+  });
+
+  it('U-LOGS-12: --follow never emits half a line', async () => {
+    const file = write('gateway.log', []);
+    const ctl = new AbortController();
+    const line = entry('info', 'split across two writes');
+
+    const run = runGatewayLogs({ logDir: dir, follow: true }, { signal: ctl.signal, pollMs: 10 });
+    await new Promise((r) => setTimeout(r, 30));
+    fs.appendFileSync(file, line.slice(0, 20));
+    await new Promise((r) => setTimeout(r, 40));
+    // Nothing may have been printed yet — the line is not terminated.
+    expect(stdout.join('')).toBe('');
+    fs.appendFileSync(file, line.slice(20) + '\n');
+    await new Promise((r) => setTimeout(r, 40));
+    ctl.abort();
+
+    expect(await run).toBe(0);
+    expect(stdout.join('')).toBe('2026-09-02T00:00:00.000Z INFO  split across two writes\n');
+  });
+
+  // ── U-LOGS-13..15: the verb is wired up ───────────────────────────────────
+
+  it('U-LOGS-13: `gateway logs` reaches the command through the lifecycle dispatcher', async () => {
+    write('gateway.log', [entry('info', 'through the verb')]);
+
+    const code = await runGatewayLifecycle(['logs'], { logDir: dir }, {} as CliConfigView);
+
+    expect(code).toBe(0);
+    expect(stdout.join('')).toContain('through the verb');
+  });
+
+  it('U-LOGS-14: the unknown-verb message lists logs', async () => {
+    const code = await runGatewayLifecycle(['nope'], {}, {} as CliConfigView);
+
+    expect(code).toBe(1);
+    expect(stderr.join('')).toContain('start|status|restart|stop|logs');
+  });
+
+  it('U-LOGS-15: `gateway logs --help` is read-only and exits 0', async () => {
+    const code = await runGatewayLogs({ help: true, logDir: dir });
+
+    expect(code).toBe(0);
+    expect(stdout.join('') + stderr.join('')).toContain('--follow');
+  });
+
+  // ── U-LOGS-16..18: the pure helpers ───────────────────────────────────────
+
+  it('U-LOGS-16: a line that is not a log record is passed through verbatim', () => {
+    expect(formatLogLine('not json at all')).toBe('not json at all');
+    expect(formatLogLine('{"ts":"t","level":"info"}')).toBe('{"ts":"t","level":"info"}');
+  });
+
+  it('U-LOGS-17: tailLines returns whole lines when the tail spans several read chunks', () => {
+    // Each line is ~1 KB, so 200 of them cross the 64 KB chunk boundary and the
+    // reverse read has to stitch chunks without leaving a fragment behind.
+    const lines = Array.from({ length: 200 }, (_, i) => `${i}:${'x'.repeat(1000)}`);
+    const file = write('big.log', lines);
+
+    const tail = tailLines(file, 5);
+
+    expect(tail).toHaveLength(5);
+    expect(tail[0]).toBe(lines[195]);
+    expect(tail[4]).toBe(lines[199]);
+  });
+
+  it('U-LOGS-18: asking for more lines than the file holds returns the whole file', () => {
+    const file = write('small.log', ['a', 'b']);
+    expect(tailLines(file, 500)).toEqual(['a', 'b']);
+  });
+
+  it('U-LOGS-19: an empty log file is not an error', async () => {
+    write('gateway.log', []);
+
+    const code = await runGatewayLogs({ logDir: dir });
+
+    expect(code).toBe(0);
+    expect(stdout.join('')).toBe('');
+  });
+});

--- a/tests/unit/cli-logs.test.ts
+++ b/tests/unit/cli-logs.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { formatLogLine, runGatewayLogs, tailLines } from '../../src/cli/commands/logs';
+import { formatLogLine, runGatewayLogs, tailFrom, tailLines } from '../../src/cli/commands/logs';
 import { runGatewayLifecycle } from '../../src/cli/commands/gateway';
 import type { CliConfigView } from '../../src/cli/http-client';
 
@@ -249,6 +249,36 @@ describe('cli gateway logs', () => {
   it('U-LOGS-18: asking for more lines than the file holds returns the whole file', () => {
     const file = write('small.log', ['a', 'b']);
     expect(tailLines(file, 500)).toEqual(['a', 'b']);
+  });
+
+  it('U-LOGS-20: the tail is exact at every chunk-boundary alignment', () => {
+    // 64-byte lines divide the 64 KB read chunk exactly, so a boundary lands on
+    // a line boundary — the case where dropping the leading fragment could take
+    // a whole line with it. Swept across counts either side of 1024 and 2048.
+    const lines = Array.from({ length: 4096 }, (_, i) => String(i).padStart(63, '0'));
+    const file = write('aligned.log', lines);
+
+    for (const n of [1, 2, 1000, 1023, 1024, 1025, 2047, 2048, 2049]) {
+      expect(tailLines(file, n)).toEqual(lines.slice(-n));
+    }
+  });
+
+  it('U-LOGS-21: the follow offset is where the tail stopped, not where the file is now', () => {
+    // `--follow` resumes from this offset. Taking a fresh size instead would
+    // skip whatever the gateway appended between the two calls: past the tail's
+    // read, before the follower's start, printed by neither. The writer is a
+    // different process, so that window is real even though nothing can
+    // interleave within this one.
+    const file = write('gateway.log', [entry('info', 'a'), entry('info', 'b')]);
+    const sizeAtRead = fs.statSync(file).size;
+
+    const { lines, endPos } = tailFrom(file, 10);
+    fs.appendFileSync(file, entry('info', 'raced') + '\n');
+
+    expect(lines).toHaveLength(2);
+    expect(endPos).toBe(sizeAtRead);
+    // Everything past endPos is exactly what the follower must go on to stream.
+    expect(fs.readFileSync(file, 'utf-8').slice(endPos)).toBe(entry('info', 'raced') + '\n');
   });
 
   it('U-LOGS-19: an empty log file is not an error', async () => {

--- a/tests/unit/cli-logs.test.ts
+++ b/tests/unit/cli-logs.test.ts
@@ -10,6 +10,23 @@ import type { CliConfigView } from '../../src/cli/http-client';
  * here writes real files and runs the real command. There is no gateway
  * process: that is the point of the command, and of testing it this way.
  */
+
+/**
+ * The default log directory is `os.homedir()/.claude-gateway/logs`, and one
+ * test needs it to land somewhere hermetic. Neither of the obvious routes
+ * works: `jest.spyOn(os, 'homedir')` throws "Cannot redefine property" on this
+ * Node, and jest hands each test file a *copy* of `process.env`, so reassigning
+ * HOME leaves the native lookup reading the real one. A module mock is what is
+ * left, and it defers to the real implementation unless a test asks otherwise —
+ * without which the suite would read whatever logs happen to exist on the
+ * machine running it.
+ */
+let mockHomeDir: string | undefined;
+jest.mock('os', () => {
+  const actual = jest.requireActual('os');
+  return { ...actual, homedir: () => mockHomeDir ?? actual.homedir() };
+});
+
 describe('cli gateway logs', () => {
   let dir: string;
   let stdout: string[];
@@ -288,5 +305,24 @@ describe('cli gateway logs', () => {
 
     expect(code).toBe(0);
     expect(stdout.join('')).toBe('');
+  });
+
+  it('U-LOGS-22: a --config that cannot be read is named, not silently defaulted', async () => {
+    // Without the warning this reports "No log file at <default dir>" — a
+    // directory the operator never asked about — while the typo in --config
+    // goes unmentioned. Same class of failure as the unexpanded `~`.
+    const missing = path.join(dir, 'typo.json');
+    mockHomeDir = dir; // hermetic default dir — see the module mock above
+    try {
+      const code = await runGatewayLogs({ config: missing });
+
+      expect(code).toBe(1);
+      expect(stderr.join('')).toContain(missing);
+      expect(stderr.join('')).toContain('falling back to the default log directory');
+      // And the fallback path it actually used is still named explicitly.
+      expect(stderr.join('')).toContain(path.join(dir, '.claude-gateway', 'logs'));
+    } finally {
+      mockHomeDir = undefined;
+    }
   });
 });

--- a/tests/unit/cli-resource-command.test.ts
+++ b/tests/unit/cli-resource-command.test.ts
@@ -121,4 +121,16 @@ describe('generated resource commands', () => {
     expect(stderr.join('')).toBe('');
     expect(mockRequest).toHaveBeenCalledTimes(1);
   });
+
+  // U-RC-435a — `--follow` is parsed as a boolean everywhere so that
+  // `gateway --follow logs` does not swallow its own verb (#435), but it means
+  // nothing to a resource command. Parsing globally must not make it *accepted*
+  // globally, or the guard above quietly stops covering it.
+  it('U-RC-435a: --follow is still a typo on a resource command', async () => {
+    const code = await runCli(['crons', 'list', '--follow']);
+
+    expect(code).toBe(1);
+    expect(stderr.join('')).toContain('Unknown flag(s): --follow');
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/config-watcher.test.ts
+++ b/tests/unit/config-watcher.test.ts
@@ -111,12 +111,14 @@ describe('config-watcher', () => {
     alfredExtraFlags?: string[];
     alfredDangerouslySkip?: boolean;
     publicUrl?: string;
+    logs?: Record<string, unknown>;
   }): Record<string, unknown> {
     return {
       gateway: {
         logDir: '/tmp/claude-gateway-test-logs',
         timezone: 'Asia/Bangkok',
         ...(overrides?.publicUrl ? { publicUrl: overrides.publicUrl } : {}),
+        ...(overrides?.logs ? { logs: overrides.logs } : {}),
       },
       agents: [
         {
@@ -178,6 +180,60 @@ describe('config-watcher', () => {
       newValue: 'claude-sonnet-4-6',
       hotReloadable: true,
     });
+
+    watcher.stop();
+  });
+
+  // ---------------------------------------------------------------------------
+  // U-CW-12: gateway.logs is diffed and hot-reloadable (#435)
+  // ---------------------------------------------------------------------------
+  it('U-CW-12: emits gateway.logs as a hot-reloadable gateway-level change', () => {
+    // Without this the block would be a silent no-op: a field the watcher does
+    // not diff produces no change at all, so an operator editing `level` sees
+    // nothing happen and gets no hint that a restart is needed either.
+    const configPath = path.join(tmpDir, 'config.json');
+    writeConfigFile(configPath, rawConfig({ logs: { level: 'info' } }));
+
+    const watcher = new ConfigWatcher(configPath, loadConfig(configPath), logger);
+    const changeSpy = jest.fn();
+    watcher.on('changes', changeSpy);
+
+    writeConfigFile(configPath, rawConfig({ logs: { level: 'debug', maxFiles: 5 } }));
+    watcher.reload();
+
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    const changes: ConfigChange[] = changeSpy.mock.calls[0][0];
+    const logsChange = changes.find((c) => c.field === 'gateway.logs');
+    expect(logsChange).toMatchObject({
+      agentId: '',
+      field: 'gateway.logs',
+      oldValue: { level: 'info' },
+      newValue: { level: 'debug', maxFiles: 5 },
+      // Turning the level up to chase a live problem is exactly when a restart
+      // is unaffordable — it kills the sessions being investigated.
+      hotReloadable: true,
+    });
+
+    watcher.stop();
+  });
+
+  // ---------------------------------------------------------------------------
+  // U-CW-13: an unchanged gateway.logs block is not reported as a change
+  // ---------------------------------------------------------------------------
+  it('U-CW-13: an identical gateway.logs block produces no change', () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    writeConfigFile(configPath, rawConfig({ logs: { level: 'warn', maxFiles: 2 } }));
+
+    const watcher = new ConfigWatcher(configPath, loadConfig(configPath), logger);
+    const changeSpy = jest.fn();
+    watcher.on('changes', changeSpy);
+
+    // Same values, rewritten — deepEqual must see through the new object.
+    writeConfigFile(configPath, rawConfig({ logs: { level: 'warn', maxFiles: 2 } }));
+    watcher.reload();
+
+    const changes: ConfigChange[] = changeSpy.mock.calls[0]?.[0] ?? [];
+    expect(changes.find((c) => c.field === 'gateway.logs')).toBeUndefined();
 
     watcher.stop();
   });

--- a/tests/unit/logger-rotation.test.ts
+++ b/tests/unit/logger-rotation.test.ts
@@ -1,0 +1,298 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  configureLogging,
+  createLogger,
+  loggingConfig,
+  LOGS_DEFAULTS,
+  resetLoggingForTests,
+  startLogRetentionSweep,
+  sweepOldLogs,
+} from '../../src/logger';
+
+/**
+ * Log verbosity, rotation and retention (issue #435).
+ *
+ * The directory that motivated this measured 557 MB across 59 files on a live
+ * host after hours of uptime, 99% of it session logs and 99.98% of the largest
+ * file a single `debug` message. So the level gate is tested first and hardest:
+ * rotation bounds what is *kept*, but only the gate bounds what is *written*.
+ */
+describe('logger level gate, rotation and retention (#435)', () => {
+  let dir: string;
+  let outSpy: jest.SpyInstance;
+  let errSpy: jest.SpyInstance;
+  let stdout: string[];
+  let stderr: string[];
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-logger-'));
+    stdout = [];
+    stderr = [];
+    outSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stdout.push(chunk.toString());
+      return true;
+    });
+    errSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stderr.push(chunk.toString());
+      return true;
+    });
+    resetLoggingForTests();
+  });
+
+  afterEach(() => {
+    outSpy.mockRestore();
+    errSpy.mockRestore();
+    resetLoggingForTests();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const readLines = (file: string): string[] =>
+    fs.readFileSync(path.join(dir, file), 'utf-8').split('\n').filter(Boolean);
+
+  // ── U-LOG-01..04: the level gate ──────────────────────────────────────────
+
+  it('U-LOG-01: drops debug at the default level, on disk and on stdout', () => {
+    const log = createLogger('a1', dir);
+    log.debug('per-event noise', { line: 'x'.repeat(100) });
+    log.info('kept');
+
+    const lines = readLines('a1.log');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).level).toBe('info');
+    // stdout is duplicated into the journal under systemd, so the gate has to
+    // cover it too or the on-disk saving is paid for twice elsewhere.
+    expect(stdout.join('')).not.toContain('per-event noise');
+  });
+
+  it('U-LOG-02: level "debug" restores the old behaviour verbatim', () => {
+    configureLogging({ level: 'debug' });
+    const log = createLogger('a2', dir);
+    log.debug('now kept');
+    log.info('also kept');
+
+    expect(readLines('a2.log')).toHaveLength(2);
+  });
+
+  it('U-LOG-03: a higher level still lets warn and error through', () => {
+    configureLogging({ level: 'warn' });
+    const log = createLogger('a3', dir);
+    log.debug('no');
+    log.info('no');
+    log.warn('yes');
+    log.error('yes');
+
+    expect(readLines('a3.log').map((l) => JSON.parse(l).level)).toEqual(['warn', 'error']);
+  });
+
+  it('U-LOG-04: an unknown level falls back to the default instead of dropping everything', () => {
+    configureLogging({ level: 'verbose' as never });
+    expect(loggingConfig().level).toBe(LOGS_DEFAULTS.level);
+    const log = createLogger('a4', dir);
+    log.info('kept');
+    expect(readLines('a4.log')).toHaveLength(1);
+  });
+
+  // ── U-LOG-05..09: rotation ────────────────────────────────────────────────
+
+  it('U-LOG-05: a file past maxFileBytes is rotated and a new one started', () => {
+    configureLogging({ maxFileBytes: 400, maxFiles: 3 });
+    const log = createLogger('r1', dir);
+    for (let i = 0; i < 10; i++) log.info(`message ${i}`, { pad: 'y'.repeat(50) });
+
+    expect(fs.existsSync(path.join(dir, 'r1.log'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'r1.log.1'))).toBe(true);
+    // The live file is always below the threshold — that is the whole point.
+    expect(fs.statSync(path.join(dir, 'r1.log')).size).toBeLessThanOrEqual(400);
+  });
+
+  it('U-LOG-06: at most maxFiles generations are kept, and the oldest is deleted', () => {
+    configureLogging({ maxFileBytes: 200, maxFiles: 2 });
+    const log = createLogger('r2', dir);
+    for (let i = 0; i < 40; i++) log.info(`message ${i}`, { pad: 'z'.repeat(50) });
+
+    const generations = fs.readdirSync(dir).filter((n) => /^r2\.log\.\d+$/.test(n)).sort();
+    expect(generations).toEqual(['r2.log.1', 'r2.log.2']);
+    expect(fs.existsSync(path.join(dir, 'r2.log.3'))).toBe(false);
+  });
+
+  it('U-LOG-07: generations shift, so .log.1 always holds the most recently rotated content', () => {
+    configureLogging({ maxFileBytes: 150, maxFiles: 2 });
+    const log = createLogger('r3', dir);
+    log.info('first', { pad: 'a'.repeat(100) });
+    log.info('second', { pad: 'b'.repeat(100) });
+    log.info('third', { pad: 'c'.repeat(100) });
+
+    expect(fs.readFileSync(path.join(dir, 'r3.log.1'), 'utf-8')).toContain('second');
+    expect(fs.readFileSync(path.join(dir, 'r3.log.2'), 'utf-8')).toContain('first');
+  });
+
+  it('U-LOG-08: maxFiles 0 keeps no generations — the live file simply starts over', () => {
+    configureLogging({ maxFileBytes: 150, maxFiles: 0 });
+    const log = createLogger('r4', dir);
+    log.info('first', { pad: 'a'.repeat(100) });
+    log.info('second', { pad: 'b'.repeat(100) });
+
+    expect(fs.readdirSync(dir).filter((n) => n.startsWith('r4.log'))).toEqual(['r4.log']);
+    const live = fs.readFileSync(path.join(dir, 'r4.log'), 'utf-8');
+    expect(live).toContain('second');
+    // Started over, not merely appended to — otherwise "keep no generations"
+    // would be indistinguishable from "never rotate", which is unbounded growth.
+    expect(live).not.toContain('first');
+  });
+
+  it('U-LOG-20: lowering maxFiles collects the generations it orphaned', () => {
+    // A rename clobbers its destination, so the cap looks self-enforcing until
+    // the config changes underneath it: generations above the new cap have
+    // nothing renaming onto them and would sit there until they aged out.
+    configureLogging({ maxFileBytes: 150, maxFiles: 5 });
+    const log5 = createLogger('r6', dir);
+    for (let i = 0; i < 8; i++) log5.info(`m${i}`, { pad: 'a'.repeat(100) });
+    expect(fs.readdirSync(dir).filter((n) => /^r6\.log\.\d+$/.test(n)).length).toBeGreaterThan(2);
+
+    resetLoggingForTests();
+    configureLogging({ maxFileBytes: 150, maxFiles: 2 });
+    const log2 = createLogger('r6', dir);
+    for (let i = 0; i < 4; i++) log2.info(`n${i}`, { pad: 'b'.repeat(100) });
+
+    expect(fs.readdirSync(dir).filter((n) => /^r6\.log\.\d+$/.test(n)).sort()).toEqual([
+      'r6.log.1',
+      'r6.log.2',
+    ]);
+  });
+
+  it('U-LOG-09: two loggers on the same file share one size counter, so rotation is not late', () => {
+    // `createLogger(agentConfig.id, …)` is called from both the boot path and
+    // the runner constructor, so one file really does have several writers.
+    // Per-instance counters would each see half the bytes and rotate late.
+    configureLogging({ maxFileBytes: 400, maxFiles: 1 });
+    const a = createLogger('shared', dir);
+    const b = createLogger('shared', dir);
+    const file = path.join(dir, 'shared.log');
+
+    // Sampled after every write, not just at the end: a late-rotating writer
+    // overshoots and then rotates back under the threshold, so the final size
+    // alone cannot tell the two apart.
+    const sizes: number[] = [];
+    for (let i = 0; i < 8; i++) {
+      a.info(`a${i}`, { pad: 'x'.repeat(40) });
+      sizes.push(fs.statSync(file).size);
+      b.info(`b${i}`, { pad: 'x'.repeat(40) });
+      sizes.push(fs.statSync(file).size);
+    }
+
+    expect(Math.max(...sizes)).toBeLessThanOrEqual(400);
+  });
+
+  it('U-LOG-10: rotation never throws into the caller', () => {
+    configureLogging({ maxFileBytes: 100, maxFiles: 2 });
+    const log = createLogger('r5', dir);
+    log.info('seed', { pad: 'q'.repeat(200) });
+    // A directory where the rotated generation should go makes every rename
+    // fail. Logging must still be a call that returns.
+    fs.mkdirSync(path.join(dir, 'r5.log.1'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'r5.log.1', 'blocker'), 'x');
+
+    expect(() => log.info('after', { pad: 'q'.repeat(200) })).not.toThrow();
+  });
+
+  // ── U-LOG-11..13: the write-failure latch ─────────────────────────────────
+
+  it('U-LOG-11: a failed append is reported once, not swallowed and not repeated', () => {
+    // A real failure rather than a mocked one: a directory sitting where the
+    // log file belongs makes every append throw EISDIR, which is the same shape
+    // as the full disk / permission change this latch exists for.
+    fs.mkdirSync(path.join(dir, 'w1.log'), { recursive: true });
+    const log = createLogger('w1', dir);
+
+    expect(() => log.info('one')).not.toThrow();
+    log.info('two');
+    log.info('three');
+
+    const reports = stderr.filter((s) => s.includes('[logger] cannot write'));
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toContain('EISDIR');
+    expect(reports[0]).toContain(path.join(dir, 'w1.log'));
+  });
+
+  // ── U-LOG-12..16: age-based retention ─────────────────────────────────────
+
+  it('U-LOG-12: files older than retentionDays are removed, newer ones kept', () => {
+    const old = path.join(dir, 'old.log');
+    const fresh = path.join(dir, 'fresh.log');
+    fs.writeFileSync(old, 'x');
+    fs.writeFileSync(fresh, 'x');
+    const longAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(old, longAgo / 1000, longAgo / 1000);
+
+    const removed = sweepOldLogs(dir, 14);
+
+    expect(removed).toEqual([old]);
+    expect(fs.existsSync(old)).toBe(false);
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+
+  it('U-LOG-13: rotated generations age out too', () => {
+    const gen = path.join(dir, 'a.log.2');
+    fs.writeFileSync(gen, 'x');
+    const longAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(gen, longAgo / 1000, longAgo / 1000);
+
+    expect(sweepOldLogs(dir, 14)).toEqual([gen]);
+  });
+
+  it('U-LOG-14: retentionDays 0 keeps forever', () => {
+    const old = path.join(dir, 'old.log');
+    fs.writeFileSync(old, 'x');
+    const longAgo = Date.now() - 900 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(old, longAgo / 1000, longAgo / 1000);
+
+    expect(sweepOldLogs(dir, 0)).toEqual([]);
+    expect(fs.existsSync(old)).toBe(true);
+  });
+
+  it('U-LOG-15: the sweep only deletes log files — the directory is not exclusively ours', () => {
+    const stranger = path.join(dir, 'notes.txt');
+    fs.writeFileSync(stranger, 'x');
+    const longAgo = Date.now() - 900 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(stranger, longAgo / 1000, longAgo / 1000);
+
+    expect(sweepOldLogs(dir, 1)).toEqual([]);
+    expect(fs.existsSync(stranger)).toBe(true);
+  });
+
+  it('U-LOG-16: startLogRetentionSweep sweeps at boot and reports what it removed', () => {
+    configureLogging({ retentionDays: 14 });
+    const old = path.join(dir, 'stale.log');
+    fs.writeFileSync(old, 'x');
+    const longAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(old, longAgo / 1000, longAgo / 1000);
+
+    const seen: string[][] = [];
+    const stop = startLogRetentionSweep(dir, (removed) => seen.push(removed));
+    stop();
+
+    expect(seen).toEqual([[old]]);
+    expect(fs.existsSync(old)).toBe(false);
+  });
+
+  it('U-LOG-17: an unreadable log directory is not a crash at boot', () => {
+    expect(() => sweepOldLogs(path.join(dir, 'nope'), 14)).not.toThrow();
+    expect(sweepOldLogs(path.join(dir, 'nope'), 14)).toEqual([]);
+  });
+
+  // ── U-LOG-18: defaults ────────────────────────────────────────────────────
+
+  it('U-LOG-18: a config with no gateway.logs block runs on defaults', () => {
+    const applied = configureLogging(undefined);
+    expect(applied).toEqual(LOGS_DEFAULTS);
+  });
+
+  it('U-LOG-19: nonsense thresholds fall back rather than rotating every line', () => {
+    const applied = configureLogging({ maxFileBytes: 0, maxFiles: -1, retentionDays: Number.NaN });
+    expect(applied.maxFileBytes).toBe(LOGS_DEFAULTS.maxFileBytes);
+    expect(applied.maxFiles).toBe(LOGS_DEFAULTS.maxFiles);
+    expect(applied.retentionDays).toBe(LOGS_DEFAULTS.retentionDays);
+  });
+});

--- a/tests/unit/logger-rotation.test.ts
+++ b/tests/unit/logger-rotation.test.ts
@@ -282,6 +282,31 @@ describe('logger level gate, rotation and retention (#435)', () => {
     expect(sweepOldLogs(path.join(dir, 'nope'), 14)).toEqual([]);
   });
 
+  it('U-LOG-21: the daily sweep is scheduled even when retention starts disabled', () => {
+    // `retentionDays` is read on each run, so a policy reloaded later takes
+    // effect at the next sweep — but only if a timer exists to reach it. One
+    // that was never started because retention happened to be 0 at boot could
+    // not, and retention would stay off until a restart.
+    configureLogging({ retentionDays: 0 });
+    const timers = jest.spyOn(global, 'setInterval');
+    const stop = startLogRetentionSweep(dir);
+    expect(timers).toHaveBeenCalledTimes(1);
+
+    // Turn retention on the way a config reload would, then let the timer fire.
+    const old = path.join(dir, 'stale.log');
+    fs.writeFileSync(old, 'x');
+    const longAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(old, longAgo / 1000, longAgo / 1000);
+    configureLogging({ retentionDays: 14 });
+
+    const tick = timers.mock.calls[0][0] as () => void;
+    tick();
+
+    expect(fs.existsSync(old)).toBe(false);
+    stop();
+    timers.mockRestore();
+  });
+
   // ── U-LOG-18: defaults ────────────────────────────────────────────────────
 
   it('U-LOG-18: a config with no gateway.logs block runs on defaults', () => {


### PR DESCRIPTION
Closes #435

## What the measurement changed

The issue asks for two halves — a `gateway logs` reader and a bounded writer. Measuring the live log directory first reordered them.

| | |
|---|---|
| Log directory | **557 MB across 59 files** (the issue said 553 MB; it grew during the check) |
| Largest single file | **217 MB** |
| Session logs | **99% of the total** |
| Everything else | **6.1 MB across ~40 files**; `gateway.log` is 31 KB |
| Level mix, first 20k lines of the largest file | **19,995 `debug` : 5 `info`** |

Every session stream event is logged at `debug` (`src/session/process.ts:900`). So the level gate, not rotation, is the fix that matters here: rotation alone would have gone on writing all 551 MB and merely deleted it sooner. **Rotation and retention bound what is *kept*; only the level bounds what is *written*.**

`level` defaults to `info`. This does not affect `debug-bundle`, which selects on warn/error and `submit-diag` — and `submit-diag` is emitted via `logWarn` (`src/shell/claude-pty-shell.ts:604`), so it still passes the gate.

## Write side — `src/logger.ts`

New optional `gateway.logs` config block; omit it entirely and the defaults apply.

| Field | Default |
|---|---|
| `level` | `info` |
| `maxFileBytes` | 16 MiB |
| `maxFiles` | `3` |
| `retentionDays` | `14` |

- **Level gate** on the file *and* stdout. stdout is duplicated into the systemd journal, so gating only the file would pay for the volume twice.
- **Size rotation**, `<name>.log` → `.log.1` → `.log.N`. Lowering `maxFiles` collects the generations it orphans — `renameSync` clobbers its destination, so a fixed cap looks self-enforcing right up until the config changes underneath it.
- **Age sweep** at boot and once a day, modelled on `startBackupCleanup()`. Age rather than count, because each session writes its own `<agent>:session:<uuid>.log` and never returns to it, so a per-stream generation cap can never reach them. The timer is unref'd.
- **Write failures surface.** The append was wrapped in a bare `catch {}`: a full disk or a permission change silently stopped all file logging, which is precisely the failure that makes the next incident undiagnosable. Now latched and reported once to stderr — reporting every occurrence would be its own denial of service, since the failing call *is* the logger.

Two decisions worth flagging for review:

- **Policy is module state, not a per-logger argument.** There is one policy per process and `createLogger()` has 13 call sites, several of which (routers, the session process) have no access to the gateway config. Threading an options bag through all 13 would put the same value in 13 places and let them drift. `configureLogging()` is called in `src/index.ts` before the first logger exists — verified to be the only process entry point (`dist/entry.js`), so it covers the session loggers too.
- **The size counter is shared per absolute path.** One file legitimately has several logger instances — `createLogger(agentConfig.id, …)` runs from both the boot path and the runner constructor — and per-instance counters each see only their own share and rotate late.

## Read side

```
claude-gateway gateway logs [--follow] [--lines <n>] [--agent <id>] [--json] [--logDir <path>] [--config <path>]
```

Reads the files directly, so it answers whether or not the gateway is running — which is usually exactly when you need it.

- `resolveLogDir()` and the directory listing move out of `debug-bundle` into `src/cli/logs-dir.ts`. Two copies would drift, and the tilde bug is what a drifted copy looks like: the shipped config template writes a literal `~`, and `readdirSync('~/…')` throws ENOENT — which reads exactly like "the directory is empty".
- **Every failure is explicit.** An unknown `--agent` names the path it tried and lists the ids that do exist; an unreadable directory reports its errno. A log reader must never answer "no logs" when the real answer is "I looked in the wrong place".
- **`--follow` polls and compares the inode** rather than using `fs.watch`. This is where the two halves of the issue meet: the reader holds a file the writer is free to rename out from under it, and a watcher would hold the dead inode and go quiet forever while the gateway wrote happily into the new file.
- `--follow` is registered as a *global* boolean flag because the verb is a positional — `gateway --follow logs` would otherwise consume `logs` as the flag's value and leave no command at all. No generated resource command declares a `--follow` value flag (verified).

`--json` prints the stored lines verbatim. Note this output is **not** redacted, unlike `debug-bundle` — it is the local file you could already `cat`. The README says so where the command is documented.

## Tests

48 new tests across `tests/unit/logger-rotation.test.ts`, `tests/unit/cli-logs.test.ts`, `tests/unit/cli-logs-dir.test.ts`.

Each of the **12 guards was revert-proven** — patched back out, confirmed its tests fail for the right reason, restored. Two tests did not survive that and were strengthened:

- `maxFiles: 0` passed with rotation entirely removed, because it only checked that the live file contained the newest line. It now asserts the file *restarted* — otherwise "keep no generations" is indistinguishable from "never rotate", which is unbounded growth.
- The shared-counter test sampled the size only at the end. A late-rotating writer overshoots (423 bytes against a 400-byte threshold, measured) and then rotates back under it, so the final size alone cannot tell the two apart. It now samples after every write.

Full suite: **235 suites / 4277 tests passing** (baseline 232 / 4219). `npx tsc --noEmit` clean and `npm run gen-cli:check` reports the generated files up to date. There is no `lint` script in this repo, so no lint gate was run — an earlier version of this line claimed one, which was wrong.

## Note on the issue text

#435 cites `src/session/process.ts:287` as the per-stream-event `debug` site. That line is the `createLogger` call; the actual site is `src/session/process.ts:900`. The claim itself is correct — only the line number is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
