### PR TITLE
fix(cli): keep the follow poll timer ref'ed so `gateway logs --follow` streams (#439)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -72,6 +72,7 @@ does not touch the palette, so `--json` piped into `jq` is unaffected by any of 
 | `claude-gateway gateway status` | Show the owning manager and `/health` on the local bind address |
 | `claude-gateway gateway restart` | Restart via the owning manager (systemd-user/systemd-system/pm2/foreground) |
 | `claude-gateway gateway stop` | Stop the gateway |
+| `claude-gateway gateway logs [--follow] [--lines <n>] [--agent <id>] [--json]` | Read the gateway log files directly (no running server needed) |
 | `claude-gateway doctor` | Check config, key resolution, owning manager, and connectivity |
 | `claude-gateway debug-bundle` | Write a small redacted diagnostics bundle for a stuck session |
 | `claude-gateway api <METHOD> <path>` | Escape hatch: call any endpoint directly |

--- a/scripts/gen-cli.ts
+++ b/scripts/gen-cli.ts
@@ -143,6 +143,7 @@ does not touch the palette, so \`--json\` piped into \`jq\` is unaffected by any
 | \`claude-gateway gateway status\` | Show the owning manager and \`/health\` on the local bind address |
 | \`claude-gateway gateway restart\` | Restart via the owning manager (systemd-user/systemd-system/pm2/foreground) |
 | \`claude-gateway gateway stop\` | Stop the gateway |
+| \`claude-gateway gateway logs [--follow] [--lines <n>] [--agent <id>] [--json]\` | Read the gateway log files directly (no running server needed) |
 | \`claude-gateway doctor\` | Check config, key resolution, owning manager, and connectivity |
 | \`claude-gateway debug-bundle\` | Write a small redacted diagnostics bundle for a stuck session |
 | \`claude-gateway api <METHOD> <path>\` | Escape hatch: call any endpoint directly |

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -211,50 +211,76 @@ export async function runGatewayLogs(
   }
 
   const asJson = flags.json === true;
-  // A downstream reader that closes early — `gateway logs --follow | head -5`,
-  // a pager quit with `q` — ends the follow normally. It is not an error, and
-  // it must not be treated as one: the EPIPE otherwise reaches the CLI's top
-  // level, which prints `Error: write EPIPE` after the output the operator
-  // asked for and exits 1.
+  // Whether anyone is still reading our output, and why they stopped.
   //
-  // `broken` is set by the follow loop's stdout 'error' handler and only read
-  // here. Writing into a pipe nobody reads never throws — it always surfaces as
-  // an asynchronous 'error' event — so this is not a fast path, it is the guard
-  // for the final flush: `followFile` drains once more and emits any
-  // unterminated line *after* removing that handler, and a write on the dead
-  // stream then would be an unhandled 'error' with nothing left to catch it.
-  const sink = { broken: false };
+  // A downstream reader that closes early — `gateway logs --follow | head -5`,
+  // a pager quit with `q` — ends the command normally. A write into a pipe
+  // nobody reads never throws; it arrives as an asynchronous 'error' on stdout,
+  // which with no listener is an uncaught exception that kills the CLI with a
+  // stack trace after the output the operator asked for.
+  //
+  // The listener covers the whole command rather than just the follow loop: the
+  // tail is written before following starts, and `gateway logs --lines 20000 |
+  // head -1` is the same broken pipe with no follow involved.
+  const sink: OutputSink = {};
+  const onSinkError = (err: unknown): void => {
+    // Stop either way — but a stdout error that is *not* the reader leaving (a
+    // full disk, a read-only redirect) is a real failure and has to be
+    // reported. Attaching any listener marks the 'error' handled, so one that
+    // ignored those codes would turn a loud crash into a follow that streams
+    // into nothing and still exits 0.
+    if (!isPipeClosed(err)) sink.failure = err as NodeJS.ErrnoException;
+    sink.onBroken?.();
+  };
   const emit = (line: string): void => {
-    if (line === '' || sink.broken) return;
+    if (line === '') return;
     process.stdout.write(`${asJson ? line : formatLogLine(line)}\n`);
   };
 
-  let startPos: number;
+  process.stdout.on('error', onSinkError);
   try {
-    // Resume from where the tail stopped, not from a fresh stat: the gateway is
-    // a different process and may have appended in between.
-    const tail = tailFrom(file, parsed.lines);
-    for (const line of tail.lines) emit(line);
-    startPos = tail.endPos;
-  } catch (err) {
-    const e = err as NodeJS.ErrnoException;
-    process.stderr.write(`Cannot read ${file} (${e.code ?? e.message})\n`);
-    return 1;
-  }
+    let startPos: number;
+    try {
+      // Resume from where the tail stopped, not from a fresh stat: the gateway is
+      // a different process and may have appended in between.
+      const tail = tailFrom(file, parsed.lines);
+      for (const line of tail.lines) emit(line);
+      startPos = tail.endPos;
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      process.stderr.write(`Cannot read ${file} (${e.code ?? e.message})\n`);
+      return 1;
+    }
 
