### PR TITLE
fix(pty): detect the bypass dialog by structure, not screen position (#436)

### DIFF
--- a/src/shell/bypass-dialog.ts
+++ b/src/shell/bypass-dialog.ts
@@ -26,9 +26,10 @@
  * reordering must not send us to "No, exit"), and anything unparseable or
  * ambiguous produces no keystroke at all.
  *
- * This module is the pure decision — kept free of node-pty / screen imports so
- * it is cheap to unit-test in isolation, same pattern as menu-probe.ts's
- * decideProbeAttempt and menu-cancel.ts's decideMenuCancel. See
+ * This module is the pure detection + decision — kept free of node-pty / screen
+ * imports so it is cheap to unit-test in isolation, same pattern as
+ * menu-probe.ts's decideProbeAttempt and menu-cancel.ts's decideMenuCancel.
+ * ScreenModel.detectDialog() calls isBypassDialogOnScreen() below; see
  * Driver.maybeHandleDialog() in claude-pty-shell.ts for where it is wired in.
  */
 
@@ -41,6 +42,20 @@
  */
 export const BYPASS_ACCEPT_LABEL = 'Yes, I accept';
 export const BYPASS_DECLINE_LABEL = 'No, exit';
+
+/**
+ * The dialog's own confirm affordance, rendered a line or two below the option
+ * rows ("Enter to confirm · Esc to cancel"). Only the stable prefix is matched.
+ *
+ * Required by {@link isBypassDialogOnScreen} for the same reason
+ * TUI_REQUEST_TOO_LARGE_DISMISS is required by detectRequestTooLarge(): the
+ * labels alone appear in ordinary prose (this very dialog's warning text, a
+ * chat reply explaining it, re-injected history quoting it), whereas the
+ * footer is the affordance the live overlay renders — and it is exactly the
+ * affordance the accepting keystroke relies on, so gating on it keeps
+ * detection and the action consistent.
+ */
+export const BYPASS_CONFIRM_FOOTER = 'Enter to confirm';
 
 /** Arrow keystrokes used to walk the caret onto the accept row. */
 export const BYPASS_KEY_DOWN = '\x1b[B';
@@ -77,12 +92,12 @@ export const BYPASS_MAX_KEYS = 60;
  * Consecutive rounds with no dialog on screen before the keystroke ceiling is
  * considered spent on a dialog that is gone.
  *
- * Not 1: detection needs both TUI_BYPASS_PERMS markers inside the same bottom
- * region (screen.ts DIALOG_REGION_ROWS), so a repaint that shifts the box by a
- * row drops the header out of that window for a single read. Resetting on one
- * miss would zero the counter mid-dialog — precisely the case the ceiling
- * exists for. Requiring sustained absence costs the next dialog one extra
- * cooldown round at most.
+ * Not 1: detection is structural (see isBypassDialogOnScreen), so a mid-repaint
+ * frame — the option rows drawn but the footer not yet, or the caret momentarily
+ * on neither row — reads as "no dialog" for a single round while the dialog is
+ * still very much up. Resetting on one miss would zero the counter mid-dialog —
+ * precisely the case the ceiling exists for. Requiring sustained absence costs
+ * the next dialog one extra cooldown round at most.
  */
 export const BYPASS_RESET_AFTER_MISSES = 2;
 
@@ -182,6 +197,60 @@ function findRow(lines: string[], re: RegExp): OptionRow | null {
 }
 
 /**
+ * Is a live, drivable bypass-permissions dialog on this screen?
+ *
+ * This replaced a positional test — "both marker substrings inside the bottom
+ * 20 rows" — which assumed a modal is always anchored to the bottom. This
+ * dialog is not: it renders at boot, before there is any conversation to push
+ * it down, so on a clean start it sits at the TOP of the screen with the rest
+ * blank. Both markers then fall outside the window, detection returns null,
+ * nothing is pressed, and the session dies at the 120 s startup timeout and
+ * respawns into the same dialog (issue #436). Whether a given boot emitted
+ * enough output to push the dialog into the window is what made the wedge look
+ * random.
+ *
+ * The window was never really about position, though — it was a cheap proxy for
+ * "this is the live modal, not text that quotes it". Quoted text is a genuine
+ * hazard: an agent explaining this dialog, or re-injected conversation history,
+ * puts the same characters on the same screen, and a mis-aimed Enter can land on
+ * "No, exit" and kill Claude Code unrecoverably. So the proxy is replaced with
+ * the thing it was proxying for — four structural properties, all position-
+ * independent, all read off a verbatim capture of the real dialog:
+ *
+ *   1. Both option labels occupy a WHOLE row (findRow's anchored patterns), so
+ *      prose that mentions them mid-sentence never qualifies.
+ *   2. Exactly ONE of those two rows carries the ❯ caret. Zero means the frame
+ *      is still rendering (or is not a live select); two is a shape we do not
+ *      understand.
+ *   3. The dialog's own confirm footer renders BELOW the option rows.
+ *   4. Nothing but blank rows renders below that footer.
+ *
+ * (4) is the load-bearing one, and it is what the old bottom-region test was
+ * actually encoding: a live modal owns the screen. Quoted text never can — the
+ * input box, its border and the status bar always render underneath it — so
+ * scrollback, a pasted dialog, and re-injected history all fail (4) no matter
+ * where on the screen they land.
+ *
+ * Fail-safe in the same direction as before: anything unrecognised reads as "no
+ * dialog", which means no keystroke and an operator who simply sees the dialog.
+ */
+export function isBypassDialogOnScreen(screenText: string): boolean {
+  const lines = screenText.split('\n');
+  const accept = findRow(lines, ACCEPT_ROW_RE);
+  const decline = findRow(lines, DECLINE_ROW_RE);
+  if (!accept || !decline) return false;
+  // Exactly one caret: equal flags mean either none (still rendering) or both
+  // (unrecognised shape). Same rule decideBypassDialogAction() acts on.
+  if (accept.caret === decline.caret) return false;
+  const lastOptionRow = Math.max(accept.line, decline.line);
+  const footer = lines.findIndex(
+    (l, i) => i > lastOptionRow && l.includes(BYPASS_CONFIRM_FOOTER),
+  );
+  if (footer === -1) return false;
+  return lines.slice(footer + 1).every((l) => l.trim() === '');
+}
+
+/**
  * Decide the single keystroke to send at a bypass-permissions dialog, given
  * the screen region the dialog was detected in.
  *
@@ -206,6 +275,19 @@ export function decideBypassDialogAction(
     return { kind: 'wait', reason: `keystroke budget exhausted after ${state.keys} keys` };
   }
 
+  // The caller only gets here after detectDialog() fired, and both now read the
+  // whole screen — so "act only on what was detected" can no longer be enforced
+  // by handing this function a narrow region. It is enforced by applying the
+  // same structural rule here instead, which also keeps the two layers from
+  // drifting apart if either is edited alone.
+  if (!isBypassDialogOnScreen(dialogText)) {
+    return { kind: 'wait', reason: 'no live bypass dialog on screen' };
+  }
+
+  // The checks below are reached only for a screen that already satisfies that
+  // rule, so several are belt-and-braces. They are kept deliberately: each one
+  // states an invariant this decision depends on, and a keystroke sent on a
+  // wrong assumption here can pick "No, exit" and end the session for good.
   const lines = dialogText.split('\n');
   const accept = findRow(lines, ACCEPT_ROW_RE);
   if (!accept) return { kind: 'wait', reason: 'accept row not parseable on screen' };

--- a/src/shell/bypass-dialog.ts
+++ b/src/shell/bypass-dialog.ts
@@ -57,6 +57,29 @@ export const BYPASS_DECLINE_LABEL = 'No, exit';
  */
 export const BYPASS_CONFIRM_FOOTER = 'Enter to confirm';
 
