### PR TITLE
feat(models): add Claude Fable 5.1 and give it the bare `fable` alias

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -10,17 +10,19 @@
       "claude.dangerouslySkipPermissions"
     ]
   },
-  "configVersion": "1.0.30",
+  "configVersion": "1.0.31",
   "gateway": {
     "logDir": "~/.claude-gateway/logs",
     "timezone": "Asia/Bangkok",
     "bind": "127.0.0.1",
     "models": [
-      { "id": "claude-fable-5[1m]",        "label": "Fable 5 (1M)",     "alias": "fable[1m]",   "contextWindow": 1000000 },
+      { "id": "claude-fable-5-1[1m]",      "label": "Fable 5.1 (1M)",   "alias": "fable[1m]",   "contextWindow": 1000000 },
+      { "id": "claude-fable-5[1m]",        "label": "Fable 5 (1M)",     "alias": "fable5[1m]",  "contextWindow": 1000000 },
       { "id": "claude-opus-5[1m]",         "label": "Opus 5 (1M)",      "alias": "opus[1m]",    "contextWindow": 1000000 },
       { "id": "claude-opus-4-8[1m]",       "label": "Opus 4.8 (1M)",    "alias": "opus48[1m]",  "contextWindow": 1000000 },
       { "id": "claude-sonnet-5[1m]",       "label": "Sonnet 5 (1M)",    "alias": "sonnet[1m]",  "contextWindow": 1000000 },
-      { "id": "claude-fable-5",            "label": "Fable 5",          "alias": "fable",       "contextWindow": 200000 },
+      { "id": "claude-fable-5-1",          "label": "Fable 5.1",        "alias": "fable",       "contextWindow": 200000 },
+      { "id": "claude-fable-5",            "label": "Fable 5",          "alias": "fable5",      "contextWindow": 200000 },
       { "id": "claude-opus-5",             "label": "Opus 5",           "alias": "opus",        "contextWindow": 200000 },
       { "id": "claude-opus-4-8",           "label": "Opus 4.8",         "alias": "opus48",      "contextWindow": 200000 },
       { "id": "claude-opus-4-6",           "label": "Opus 4.6",         "alias": "opus46",      "contextWindow": 200000 },

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -884,12 +884,22 @@ const BOT_COMMANDS = [
 // reached only when the gateway call itself fails, so it is two fallbacks deep
 // and will drift — keep it roughly in step with DEFAULT_MODELS
 // (src/agent/runner.ts) and config.template.json gateway.models.
+//
+// `alias` is never read in this process: validModelRows() keeps only id and
+// label, and the picker's callback data is `model:<id>`. It is carried anyway
+// so this list stays diffable against the two registries it mirrors, and so
+// the cross-registry sync test can compare alias mappings — that test is the
+// only thing standing between this copy and the silent drift that already lost
+// it Opus 5 once. Do not drop the column to "clean up"; it would blind the
+// guard, not simplify it.
 const AVAILABLE_MODELS = [
-  { id: 'claude-fable-5[1m]',        label: 'Fable 5 (1M)',     alias: 'fable[1m]' },
+  { id: 'claude-fable-5-1[1m]',      label: 'Fable 5.1 (1M)',   alias: 'fable[1m]' },
+  { id: 'claude-fable-5[1m]',        label: 'Fable 5 (1M)',     alias: 'fable5[1m]' },
   { id: 'claude-opus-5[1m]',         label: 'Opus 5 (1M)',      alias: 'opus[1m]' },
   { id: 'claude-opus-4-8[1m]',       label: 'Opus 4.8 (1M)',    alias: 'opus48[1m]' },
   { id: 'claude-sonnet-5[1m]',       label: 'Sonnet 5 (1M)',    alias: 'sonnet[1m]' },
-  { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable' },
+  { id: 'claude-fable-5-1',          label: 'Fable 5.1',        alias: 'fable' },
+  { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable5' },
   { id: 'claude-opus-5',             label: 'Opus 5',           alias: 'opus' },
   { id: 'claude-opus-4-8',           label: 'Opus 4.8',         alias: 'opus48' },
   { id: 'claude-opus-4-6',           label: 'Opus 4.6',         alias: 'opus46' },

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -61,12 +61,31 @@ const TOO_LARGE_HISTORY_LADDER: readonly number[] = [MAX_HISTORY_MESSAGES, 40, 3
 
 export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
+// Fable 5.1 takes the bare `fable` alias and Fable 5 is demoted to `fable5`,
+// following the "bare alias = newest of the family" convention the rest of this
+// list uses — the same demotion Opus 4.8 took to `opus48` when Opus 5 landed.
+//
+// Note that `fable` therefore points at a model not every provider has
+// entitled yet; ours answers `400 model not supported` for it today, until
+// Crown-Labs/getpod#2538 adds it to the catalog. This only affects someone
+// typing `/model fable` from now on: selection stores the resolved id, not the
+// alias, so an agent already on Fable 5 stays on claude-fable-5 and existing
+// configs have their claude-fable-5 row rewritten to `fable5` by
+// migrateModels(). Nobody is moved onto 5.1 by this change.
+//
+// Both Fable 5.x entries carry the same 200k/1M split as the rest: their CLI
+// catalog entry says `native_1m`, but native 1M only applies when the base URL
+// is api.anthropic.com. Behind a proxy the `[1m]` id suffix and the
+// `context-1m-2025-08-07` beta header are what actually buy the larger window,
+// which is exactly what the paired rows below encode.
 export const DEFAULT_MODELS: ModelConfig[] = [
-  { id: 'claude-fable-5[1m]',        label: 'Fable 5 (1M)',     alias: 'fable[1m]',   contextWindow: 1000000 },
+  { id: 'claude-fable-5-1[1m]',      label: 'Fable 5.1 (1M)',   alias: 'fable[1m]',   contextWindow: 1000000 },
+  { id: 'claude-fable-5[1m]',        label: 'Fable 5 (1M)',     alias: 'fable5[1m]',  contextWindow: 1000000 },
   { id: 'claude-opus-5[1m]',         label: 'Opus 5 (1M)',      alias: 'opus[1m]',    contextWindow: 1000000 },
   { id: 'claude-opus-4-8[1m]',       label: 'Opus 4.8 (1M)',    alias: 'opus48[1m]',  contextWindow: 1000000 },
   { id: 'claude-sonnet-5[1m]',       label: 'Sonnet 5 (1M)',    alias: 'sonnet[1m]',  contextWindow: 1000000 },
-  { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable',       contextWindow: 200000 },
+  { id: 'claude-fable-5-1',          label: 'Fable 5.1',        alias: 'fable',       contextWindow: 200000 },
+  { id: 'claude-fable-5',            label: 'Fable 5',          alias: 'fable5',      contextWindow: 200000 },
   { id: 'claude-opus-5',             label: 'Opus 5',           alias: 'opus',        contextWindow: 200000 },
   { id: 'claude-opus-4-8',           label: 'Opus 4.8',         alias: 'opus48',      contextWindow: 200000 },
   { id: 'claude-opus-4-6',           label: 'Opus 4.6',         alias: 'opus46',      contextWindow: 200000 },

--- a/tests/unit/config-migration-real-upgrade.test.ts
+++ b/tests/unit/config-migration-real-upgrade.test.ts
@@ -415,3 +415,122 @@ describe('config migration — GPT models reach existing installs', () => {
     });
   });
 });
+
+/**
+ * Fable 5.1 reaches existing installs.
+ *
+ * Same shape as the GPT block above, and for the same reason: an install that
+ * already pins its own gateway.models list never sees a model added only to
+ * DEFAULT_MODELS. The template entry AND the configVersion bump are both part
+ * of the feature — migrateModels() only runs when the template version is
+ * ahead of the user's, so forgetting the bump ships a model nobody receives.
+ *
+ * The pre-Fable-5.1 fixture pins configVersion 1.0.30, the version immediately
+ * before this change: that makes the first test fail if the bump is reverted,
+ * rather than passing on the slack left by some older bump.
+ */
+describe('config migration — Fable 5.1 reaches existing installs', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fable51-upgrade-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** A realistic pre-Fable-5.1 install: bind already set (so bind isn't the
+   *  migration trigger), the previous Fable rows, plus a custom BYOK model. */
+  function writePreFable51Config(): string {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          configVersion: '1.0.30',
+          gateway: {
+            bind: '0.0.0.0',
+            models: [
+              { id: 'claude-fable-5[1m]', label: 'Fable 5 (1M)', alias: 'fable[1m]', contextWindow: 1000000 },
+              { id: 'claude-fable-5', label: 'Fable 5', alias: 'fable', contextWindow: 200000 },
+              { id: 'openrouter/custom-model', label: 'My BYOK', alias: 'mine', contextWindow: 128000 },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+    return configPath;
+  }
+
+  it('uses a template version newer than the pre-Fable-5.1 registry', () => {
+    expect(compareSemver(templateVersion(), '1.0.30')).toBeGreaterThan(0);
+  });
+
+  it('adds both Fable 5.1 variants with the right aliases and windows', () => {
+    const configPath = writePreFable51Config();
+
+    const result = runRealUpgrade(configPath);
+
+    expect(result.needed).toBe(true);
+    expect(result.addedFields).toContain('gateway.models[claude-fable-5-1]');
+    expect(result.addedFields).toContain('gateway.models[claude-fable-5-1[1m]]');
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(migrated.configVersion).toBe(templateVersion());
+    expect(migrated.gateway.models).toContainEqual({
+      id: 'claude-fable-5-1',
+      label: 'Fable 5.1',
+      alias: 'fable',
+      contextWindow: 200000,
+    });
+    expect(migrated.gateway.models).toContainEqual({
+      id: 'claude-fable-5-1[1m]',
+      label: 'Fable 5.1 (1M)',
+      alias: 'fable[1m]',
+      contextWindow: 1000000,
+    });
+  });
+
+  /**
+   * The upgrade repoints `fable` from Fable 5 to Fable 5.1, so an existing
+   * install's own claude-fable-5 row — which stores alias `fable` — has to be
+   * rewritten to `fable5`. If it were merely left alone, the migrated config
+   * would carry two rows both claiming `fable`, and /model fable would resolve
+   * to whichever came first. This is the guard for that.
+   */
+  it('rewrites the existing Fable 5 rows to the demoted `fable5` alias', () => {
+    const configPath = writePreFable51Config();
+    runRealUpgrade(configPath);
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const byAlias = (alias: string) =>
+      migrated.gateway.models.find((m: { alias: string }) => m.alias === alias);
+    const byId = (id: string) =>
+      migrated.gateway.models.find((m: { id: string }) => m.id === id);
+
+    expect(byId('claude-fable-5')?.alias).toBe('fable5');
+    expect(byId('claude-fable-5[1m]')?.alias).toBe('fable5[1m]');
+    expect(byAlias('fable')?.id).toBe('claude-fable-5-1');
+    expect(byAlias('fable[1m]')?.id).toBe('claude-fable-5-1[1m]');
+
+    const aliases = migrated.gateway.models.map((m: { alias: string }) => m.alias);
+    expect(new Set(aliases).size).toBe(aliases.length);
+  });
+
+  it('preserves a user-owned model that is not in the template', () => {
+    const configPath = writePreFable51Config();
+    runRealUpgrade(configPath);
+
+    const migrated = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(migrated.gateway.models).toContainEqual({
+      id: 'openrouter/custom-model',
+      label: 'My BYOK',
+      alias: 'mine',
+      contextWindow: 128000,
+    });
+  });
+});

--- a/tests/unit/models-registry.test.ts
+++ b/tests/unit/models-registry.test.ts
@@ -56,6 +56,45 @@ describe('model registry — Opus 5 is a first-class model', () => {
   });
 });
 
+describe('model registry — Fable 5.1 is a first-class model', () => {
+  it('DEFAULT_MODELS includes both Fable 5.1 variants with correct context windows', () => {
+    expect(byId(DEFAULT_MODELS, 'claude-fable-5-1')?.contextWindow).toBe(200000);
+    expect(byId(DEFAULT_MODELS, 'claude-fable-5-1[1m]')?.contextWindow).toBe(1000000);
+  });
+
+  it('the template includes both Fable 5.1 variants with correct context windows', () => {
+    const models = templateModels();
+    expect(byId(models, 'claude-fable-5-1')?.contextWindow).toBe(200000);
+    expect(byId(models, 'claude-fable-5-1[1m]')?.contextWindow).toBe(1000000);
+  });
+
+  it('Fable 5 is demoted to the `fable5` alias (kept, not dropped)', () => {
+    expect(byAlias(DEFAULT_MODELS, 'fable5')?.id).toBe('claude-fable-5');
+    expect(byAlias(DEFAULT_MODELS, 'fable5[1m]')?.id).toBe('claude-fable-5[1m]');
+    expect(byAlias(templateModels(), 'fable5')?.id).toBe('claude-fable-5');
+    expect(byAlias(templateModels(), 'fable5[1m]')?.id).toBe('claude-fable-5[1m]');
+  });
+
+  /**
+   * The "bare alias = newest of the family" convention, applied to Fable the
+   * same way `opus` -> Opus 5 and `sonnet` -> Sonnet 5 already are.
+   *
+   * Worth knowing while reading this: `fable` therefore names a model not
+   * every provider has entitled yet (ours 400s on it until
+   * Crown-Labs/getpod#2538 lands). That is deliberate and it moves nobody —
+   * handleModelCommand stores the resolved *id*, not the alias, so agents
+   * already on Fable 5 stay on claude-fable-5, and migrateModels() rewrites
+   * their row's alias to `fable5` rather than leaving two rows claiming
+   * `fable`.
+   */
+  it('the bare `fable` alias resolves to Fable 5.1 in both registries', () => {
+    expect(byAlias(DEFAULT_MODELS, 'fable')?.id).toBe('claude-fable-5-1');
+    expect(byAlias(DEFAULT_MODELS, 'fable[1m]')?.id).toBe('claude-fable-5-1[1m]');
+    expect(byAlias(templateModels(), 'fable')?.id).toBe('claude-fable-5-1');
+    expect(byAlias(templateModels(), 'fable[1m]')?.id).toBe('claude-fable-5-1[1m]');
+  });
+});
+
 describe('model registry — DEFAULT_MODELS and template stay in sync', () => {
   it('uses OpenAI-documented 1,050,000-token windows for all GPT models', () => {
     const gptIds = ['gpt-5.6-sol[1m]', 'gpt-5.6-terra[1m]', 'gpt-5.6-luna[1m]', 'gpt-5.5[1m]'];


### PR DESCRIPTION
## What

Adds **Claude Fable 5.1** to all three model registries and gives it the bare `fable` alias, demoting Fable 5 to `fable5` — the alias convention the rest of the list already follows.

| id | alias | context |
|---|---|---|
| `claude-fable-5-1` | `fable` | 200k |
| `claude-fable-5-1[1m]` | `fable[1m]` | 1M |
| `claude-fable-5` | `fable5` *(was `fable`)* | 200k |
| `claude-fable-5[1m]` | `fable5[1m]` *(was `fable[1m]`)* | 1M |

Touched: `src/agent/runner.ts` (`DEFAULT_MODELS`), `config.template.json` (`gateway.models`), `mcp/tools/telegram/receiver-server.ts` (the `/model` picker's fallback list), plus the `configVersion` bump.

## Why this alias layout

It's the existing pattern, not a new one: `opus` → Opus 5 with 4.8 demoted to `opus48`; `sonnet` → Sonnet 5 with 4.6 at `sonnet46`. Fable was the odd one out, with the bare alias pinned to the older member.

Separately, without a curated row a provider that *does* serve Fable 5.1 would surface it via the live catalog (#409) with no metadata, falling back to `DEFAULT_CONTEXT_WINDOW` (200k) for both variants — sizing `/session` and `/compact` against a fifth of the real window for the `[1m]` form.

## The repoint moves nobody — and can't leave a duplicate alias

`fable` now names a model not every provider has entitled yet; ours returns `400 model not supported` until [Crown-Labs/getpod#2538](https://github.com/Crown-Labs/getpod/issues/2538) lands. Two facts make that safe rather than disruptive, both checked in the source rather than assumed:

- **Selection stores the id, not the alias.** `handleModelCommand` (`src/agent/runner.ts:2269-2278`) resolves the alias then calls `setModel(match.id)`. An agent already on Fable 5 stays on `claude-fable-5`; only someone typing `/model fable` from now on reaches 5.1.
- **Upgrading installs get their old row renamed, not duplicated.** An existing config stores its own `claude-fable-5` row with alias `fable`. `migrateModels` (`src/config/migrator.ts:685-696`) matches by id and overwrites `alias`/`label`/`contextWindow`, so that row becomes `fable5` in the same pass that adds the 5.1 rows. Without this the migrated config would carry two rows both claiming `fable`.

That second point is the real hazard here, so it has its own test asserting the migrated alias set is still unique. Patching out the single line `existing.alias = tm.alias;` makes it fail with `Expected: "fable5" / Received: "fable"`.

## `[1m]` — verified against the CLI binary

- Fable 5.1's catalog entry carries `supports_1m_beta: true`, and `yk()` — the function deciding whether the `[1m]` suffix may be appended — gates on exactly that flag. `supports_1m_suffix` (which Fable lacks) only drives the `" (1M context)"` display label in `SI()`; it does not gate id acceptance.
- `Qo()`, which enables **native** 1M, is true only when `ANTHROPIC_BASE_URL`'s host is literally `api.anthropic.com`. Behind a proxy it never fires, so the `[1m]` suffix plus the `context-1m-2025-08-07` beta header is the only path to a 1M window here.

That also settles an earlier open question: the bare rows sitting at `contextWindow: 200000` are **correct** for this deployment, not an under-report.

## `configVersion` 1.0.30 → 1.0.31 is part of the feature

`migrateModels()` only runs when the template's version is ahead of the user's. Without the bump, neither the new rows nor the alias repoint reach anyone who has already installed. Reverting the bump alone turns the migration test red.

## Tests

`tests/unit/models-registry.test.ts` — identical id sets across all three registries, identical alias and `contextWindow` per id, alias uniqueness within `DEFAULT_MODELS`, and the Fable assertions themselves (`fable` → 5.1, `fable5` → 5, both variants' context windows). There is deliberately no general "every bare id has a `[1m]` twin" invariant: it would not be true of the existing list — Opus 4.6, Sonnet 4.6 and Haiku 4.5 have no `[1m]` row, and the four GPT rows have no bare row.

`tests/unit/config-migration-real-upgrade.test.ts` — a real 1.0.30 → 1.0.31 upgrade adds both 5.1 rows, rewrites the user's Fable 5 rows to `fable5`, keeps the alias set unique, and preserves an unrelated BYOK model.

Every guard revert-proven individually: reverting the alias swap in `runner.ts` alone fails 4 tests, in `config.template.json` alone 3, in the Telegram picker alone 1 (the cross-registry sync guard), and patching out the migrator's alias update fails the new uniqueness test.

## Gates

- `tsc --noEmit` clean
- `npm run gen-cli:check` up to date
- `npm test` — **4308 / 4308 passing**, 236 suites

## Scope

Fable 5.1 only. An earlier revision of this branch also added Opus 4.7 rows; that model is entitled and answers today but has no row in any registry — a gap left when 4.8 landed. It was out of scope here and was removed; the gap still stands and is worth its own change. Five `gemini-3.x` models the pool serves are likewise absent, left out because I have no verified context windows for them, and flagged in #2538.

## Verification limit, stated plainly

`claude-fable-5-1` and its `[1m]` form cannot be exercised end-to-end while the provider still 400s on the bare id. The `[1m]` support claim rests on the CLI catalog flag and the `yk()` gate, not on a live request.