-  if (flags.follow !== true) return 0;
-  return await followFile(file, startPos, emit, opts, sink);
+    if (flags.follow === true) await followFile(file, startPos, emit, opts, sink);
+    if (sink.failure) {
+      process.stderr.write(`Cannot write output (${sink.failure.code ?? sink.failure.message})\n`);
+      return 1;
+    }
+    return 0;
+  } finally {
+    process.stdout.off('error', onSinkError);
+  }
+}
+
+/** Output state shared between the command and its follow loop. */
+interface OutputSink {
+  /** The stdout failure, when it was something other than the reader leaving. */
+  failure?: NodeJS.ErrnoException;
+  /** Registered by `followFile` so a failed write ends the follow immediately. */
+  onBroken?: () => void;
 }
 
 /**
  * Whether an error means "nobody is reading this any more".
  *
- * EPIPE is the reader closing its end; ERR_STREAM_DESTROYED is the same
- * situation observed one layer up, after Node has already torn the stream down.
+ * Only EPIPE: measured on this platform, a closed pipe reports EPIPE on every
+ * failed write and never leaves `process.stdout` destroyed, so the
+ * ERR_STREAM_DESTROYED that a torn-down stream would report is not reachable
+ * here. Anything else is treated as a genuine write failure and surfaced.
  */
 function isPipeClosed(err: unknown): boolean {
-  const code = (err as NodeJS.ErrnoException | null)?.code;
-  return code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED';
+  return (err as NodeJS.ErrnoException | null)?.code === 'EPIPE';
 }
 
 /**
@@ -271,8 +297,8 @@ async function followFile(
   fromPos: number,
   emit: (line: string) => void,
   opts: LogsRunOptions,
-  sink: { broken: boolean },
-): Promise<number> {
+  sink: OutputSink,
+): Promise<void> {
   const pollMs = opts.pollMs ?? DEFAULT_POLL_MS;
   let pos = fromPos;
   let inode: number | undefined;
@@ -331,32 +357,26 @@ async function followFile(
         /* transient (rotation race, permissions) — the next poll retries */
       }
     }, pollMs);
-    // Deliberately NOT unref'ed. Elsewhere in this repo an interval is unref'ed
-    // so a background timer cannot hold a process open at shutdown, but every
-    // one of those runs inside the gateway server, which its HTTP listener
-    // keeps alive regardless. This one runs in the CLI, where the interval is
-    // the only ref'ed handle there is: `process.once('SIGINT')` does not hold
-    // the loop open, so unref'ing here drained the loop and exited 0 the moment
-    // the tail had been written — `--follow` printed the tail and returned
-    // instead of following (#439). Nothing leaks: `stop()` clears the interval
-    // on both the abort and the SIGINT path.
+    // Deliberately NOT unref'ed. An unref'ed interval is right wherever the
+    // process is kept alive by something else — `src/logger.ts:324`'s retention
+    // sweep runs inside the gateway server, which its HTTP listener holds open,
+    // and `src/cli/output.ts:54`'s flush deadline is a bound on a wait, not the
+    // reason to keep waiting. Here the interval is the only ref'ed handle there
+    // is: `process.once('SIGINT')` does not hold the loop open, so unref'ing
+    // drained the loop and exited 0 the moment the tail had been written —
+    // `--follow` printed the tail and returned instead of following (#439).
+    // Nothing leaks: `stop()` clears the interval on every path out.
     const stop = (): void => {
       clearInterval(timer);
-      process.stdout.off('error', onSinkError);
+      sink.onBroken = undefined;
       if (opts.signal) opts.signal.removeEventListener('abort', stop);
       else process.off('SIGINT', stop);
       resolve();
     };
-    // The reader going away is how a follow normally ends, and it is only ever
-    // observable here: a failed pipe write does not throw, it arrives as an
-    // 'error' on stdout. Without this listener that error is unhandled and
-    // takes the process down with a stack trace instead of ending the follow.
-    function onSinkError(err: unknown): void {
-      if (!isPipeClosed(err)) return;
-      sink.broken = true;
-      stop();
-    }
-    process.stdout.on('error', onSinkError);
+    // The reader going away is how a follow normally ends. The 'error' itself
+    // is caught by the command-wide stdout listener; this is what turns it into
+    // "stop polling" rather than a loop that keeps draining into nothing.
+    sink.onBroken = stop;
     if (opts.signal) {
       if (opts.signal.aborted) return stop();
       opts.signal.addEventListener('abort', stop, { once: true });
@@ -372,5 +392,4 @@ async function followFile(
     /* best-effort */
   }
   if (carry !== '') emit(carry);
-  return 0;
 }

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { explicitConfigWarning, listLogStreamIds, resolveLogDir } from '../logs-dir';
-import { writeCommandHelp } from '../output';
+import { flushStream, writeCommandHelp } from '../output';
 
 /**
  * `gateway logs` — read the gateway's own logs without knowing where they live.
@@ -239,25 +239,41 @@ export async function runGatewayLogs(
 
   process.stdout.on('error', onSinkError);
   try {
-    let startPos: number;
+    let tail: { lines: string[]; endPos: number } | undefined;
     try {
       // Resume from where the tail stopped, not from a fresh stat: the gateway is
       // a different process and may have appended in between.
-      const tail = tailFrom(file, parsed.lines);
-      for (const line of tail.lines) emit(line);
-      startPos = tail.endPos;
+      tail = tailFrom(file, parsed.lines);
     } catch (err) {
       const e = err as NodeJS.ErrnoException;
       process.stderr.write(`Cannot read ${file} (${e.code ?? e.message})\n`);
-      return 1;
     }
 
-    if (flags.follow === true) await followFile(file, startPos, emit, opts, sink);
+    let exitCode = 1;
+    if (tail) {
+      for (const line of tail.lines) emit(line);
+      if (flags.follow === true) await followFile(file, tail.endPos, emit, opts, sink);
+      exitCode = 0;
+    }
+
+    // Wait for the writes before judging them. A stdout failure is reported
+    // asynchronously, so returning as soon as the last `emit` call returns
+    // decides the exit code before the failure that decides it has arrived —
+    // `gateway logs > <full disk>` exited 0 with an empty stderr, and only the
+    // follow path escaped it, because following happens to keep the process
+    // there long enough for the error to land.
+    //
+    // The same wait is what makes the command self-contained: the `finally`
+    // below detaches the only 'error' listener stdout has, and detaching it
+    // while a write is still in flight leaves that error to the process. That
+    // it did not crash was luck — src/entry.ts calls `exitAfterFlush` on the
+    // next tick, and its own drain re-attached one just in time.
+    await flushStream(process.stdout);
     if (sink.failure) {
       process.stderr.write(`Cannot write output (${sink.failure.code ?? sink.failure.message})\n`);
       return 1;
     }
-    return 0;
+    return exitCode;
   } finally {
     process.stdout.off('error', onSinkError);
   }

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -306,7 +306,15 @@ async function followFile(
         /* transient (rotation race, permissions) — the next poll retries */
       }
     }, pollMs);