+/**
+ * The dialog's heading — the same string screen.ts lists first in
+ * TUI_BYPASS_PERMS, repeated here for the dependency-free reason above, with a
+ * unit test asserting the two never drift apart.
+ *
+ * Required by {@link isBypassDialogOnScreen} so that predicate is the COMPLETE
+ * rule rather than half of one split across two files. See the note there.
+ */
+export const BYPASS_HEADING = 'Bypass Permissions mode';
+
+/**
+ * How far apart the dialog's own rows may sit before they stop being one block.
+ *
+ * The real capture has the two options on adjacent rows and the footer two rows
+ * below them (one blank row between). These bounds allow a little repaint slack
+ * while still requiring the elements to be visually together: without them the
+ * "structure" was only an ordering, so an option row, a second option row 15
+ * lines further down and any sentence containing "Enter to confirm" below that
+ * satisfied it — on a screen of ordinary conversation (review round 2, M3).
+ */
+export const BYPASS_MAX_ROW_GAP = 2;
+export const BYPASS_MAX_FOOTER_GAP = 3;
+
 /** Arrow keystrokes used to walk the caret onto the accept row. */
 export const BYPASS_KEY_DOWN = '\x1b[B';
 export const BYPASS_KEY_UP = '\x1b[A';
@@ -127,8 +150,8 @@ export interface BypassDialogState {
  * Record a round in which no dialog was detected, clearing the keystroke count
  * once the dialog has been absent for BYPASS_RESET_AFTER_MISSES consecutive
  * rounds so the next dialog starts with a full allowance. Tolerating a single
- * miss keeps a one-round detection flicker (a repaint shifting the header out
- * of the detection window) from silently refilling the allowance mid-dialog.
+ * miss keeps a one-round detection flicker (a repaint catching the dialog
+ * half-drawn) from silently refilling the allowance mid-dialog.
  */
 export function noteDialogAbsent(state: BypassDialogState): void {
   state.misses++;
@@ -142,7 +165,7 @@ export function noteDialogPresent(state: BypassDialogState): void {
 
 /** One option row of the dialog as it appears on screen. */
 interface OptionRow {
-  /** Line index within the scanned region — decides Down vs Up. */
+  /** Line index within the screen text — decides Down vs Up. */
   line: number;
   /** The ❯ caret is on this row. */
   caret: boolean;
@@ -184,7 +207,7 @@ const ACCEPT_ROW_RE = rowPattern(BYPASS_ACCEPT_LABEL);
 const DECLINE_ROW_RE = rowPattern(BYPASS_DECLINE_LABEL);
 
 /**
- * Find the option row nearest the bottom of the region. A live modal is the
+ * Find the option row nearest the bottom of the screen. A live modal is the
  * bottom-most thing on screen, so scanning upward from the end means quoted
  * scrollback above it can never be the row we act on.
  */
@@ -214,27 +237,52 @@ function findRow(lines: string[], re: RegExp): OptionRow | null {
  * hazard: an agent explaining this dialog, or re-injected conversation history,
  * puts the same characters on the same screen, and a mis-aimed Enter can land on
  * "No, exit" and kill Claude Code unrecoverably. So the proxy is replaced with
- * the thing it was proxying for — four structural properties, all position-
+ * the thing it was proxying for — structural properties, all position-
  * independent, all read off a verbatim capture of the real dialog:
  *
- *   1. Both option labels occupy a WHOLE row (findRow's anchored patterns), so
+ *   1. The dialog's heading is somewhere on screen. Cheap substring reject.
+ *   2. Both option labels occupy a WHOLE row (findRow's anchored patterns), so
  *      prose that mentions them mid-sentence never qualifies.
- *   2. Exactly ONE of those two rows carries the ❯ caret. Zero means the frame
+ *   3. Exactly ONE of those two rows carries the ❯ caret. Zero means the frame
  *      is still rendering (or is not a live select); two is a shape we do not
  *      understand.
- *   3. The dialog's own confirm footer renders BELOW the option rows.
- *   4. Nothing but blank rows renders below that footer.
+ *   4. The rows and the footer form one BLOCK — the options within
+ *      BYPASS_MAX_ROW_GAP rows of each other, the footer within
+ *      BYPASS_MAX_FOOTER_GAP below them. Without this the three elements only
+ *      had to appear in order, so an option row, an unrelated option row 15
+ *      lines later and a sentence containing "Enter to confirm" further down
+ *      still qualified (review round 2, finding M3).
+ *   5. The dialog's own confirm footer renders BELOW the option rows.
+ *   6. Nothing but blank rows renders below that footer.
  *
- * (4) is the load-bearing one, and it is what the old bottom-region test was
+ * (6) is the load-bearing one, and it is what the old bottom-region test was
  * actually encoding: a live modal owns the screen. Quoted text never can — the
  * input box, its border and the status bar always render underneath it — so
- * scrollback, a pasted dialog, and re-injected history all fail (4) no matter
+ * scrollback, a pasted dialog, and re-injected history all fail (6) no matter
  * where on the screen they land.
+ *
+ * (6) is deliberately ZERO-tolerance: not even a box border may follow the
+ * footer. A future Claude Code that draws this dialog inside a box, or paints a
+ * status line beneath it, would therefore stop being detected. That is the
+ * intended direction of the trade — a miss is fail-safe (the operator sees the
+ * dialog, and maybeHandleDialog() now logs a warning naming this exact case),
+ * whereas relaxing (6) to tolerate border rows would admit a quoted dialog
+ * sitting above an EMPTY input box, whose rows are themselves nothing but
+ * border characters. Given "No, exit" is unrecoverable and a visible dialog is
+ * not, a miss beats a false accept (review round 2, finding M2 — accepted as
+ * accurate, resolved this way rather than by relaxing the rule).
  *
  * Fail-safe in the same direction as before: anything unrecognised reads as "no
  * dialog", which means no keystroke and an operator who simply sees the dialog.
  */
 export function isBypassDialogOnScreen(screenText: string): boolean {
+  // The heading gate lives HERE rather than in ScreenModel.detectDialog() so
+  // that this predicate is the whole rule. When detectDialog() held it, the
+  // action layer re-applied only the structural half, and a screen carrying a
+  // perfect dialog shape without the heading produced a live Enter if
+  // decideBypassDialogAction() was ever called from anywhere else — the exact
+  // drift the two-layer design claimed to prevent (review round 2, finding H1).
+  if (!screenText.includes(BYPASS_HEADING)) return false;
   const lines = screenText.split('\n');
   const accept = findRow(lines, ACCEPT_ROW_RE);
   const decline = findRow(lines, DECLINE_ROW_RE);
@@ -242,17 +290,19 @@ export function isBypassDialogOnScreen(screenText: string): boolean {
   // Exactly one caret: equal flags mean either none (still rendering) or both
   // (unrecognised shape). Same rule decideBypassDialogAction() acts on.
   if (accept.caret === decline.caret) return false;
+  if (Math.abs(accept.line - decline.line) > BYPASS_MAX_ROW_GAP) return false;
   const lastOptionRow = Math.max(accept.line, decline.line);
   const footer = lines.findIndex(
     (l, i) => i > lastOptionRow && l.includes(BYPASS_CONFIRM_FOOTER),
   );
   if (footer === -1) return false;
+  if (footer - lastOptionRow > BYPASS_MAX_FOOTER_GAP) return false;
   return lines.slice(footer + 1).every((l) => l.trim() === '');
 }
 
 /**
  * Decide the single keystroke to send at a bypass-permissions dialog, given
- * the screen region the dialog was detected in.
+ * the screen text the dialog was detected on.
  *
  * Callers send at most one key per call and re-read the screen before the
  * next one (the DIALOG_ACTION_COOLDOWN_MS re-entry in maybeHandleDialog()),

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -14,7 +14,7 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as readline from 'readline';
 import { translateArgs, sanitizeUserText } from './args';
-import { ScreenModel, MenuOption, parseMenuChoice, formatMenuPrompt, formatPermissionPrompt, extractChannelContent, isPtyActivelyWorking, parseInteractivePrompt } from './screen';
+import { ScreenModel, MenuOption, parseMenuChoice, formatMenuPrompt, formatPermissionPrompt, extractChannelContent, isPtyActivelyWorking, parseInteractivePrompt, TUI_BYPASS_PERMS } from './screen';
 import { PtyHost } from './pty-host';
 import { TranscriptTailer, AssistantRecord, UsageInfo } from './tailer';
 import { ProtocolEmitter } from './emitter';
@@ -204,6 +204,9 @@ class Driver {
   // whose dialog has no row numbers, and the key that accepts (see
   // bypass-dialog.ts). Reset once the dialog leaves the screen.
   private bypassDialog: BypassDialogState = { keys: 0, misses: 0 };
+  // Latch for the "markers on screen but the dialog did not validate" warning
+  // below, so it is reported once per run of such rounds rather than every 2 s.
+  private bypassMarkerWarned = false;
   // In-flight behavioral probe round, advanced synchronously by tick() at a
   // single chokepoint — the same tick-driven pattern as menuCancel and
   // interrupting (review round 2, finding 6; replaced a detached async
@@ -1039,14 +1042,32 @@ class Driver {
     const dialog = this.screen.detectDialog();
     if (!dialog) {
       // No dialog this round. The keystroke allowance is only refilled once it
-      // has been absent for several consecutive rounds: detectDialog() needs
-      // both markers inside the same bottom region, so a repaint that shifts
-      // the box by a row can hide it for a single read while it is still very
-      // much up, and refilling there would defeat the allowance entirely.
+      // has been absent for several consecutive rounds: detection is structural
+      // (see isBypassDialogOnScreen), so a mid-repaint frame can read as absent
+      // for a single round while the dialog is still very much up, and refilling
+      // there would defeat the allowance entirely.
       noteDialogAbsent(this.bypassDialog);
+      // A detector that returns null without a word is how #436 stayed hidden:
+      // the symptom (a 120 s startup timeout) is three layers away from the
+      // cause (detection that never fired), with no breadcrumb in between. When
+      // the markers ARE on screen but the structure does not validate, say so —
+      // once per run, since the common case is an agent's own reply quoting the
+      // dialog, which is precisely what must not attract a keystroke.
+      if (this.screen.text().includes(TUI_BYPASS_PERMS[0])) {
+        if (!this.bypassMarkerWarned) {
+          this.bypassMarkerWarned = true;
+          logWarn(
+            'Bypass Permissions marker on screen but no live dialog validated — not acting ' +
+              '(quoted text, or a dialog shape this build does not recognise)',
+          );
+        }
+      } else {
+        this.bypassMarkerWarned = false;
+      }
       return;
     }
     noteDialogPresent(this.bypassDialog);
+    this.bypassMarkerWarned = false;
     this.lastDialogActionAt = now;
 
     if (dialog === 'bypass-permissions') {

--- a/src/shell/claude-pty-shell.ts
+++ b/src/shell/claude-pty-shell.ts
@@ -1049,15 +1049,20 @@ class Driver {
       noteDialogAbsent(this.bypassDialog);
       // A detector that returns null without a word is how #436 stayed hidden:
       // the symptom (a 120 s startup timeout) is three layers away from the
-      // cause (detection that never fired), with no breadcrumb in between. When
-      // the markers ARE on screen but the structure does not validate, say so —
-      // once per run, since the common case is an agent's own reply quoting the
-      // dialog, which is precisely what must not attract a keystroke.
-      if (this.screen.text().includes(TUI_BYPASS_PERMS[0])) {
+      // cause (detection that never fired), with no breadcrumb in between.
+      //
+      // Gated on the SAME substring test detectDialog() uses, not on one marker:
+      // "Bypass Permissions mode" alone appears in this repo's own README and in
+      // any reply discussing the dialog, so warning on it would be noise. Both
+      // markers present means we cleared the cheap gate and it was the structural
+      // test that refused — the case actually worth a line. Warned once per run
+      // of such rounds; the common cause is a reply quoting the dialog, which is
+      // precisely what must not attract a keystroke.
+      if (TUI_BYPASS_PERMS.every((s) => this.screen.dialogText().includes(s))) {
         if (!this.bypassMarkerWarned) {
           this.bypassMarkerWarned = true;
           logWarn(
-            'Bypass Permissions marker on screen but no live dialog validated — not acting ' +
+            'Bypass Permissions markers on screen but no live dialog validated — not acting ' +
               '(quoted text, or a dialog shape this build does not recognise)',
           );
         }

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -1,5 +1,5 @@
 import { Terminal } from '@xterm/headless';
-import { isBypassDialogOnScreen } from './bypass-dialog';
+import { isBypassDialogOnScreen, BYPASS_CONFIRM_FOOTER } from './bypass-dialog';
 
 export type DialogKind = 'bypass-permissions';
 
@@ -43,12 +43,14 @@ export const TUI_BUSY_MARKER = 'esc to interrupt';
 export const TUI_PROMPT_RE = /^❯ /m;
 export const TUI_BYPASS_PERMS = ['Bypass Permissions mode', 'Yes, I accept'] as const;
 
-/**
- * The bypass dialog's confirm footer. It lives in bypass-dialog.ts, next to the
- * option-row patterns it is matched together with, and is re-exported here so
- * this file remains the index of every TUI matcher.
+/*
+ * NOTE: the bypass dialog's remaining matchers — the option-row patterns and the
+ * "Enter to confirm" footer — live in bypass-dialog.ts, next to the decision
+ * that consumes them, so that module stays dependency-free and unit-testable
+ * on its own. They are deliberately NOT re-exported here: an alias nobody
+ * imports is dead code, and this pointer keeps the "one file to touch when the
+ * UI changes" intent without it.
  */
-export { BYPASS_CONFIRM_FOOTER as TUI_BYPASS_CONFIRM_FOOTER } from './bypass-dialog';
 
 /**
  * Rows from the bottom of the screen scanned for a bottom-anchored overlay.
@@ -110,12 +112,22 @@ export const TUI_SYNTHETIC_MODEL = '<synthetic>';
  * and never collapses runs of spaces, so the broken fragment stays broken after a
  * round-trip through the screen buffer. Only the re-injected copy is altered;
  * live detection of a genuine overlay is untouched.
+ *
+ * The bypass dialog's confirm footer is defanged the same way and for the same
+ * reason. isBypassDialogOnScreen() rejects re-injected history today because the
+ * input box and status bar paint below it, failing the "nothing below the footer"
+ * rule — but that is a fact about how Claude Code happens to render, not an
+ * invariant we control, and the 32MB loop above is precisely the bug that proved
+ * a footer-requirement guard is not enough against a verbatim captured copy.
+ * Breaking the footer costs nothing and makes the bypass detector unreachable
+ * from re-injected text by construction (review round 2, finding M4).
  */
 export function neutralizeTuiTriggers(text: string): string {
   if (!text) return text;
   return text
     .split(TUI_REQUEST_TOO_LARGE).join('Request too large ( max')
-    .split(TUI_REQUEST_TOO_LARGE_DISMISS).join('esc to go  back');
+    .split(TUI_REQUEST_TOO_LARGE_DISMISS).join('esc to go  back')
+    .split(BYPASS_CONFIRM_FOOTER).join('Enter to  confirm');
 }
 
 /** A numbered option row, with an optional leading ❯/> highlight marker. */
@@ -406,21 +418,6 @@ export class ScreenModel {
     return this.rowsText(0, this.term.rows);
   }
 
-  /**
-   * The bottom `rows` lines of the visible screen. Active modal UI — permission
-   * dialogs, error overlays, the input box — renders anchored to the bottom,
-   * whereas conversation/scrollback flows in the upper area. Matching a marker
-   * against this region instead of the full buffer keeps a reply (or re-injected
-   * history) that merely quotes a marker from tripping a detector, since that
-   * text sits above the active zone. Reduces false positives sharply but is not
-   * absolute (text can briefly be the bottom-most line), so prefer an
-   * authoritative transcript signal where one exists.
-   */
-  bottomText(rows: number): string {
-    const start = Math.max(0, this.term.rows - rows);
-    return this.rowsText(start, this.term.rows);
-  }
-
   private rowsText(startRow: number, endRow: number): string {
     const buf = this.term.buffer.active;
     const lines: string[] = [];
@@ -504,18 +501,13 @@ export class ScreenModel {
   }
 
   detectDialog(): DialogKind | null {
-    // Cheap substring gate first — both markers anywhere on screen — then the
-    // structural test that actually decides. The markers alone are not evidence
-    // of a live modal: this dialog's own warning prose repeats "Bypass
-    // Permissions mode", and a chat reply or re-injected history can carry both
-    // strings verbatim. isBypassDialogOnScreen() requires the two option rows to
-    // be whole rows with exactly one caret, the confirm footer below them, and
-    // nothing but blank rows below that — a live modal owns the screen, quoted
-    // text never does.
-    const text = this.dialogText();
-    if (!TUI_BYPASS_PERMS.every((s) => text.includes(s))) return null;
-    if (!isBypassDialogOnScreen(text)) return null;
-    return 'bypass-permissions';
+    // The whole rule lives in isBypassDialogOnScreen(), including the heading
+    // substring check that used to sit here. Keeping half the rule at this layer
+    // was a real drift hazard: decideBypassDialogAction() re-applies the
+    // predicate to refuse acting on a screen that is not a live dialog, and a
+    // half-rule meant the ACTION layer — the one that emits keystrokes — was the
+    // weaker of the two (review round 2, finding H1).
+    return isBypassDialogOnScreen(this.dialogText()) ? 'bypass-permissions' : null;
   }
 
   /**

--- a/src/shell/screen.ts
+++ b/src/shell/screen.ts
@@ -1,4 +1,5 @@
 import { Terminal } from '@xterm/headless';
+import { isBypassDialogOnScreen } from './bypass-dialog';
 
 export type DialogKind = 'bypass-permissions';
 
@@ -43,14 +44,22 @@ export const TUI_PROMPT_RE = /^❯ /m;
 export const TUI_BYPASS_PERMS = ['Bypass Permissions mode', 'Yes, I accept'] as const;
 
 /**
- * Rows from the bottom of the screen that detectDialog() scans. A modal dialog is
- * anchored to the bottom; this window comfortably covers a tall dialog box while
- * excluding the upper ~60% of the buffer where conversation/scrollback lives.
+ * The bypass dialog's confirm footer. It lives in bypass-dialog.ts, next to the
+ * option-row patterns it is matched together with, and is re-exported here so
+ * this file remains the index of every TUI matcher.
+ */
+export { BYPASS_CONFIRM_FOOTER as TUI_BYPASS_CONFIRM_FOOTER } from './bypass-dialog';
+
+/**
+ * Rows from the bottom of the screen scanned for a bottom-anchored overlay.
  *
- * Conservative on purpose: if a future dialog renders taller than this and the
- * markers fall outside the window, the only effect is the auto-accept doesn't
- * fire — the operator simply sees the dialog (fail-safe), it never mis-accepts.
- * Bump this if Claude Code's dialog grows.
+ * Used by parseInteractivePrompt() for the tool-permission prompt, which really
+ * does render at the bottom, below the conversation. It is NOT used for the
+ * bypass-permissions dialog: that one appears at boot, before there is any
+ * conversation to push it down, so it renders at the TOP of an otherwise blank
+ * screen and fell outside this window entirely (issue #436). See
+ * isBypassDialogOnScreen() in bypass-dialog.ts for the structural test that
+ * replaced the positional one there.
  */
 const DIALOG_REGION_ROWS = 20;
 
@@ -483,22 +492,30 @@ export class ScreenModel {
    * dialog's follow-up action (see decideBypassDialogAction in bypass-dialog.ts)
    * reads the same rows the detection was made from — acting on a wider view
    * could send keystrokes because of text that never triggered the detector.
+   *
+   * That region is now the whole screen: the bypass dialog is not bottom-anchored
+   * (issue #436), so it is told apart from text that merely quotes it by its
+   * structure rather than by where it sits. Since the region no longer excludes
+   * anything, the "act only on what was detected" guarantee is enforced inside
+   * decideBypassDialogAction(), which applies the same structural test.
    */
   dialogText(): string {
-    return this.bottomText(DIALOG_REGION_ROWS);
+    return this.text();
   }
 
   detectDialog(): DialogKind | null {
-    // Scan only the bottom region: a real modal dialog renders there, while a
-    // reply/history quoting "Bypass Permissions mode … Yes, I accept" sits in the
-    // scrollback above and must not trigger the auto-accept keystroke. The dialog
-    // has no transcript signal, so this region guard (plus requiring BOTH markers)
-    // is the available defense.
+    // Cheap substring gate first — both markers anywhere on screen — then the
+    // structural test that actually decides. The markers alone are not evidence
+    // of a live modal: this dialog's own warning prose repeats "Bypass
+    // Permissions mode", and a chat reply or re-injected history can carry both
+    // strings verbatim. isBypassDialogOnScreen() requires the two option rows to
+    // be whole rows with exactly one caret, the confirm footer below them, and
+    // nothing but blank rows below that — a live modal owns the screen, quoted
+    // text never does.
     const text = this.dialogText();
-    if (TUI_BYPASS_PERMS.every((s) => text.includes(s))) {
-      return 'bypass-permissions';
-    }
-    return null;
+    if (!TUI_BYPASS_PERMS.every((s) => text.includes(s))) return null;
+    if (!isBypassDialogOnScreen(text)) return null;
+    return 'bypass-permissions';
   }
 
   /**

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -32,6 +32,7 @@ import {
   BYPASS_ACCEPT_LABEL,
   BYPASS_DECLINE_LABEL,
   BYPASS_CONFIRM_FOOTER,
+  BYPASS_HEADING,
 } from '../../src/shell/bypass-dialog';
 import { shouldAdoptOrphanWake, OrphanWakeObs } from '../../src/shell/orphan-wake';
 import * as os from 'os';
@@ -164,6 +165,40 @@ describe('neutralizeTuiTriggers (history detox)', () => {
 
   it('handles empty input', () => {
     expect(neutralizeTuiTriggers('')).toBe('');
+  });
+
+  // Review round 2, finding M4. The bypass detector currently rejects re-injected
+  // history because Claude Code paints the input box below it, failing the
+  // "nothing below the footer" rule — but that is a fact about how Claude Code
+  // renders, not an invariant we own, and the 32MB loop above is exactly the bug
+  // that proved a footer-requirement guard insufficient against a verbatim copy.
+  // Breaking the footer makes the bypass detector unreachable from re-injected
+  // text by construction.
+  it('breaks the bypass dialog footer so re-injected history cannot fake a dialog', async () => {
+    const quoted = [
+      'Assistant: the dialog that wedged the session looked like this:',
+      '  WARNING: Claude Code running in Bypass Permissions mode',
+      '  ❯ No, exit',
+      '    Yes, I accept',
+      '',
+      '  Enter to confirm · Esc to cancel',
+    ].join('\n');
+
+    // Verbatim, this text is a detectable dialog when it owns the screen.
+    const verbatimScreen = await renderScreen([
+      ...quoted.split('\n'),
+      ...Array.from({ length: 44 }, () => ''),
+    ]);
+    expect(verbatimScreen.detectDialog()).toBe('bypass-permissions');
+
+    // After the detox it can never be, however it lands on screen.
+    const detoxed = neutralizeTuiTriggers(quoted);
+    expect(detoxed).not.toContain(BYPASS_CONFIRM_FOOTER);
+    const detoxedScreen = await renderScreen([
+      ...detoxed.split('\n'),
+      ...Array.from({ length: 44 }, () => ''),
+    ]);
+    expect(detoxedScreen.detectDialog()).toBeNull();
   });
 });
 
@@ -988,6 +1023,76 @@ describe('ScreenModel detectDialog (structural, not positional)', () => {
     expect(isBypassDialogOnScreen(screen.text())).toBe(true);
     expect(isBypassDialogOnScreen(screen.text().replace(BYPASS_CONFIRM_FOOTER, 'Enter to  confirm'))).toBe(false);
   });
+
+  // Review round 2, finding H1. The heading check used to live in detectDialog()
+  // rather than in the predicate, so decideBypassDialogAction() — which re-applies
+  // the predicate to refuse acting on a non-dialog — enforced only half the rule.
+  // A screen with a perfect dialog SHAPE but no heading therefore produced a live
+  // Enter at the action layer while the detector said null. The rule is one
+  // predicate now, and this pins both layers to it.
+  it('requires the heading, so the detect and act layers cannot drift (H1)', async () => {
+    const shapeWithoutHeading = [
+      'Assistant: after you press Down the screen looks like:',
+      '',
+      ...CURRENT_ROWS_AFTER_DOWN,
+      ...DIALOG_FOOTER,
+      ...Array.from({ length: 44 }, () => ''),
+    ];
+    const screen = await renderScreen(shapeWithoutHeading);
+    expect(screen.text()).not.toContain('Bypass Permissions mode');
+    expect(isBypassDialogOnScreen(screen.text())).toBe(false);
+    expect(screen.detectDialog()).toBeNull();
+    // The layer that actually emits keystrokes must refuse too — this is the
+    // assertion that would have caught the drift.
+    expect(decideBypassDialogAction(screen.dialogText(), { keys: 0, misses: 0 })).toEqual({
+      kind: 'wait',
+      reason: 'no live bypass dialog on screen',
+    });
+  });
+
+  // Review round 2, finding M3. Before the gap bounds, the "structure" was only
+  // an ordering: the elements never had to belong to the same visual block, so
+  // three lines scattered down a screen of ordinary conversation qualified — and
+  // yielded a real `confirm`.
+  it('requires the rows and footer to be one block, not merely in order (M3)', async () => {
+    const scattered = [
+      'WARNING: Claude Code running in Bypass Permissions mode',
+      ...Array.from({ length: 5 }, () => 'noise'),
+      '    No, exit',
+      ...Array.from({ length: 15 }, () => 'unrelated conversation text'),
+      '  ❯ Yes, I accept',
+      ...Array.from({ length: 10 }, () => 'more unrelated text'),
+      '  press Enter to confirm your subscription',
+      ...Array.from({ length: 17 }, () => ''),
+    ];
+    const screen = await renderScreen(scattered);
+    expect(isBypassDialogOnScreen(screen.text())).toBe(false);
+    expect(screen.detectDialog()).toBeNull();
+    expect(decideBypassDialogAction(screen.dialogText(), { keys: 0, misses: 0 })).toEqual({
+      kind: 'wait',
+      reason: 'no live bypass dialog on screen',
+    });
+  });
+
+  // Review round 2, finding M2 — accepted as accurate, resolved by DOCUMENTING
+  // the trade rather than relaxing the rule. A boxed dialog is not detected, and
+  // that is deliberate: a miss is fail-safe (visible dialog + the new warning),
+  // whereas tolerating border rows below the footer would admit a quoted dialog
+  // sitting above an empty input box, whose rows are pure border characters.
+  // This test exists so the behaviour is a decision on record, not an accident.
+  it('fails CLOSED on a boxed rendering (deliberate — see M2)', async () => {
+    const boxed = [
+      '  ╭────────────────────────────────────────╮',
+      '  │ WARNING: Bypass Permissions mode       │',
+      '  │ ❯ No, exit                             │',
+      '  │   Yes, I accept                        │',
+      '  │ Enter to confirm · Esc to cancel       │',
+      '  ╰────────────────────────────────────────╯',
+      ...Array.from({ length: 44 }, () => ''),
+    ];
+    const screen = await renderScreen(boxed);
+    expect(screen.detectDialog()).toBeNull();
+  });
 });
 
 describe('decideBypassDialogAction (accepting the bypass dialog across Claude Code versions)', () => {
@@ -1143,6 +1248,10 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
     // The label is duplicated (this module stays dependency-free), so drift
     // would mean detectDialog() fires on a dialog whose rows we cannot parse.
     expect(TUI_BYPASS_PERMS).toContain(BYPASS_ACCEPT_LABEL);
+    // Same for the heading, which isBypassDialogOnScreen() now gates on: if it
+    // drifted from screen.ts's marker list the predicate would reject every real
+    // dialog, silently restoring the #436 wedge.
+    expect(TUI_BYPASS_PERMS).toContain(BYPASS_HEADING);
     expect(await decide([`  ❯ ${BYPASS_DECLINE_LABEL}`, `    ${BYPASS_ACCEPT_LABEL}`])).toEqual({
       kind: 'move',
       key: BYPASS_KEY_DOWN,

--- a/tests/unit/pty-shell.test.ts
+++ b/tests/unit/pty-shell.test.ts
@@ -20,6 +20,7 @@ import { decideMenuCancel, MenuCancelState } from '../../src/shell/menu-cancel';
 import { decideProbeAttempt, confirmProbeReaction, ProbeState, PROBE_MAX_ROUNDS, PROBE_RETRY_COOLDOWN_MS } from '../../src/shell/menu-probe';
 import {
   decideBypassDialogAction,
+  isBypassDialogOnScreen,
   noteDialogAbsent,
   noteDialogPresent,
   rowPattern,
@@ -30,6 +31,7 @@ import {
   BYPASS_RESET_AFTER_MISSES,
   BYPASS_ACCEPT_LABEL,
   BYPASS_DECLINE_LABEL,
+  BYPASS_CONFIRM_FOOTER,
 } from '../../src/shell/bypass-dialog';
 import { shouldAdoptOrphanWake, OrphanWakeObs } from '../../src/shell/orphan-wake';
 import * as os from 'os';
@@ -851,26 +853,95 @@ describe('TranscriptTailer onToolUse (main-chain tool_use, with name)', () => {
   });
 });
 
-describe('ScreenModel detectDialog (region-restricted)', () => {
-  it('detects the bypass dialog when it renders at the bottom (real modal)', async () => {
-    const screen = await renderScreen([
-      ...FILLER(44),
-      '  Bypass Permissions mode',
-      '  Yes, I accept',
-    ]);
+// Verbatim captures of the real dialog, taken by driving
+// `claude --dangerously-skip-permissions` through node-pty + @xterm/headless
+// and reading the screen with no keys pressed. The ONLY difference between the
+// row variants is the option rows: Claude Code <= 2.1.247 numbers them,
+// >= 2.1.248 does not (bisected to that exact release — issue #431). Both start
+// with the caret on "No, exit".
+const DIALOG_BODY = [
+  '  WARNING: Claude Code running in Bypass Permissions mode',
+  '',
+  '  In Bypass Permissions mode, Claude Code will not ask for your approval before running',
+  '  potentially dangerous commands.',
+  '  This mode should only be used in a sandboxed container/VM that has restricted internet access',
+  '  and can easily be restored if damaged.',
+  '',
+  '  By proceeding, you accept all responsibility for actions taken while running in Bypass',
+  '  Permissions mode.',
+  '',
+  '  https://code.claude.com/docs/en/security',
+  '',
+];
+const DIALOG_FOOTER = ['', '  Enter to confirm · Esc to cancel'];
+// The modal with scrollback above it and nothing below — the shape a session
+// that had already produced output shows. 34 + 12 + 2 + 2 = exactly 50 rows.
+const dialog = (rows: string[]) => [...FILLER(34), ...DIALOG_BODY, ...rows, ...DIALOG_FOOTER];
+
+/** Claude Code <= 2.1.247 — numbered rows, caret on decline. */
+const LEGACY_ROWS = ['  ❯ 1. No, exit', '    2. Yes, I accept'];
+/** Claude Code >= 2.1.248 — no row numbers, caret on decline. */
+const CURRENT_ROWS = ['  ❯ No, exit', '    Yes, I accept'];
+/** The same build after one Down: caret has moved onto the accept row. */
+const CURRENT_ROWS_AFTER_DOWN = ['    No, exit', '  ❯ Yes, I accept'];
+
+/**
+ * Issue #436, verbatim: the 50-row screen a session was killed on after its
+ * 120 s startup timeout, recovered from the driver's own timeout dump. This is
+ * what the dialog looks like on a CLEAN boot — it renders at the TOP, because
+ * there is no conversation yet to push it down, and rows 16-50 are blank.
+ *
+ * The old detector scanned the bottom 20 rows (31-50) and so matched nothing at
+ * all here: no keystroke was sent, the startup timeout fired, the session
+ * respawned into the same dialog.
+ */
+const TOP_OF_SCREEN_CAPTURE = [
+  '',
+  '─'.repeat(185),
+  '  WARNING: Claude Code running in Bypass Permissions mode',
+  '',
+  '  In Bypass Permissions mode, Claude Code will not ask for your approval before running potentially dangerous commands.',
+  '  This mode should only be used in a sandboxed container/VM that has restricted internet access and can easily be restored if damaged.',
+  '',
+  '  By proceeding, you accept all responsibility for actions taken while running in Bypass Permissions mode.',
+  '',
+  '  https://code.claude.com/docs/en/security',
+  '',
+  '  ❯ No, exit',
+  '    Yes, I accept',
+  '',
+  '  Enter to confirm · Esc to cancel',
+  ...Array.from({ length: 35 }, () => ''),
+];
+
+describe('ScreenModel detectDialog (structural, not positional)', () => {
+  it('detects the dialog at the TOP of an otherwise blank screen (issue #436 regression)', async () => {
+    // Fails on the pre-fix code: both markers sit at rows 3-13, the detector
+    // scanned rows 31-50, and every one of those rows is blank.
+    const screen = await renderScreen(TOP_OF_SCREEN_CAPTURE);
     expect(screen.detectDialog()).toBe('bypass-permissions');
   });
 
-  it('ignores the markers when they sit in the upper scrollback (quoted prose)', async () => {
-    // An agent explaining the dialog, or re-injected history: markers are near the
-    // top, above the bottom region detectDialog scans → no auto-accept keystroke.
+  it('still detects the dialog when scrollback has pushed it to the bottom', async () => {
+    const screen = await renderScreen(dialog(CURRENT_ROWS));
+    expect(screen.detectDialog()).toBe('bypass-permissions');
+  });
+
+  it('detects the numbered rendering in both positions too (<= 2.1.247)', async () => {
+    expect((await renderScreen(dialog(LEGACY_ROWS))).detectDialog()).toBe('bypass-permissions');
+    const top = [...DIALOG_BODY, ...LEGACY_ROWS, ...DIALOG_FOOTER];
+    expect((await renderScreen(top)).detectDialog()).toBe('bypass-permissions');
+  });
+
+  it('ignores prose that merely quotes the markers', async () => {
     const screen = await renderScreen([
       'Assistant: ตอน "Bypass Permissions mode" โผล่ มันจะให้กด "Yes, I accept"',
       ...FILLER(44),
       '❯ ',
     ]);
     expect(screen.detectDialog()).toBeNull();
-    // Sanity: the markers ARE on screen — only the region guard excludes them.
+    // Sanity: the markers ARE on screen — the structural test is what excludes
+    // them, and it no longer depends on WHERE on the screen they landed.
     expect(screen.text()).toContain('Bypass Permissions mode');
     expect(screen.text()).toContain('Yes, I accept');
   });
@@ -879,41 +950,47 @@ describe('ScreenModel detectDialog (region-restricted)', () => {
     const screen = await renderScreen([...FILLER(45), '  Bypass Permissions mode']);
     expect(screen.detectDialog()).toBeNull();
   });
+
+  it('ignores a dialog that has scrolled up with live content below it', async () => {
+    // The property that replaced the bottom-region window: a live modal OWNS
+    // the screen. Anything rendered below its footer — conversation lines, an
+    // idle input caret — means what is on screen is a record of a dialog, not
+    // one we can drive.
+    const screen = await renderScreen([...dialog(CURRENT_ROWS_AFTER_DOWN), ...FILLER(44), '❯ ']);
+    expect(screen.detectDialog()).toBeNull();
+  });
+
+  it('ignores the dialog while no row is highlighted (frame still rendering)', async () => {
+    const screen = await renderScreen(dialog(['    No, exit', '    Yes, I accept']));
+    expect(screen.detectDialog()).toBeNull();
+  });
+
+  it('ignores a shape with a caret on both rows', async () => {
+    const screen = await renderScreen(dialog(['  ❯ No, exit', '  ❯ Yes, I accept']));
+    expect(screen.detectDialog()).toBeNull();
+  });
+
+  it('requires the confirm footer below the option rows', async () => {
+    // Without its own affordance the rows are just two lines of text. The
+    // footer is also what the accepting Enter relies on, so detection and the
+    // action stay gated on the same evidence.
+    const screen = await renderScreen([...FILLER(34), ...DIALOG_BODY, ...CURRENT_ROWS, '', '']);
+    expect(screen.detectDialog()).toBeNull();
+  });
+
+  it('ignores a footer that renders above the option rows', async () => {
+    const screen = await renderScreen([...FILLER(34), ...DIALOG_BODY, ...DIALOG_FOOTER, ...CURRENT_ROWS]);
+    expect(screen.detectDialog()).toBeNull();
+  });
+
+  it('is a pure function of the screen text (same verdict, no ScreenModel)', async () => {
+    const screen = await renderScreen(TOP_OF_SCREEN_CAPTURE);
+    expect(isBypassDialogOnScreen(screen.text())).toBe(true);
+    expect(isBypassDialogOnScreen(screen.text().replace(BYPASS_CONFIRM_FOOTER, 'Enter to  confirm'))).toBe(false);
+  });
 });
 
 describe('decideBypassDialogAction (accepting the bypass dialog across Claude Code versions)', () => {
-  // Both fixtures are verbatim captures of the real dialog, taken by driving
-  // `claude --dangerously-skip-permissions` through node-pty + @xterm/headless
-  // and reading the screen with no keys pressed. The ONLY difference between
-  // them is the option rows: Claude Code <= 2.1.247 numbers them, >= 2.1.248
-  // does not (bisected to that exact release — issue #431). Both start with
-  // the caret on "No, exit".
-  const DIALOG_BODY = [
-    '  WARNING: Claude Code running in Bypass Permissions mode',
-    '',
-    '  In Bypass Permissions mode, Claude Code will not ask for your approval before running',
-    '  potentially dangerous commands.',
-    '  This mode should only be used in a sandboxed container/VM that has restricted internet access',
-    '  and can easily be restored if damaged.',
-    '',
-    '  By proceeding, you accept all responsibility for actions taken while running in Bypass',
-    '  Permissions mode.',
-    '',
-    '  https://code.claude.com/docs/en/security',
-    '',
-  ];
-  const DIALOG_FOOTER = ['', '  Enter to confirm · Esc to cancel'];
-  // FILLER pushes the modal down into the bottom-region window detectDialog()
-  // scans, the way a real session's scrollback does.
-  const dialog = (rows: string[]) => [...FILLER(34), ...DIALOG_BODY, ...rows, ...DIALOG_FOOTER];
-
-  /** Claude Code <= 2.1.247 — numbered rows, caret on decline. */
-  const LEGACY_ROWS = ['  ❯ 1. No, exit', '    2. Yes, I accept'];
-  /** Claude Code >= 2.1.248 — no row numbers, caret on decline. */
-  const CURRENT_ROWS = ['  ❯ No, exit', '    Yes, I accept'];
-  /** The same build after one Down: caret has moved onto the accept row. */
-  const CURRENT_ROWS_AFTER_DOWN = ['    No, exit', '  ❯ Yes, I accept'];
-
   const decide = async (rows: string[], keys = 0) => {
     const screen = await renderScreen(dialog(rows));
     // Sanity: every fixture is a screen the detector actually fires on, so the
@@ -921,6 +998,15 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
     expect(screen.detectDialog()).toBe('bypass-permissions');
     return decideBypassDialogAction(screen.dialogText(), { keys, misses: 0 });
   };
+
+  /** For screens the detector rejects: assert that, then ask the action layer
+   *  directly — it must refuse independently, so the two cannot drift apart. */
+  const decideUndetected = async (lines: string[], keys = 0) => {
+    const screen = await renderScreen(lines);
+    expect(screen.detectDialog()).toBeNull();
+    return decideBypassDialogAction(screen.dialogText(), { keys, misses: 0 });
+  };
+
 
   it('types the digit on the numbered rendering (<= 2.1.247 behavior, unchanged)', async () => {
     // Proven live on 2.1.247: the digit alone selects AND confirms — Claude
@@ -963,12 +1049,12 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
   });
 
   it('does nothing when no row is highlighted (still rendering / not the live dialog)', async () => {
-    const action = await decide(['    No, exit', '    Yes, I accept']);
+    const action = await decideUndetected(dialog(['    No, exit', '    Yes, I accept']));
     expect(action.kind).toBe('wait');
   });
 
   it('does nothing when both rows carry a caret (shape we do not understand)', async () => {
-    const action = await decide(['  ❯ No, exit', '  ❯ Yes, I accept']);
+    const action = await decideUndetected(dialog(['  ❯ No, exit', '  ❯ Yes, I accept']));
     expect(action.kind).toBe('wait');
   });
 
@@ -1004,9 +1090,10 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
   });
 
   it('does not refill the budget on a single missed detection', () => {
-    // detectDialog() needs both markers inside the same bottom region, so a
-    // repaint that shifts the box by one row hides a dialog that is still up.
-    // Refilling there would defeat the ceiling exactly when it is needed.
+    // Detection is structural, so a mid-repaint frame — rows drawn, footer not
+    // yet, or the caret momentarily on neither row — reads as absent for one
+    // round while the dialog is still up. Refilling there would defeat the
+    // ceiling exactly when it is needed.
     const state = { keys: 5, misses: 0 };
     noteDialogAbsent(state);
     expect(state.keys).toBe(5);
@@ -1063,16 +1150,17 @@ describe('decideBypassDialogAction (accepting the bypass dialog across Claude Co
   });
 
   it('ignores prose that merely quotes the labels mid-sentence', async () => {
-    const action = await decide([
+    const action = await decideUndetected(dialog([
       '  ❯ No, exit',
       '  You will be asked to pick Yes, I accept before the session starts.',
-    ]);
+    ]));
     expect(action.kind).toBe('wait');
   });
 
-  it('acts only on the region the detector fired for (quoted dialog in scrollback)', async () => {
-    // Same guard detectDialog() has: rows sitting in the upper scrollback are
-    // not a live modal, and must not attract a keystroke.
+  it('acts only on what the detector fired for (quoted dialog in scrollback)', async () => {
+    // Same rule detectDialog() applies, enforced independently here: a modal
+    // with conversation and an idle caret rendered below it is a record of a
+    // dialog, not one we can drive — and must not attract a keystroke.
     const screen = await renderScreen([...dialog(CURRENT_ROWS_AFTER_DOWN), ...FILLER(44), '❯ ']);
     expect(screen.detectDialog()).toBeNull();
     expect(decideBypassDialogAction(screen.dialogText(), { keys: 0, misses: 0 }).kind).toBe('wait');


### PR DESCRIPTION
Closes #436

## The bug

`ScreenModel.detectDialog()` scanned only the bottom 20 rows (`DIALOG_REGION_ROWS`) of the 50-row PTY screen. Claude Code's "Bypass Permissions mode" dialog renders at the **top** of the screen on a clean boot — there is no conversation output yet to push it down — so both detection markers fell outside the window:

```
  1  (blank)
  2  ────────────────────────────────────────────
  3    WARNING: Claude Code running in Bypass Permissions mode
  ...
 12    ❯ No, exit
 13      Yes, I accept
 14  (blank)
 15    Enter to confirm · Esc to cancel
 16-50  (blank)          <- the only rows detectDialog() looked at
```

`detectDialog()` returned `null`, `maybeHandleDialog()` returned without acting **or logging**, and the session sat at the dialog until the 120 s `STARTUP_TIMEOUT_MS` expired, shut down, and respawned into the same dialog.

Live evidence: 10 genuine startup timeouts across 3 sessions, **two of them on a build that already contained #432**.

This is **not** the bug #432 fixed. #432 corrected *which keystroke* is sent once the dialog is detected, and that fix is correct — it simply never ran here, because on a clean boot the dialog was never detected in the first place. Both are needed.

### Why it was intermittent

A boot that happens to emit some output first pushes the dialog down into rows 31-50 and detection works. A clean boot leaves it at row 3 and detection silently fails. That is the whole source of the intermittency.

## Why the fix is not "make the window bigger"

The window is the only thing standing between the auto-accept and a chat reply — or re-injected conversation history — that quotes the dialog's text. That text is real characters on a real screen, and a false accept sends `Enter`, which with the caret on its default row means **"No, exit"**: Claude Code terminates, unrecoverably.

So the window is a *proxy* for "this is the live modal, not quoted text". This PR replaces the proxy with the property it was standing in for.

## The fix

New `isBypassDialogOnScreen()` in `bypass-dialog.ts` (already dependency-free and already the owner of the option-row patterns) requires all of:

1. both option labels present as **whole rows** (not embedded in prose);
2. **exactly one** `❯` caret across those two rows;
3. the dialog's own `Enter to confirm` footer rendered **below** the option rows;
4. **nothing but blank rows below that footer**.

Rule 4 is the load-bearing one. A live modal owns the screen; quoted text always has the input box, its border and the status bar rendered underneath it — so no quoting or scrollback scenario can satisfy it, at any screen position. This is the same shape as the existing `detectRequestTooLarge()` guard, which requires the overlay's own dismiss footer precisely because the error prefix alone appears in ordinary prose.

Notably this also means `neutralizeTuiTriggers()` does **not** need widening to defang the bypass text in re-injected history: re-injected history renders inside the input box and can never satisfy rule 4.

### Defence in depth

`dialogText()` now returns the whole screen, so the "act only on what was detected" invariant can no longer be enforced by handing `decideBypassDialogAction()` a narrow region. It is enforced by applying the **identical structural test inside that function too**, which also stops the two layers drifting apart if either is edited alone. Every existing safety check there is kept — each states an invariant the decision depends on, and a keystroke sent on a wrong assumption can pick "No, exit".

### No longer silent

`maybeHandleDialog()` now logs one warning (latched, so once per run of such rounds rather than every 2 s) when the bypass markers are on screen but the dialog does not validate. The silent `null` return is why this took two investigations to find: the symptom was three layers away from the cause, with no breadcrumb in between.

## Regression test proven against the pre-fix code

The headline test is built from the **verbatim 50-row capture** above. Reverting only `dialogText()`/`detectDialog()` to their pre-fix form (leaving everything else in place, so the suite still compiles and the failures are real rather than a build error) turns **9 tests red**, including:

```
✕ detects the dialog at the TOP of an otherwise blank screen (issue #436 regression)
✕ detects the numbered rendering in both positions too (<= 2.1.247)
✕ ignores the dialog while no row is highlighted (frame still rendering)
✕ ignores a shape with a caret on both rows
✕ requires the confirm footer below the option rows
✕ ignores a footer that renders above the option rows
✕ does nothing when no row is highlighted
✕ does nothing when both rows carry a caret
✕ ignores prose that merely quotes the labels mid-sentence
```

Ten `detectDialog` tests in total now cover: top-of-screen (#436), still detected at the bottom, both Claude Code renderings in both positions, prose quoting the labels, a dialog scrolled up with live content below it, no caret, two carets, footer missing, and footer above the rows.

## Out of scope

- `DIALOG_REGION_ROWS` itself is unchanged — `parseInteractivePrompt()` still uses it for the genuinely bottom-anchored permission prompt, which is a different detector with a different liveness proof (the behavioural probe). Its doc comment now says so explicitly.
- `skipDangerousModePermissionPrompt` in the Claude Code config would stop the dialog appearing at all, but it is a machine-global file the gateway does not own, and it would mask this bug rather than fix it.

## Verification

- `npm run typecheck` — clean
- `npm test` — **4227 passed / 4227 total**, 232 suites
- Revert proof performed as described above, then restored and re-greened