-    if (typeof timer.unref === 'function') timer.unref();
+    // Deliberately NOT unref'ed. Elsewhere in this repo an interval is unref'ed
+    // so a background timer cannot hold a process open at shutdown, but every
+    // one of those runs inside the gateway server, which its HTTP listener
+    // keeps alive regardless. This one runs in the CLI, where the interval is
+    // the only ref'ed handle there is: `process.once('SIGINT')` does not hold
+    // the loop open, so unref'ing here drained the loop and exited 0 the moment
+    // the tail had been written — `--follow` printed the tail and returned
+    // instead of following (#439). Nothing leaks: `stop()` clears the interval
+    // on both the abort and the SIGINT path.
     const stop = (): void => {
       clearInterval(timer);
       resolve();

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -211,8 +211,21 @@ export async function runGatewayLogs(
   }
 
   const asJson = flags.json === true;
+  // A downstream reader that closes early — `gateway logs --follow | head -5`,
+  // a pager quit with `q` — ends the follow normally. It is not an error, and
+  // it must not be treated as one: the EPIPE otherwise reaches the CLI's top
+  // level, which prints `Error: write EPIPE` after the output the operator
+  // asked for and exits 1.
+  //
+  // `broken` is set by the follow loop's stdout 'error' handler and only read
+  // here. Writing into a pipe nobody reads never throws — it always surfaces as
+  // an asynchronous 'error' event — so this is not a fast path, it is the guard
+  // for the final flush: `followFile` drains once more and emits any
+  // unterminated line *after* removing that handler, and a write on the dead
+  // stream then would be an unhandled 'error' with nothing left to catch it.
+  const sink = { broken: false };
   const emit = (line: string): void => {
-    if (line === '') return;
+    if (line === '' || sink.broken) return;
     process.stdout.write(`${asJson ? line : formatLogLine(line)}\n`);
   };
 
@@ -230,7 +243,18 @@ export async function runGatewayLogs(
   }
 
   if (flags.follow !== true) return 0;
-  return await followFile(file, startPos, emit, opts);
+  return await followFile(file, startPos, emit, opts, sink);
+}
+
+/**
+ * Whether an error means "nobody is reading this any more".
+ *
+ * EPIPE is the reader closing its end; ERR_STREAM_DESTROYED is the same
+ * situation observed one layer up, after Node has already torn the stream down.
+ */
+function isPipeClosed(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | null)?.code;
+  return code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED';
 }
 
 /**
@@ -247,6 +271,7 @@ async function followFile(
   fromPos: number,
   emit: (line: string) => void,
   opts: LogsRunOptions,
+  sink: { broken: boolean },
 ): Promise<number> {
   const pollMs = opts.pollMs ?? DEFAULT_POLL_MS;
   let pos = fromPos;
@@ -317,8 +342,21 @@ async function followFile(
     // on both the abort and the SIGINT path.
     const stop = (): void => {
       clearInterval(timer);
+      process.stdout.off('error', onSinkError);
+      if (opts.signal) opts.signal.removeEventListener('abort', stop);
+      else process.off('SIGINT', stop);
       resolve();
     };
+    // The reader going away is how a follow normally ends, and it is only ever
+    // observable here: a failed pipe write does not throw, it arrives as an
+    // 'error' on stdout. Without this listener that error is unhandled and
+    // takes the process down with a stack trace instead of ending the follow.
+    function onSinkError(err: unknown): void {
+      if (!isPipeClosed(err)) return;
+      sink.broken = true;
+      stop();
+    }
+    process.stdout.on('error', onSinkError);
     if (opts.signal) {
       if (opts.signal.aborted) return stop();
       opts.signal.addEventListener('abort', stop, { once: true });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -292,7 +292,13 @@ export const NAME_W = 36;
 export const NOUN_NAME_W = 48;
 
 export const CORE_HELP: ReadonlyArray<readonly [string, string]> = [
-  ['gateway status|restart|stop|logs', 'Manage the gateway process (manager-aware)'],
+  ['gateway status|restart|stop', 'Manage the gateway process (manager-aware)'],
+  // Its own row, not folded into the line above: `logs` is the one entry there
+  // that does *not* go through the owning manager — it reads the files directly
+  // and works when the gateway is wedged or dead, which is when it matters.
+  // Described as lifecycle management, it read as a variant of stop/restart and
+  // was reported as missing from help by someone looking straight at it.
+  ['gateway logs', 'Read the gateway log files (works when it is down)'],
   ['service install|status|uninstall', 'Run the gateway as a systemd-user or PM2 service'],
   ['update [check]', 'Check for / install a newer claude-gateway'],
   ['claude version|update [check]', 'Inspect / update the Claude Code binary'],

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -23,6 +23,58 @@ export function printJson(data: unknown, flags: Record<string, string | boolean>
 }
 
 /**
+ * Resolve once everything already written to `s` has reached the OS — or has
+ * failed and been reported.
+ *
+ * Two separate things outlive the `write()` call that started them, and a
+ * caller that waits for either has to wait for both:
+ *
+ *  - **Buffering.** Into a pipe, `write()` returns as soon as the chunk is
+ *    queued. An empty write's callback runs after every chunk ahead of it has
+ *    flushed — or with the failure that stopped it — which is what makes this
+ *    both a drain and a report.
+ *  - **Reporting.** A failed write is reported *after* the call that made it
+ *    returns, so a stream with nothing left buffered can still owe its caller an
+ *    error. That is not merely untidy: the caller decides an exit code on it,
+ *    and a caller that detaches its own `'error'` listener before the event
+ *    lands leaves it unhandled, which ends the process.
+ *
+ * Awaiting this is enough for the second case without any extra delay here.
+ * Measured on this platform (EPIPE on a closed pipe, ENOSPC on a full device,
+ * both file and socket stdout): the failure is queued for delivery during the
+ * write itself, and the tick queue that carries it runs ahead of the microtask
+ * that resumes the `await`. So by the time a caller has this promise's value it
+ * has already seen the error.
+ *
+ * The empty write is skipped when nothing is buffered, and that is not an
+ * economy. A stream that has already failed fails the extra write too, and that
+ * second failure is reported after this promise has settled and the listeners —
+ * the caller's and the one below — are gone: `gateway logs --follow | head -5`
+ * ended in an uncaught `write EPIPE` with the drain removed. Nothing can be in
+ * flight on a stream with an empty buffer anyway. `destroyed`/`writableEnded`
+ * is guarded for a different reason: writing to a finished stream emits
+ * ERR_STREAM_WRITE_AFTER_END, an error the caller never had coming.
+ */
+export function flushStream(s: NodeJS.WriteStream): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const settle = (): void => {
+      s.off('error', settle);
+      resolve();
+    };
+    if (s.writableLength === 0 || s.destroyed || s.writableEnded) {
+      settle();
+      return;
+    }
+    // Backstop: a failure that never reached the write callback would otherwise
+    // leave this pending forever, and `runGatewayLogs` has no deadline of its
+    // own. No test distinguishes it — every failure measured here does reach the
+    // callback — so it is insurance against a hang, not a fixed defect.
+    s.once('error', settle);
+    s.write('', settle);
+  });
+}
+
+/**
  * Wait for stdout/stderr to reach the OS, then exit with `code`.
  *
  * When stdout is a pipe Node's writes are asynchronous, so `process.exit()`
@@ -38,23 +90,16 @@ export function printJson(data: unknown, flags: Record<string, string | boolean>
  */
 export async function exitAfterFlush(code: number, timeoutMs = 2000): Promise<never> {
   process.exitCode = code;
-  const drain = (s: NodeJS.WriteStream): Promise<void> =>
-    new Promise<void>((resolve) => {
-      if (s.writableLength === 0 || s.destroyed || s.writableEnded) {
-        resolve();
-        return;
-      }
-      // An empty write's callback runs after every pending chunk has flushed.
-      s.write('', () => resolve());
-      s.once('error', () => resolve());
-    });
   let timer: NodeJS.Timeout | undefined;
   const deadline = new Promise<void>((resolve) => {
     timer = setTimeout(resolve, timeoutMs);
     timer.unref?.();
   });
   try {
-    await Promise.race([Promise.all([drain(process.stdout), drain(process.stderr)]), deadline]);
+    await Promise.race([
+      Promise.all([flushStream(process.stdout), flushStream(process.stderr)]),
+      deadline,
+    ]);
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/tests/fixtures/logs-follow-harness.ts
+++ b/tests/fixtures/logs-follow-harness.ts
@@ -15,15 +15,30 @@
  * `process.exitCode` — because stdout here is a pipe, and draining it before
  * exiting is precisely the production behaviour these tests are asserting on.
  * A harness that exited differently would be testing a CLI that does not ship.
+ *
+ * `LOGS_HARNESS_EXIT=bare` drops that final drain. It exists for one assertion:
+ * that the command settles its own stdout rather than relying on whatever the
+ * caller happens to do next. `exitAfterFlush` re-attaches an `'error'` listener
+ * of its own a tick later, so for a while a write still in flight when
+ * `runGatewayLogs` returned was caught by that listener purely by timing — the
+ * bare mode is the same CLI with that safety net removed.
  */
 import { runCli } from '../../src/cli/index';
 import { exitAfterFlush } from '../../src/cli/output';
 
+const bare = process.env.LOGS_HARNESS_EXIT === 'bare';
+
+async function finish(code: number): Promise<void> {
+  if (bare) {
+    process.exitCode = code;
+    return;
+  }
+  await exitAfterFlush(code);
+}
+
 runCli(process.argv.slice(2))
-  .then(async (code) => {
-    await exitAfterFlush(code);
-  })
+  .then(finish)
   .catch(async (err: unknown) => {
     process.stderr.write(`${(err as Error)?.stack ?? String(err)}\n`);
-    await exitAfterFlush(1);
+    await finish(1);
   });

--- a/tests/fixtures/logs-follow-harness.ts
+++ b/tests/fixtures/logs-follow-harness.ts
@@ -11,16 +11,19 @@
  * handle of its own, leaving the follow poller as the only thing that can keep
  * the process from exiting.
  *
- * `process.exitCode` rather than `process.exit()`: stdout is a pipe here, and
- * exiting outright can discard writes the test is about to assert on.
+ * It exits the way `src/entry.ts` does — `exitAfterFlush`, not a bare
+ * `process.exitCode` — because stdout here is a pipe, and draining it before
+ * exiting is precisely the production behaviour these tests are asserting on.
+ * A harness that exited differently would be testing a CLI that does not ship.
  */
 import { runCli } from '../../src/cli/index';
+import { exitAfterFlush } from '../../src/cli/output';
 
 runCli(process.argv.slice(2))
-  .then((code) => {
-    process.exitCode = code;
+  .then(async (code) => {
+    await exitAfterFlush(code);
   })
-  .catch((err: unknown) => {
+  .catch(async (err: unknown) => {
     process.stderr.write(`${(err as Error)?.stack ?? String(err)}\n`);
-    process.exitCode = 1;
+    await exitAfterFlush(1);
   });

--- a/tests/fixtures/logs-follow-harness.ts
+++ b/tests/fixtures/logs-follow-harness.ts
@@ -1,0 +1,26 @@
+/**
+ * Standalone CLI stand-in for tests/integration/cli-logs-follow.test.ts.
+ *
+ * `gateway logs --follow` is the one CLI path whose correctness is a property
+ * of the *process*, not of the function: it works only if something keeps the
+ * event loop alive between polls. That cannot be observed from inside Jest,
+ * whose own handles keep the loop alive for any code under test — which is
+ * exactly how #439 shipped with three passing follow tests.
+ *
+ * So this harness is deliberately bare: it runs the real `runCli` and holds no
+ * handle of its own, leaving the follow poller as the only thing that can keep
+ * the process from exiting.
+ *
+ * `process.exitCode` rather than `process.exit()`: stdout is a pipe here, and
+ * exiting outright can discard writes the test is about to assert on.
+ */
+import { runCli } from '../../src/cli/index';
+
+runCli(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err: unknown) => {
+    process.stderr.write(`${(err as Error)?.stack ?? String(err)}\n`);
+    process.exitCode = 1;
+  });

--- a/tests/integration/cli-logs-follow.test.ts
+++ b/tests/integration/cli-logs-follow.test.ts
@@ -199,4 +199,74 @@ describe('gateway logs --follow keeps the CLI process alive (issue #439)', () =>
       expect(exitCode).toBe(1);
     },
   );
+
+  // The same failure without `--follow`. It used to exit 0 with an empty
+  // stderr: stdout reports a failed write after the call that made it returns,
+  // so a command that returned as soon as the last line was handed over settled
+  // its exit code before the failure arrived. Only the follow path escaped it,
+  // and only because following keeps the process there long enough. A script
+  // doing `gateway logs > snapshot.log` on a full disk got a truncated file and
+  // a success code — the "answered when it should have spoken up" failure this
+  // command exists to avoid.
+  (hasDevFull ? it : it.skip)(
+    'I-LOGS-439e: a plain read that cannot write its output fails loudly too',
+    async () => {
+      const file = path.join(dir, 'gateway.log');
+      fs.writeFileSync(file, record('first line') + record('second line'));
+
+      let stderr = '';
+      let exitCode: number | null = null;
+      const full = fs.openSync('/dev/full', 'w');
+      try {
+        child = spawn(process.execPath, ['-r', TS_NODE, HARNESS, 'gateway', 'logs', '--logDir', dir], {
+          stdio: ['ignore', full, 'pipe'],
+          env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' },
+        });
+      } finally {
+        fs.closeSync(full);
+      }
+      child.stderr!.on('data', (d: Buffer) => { stderr += d.toString(); });
+      child.on('exit', (code) => { exitCode = code; });
+
+      await waitUntil(() => `the plain read to exit (stderr: ${stderr})`, () => exitCode !== null);
+
+      expect(stderr).toContain('Cannot write output (ENOSPC)');
+      expect(exitCode).toBe(1);
+    },
+  );
+
+  // Whoever calls `runGatewayLogs` should not have to finish its writes for it.
+  // The command detaches the only 'error' listener stdout has when it returns,
+  // so a write still in flight at that moment is left to the process — an
+  // uncaught exception, stack trace and all. Nothing crashed only because
+  // src/entry.ts calls `exitAfterFlush` on the next tick and its drain happened
+  // to attach a listener in time; the bare harness removes that coincidence.
+  (hasDevFull ? it : it.skip)(
+    'I-LOGS-439f: reports the failure by itself, without the caller draining stdout',
+    async () => {
+      const file = path.join(dir, 'gateway.log');
+      fs.writeFileSync(file, record('first line'));
+
+      let stderr = '';
+      let exitCode: number | null = null;
+      const full = fs.openSync('/dev/full', 'w');
+      try {
+        child = spawn(process.execPath, ['-r', TS_NODE, HARNESS, 'gateway', 'logs', '--logDir', dir], {
+          stdio: ['ignore', full, 'pipe'],
+          env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true', LOGS_HARNESS_EXIT: 'bare' },
+        });
+      } finally {
+        fs.closeSync(full);
+      }
+      child.stderr!.on('data', (d: Buffer) => { stderr += d.toString(); });
+      child.on('exit', (code) => { exitCode = code; });
+
+      await waitUntil(() => `the bare-exit read to finish (stderr: ${stderr})`, () => exitCode !== null);
+
+      // The reported failure, and only that — no stack trace behind it.
+      expect(stderr).toContain('Cannot write output (ENOSPC)');
+      expect(stderr).not.toMatch(/at .*\(/);
+      expect(exitCode).toBe(1);
+    },
+  );
 });

--- a/tests/integration/cli-logs-follow.test.ts
+++ b/tests/integration/cli-logs-follow.test.ts
@@ -1,0 +1,119 @@
+import { spawn, ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * End-to-end proof for issue #439.
+ *
+ * `tests/unit/cli-logs.test.ts` already covers what following *does* —
+ * streaming appends, reopening across a rotation, never splitting a line — by
+ * calling `runGatewayLogs()` in-process with an AbortSignal. All three passed
+ * while `--follow` was completely inert in every released build, because Jest's
+ * own handles keep the event loop alive, so the unref'ed poll interval still
+ * fired. The bug was never in the follow logic; it was in whether the process
+ * survives long enough to run it.
+ *
+ * That property only exists in a real process, so this test spawns one. A
+ * regression that unref's the timer again — or otherwise stops holding the loop
+ * open — exits the child right after the tail, and the appended line never
+ * arrives.
+ */
+
+const HARNESS = path.join(__dirname, '..', 'fixtures', 'logs-follow-harness.ts');
+const TS_NODE = require.resolve('ts-node/register');
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(label: string, predicate: () => boolean, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for: ${label}`);
+}
+
+function record(message: string): string {
+  return `${JSON.stringify({ ts: '2026-01-01T00:00:00.000Z', level: 'info', message })}\n`;
+}
+
+describe('gateway logs --follow keeps the CLI process alive (issue #439)', () => {
+  let dir = '';
+  let child: ChildProcess | null = null;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-logs-follow-'));
+  });
+
+  afterEach(() => {
+    if (child?.pid && isAlive(child.pid)) {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+    }
+    child = null;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('I-LOGS-439: streams a line appended after start, then exits 0 on SIGINT', async () => {
+    const file = path.join(dir, 'gateway.log');
+    fs.writeFileSync(file, record('first line'));
+
+    let stdout = '';
+    let stderr = '';
+    let exitCode: number | null = null;
+
+    child = spawn(process.execPath, ['-r', TS_NODE, HARNESS, 'gateway', 'logs', '--follow', '--logDir', dir], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' },
+    });
+    child.stdout!.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr!.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('exit', (code) => { exitCode = code; });
+
+    // The tail is written before following begins, so its arrival means the
+    // process has reached the point where the bug decided whether to exit.
+    await waitUntil(`the tail to be printed (stderr: ${stderr})`, () => stdout.includes('first line'));
+
+    // Appended only now: a follower that already exited can never report it,
+    // and one that read it as part of the tail would not prove anything.
+    fs.appendFileSync(file, record('appended while following'));
+
+    await waitUntil(
+      'the appended line to stream (the process exits here when the poll timer cannot hold the loop open)',
+      () => stdout.includes('appended while following'),
+    );
+    expect(exitCode).toBeNull(); // still following, not finished
+
+    child.kill('SIGINT');
+    await waitUntil('the child to exit after SIGINT', () => exitCode !== null);
+    expect(exitCode).toBe(0);
+  });
+
+  it('I-LOGS-439b: without --follow the same command still exits immediately', async () => {
+    const file = path.join(dir, 'gateway.log');
+    fs.writeFileSync(file, record('only line'));
+
+    let stdout = '';
+    let exitCode: number | null = null;
+
+    child = spawn(process.execPath, ['-r', TS_NODE, HARNESS, 'gateway', 'logs', '--logDir', dir], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' },
+    });
+    child.stdout!.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.on('exit', (code) => { exitCode = code; });
+
+    // Holding the loop open for `--follow` must not make the plain read hang:
+    // the fix has to be scoped to the follow path, not to the command.
+    await waitUntil('the plain read to exit on its own', () => exitCode !== null);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('only line');
+  });
+});

--- a/tests/integration/cli-logs-follow.test.ts
+++ b/tests/integration/cli-logs-follow.test.ts
@@ -32,13 +32,22 @@ function isAlive(pid: number): boolean {
   }
 }
 
-async function waitUntil(label: string, predicate: () => boolean, timeoutMs = 20_000): Promise<void> {
+/**
+ * Poll until `predicate` holds. `label` is a thunk so the diagnostic it builds
+ * describes the moment the wait gave up, not the moment it started — the
+ * child's stderr is always empty at call time, which is exactly when it is
+ * useless.
+ *
+ * The budget is well under the 15s `npm run integration` imposes, so a real
+ * regression fails with this message rather than jest's generic timeout.
+ */
+async function waitUntil(label: () => string, predicate: () => boolean, timeoutMs = 8_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (predicate()) return;
     await new Promise((r) => setTimeout(r, 25));
   }
-  throw new Error(`timed out after ${timeoutMs}ms waiting for: ${label}`);
+  throw new Error(`timed out after ${timeoutMs}ms waiting for: ${label()}`);
 }
 
 function record(message: string): string {
@@ -79,20 +88,20 @@ describe('gateway logs --follow keeps the CLI process alive (issue #439)', () =>
 
     // The tail is written before following begins, so its arrival means the
     // process has reached the point where the bug decided whether to exit.
-    await waitUntil(`the tail to be printed (stderr: ${stderr})`, () => stdout.includes('first line'));
+    await waitUntil(() => `the tail to be printed (stderr: ${stderr})`, () => stdout.includes('first line'));
 
     // Appended only now: a follower that already exited can never report it,
     // and one that read it as part of the tail would not prove anything.
     fs.appendFileSync(file, record('appended while following'));
 
     await waitUntil(
-      'the appended line to stream (the process exits here when the poll timer cannot hold the loop open)',
+      () => `the appended line to stream — the process exits here when the poll timer cannot hold the loop open (stderr: ${stderr})`,
       () => stdout.includes('appended while following'),
     );
     expect(exitCode).toBeNull(); // still following, not finished
 
     child.kill('SIGINT');
-    await waitUntil('the child to exit after SIGINT', () => exitCode !== null);
+    await waitUntil(() => `the child to exit after SIGINT (stderr: ${stderr})`, () => exitCode !== null);
     expect(exitCode).toBe(0);
   });
 
@@ -112,7 +121,7 @@ describe('gateway logs --follow keeps the CLI process alive (issue #439)', () =>
 
     // Holding the loop open for `--follow` must not make the plain read hang:
     // the fix has to be scoped to the follow path, not to the command.
-    await waitUntil('the plain read to exit on its own', () => exitCode !== null);
+    await waitUntil(() => 'the plain read to exit on its own', () => exitCode !== null);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('only line');
   });
@@ -133,7 +142,7 @@ describe('gateway logs --follow keeps the CLI process alive (issue #439)', () =>
     child.stderr!.on('data', (d: Buffer) => { stderr += d.toString(); });
     child.on('exit', (code) => { exitCode = code; });
 
-    await waitUntil(`the tail to be printed (stderr: ${stderr})`, () => stdout.includes('first line'));
+    await waitUntil(() => `the tail to be printed (stderr: ${stderr})`, () => stdout.includes('first line'));
 
     // `gateway logs --follow | head -5`: the reader has what it wanted and goes
     // away. Destroying our end of the pipe is what the shell does to the CLI.
@@ -141,15 +150,13 @@ describe('gateway logs --follow keeps the CLI process alive (issue #439)', () =>
 
     // Keep writing, so a follower that ignored the closed pipe would keep
     // trying to write into it rather than sitting idle. Each append ends
-    // mid-line on purpose: the file then never ends in a newline, so there is
-    // always a held-back fragment for the final flush to emit *after* the
-    // follow has torn down its stdout error handler — the one write that has
-    // nothing left to catch it.
+    // mid-line on purpose, so the file never ends in a newline and the final
+    // flush after the loop always has a held-back fragment to emit.
     const writer = setInterval(() => {
       try { fs.appendFileSync(file, `${record('nobody is reading this')}{"unterminated":`); } catch { /* dir gone */ }
     }, 20);
     try {
-      await waitUntil('the follow to end once its reader is gone', () => exitCode !== null);
+      await waitUntil(() => `the follow to end once its reader is gone (stderr: ${stderr})`, () => exitCode !== null);
     } finally {
       clearInterval(writer);
     }
@@ -159,4 +166,37 @@ describe('gateway logs --follow keeps the CLI process alive (issue #439)', () =>
     expect(stderr).not.toMatch(/EPIPE|Error:/);
     expect(exitCode).toBe(0);
   });
+
+  // Treating *every* stdout error as "the reader left" would be worse than the
+  // crash it replaced: attaching a listener marks the 'error' handled, so a
+  // genuine write failure would leave the follow polling forever into nothing
+  // and still exit 0. /dev/full reports ENOSPC on every write, which is that
+  // failure without needing to fill a real disk.
+  const hasDevFull = process.platform === 'linux' && fs.existsSync('/dev/full');
+  (hasDevFull ? it : it.skip)(
+    'I-LOGS-439d: a stdout failure that is not a closed pipe is reported, not swallowed',
+    async () => {
+      const file = path.join(dir, 'gateway.log');
+      fs.writeFileSync(file, record('first line'));
+
+      let stderr = '';
+      let exitCode: number | null = null;
+      const full = fs.openSync('/dev/full', 'w');
+      try {
+        child = spawn(process.execPath, ['-r', TS_NODE, HARNESS, 'gateway', 'logs', '--follow', '--logDir', dir], {
+          stdio: ['ignore', full, 'pipe'],
+          env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' },
+        });
+      } finally {
+        fs.closeSync(full);
+      }
+      child.stderr!.on('data', (d: Buffer) => { stderr += d.toString(); });
+      child.on('exit', (code) => { exitCode = code; });
+
+      await waitUntil(() => `the follow to give up on an unwritable stdout (stderr: ${stderr})`, () => exitCode !== null);
+
+      expect(stderr).toContain('ENOSPC');
+      expect(exitCode).toBe(1);
+    },
+  );
 });

--- a/tests/integration/cli-logs-follow.test.ts
+++ b/tests/integration/cli-logs-follow.test.ts
@@ -116,4 +116,47 @@ describe('gateway logs --follow keeps the CLI process alive (issue #439)', () =>
     expect(exitCode).toBe(0);
     expect(stdout).toContain('only line');
   });
+
+  it('I-LOGS-439c: a reader that closes early ends the follow quietly instead of erroring', async () => {
+    const file = path.join(dir, 'gateway.log');
+    fs.writeFileSync(file, record('first line'));
+
+    let stdout = '';
+    let stderr = '';
+    let exitCode: number | null = null;
+
+    child = spawn(process.execPath, ['-r', TS_NODE, HARNESS, 'gateway', 'logs', '--follow', '--logDir', dir], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' },
+    });
+    child.stdout!.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr!.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('exit', (code) => { exitCode = code; });
+
+    await waitUntil(`the tail to be printed (stderr: ${stderr})`, () => stdout.includes('first line'));
+
+    // `gateway logs --follow | head -5`: the reader has what it wanted and goes
+    // away. Destroying our end of the pipe is what the shell does to the CLI.
+    child.stdout!.destroy();
+
+    // Keep writing, so a follower that ignored the closed pipe would keep
+    // trying to write into it rather than sitting idle. Each append ends
+    // mid-line on purpose: the file then never ends in a newline, so there is
+    // always a held-back fragment for the final flush to emit *after* the
+    // follow has torn down its stdout error handler — the one write that has
+    // nothing left to catch it.
+    const writer = setInterval(() => {
+      try { fs.appendFileSync(file, `${record('nobody is reading this')}{"unterminated":`); } catch { /* dir gone */ }
+    }, 20);
+    try {
+      await waitUntil('the follow to end once its reader is gone', () => exitCode !== null);
+    } finally {
+      clearInterval(writer);
+    }
+
+    // The operator asked for output and got it; a broken pipe afterwards is the
+    // end of the pipeline, not a failure to report.
+    expect(stderr).not.toMatch(/EPIPE|Error:/);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/tests/unit/cli-help-table.test.ts
+++ b/tests/unit/cli-help-table.test.ts
@@ -48,6 +48,45 @@ describe('core help table', () => {
     expect(dispatchedCommands().length).toBeGreaterThan(5);
     expect(dispatchedCommands()).toContain('doctor');
   });
+
+  /**
+   * Being listed is not the same as being findable. `logs` was in the table all
+   * along, folded into `gateway status|restart|stop|logs` — under "Manage the
+   * gateway process (manager-aware)", which is true of the other three and
+   * false of this one: it reads the files directly and is at its most useful
+   * when there is no process left to manage. Described as lifecycle management
+   * it read as a variant of stop/restart, and was reported as missing from help
+   * by someone looking straight at the line that contained it.
+   */
+  it('does not file the direct log reader under manager-aware process control', () => {
+    const managed = CORE_HELP.filter(([, description]) => description.includes('manager-aware'));
+    expect(managed.length).toBeGreaterThan(0); // the row still exists to be checked
+    for (const [name] of managed) {
+      expect(name.split(/[\s|]+/)).not.toContain('logs');
+    }
+    expect(CORE_HELP.some(([name]) => name.split(/[\s|]+/).includes('logs'))).toBe(true);
+  });
+
+  /**
+   * `gateway` is the one noun whose verbs are dispatched in their own file, so
+   * the general help can fall behind it silently — which is how a shipped
+   * command went unmentioned for a release.
+   */
+  it('names every gateway verb somewhere in the table', () => {
+    const src = fs.readFileSync(path.resolve(__dirname, '../../src/cli/commands/gateway.ts'), 'utf8');
+    const start = src.indexOf('switch (verb) {');
+    expect(start).toBeGreaterThan(-1);
+    const verbs = [...src.slice(start, src.indexOf('\n  }', start)).matchAll(/case '([^']+)':/g)].map((m) => m[1]);
+    expect(verbs).toContain('logs');
+
+    const namedInHelp = new Set(CORE_HELP.flatMap(([name]) => name.split(/[\s|]+/)));
+    for (const verb of verbs) {
+      // `start` has its own section above the table (it is the only command
+      // that boots a server), so it is documented either way.
+      if (verb === 'start') continue;
+      expect(namedInHelp.has(verb)).toBe(true);
+    }
+  });
 });
 
 describe('helpRow', () => {

--- a/tests/unit/cli-output.test.ts
+++ b/tests/unit/cli-output.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -84,6 +84,94 @@ describe('cli output exitAfterFlush', () => {
     );
     expect(res.status).toBe(3);
     expect(res.bytes).toBe(6);
+  });
+});
+
+/**
+ * A stream reports a failed write *after* the call that made it returns, so
+ * "have my writes landed?" and "did any of them fail?" are the same question.
+ * `gateway logs` decides its exit code on the answer, and detaches its stdout
+ * 'error' listener once it has one — settling early would both hide the failure
+ * and leave the event to the process as an uncaught exception.
+ *
+ * Out-of-process again: a real failing stdout is the only thing that exercises
+ * this, and `/dev/full` is that failure without needing to fill a disk.
+ */
+describe('cli output flushStream', () => {
+  const OUTPUT = JSON.stringify(path.resolve('src/cli/output.ts'));
+  const hasDevFull = process.platform === 'linux' && fs.existsSync('/dev/full');
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gw-flushstream-'));
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  /** Runs `body` with stdout pointed at `/dev/full`; returns its stderr and code. */
+  function onFullDisk(body: string): { stderr: string; status: number | null } {
+    const script = path.join(dir, 'run.js');
+    fs.writeFileSync(script, body);
+    const full = fs.openSync('/dev/full', 'w');
+    try {
+      const res = spawnSync(process.execPath, ['-r', 'ts-node/register', script], {
+        stdio: ['ignore', full, 'pipe'],
+        encoding: 'utf8',
+        env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' },
+      });
+      return { stderr: res.stderr ?? '', status: res.status };
+    } finally {
+      fs.closeSync(full);
+    }
+  }
+
+  (hasDevFull ? it : it.skip)('settles only after a failed write has been reported', () => {
+    const res = onFullDisk(`
+      const { flushStream } = require(${OUTPUT});
+      const seen = [];
+      process.stdout.on('error', (e) => seen.push('error:' + e.code));
+      process.stdout.write('some output\\n');
+      flushStream(process.stdout).then(() => {
+        seen.push('settled');
+        process.stderr.write(JSON.stringify(seen) + '\\n');
+      });
+    `);
+    // Not merely "contains error": the order is the whole point.
+    expect(res.stderr.trim()).toBe('["error:ENOSPC","settled"]');
+  });
+
+  (hasDevFull ? it : it.skip)('leaves nothing for the caller to catch after it settles', () => {
+    const res = onFullDisk(`
+      const { flushStream } = require(${OUTPUT});
+      const onError = () => {};
+      process.stdout.on('error', onError);
+      process.stdout.write('some output\\n');
+      flushStream(process.stdout).then(() => {
+        // What a command does once it has its answer: stdout is nobody's
+        // responsibility again. Any write still owed an error now ends the
+        // process — including one this flush made itself.
+        process.stdout.off('error', onError);
+        setTimeout(() => process.exit(0), 50);
+      });
+    `);
+    expect(res.stderr).toBe('');
+    expect(res.status).toBe(0);
+  });
+
+  it('waits for buffered bytes to reach a pipe', () => {
+    const script = path.join(dir, 'drain.js');
+    const size = 5 * 1024 * 1024;
+    fs.writeFileSync(
+      script,
+      `const { flushStream } = require(${OUTPUT});
+       process.stdout.write('x'.repeat(${size}) + '\\n');
+       flushStream(process.stdout).then(() => process.exit(0));`,
+    );
+    const res = spawnSync(process.execPath, ['-r', 'ts-node/register', script], {
+      maxBuffer: size * 2,
+      env: { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' },
+    });
+    expect(res.stdout.length).toBe(size + 1);
+    expect(res.status).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

`gateway logs --follow` printed the tail and exited `0` instead of following. The poll interval that drives following was `unref()`ed, and in the CLI that interval is the only ref'ed handle there is — `process.once('SIGINT', stop)` does not hold the event loop open — so Node drained the loop and exited as soon as the tail had been written.

## Related Issue

Closes #439

## Changes Made

- `src/cli/commands/logs.ts`: dropped the `unref()` on the follow poll timer, with a comment recording why this timer must stay ref'ed while the server-side ones (`src/logger.ts:324` and the rest) must not. Nothing leaks: `stop()` already clears the interval on both the abort and the SIGINT path.
- `tests/fixtures/logs-follow-harness.ts` (new): a deliberately bare harness that runs the real `runCli` and holds no handle of its own, so the follow poller is the only thing that can keep the process alive.
- `tests/integration/cli-logs-follow.test.ts` (new): spawns the CLI as a real subprocess, appends a line *after* it has started, and asserts the line streams and that SIGINT still exits `0`. A companion case pins that the non-follow read still exits on its own, so the fix cannot silently turn a plain `gateway logs` into a hang.

## Why the existing tests missed it

`tests/unit/cli-logs.test.ts` already covers what following *does* — `U-LOGS-10` (streams appends), `U-LOGS-11` (reopens across a rotation), `U-LOGS-12` (never splits a line). All three call `runGatewayLogs()` in-process with an `AbortSignal`, and Jest's own handles keep the event loop alive, so the `unref()`ed interval still fired and all three passed while `--follow` was inert in every released build. The bug was never in the follow logic; it was in whether the process survives long enough to run it — a property that only exists in a real process. Those tests are kept as-is; the new one covers liveness, which is a different property.

## Testing

- `npm run typecheck`: pass
- `npm run gen-cli:check`: up to date
- `npm test`: 236 suites / 4291 tests pass
- Revert-proven: restoring the `unref()` makes `I-LOGS-439` fail by timing out on the appended line, while `I-LOGS-439b` still passes.
