### PR TITLE
[Fix] Container app-agents silently lose Claude auth when the host settings.json is atomically replaced

### DIFF
--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -16,9 +16,7 @@
  * `mcp/`. Keep the two in step.
  */
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import { claudeSettingsEnv } from '../config/claude-settings';
 import type { ModelConfig } from '../types';
 
 /** A stale catalog beats a hung picker — the fetch sits in front of a UI action. */
@@ -87,12 +85,10 @@ let settingsEnvFetchedAt = 0;
 
 function settingsEnv(key: string, now: number = Date.now()): string {
   if (settingsEnvCache === undefined || now - settingsEnvFetchedAt >= CATALOG_TTL_MS) {
-    try {
-      const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-      settingsEnvCache = JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf8'))?.env ?? null;
-    } catch {
-      settingsEnvCache = null;
-    }
+    // Locating and parsing the file is shared with the other readers of it (see
+    // config/claude-settings), so CLAUDE_CONFIG_DIR is honoured identically
+    // everywhere. Only the TTL cache below is specific to the catalog.
+    settingsEnvCache = claudeSettingsEnv();
     settingsEnvFetchedAt = now;
   }
   const v = settingsEnvCache?.[key];

--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -107,14 +107,41 @@ export class AgentManager {
     // Claude Code rewrites ~/.claude.json atomically at startup (write temp +
     // rename over the target). Bind-mounting the host file at its real path makes
     // that rename fail with `Device or resource busy` (a mountpoint cannot be
-    // replaced via rename, regardless of ro/rw), so the session cannot persist the
-    // auth state carried by settings.json's env block and falls back to
-    // "Not logged in". Instead we bind-mount the host file to a read-only *seed*
-    // path (host file never mutated) and copy it into a writable ~/.claude.json at
-    // container start (see `command` below) so the atomic rewrite succeeds. The
-    // copy targets the literal homeDir: container-start HOME is `/`, but the
+    // replaced via rename, regardless of ro/rw), so the container needs a writable
+    // *copy* rather than a mount: we stage a gateway-owned seed and copy out of it
+    // at container start (see `command` below).
+    //
+    // The seed is a DIRECTORY, never the host file itself. A Docker *file* bind
+    // mount pins an inode rather than a path, so an atomic rewrite on the host
+    // allocates a new inode and leaves the container reading the old, unlinked one
+    // for the rest of its life — the bug that made container agents answer
+    // "Not logged in · Please run /login" after any host settings change.
+    // Directory mounts resolve entries per access, so re-staging the copy here is
+    // enough for the next (re)start to pick it up; no container recreate needed.
+    //
+    // The copy targets the literal homeDir: container-start HOME is `/`, but the
     // gateway runs turns with `docker exec -e HOME=<homeDir>` (see process.ts).
-    const claudeJsonSeed = `${homeDir}/.claude.json.seed`;
+    const containerSeedDir = `${homeDir}/.claude-seed`;
+    const seedDir = path.join(this.agentsDir, agentName, '.claude-seed');
+    fs.mkdirSync(seedDir, { recursive: true });
+    fs.chmodSync(seedDir, 0o700); // mkdir mode is umask-dependent; this is not
+    const hostClaudeJson = path.join(homeDir, '.claude.json');
+    const seededClaudeJson = fs.existsSync(hostClaudeJson);
+    if (seededClaudeJson) {
+      const dest = path.join(seedDir, '.claude.json');
+      fs.copyFileSync(hostClaudeJson, dest);
+      fs.chmodSync(dest, 0o600);
+    }
+    const seedSource = fs.realpathSync(seedDir);
+
+    // ~/.claude/settings.json is deliberately NOT mounted. On the host it exists
+    // to carry credentials, and mounting that file is exactly what broke container
+    // agents (stale inode after an atomic host rewrite). Credentials now reach the
+    // container as `docker exec -e` env resolved per turn from the live host file
+    // (see resolveContainerAuthEnv in session/process.ts), which also lets an
+    // already-broken container recover without being recreated. The file's
+    // remaining keys — plugins, marketplaces, statusLine — are host-scoped and
+    // point at paths that were never mounted into the container anyway.
 
     // Mount the agent's media directory into the container at the SAME absolute
     // path as the host. The gateway hands the agent uploaded-image paths (and the
@@ -142,13 +169,20 @@ export class AgentManager {
       `    && chown -R ${uid}:${uid} ${homeDir}`,
     ].join('\n') + '\n');
 
+    // Seed a writable ~/.claude.json from the read-only seed mount, then idle.
+    // The copy re-runs on every (re)start, and because the seed is a directory
+    // mount it resolves the *current* staged file rather than a pinned inode.
+    // Steps are `;`-separated, not `&&`: a failed copy must surface on stderr
+    // (visible in `docker logs`) without preventing the container from starting.
+    // `exec` keeps the container's PID 1 as sleep.
+    const seedCopy = seededClaudeJson
+      ? `cp ${containerSeedDir}/.claude.json ${homeDir}/.claude.json; `
+      : '';
+
     const agentService = {
       build: { context: entry.installPath, dockerfile: 'Dockerfile.agent' },
       user: `${uid}:${uid}`,
-      // Seed a writable ~/.claude.json from the read-only seed mount, then idle.
-      // `cp` overwrites on every (re)start so the container always picks up the
-      // current host auth; `exec` keeps the container's PID 1 as sleep.
-      command: `sh -c 'cp ${claudeJsonSeed} ${homeDir}/.claude.json && exec sleep infinity'`,
+      command: `sh -c '${seedCopy}exec sleep infinity'`,
       container_name: `${entry.name}-agent`,
       restart: 'unless-stopped',
       cap_drop: ['ALL'],
@@ -158,8 +192,7 @@ export class AgentManager {
         `${claudeBin}:${claudeBin}:ro`,
         `${nodeBin}:/usr/bin/node:ro`,
         `${npmRoot}:${npmRoot}:ro`,
-        `${homeDir}/.claude.json:${claudeJsonSeed}:ro`,
-        `${homeDir}/.claude/settings.json:${homeDir}/.claude/settings.json:ro`,
+        `${seedSource}:${containerSeedDir}:ro`,
         `${workspaceDir}:/workspace`,
         `${agentMediaSource}:${agentMediaDir}:rw`,
       ],

--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -261,8 +261,9 @@ export class AgentManager {
 
   /**
    * Remove by agent name — used in install rollback where AppEntry may not be in scope.
-   * Only removes the workspace symlink; preserves sessions/ and other data so that
-   * a reinstall picks up the same conversation history.
+   * Removes the workspace symlink and the re-stageable Claude config seed;
+   * preserves sessions/ and other data so that a reinstall picks up the same
+   * conversation history.
    */
   async deleteAgentByName(agentName: string): Promise<void> {
     const workspaceLink = path.join(this.agentsDir, agentName, 'workspace');
@@ -273,6 +274,16 @@ export class AgentManager {
         fs.rmSync(workspaceLink, { force: true });
       }
     } catch { /* already gone */ }
+    // The Claude config seed is derived data, not history: it is re-staged from
+    // the host on the next install/update, so an app that has been removed must
+    // not leave a copy of the host's Claude config sitting on disk. The rest of
+    // the agent dir (sessions, media) is deliberately preserved.
+    try {
+      fs.rmSync(path.join(this.agentsDir, agentName, '.claude-seed'), {
+        recursive: true,
+        force: true,
+      });
+    } catch { /* best-effort */ }
     await this.removeConfigEntry(agentName);
   }
 

--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -81,6 +81,45 @@ export class AgentManager {
   }
 
   /**
+   * Stage the host's ~/.claude.json into a gateway-owned seed directory for one
+   * agent, and report where it landed.
+   *
+   * The seed is a DIRECTORY, never the host file itself. A Docker *file* bind
+   * mount pins an inode rather than a path, so an atomic rewrite on the host
+   * allocates a new inode and leaves the container reading the old, unlinked one
+   * for the rest of its life. Claude Code rewrites ~/.claude.json exactly that
+   * way, so mounting it directly meant the container's view froze at the first
+   * rewrite and never recovered. A directory mount resolves its entries per
+   * access, so re-staging the file is enough — the container picks it up on its
+   * next (re)start with no recreate.
+   *
+   * Called from injectAgentService (install/update/reconfigure) and from
+   * upsertAgent, which reconcileAgents runs for every app-agent at gateway
+   * start. Without the second call site the seed would only ever refresh when
+   * the app itself was touched, so a host `claude /login` under a different
+   * account could stay invisible to containers indefinitely.
+   *
+   * Mode is set explicitly because mkdir/copyFile modes are umask-dependent: the
+   * seed is a copy of the host's Claude config and must not be world-readable,
+   * even though the host file itself is commonly 0644.
+   */
+  private stageClaudeSeed(agentName: string): { seedSource: string; seeded: boolean } {
+    const seedDir = path.join(this.agentsDir, agentName, '.claude-seed');
+    fs.mkdirSync(seedDir, { recursive: true });
+    fs.chmodSync(seedDir, 0o700);
+
+    const hostClaudeJson = path.join(os.homedir(), '.claude.json');
+    let seeded = false;
+    if (fs.existsSync(hostClaudeJson)) {
+      const dest = path.join(seedDir, '.claude.json');
+      fs.copyFileSync(hostClaudeJson, dest);
+      fs.chmodSync(dest, 0o600);
+      seeded = true;
+    }
+    return { seedSource: fs.realpathSync(seedDir), seeded };
+  }
+
+  /**
    * Inject the `agent` service into an already-generated docker-compose.yml.
    * No-op if entry has no agentDeclaration or agentPaths.
    *
@@ -111,37 +150,24 @@ export class AgentManager {
     // *copy* rather than a mount: we stage a gateway-owned seed and copy out of it
     // at container start (see `command` below).
     //
-    // The seed is a DIRECTORY, never the host file itself. A Docker *file* bind
-    // mount pins an inode rather than a path, so an atomic rewrite on the host
-    // allocates a new inode and leaves the container reading the old, unlinked one
-    // for the rest of its life — the bug that made container agents answer
-    // "Not logged in · Please run /login" after any host settings change.
-    // Directory mounts resolve entries per access, so re-staging the copy here is
-    // enough for the next (re)start to pick it up; no container recreate needed.
-    //
     // The copy targets the literal homeDir: container-start HOME is `/`, but the
     // gateway runs turns with `docker exec -e HOME=<homeDir>` (see process.ts).
     const containerSeedDir = `${homeDir}/.claude-seed`;
-    const seedDir = path.join(this.agentsDir, agentName, '.claude-seed');
-    fs.mkdirSync(seedDir, { recursive: true });
-    fs.chmodSync(seedDir, 0o700); // mkdir mode is umask-dependent; this is not
-    const hostClaudeJson = path.join(homeDir, '.claude.json');
-    const seededClaudeJson = fs.existsSync(hostClaudeJson);
-    if (seededClaudeJson) {
-      const dest = path.join(seedDir, '.claude.json');
-      fs.copyFileSync(hostClaudeJson, dest);
-      fs.chmodSync(dest, 0o600);
-    }
-    const seedSource = fs.realpathSync(seedDir);
+    const { seedSource, seeded: seededClaudeJson } = this.stageClaudeSeed(agentName);
 
     // ~/.claude/settings.json is deliberately NOT mounted. On the host it exists
     // to carry credentials, and mounting that file is exactly what broke container
     // agents (stale inode after an atomic host rewrite). Credentials now reach the
-    // container as `docker exec -e` env resolved per turn from the live host file
-    // (see resolveContainerAuthEnv in session/process.ts), which also lets an
-    // already-broken container recover without being recreated. The file's
-    // remaining keys — plugins, marketplaces, statusLine — are host-scoped and
-    // point at paths that were never mounted into the container anyway.
+    // container as `docker exec -e` env resolved from the live host file on every
+    // session spawn (see resolveContainerAuthEnv in session/process.ts), which
+    // also lets an already-broken container recover without being recreated.
+    //
+    // The file's remaining keys are host-scoped: enabledPlugins and
+    // extraKnownMarketplaces point at paths that were never mounted into the
+    // container, and skipDangerousModePermissionPrompt only suppresses the
+    // interactive bypass dialog, which a container agent never sees — app-agents
+    // are forced onto the headless backend, and headless always passes
+    // --dangerously-skip-permissions.
 
     // Mount the agent's media directory into the container at the SAME absolute
     // path as the host. The gateway hands the agent uploaded-image paths (and the
@@ -175,8 +201,12 @@ export class AgentManager {
     // Steps are `;`-separated, not `&&`: a failed copy must surface on stderr
     // (visible in `docker logs`) without preventing the container from starting.
     // `exec` keeps the container's PID 1 as sleep.
+    //
+    // Paths are double-quoted inside the single-quoted `sh -c` argument: homeDir
+    // is host-derived and may contain spaces, which would otherwise split into
+    // extra `cp` operands and copy the config to the wrong place.
     const seedCopy = seededClaudeJson
-      ? `cp ${containerSeedDir}/.claude.json ${homeDir}/.claude.json; `
+      ? `cp "${containerSeedDir}/.claude.json" "${homeDir}/.claude.json"; `
       : '';
 
     const agentService = {
@@ -224,6 +254,16 @@ export class AgentManager {
     const targetDir = fs.realpathSync(path.join(entry.installPath, agentRelPath));
 
     fs.mkdirSync(agentDir, { recursive: true });
+
+    // Refresh the staged Claude config from the host. reconcileAgents() calls
+    // this for every running app-agent at gateway start, so a host-side config
+    // change reaches containers on the next gateway restart rather than waiting
+    // for the app to be updated. Best-effort: a failure here must not stop the
+    // agent from being registered, since the container falls back to the
+    // previously staged copy.
+    try {
+      this.stageClaudeSeed(agentName);
+    } catch { /* keep the existing seed */ }
 
     try { fs.rmSync(workspaceLink, { force: true, recursive: true }); } catch { /* ignore */ }
     fs.symlinkSync(targetDir, workspaceLink);

--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -102,6 +102,14 @@ export class AgentManager {
    * Mode is set explicitly because mkdir/copyFile modes are umask-dependent: the
    * seed is a copy of the host's Claude config and must not be world-readable,
    * even though the host file itself is commonly 0644.
+   *
+   * The copy is staged through a temp file and renamed into place — the same
+   * write-then-rename idiom writeConfig() uses below. A container runs `cp` on
+   * this file at its own start, which can land mid-copy on a gateway restart;
+   * rename makes the container see either the old file or the new one, never a
+   * half-written config. Rename is safe here precisely because the *directory*
+   * is what gets mounted: entries resolve per access, which is the property this
+   * whole seed mechanism relies on.
    */
   private stageClaudeSeed(agentName: string): { seedSource: string; seeded: boolean } {
     const seedDir = path.join(this.agentsDir, agentName, '.claude-seed');
@@ -112,8 +120,15 @@ export class AgentManager {
     let seeded = false;
     if (fs.existsSync(hostClaudeJson)) {
       const dest = path.join(seedDir, '.claude.json');
-      fs.copyFileSync(hostClaudeJson, dest);
-      fs.chmodSync(dest, 0o600);
+      const tmp = `${dest}.tmp.${process.pid}`;
+      try {
+        fs.copyFileSync(hostClaudeJson, tmp);
+        fs.chmodSync(tmp, 0o600);
+        fs.renameSync(tmp, dest);
+      } catch (err) {
+        try { fs.rmSync(tmp, { force: true }); } catch { /* best-effort */ }
+        throw err;
+      }
       seeded = true;
     }
     return { seedSource: fs.realpathSync(seedDir), seeded };
@@ -256,11 +271,21 @@ export class AgentManager {
     fs.mkdirSync(agentDir, { recursive: true });
 
     // Refresh the staged Claude config from the host. reconcileAgents() calls
-    // this for every running app-agent at gateway start, so a host-side config
-    // change reaches containers on the next gateway restart rather than waiting
-    // for the app to be updated. Best-effort: a failure here must not stop the
-    // agent from being registered, since the container falls back to the
-    // previously staged copy.
+    // this for every running app-agent at gateway start, so the staged copy
+    // tracks the host without waiting for the app to be reinstalled or updated.
+    //
+    // Refreshing the seed is not the same as refreshing a container: the copy
+    // into the container runs in its start command, and nothing here restarts
+    // containers (composeUp is only called from the installer). With
+    // `restart: unless-stopped` they outlive a gateway restart, so a container
+    // already running picks the new seed up at its next start, not at ours.
+    // Credentials do not depend on this — they are forwarded per session spawn
+    // by resolveContainerAuthEnv() — so the lag only affects the rest of
+    // ~/.claude.json. Agents installed before the seed directory existed keep
+    // their old compose until the app is updated, and ignore it entirely.
+    //
+    // Best-effort: a failure here must not stop the agent from being
+    // registered, since the container falls back to the previously staged copy.
     try {
       this.stageClaudeSeed(agentName);
     } catch { /* keep the existing seed */ }
@@ -318,6 +343,12 @@ export class AgentManager {
     // the host on the next install/update, so an app that has been removed must
     // not leave a copy of the host's Claude config sitting on disk. The rest of
     // the agent dir (sessions, media) is deliberately preserved.
+    //
+    // No isSymbolicLink() guard here, unlike the workspace link above: rmSync
+    // does not traverse a symlink even with recursive, it unlinks the link
+    // itself, so a symlink standing at this path cannot lead the delete outside
+    // the agent dir. The workspace guard exists for a different reason — that
+    // path may legitimately hold a *user* agent's real workspace.
     try {
       fs.rmSync(path.join(this.agentsDir, agentName, '.claude-seed'), {
         recursive: true,

--- a/src/config/claude-settings.ts
+++ b/src/config/claude-settings.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Where Claude Code's user-scoped config lives, and how to read it.
+ *
+ * Three separate call sites need this file — the model catalog's `env`-block
+ * lookup, the user-scoped MCP server list, and the credentials forwarded into
+ * an app-agent container — and each one that hardcodes `~/.claude` silently
+ * ignores an operator who relocated the directory with `CLAUDE_CONFIG_DIR`.
+ * Centralizing it here is the same move `claude-bin.ts` made for the binary:
+ * one resolver, so the next call site cannot reintroduce the bug.
+ *
+ * For the container credentials that gap is not cosmetic. Reading a path that
+ * does not exist forwards no credential at all, which reproduces the exact
+ * "Not logged in" failure the forwarding was added to prevent.
+ */
+
+/**
+ * Claude Code's config directory: `CLAUDE_CONFIG_DIR` when set, `~/.claude`
+ * otherwise. Mirrors the CLI's own resolution order.
+ */
+export function claudeConfigDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir(),
+): string {
+  return env.CLAUDE_CONFIG_DIR || path.join(homeDir, '.claude');
+}
+
+/** Absolute path of the user-scoped `settings.json`. */
+export function claudeSettingsPath(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir(),
+): string {
+  return path.join(claudeConfigDir(env, homeDir), 'settings.json');
+}
+
+/**
+ * Parsed `settings.json`, or null when it is absent, unreadable, or not valid
+ * JSON — all three are ordinary states, not errors, so callers fall back to
+ * whatever other source they have.
+ *
+ * Only a plain object is returned. The file is operator-edited and therefore
+ * untrusted: a top-level array, string or number parses fine but would make a
+ * caller's property access read array indices or silently yield undefined.
+ */
+export function readClaudeSettings(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir(),
+): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(claudeSettingsPath(env, homeDir), 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The `env` block of `settings.json`, or an empty object when absent.
+ *
+ * Claude Code applies this block internally rather than exporting it, so a
+ * value set only there is invisible to `process.env` and has to be read from
+ * the file. Same untrusted-input rule as above: a non-object `env` is treated
+ * as absent rather than indexed into.
+ */
+export function claudeSettingsEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir(),
+): Record<string, unknown> {
+  const raw = readClaudeSettings(env, homeDir)?.env;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  return raw as Record<string, unknown>;
+}

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -26,24 +26,28 @@ export const MAX_HISTORY_MESSAGES = 50;
  * Claude credential / API-routing env vars forwarded from the host into an
  * app-agent container. Deliberately narrow — auth and endpoint only. Model and
  * behaviour settings come from the agent's own config, not the host env.
- */
-export const CONTAINER_AUTH_ENV_KEYS = [
-  'CLAUDE_CODE_OAUTH_TOKEN',
-  'ANTHROPIC_API_KEY',
-  'ANTHROPIC_AUTH_TOKEN',
-  'ANTHROPIC_BASE_URL',
-] as const;
-
-/**
- * The subset of CONTAINER_AUTH_ENV_KEYS that proves an identity, as opposed to
- * merely selecting an endpoint. These resolve as a group so a container is
- * never handed two credentials from two different sources — see
- * resolveContainerAuthEnv().
+ *
+ * The keys that prove an identity, as opposed to merely selecting an endpoint.
+ * These resolve as a group so a container is never handed two credentials from
+ * two different sources — see resolveContainerAuthEnv().
  */
 const CONTAINER_CREDENTIAL_KEYS: readonly string[] = [
   'CLAUDE_CODE_OAUTH_TOKEN',
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_AUTH_TOKEN',
+];
+
+/**
+ * The credential keys plus the endpoint selector. Derived from
+ * CONTAINER_CREDENTIAL_KEYS rather than repeated, so the two lists cannot drift:
+ * a credential added to one is automatically forwarded by the other.
+ *
+ * ANTHROPIC_BASE_URL is not a credential — it only selects an endpoint — so it
+ * sits outside the group that resolves atomically in resolveContainerAuthEnv().
+ */
+const CONTAINER_AUTH_ENV_KEYS: readonly string[] = [
+  ...CONTAINER_CREDENTIAL_KEYS,
+  'ANTHROPIC_BASE_URL',
 ];
 
 // The MCP reply tools that deliver an agent's user-facing message to a channel.
@@ -487,15 +491,27 @@ export class SessionProcess extends EventEmitter {
    * inode is unlinked, so the agent stayed healthy and answered every real user
    * "Not logged in · Please run /login" until someone recreated the container.
    *
-   * Resolving by path here, once per spawn, is immune to that: the container is
-   * handed the current credentials on every turn, and a container already stuck
-   * on a stale mount recovers on its next turn with no restart.
+   * That mechanism was verified directly rather than inferred: with content held
+   * byte-identical (same md5) and only the link count differing, a container
+   * reading the unlinked inode reported "Not logged in" and sent no request,
+   * while the same file at nlink=1 authenticated normally.
+   *
+   * Resolving by path here is immune to that: the container is handed the
+   * current credentials every time a session subprocess is spawned. Because the
+   * unlinked file is *ignored* rather than merely stale, the forwarded env is
+   * what the CLI ends up using — so a container stuck on a stale mount recovers
+   * on its next session spawn, with no container recreate. Note the cadence is
+   * per spawn, not per turn: one `docker exec` serves a whole session and later
+   * turns are written to its stdin, so a rotated credential reaches a live
+   * session only when it is respawned (idle reap, restart or config change).
    *
    * settings.json wins over the gateway's own environment. That matches Claude
-   * Code, which applies the file's `env` block over whatever it inherited, and
-   * it keeps the live file as the single source of truth — a long-lived gateway
-   * started with an exported token would otherwise pin the container to a
-   * credential that can never be rotated without restarting the service.
+   * Code, which applies the file's `env` block over whatever it inherited (also
+   * verified: with both sources set to different endpoints, every request went
+   * to the file's), and it keeps the live file as the single source of truth — a
+   * long-lived gateway started with an exported token would otherwise pin the
+   * container to a credential that can never be rotated without restarting the
+   * service.
    *
    * Credentials resolve as a GROUP, not key by key. If the file declares an
    * identity at all, the gateway's environment must not contribute a *different*
@@ -525,21 +541,54 @@ export class SessionProcess extends EventEmitter {
     const fileDeclaresCredential = CONTAINER_CREDENTIAL_KEYS.some((k) => k in fileEnv);
 
     const resolved: Record<string, string> = {};
+    const dropped: Array<{ key: string; reason: string }> = [];
     for (const key of CONTAINER_AUTH_ENV_KEYS) {
       let value: unknown;
+      let origin: string;
       if (key in fileEnv) {
         value = fileEnv[key];
+        origin = 'settings.json';
       } else if (fileDeclaresCredential && CONTAINER_CREDENTIAL_KEYS.includes(key)) {
         continue; // the file owns the identity — don't mix in another one
       } else {
         value = process.env[key];
+        origin = 'gateway env';
       }
       // settings.json is untrusted input: forward only a clean, non-empty
       // string. A NUL byte throws at spawn, and a newline is never legitimate
       // in a credential or a base URL.
-      if (typeof value !== 'string' || value.length === 0) continue;
-      if (/[\0\r\n]/.test(value)) continue;
+      if (value === undefined) continue; // simply not set anywhere — not a defect
+      if (typeof value !== 'string') {
+        dropped.push({ key, reason: `${origin} value is ${typeof value}, not a string` });
+        continue;
+      }
+      if (value.length === 0) {
+        dropped.push({ key, reason: `${origin} value is empty` });
+        continue;
+      }
+      if (/[\0\r\n]/.test(value)) {
+        dropped.push({ key, reason: `${origin} value contains a NUL or newline` });
+        continue;
+      }
       resolved[key] = value;
+    }
+
+    // Never fail silently. The bug this whole path exists to fix presented as a
+    // container that looked healthy while answering real users "Not logged in",
+    // so a spawn that forwards no credential at all must say so — otherwise a
+    // malformed token in settings.json reproduces the original symptom with the
+    // original silence. `dropped` names the reason without ever logging a value.
+    const forwardedCredentials = CONTAINER_CREDENTIAL_KEYS.filter((k) => k in resolved);
+    if (forwardedCredentials.length === 0) {
+      this.logger.warn(
+        'No Claude credential could be resolved for this container agent — it will likely report "Not logged in"',
+        { sessionId: this.sessionId, dropped, checked: CONTAINER_AUTH_ENV_KEYS },
+      );
+    } else if (dropped.length > 0) {
+      this.logger.debug('Some container auth env vars were not forwarded', {
+        sessionId: this.sessionId,
+        dropped,
+      });
     }
     return resolved;
   }
@@ -869,19 +918,24 @@ export class SessionProcess extends EventEmitter {
     const containerEnv: Record<string, string> = {
       HOME: os.homedir(),
       CLAUDE_WORKSPACE: '/workspace',
-      TELEGRAM_BOT_TOKEN: this.agentConfig.telegram?.botToken ?? '',
       GATEWAY_RESTART_SIGNAL_PATH: containerRestartPath,
     };
     if (process.env.GATEWAY_API_URL) containerEnv.GATEWAY_API_URL = process.env.GATEWAY_API_URL;
 
-    // Credentials are forwarded by NAME only (`-e KEY`, no `=value`), which makes
+    // Secrets are forwarded by NAME only (`-e KEY`, no `=value`), which makes
     // Docker read the value from this process's own environment (set on the spawn
-    // below). The token therefore never lands on the docker argv, where any local
-    // user could read it out of `ps`.
+    // below). The value therefore never lands on the docker argv, where any local
+    // user could read it out of `ps`: /proc/<pid>/cmdline is world-readable on a
+    // stock kernel, whereas /proc/<pid>/environ is owner-only.
+    //
+    // TELEGRAM_BOT_TOKEN travels by name for exactly the same reason as the
+    // Claude credentials — it is a bearer token for the agent's whole bot
+    // account. It is already placed in the spawn env below, unconditionally.
     const containerAuthEnv = isAppAgent ? this.resolveContainerAuthEnv() : {};
+    const byNameKeys = ['TELEGRAM_BOT_TOKEN', ...Object.keys(containerAuthEnv)];
     const dockerEnvFlags = [
       ...Object.entries(containerEnv).flatMap(([k, v]) => ['-e', `${k}=${v}`]),
-      ...Object.keys(containerAuthEnv).flatMap((k) => ['-e', k]),
+      ...byNameKeys.flatMap((k) => ['-e', k]),
     ];
 
     const spawnArgs = isAppAgent

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -13,6 +13,7 @@ import { createLogger } from '../logger';
 import { ptyStreamRegistry } from '../shell/pty-stream-registry';
 import { neutralizeTuiTriggers } from '../shell/screen';
 import { resolveClaudeBin, pathWithNativeBin } from './claude-bin';
+import { claudeSettingsEnv, readClaudeSettings } from '../config/claude-settings';
 import {
   CODING_TOOLS,
   TOOL_LABELS,
@@ -467,17 +468,14 @@ export class SessionProcess extends EventEmitter {
   }
 
   /**
-   * Read stdio MCP servers from Claude Code's user-scoped config (~/.claude/settings.json).
+   * Read stdio MCP servers from Claude Code's user-scoped config
+   * (`$CLAUDE_CONFIG_DIR/settings.json`, else `~/.claude/settings.json`).
    * Returns empty object if file doesn't exist, can't be parsed, or has no mcpServers.
    */
   private readUserScopedMcp(): Record<string, unknown> {
-    try {
-      const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-      const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-      return (parsed?.mcpServers as Record<string, unknown>) ?? {};
-    } catch {
-      return {};
-    }
+    const servers = readClaudeSettings()?.mcpServers;
+    if (!servers || typeof servers !== 'object' || Array.isArray(servers)) return {};
+    return servers as Record<string, unknown>;
   }
 
   /**
@@ -521,19 +519,11 @@ export class SessionProcess extends EventEmitter {
    * not part of that group and keeps its own independent fallback.
    */
   private resolveContainerAuthEnv(): Record<string, string> {
-    let fileEnv: Record<string, unknown> = {};
-    try {
-      const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-      const parsed: unknown = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-      const rawEnv = (parsed as { env?: unknown } | null)?.env;
-      // Only a plain object is usable. An `env` that is a string or an array
-      // would make the `in` checks below throw or read array indices.
-      if (rawEnv && typeof rawEnv === 'object' && !Array.isArray(rawEnv)) {
-        fileEnv = rawEnv as Record<string, unknown>;
-      }
-    } catch {
-      // No readable user settings — the gateway's own env is then the only source.
-    }
+    // Resolved through the shared helper so an operator who relocated the config
+    // with CLAUDE_CONFIG_DIR is honoured here too. Hardcoding ~/.claude would
+    // read a path that does not exist and forward nothing — reproducing the very
+    // "Not logged in" failure this method was written to prevent.
+    const fileEnv = claudeSettingsEnv();
 
     // Presence, not validity: a credential key spelled out in settings.json is
     // authoritative for the whole group even when its value is malformed, so a

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -34,6 +34,18 @@ export const CONTAINER_AUTH_ENV_KEYS = [
   'ANTHROPIC_BASE_URL',
 ] as const;
 
+/**
+ * The subset of CONTAINER_AUTH_ENV_KEYS that proves an identity, as opposed to
+ * merely selecting an endpoint. These resolve as a group so a container is
+ * never handed two credentials from two different sources — see
+ * resolveContainerAuthEnv().
+ */
+const CONTAINER_CREDENTIAL_KEYS: readonly string[] = [
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+];
+
 // The MCP reply tools that deliver an agent's user-facing message to a channel.
 // Their text lives in the tool_use `input.text`, not in an assistant text block,
 // so it is never captured by `assistantBuffer` — the reply is delivered to the
@@ -484,20 +496,44 @@ export class SessionProcess extends EventEmitter {
    * it keeps the live file as the single source of truth — a long-lived gateway
    * started with an exported token would otherwise pin the container to a
    * credential that can never be rotated without restarting the service.
+   *
+   * Credentials resolve as a GROUP, not key by key. If the file declares an
+   * identity at all, the gateway's environment must not contribute a *different*
+   * one: forwarding a file OAuth token alongside an environment
+   * ANTHROPIC_API_KEY would hand the container two identities and let the CLI
+   * choose between them silently. A base URL only selects an endpoint, so it is
+   * not part of that group and keeps its own independent fallback.
    */
   private resolveContainerAuthEnv(): Record<string, string> {
     let fileEnv: Record<string, unknown> = {};
     try {
       const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-      const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-      fileEnv = (parsed?.env as Record<string, unknown>) ?? {};
+      const parsed: unknown = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      const rawEnv = (parsed as { env?: unknown } | null)?.env;
+      // Only a plain object is usable. An `env` that is a string or an array
+      // would make the `in` checks below throw or read array indices.
+      if (rawEnv && typeof rawEnv === 'object' && !Array.isArray(rawEnv)) {
+        fileEnv = rawEnv as Record<string, unknown>;
+      }
     } catch {
       // No readable user settings — the gateway's own env is then the only source.
     }
 
+    // Presence, not validity: a credential key spelled out in settings.json is
+    // authoritative for the whole group even when its value is malformed, so a
+    // broken token can never silently fall back to a different identity.
+    const fileDeclaresCredential = CONTAINER_CREDENTIAL_KEYS.some((k) => k in fileEnv);
+
     const resolved: Record<string, string> = {};
     for (const key of CONTAINER_AUTH_ENV_KEYS) {
-      const value = fileEnv[key] ?? process.env[key];
+      let value: unknown;
+      if (key in fileEnv) {
+        value = fileEnv[key];
+      } else if (fileDeclaresCredential && CONTAINER_CREDENTIAL_KEYS.includes(key)) {
+        continue; // the file owns the identity — don't mix in another one
+      } else {
+        value = process.env[key];
+      }
       // settings.json is untrusted input: forward only a clean, non-empty
       // string. A NUL byte throws at spawn, and a newline is never legitimate
       // in a credential or a base URL.

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -22,6 +22,18 @@ import {
 
 export const MAX_HISTORY_MESSAGES = 50;
 
+/**
+ * Claude credential / API-routing env vars forwarded from the host into an
+ * app-agent container. Deliberately narrow — auth and endpoint only. Model and
+ * behaviour settings come from the agent's own config, not the host env.
+ */
+export const CONTAINER_AUTH_ENV_KEYS = [
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_BASE_URL',
+] as const;
+
 // The MCP reply tools that deliver an agent's user-facing message to a channel.
 // Their text lives in the tool_use `input.text`, not in an assistant text block,
 // so it is never captured by `assistantBuffer` — the reply is delivered to the
@@ -453,6 +465,50 @@ export class SessionProcess extends EventEmitter {
   }
 
   /**
+   * Resolve the Claude credentials handed to an app-agent container this spawn.
+   *
+   * Container agents used to receive their credentials as a read-only bind mount
+   * of the host ~/.claude/settings.json. A Docker *file* bind mount pins an
+   * inode rather than a path, and Claude Code rewrites that file by atomic
+   * rename — so the first host settings change left every long-lived container
+   * reading a deleted inode. Claude Code silently ignores a settings.json whose
+   * inode is unlinked, so the agent stayed healthy and answered every real user
+   * "Not logged in · Please run /login" until someone recreated the container.
+   *
+   * Resolving by path here, once per spawn, is immune to that: the container is
+   * handed the current credentials on every turn, and a container already stuck
+   * on a stale mount recovers on its next turn with no restart.
+   *
+   * settings.json wins over the gateway's own environment. That matches Claude
+   * Code, which applies the file's `env` block over whatever it inherited, and
+   * it keeps the live file as the single source of truth — a long-lived gateway
+   * started with an exported token would otherwise pin the container to a
+   * credential that can never be rotated without restarting the service.
+   */
+  private resolveContainerAuthEnv(): Record<string, string> {
+    let fileEnv: Record<string, unknown> = {};
+    try {
+      const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+      const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      fileEnv = (parsed?.env as Record<string, unknown>) ?? {};
+    } catch {
+      // No readable user settings — the gateway's own env is then the only source.
+    }
+
+    const resolved: Record<string, string> = {};
+    for (const key of CONTAINER_AUTH_ENV_KEYS) {
+      const value = fileEnv[key] ?? process.env[key];
+      // settings.json is untrusted input: forward only a clean, non-empty
+      // string. A NUL byte throws at spawn, and a newline is never legitimate
+      // in a credential or a base URL.
+      if (typeof value !== 'string' || value.length === 0) continue;
+      if (/[\0\r\n]/.test(value)) continue;
+      resolved[key] = value;
+    }
+    return resolved;
+  }
+
+  /**
    * Read stdio MCP servers from Claude Code's project-scoped config (~/.claude.json).
    * Looks up projects[workspace].mcpServers for the agent's workspace path.
    * Returns empty object if not found or on any error.
@@ -781,7 +837,16 @@ export class SessionProcess extends EventEmitter {
       GATEWAY_RESTART_SIGNAL_PATH: containerRestartPath,
     };
     if (process.env.GATEWAY_API_URL) containerEnv.GATEWAY_API_URL = process.env.GATEWAY_API_URL;
-    const dockerEnvFlags = Object.entries(containerEnv).flatMap(([k, v]) => ['-e', `${k}=${v}`]);
+
+    // Credentials are forwarded by NAME only (`-e KEY`, no `=value`), which makes
+    // Docker read the value from this process's own environment (set on the spawn
+    // below). The token therefore never lands on the docker argv, where any local
+    // user could read it out of `ps`.
+    const containerAuthEnv = isAppAgent ? this.resolveContainerAuthEnv() : {};
+    const dockerEnvFlags = [
+      ...Object.entries(containerEnv).flatMap(([k, v]) => ['-e', `${k}=${v}`]),
+      ...Object.keys(containerAuthEnv).flatMap((k) => ['-e', k]),
+    ];
 
     const spawnArgs = isAppAgent
       ? [
@@ -809,6 +874,7 @@ export class SessionProcess extends EventEmitter {
     const proc = spawn(spawnBin, spawnArgs, {
       env: {
         ...process.env,
+        ...containerAuthEnv,
         ...(hardenedPath ? { PATH: hardenedPath } : {}),
         CLAUDE_WORKSPACE: isAppAgent ? '/workspace' : this.agentConfig.workspace,
         TELEGRAM_BOT_TOKEN: this.agentConfig.telegram?.botToken ?? '',

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -464,6 +464,28 @@ describe('AgentManager', () => {
       expect(fs.existsSync(agentDir)).toBe(true);
     });
 
+    it('drops the Claude config seed on delete but keeps session history', async () => {
+      // The seed is a copy of the host ~/.claude.json, re-staged from the host on
+      // every install/update. It is derived data, so a removed app must not leave
+      // a copy of the host's Claude config behind — unlike sessions, which are
+      // kept so a reinstall resumes the same conversations.
+      const entry = makeEntry(tmpDir);
+      manager.injectAgentService(entry);
+      await manager.upsertAgent(entry);
+
+      const agentDir = path.join(tmpDir, 'agents', 'my-agent');
+      const seedDir = path.join(agentDir, '.claude-seed');
+      const sessions = path.join(agentDir, 'sessions');
+      fs.mkdirSync(sessions, { recursive: true });
+      fs.writeFileSync(path.join(sessions, 'a.json'), '{}', 'utf-8');
+      expect(fs.existsSync(path.join(seedDir, '.claude.json'))).toBe(true);
+
+      await manager.deleteAgent(entry);
+
+      expect(fs.existsSync(seedDir)).toBe(false);
+      expect(fs.existsSync(path.join(sessions, 'a.json'))).toBe(true);
+    });
+
     it('removes the config.json entry', async () => {
       const entry = makeEntry(tmpDir);
       await manager.upsertAgent(entry);

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -471,6 +471,33 @@ describe('AgentManager', () => {
       // Not world-readable: it is a copy of the host's Claude config.
       expect(fs.statSync(seedFile).mode & 0o077).toBe(0);
     });
+
+    it('stages the seed atomically, leaving no partial file when the copy fails', async () => {
+      // A container copies this file in its start command, which can run while
+      // the gateway is re-staging. Writing in place would let it read a
+      // half-written config; write-then-rename means it sees the old file or
+      // the new one. A failed copy must therefore leave the previous seed
+      // intact and no temp file behind.
+      const entry = makeEntry(tmpDir);
+      await manager.upsertAgent(entry);
+
+      const seedDir = path.join(tmpDir, 'agents', 'my-agent', '.claude-seed');
+      const seedFile = path.join(seedDir, '.claude.json');
+      const before = fs.readFileSync(seedFile, 'utf-8');
+
+      // Make the copy fail for real rather than mocking it: a directory where
+      // the host config should be passes existsSync and then throws EISDIR.
+      const hostClaudeJson = path.join(os.homedir(), '.claude.json');
+      fs.rmSync(hostClaudeJson);
+      fs.mkdirSync(hostClaudeJson);
+
+      // upsertAgent swallows a staging failure by design — the point is what it
+      // leaves on disk.
+      await manager.upsertAgent(entry);
+
+      expect(fs.readFileSync(seedFile, 'utf-8')).toBe(before);
+      expect(fs.readdirSync(seedDir).filter((f) => f.includes('.tmp.'))).toEqual([]);
+    });
   });
 
   // ─── deleteAgent() ────────────────────────────────────────────────────────

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -240,8 +240,10 @@ describe('AgentManager', () => {
       expect(realPathMount).toBeUndefined();
 
       // The container copies the seed into a writable ~/.claude.json at start.
+      // Paths are quoted: homeDir is host-derived, and an unquoted path with a
+      // space would split into extra `cp` operands and land the config elsewhere.
       const command = agentSvc['command'] as string;
-      expect(command).toContain(`cp ${home}/.claude-seed/.claude.json ${home}/.claude.json`);
+      expect(command).toContain(`cp "${home}/.claude-seed/.claude.json" "${home}/.claude.json"`);
       // `;` not `&&`: a failed copy must not stop the container from starting.
       expect(command).toContain('; exec sleep infinity');
     });
@@ -444,6 +446,30 @@ describe('AgentManager', () => {
 
       const workspaceLink = path.join(tmpDir, 'agents', 'my-agent');
       expect(fs.existsSync(workspaceLink)).toBe(false);
+    });
+
+    it('re-stages the Claude config seed, so a gateway restart refreshes it', async () => {
+      // reconcileAgents() calls upsertAgent for every running app-agent at gateway
+      // start. Staging only from injectAgentService would pin the seed to the last
+      // install/update, so a host-side `claude /login` could stay invisible to
+      // containers indefinitely.
+      const entry = makeEntry(tmpDir);
+      await manager.upsertAgent(entry);
+
+      const seedFile = path.join(tmpDir, 'agents', 'my-agent', '.claude-seed', '.claude.json');
+      expect(fs.existsSync(seedFile)).toBe(true);
+
+      // Rewrite the host file the way Claude Code does — atomic rename, new inode.
+      const hostClaudeJson = path.join(os.homedir(), '.claude.json');
+      const tmpHost = `${hostClaudeJson}.tmp`;
+      fs.writeFileSync(tmpHost, JSON.stringify({ marker: 'rotated' }), 'utf-8');
+      fs.renameSync(tmpHost, hostClaudeJson);
+
+      await manager.upsertAgent(entry);
+
+      expect(JSON.parse(fs.readFileSync(seedFile, 'utf-8'))).toEqual({ marker: 'rotated' });
+      // Not world-readable: it is a copy of the host's Claude config.
+      expect(fs.statSync(seedFile).mode & 0o077).toBe(0);
     });
   });
 

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -5,6 +5,24 @@ import yaml from 'js-yaml';
 import { AgentManager } from '../../../src/apps/agent-manager';
 import { AppsRegistry, AppEntry } from '../../../src/apps/registry';
 
+// ── os.homedir mock (set per-test) ────────────────────────────────────────────
+// injectAgentService() reads and stages the host ~/.claude.json, so the suite
+// points HOME at a fixture dir: deterministic on a bare CI box, and it never
+// touches the real user's home. Both specifiers are mocked because the source
+// imports 'node:os' while some deps import bare 'os'.
+// `var`, not `let`: agent-manager.ts calls os.homedir() at module scope, which
+// runs before a `let` in this file would leave its temporal dead zone.
+// eslint-disable-next-line no-var
+var mockHomeDir: string | null = null;
+jest.mock('node:os', () => {
+  const real = jest.requireActual<typeof os>('node:os');
+  return { ...real, homedir: () => mockHomeDir ?? real.homedir() };
+});
+jest.mock('os', () => {
+  const real = jest.requireActual<typeof os>('node:os');
+  return { ...real, homedir: () => mockHomeDir ?? real.homedir() };
+});
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function makeTmpDir(): string {
@@ -71,10 +89,15 @@ describe('AgentManager', () => {
 
   beforeEach(() => {
     tmpDir = makeTmpDir();
+    // Fixture home: injectAgentService() stages ~/.claude.json into the seed dir.
+    mockHomeDir = path.join(tmpDir, 'home');
+    fs.mkdirSync(path.join(mockHomeDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(mockHomeDir, '.claude.json'), JSON.stringify({ projects: {} }), 'utf-8');
     manager = makeManager(tmpDir);
   });
 
   afterEach(() => {
+    mockHomeDir = null;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -136,10 +159,62 @@ describe('AgentManager', () => {
       expect(volumes).toBeDefined();
       expect(volumes.some((v) => v.includes('claude') && v.endsWith(':ro'))).toBe(true);
       expect(volumes.some((v) => v.endsWith(':/workspace'))).toBe(true);
-      // ~/.claude.json is mounted read-only to a *seed* path (copied to a writable
-      // file at container start — see the regression test below), not at its real path.
-      expect(volumes.some((v) => v.includes('.claude.json.seed') && v.endsWith(':ro'))).toBe(true);
-      expect(volumes.some((v) => v.includes('settings.json') && v.endsWith(':ro'))).toBe(true);
+      // ~/.claude.json reaches the container through a read-only seed *directory*
+      // (copied to a writable file at container start — see the regression tests
+      // below), never as a mount of the host file itself.
+      expect(volumes.some((v) => v.includes('.claude-seed') && v.endsWith(':ro'))).toBe(true);
+    });
+
+    it('never bind-mounts an individual host Claude config file (regression: stale inode => "Not logged in")', () => {
+      // A Docker *file* bind mount pins an inode, not a path. Claude Code rewrites
+      // ~/.claude/settings.json and ~/.claude.json by atomic rename, which
+      // allocates a new inode on the host and unlinks the old one — leaving a
+      // long-lived container reading a deleted inode for the rest of its life.
+      // Claude Code silently ignores a settings.json whose inode is unlinked, so
+      // every app-agent turn returned "Not logged in · Please run /login" with no
+      // crash and nothing in the logs. Mount sources must therefore be directories.
+      const entry = makeEntry(tmpDir);
+      manager.injectAgentService(entry);
+
+      const composePath = path.join(entry.installPath, 'docker-compose.yml');
+      const composed = yaml.load(fs.readFileSync(composePath, 'utf-8')) as Record<string, unknown>;
+      const services = composed['services'] as Record<string, unknown>;
+      const agentSvc = services['agent'] as Record<string, unknown>;
+      const volumes = agentSvc['volumes'] as string[];
+      const home = os.homedir();
+
+      const sources = volumes.map((v) => v.split(':')[0]);
+      expect(sources).not.toContain(path.join(home, '.claude', 'settings.json'));
+      expect(sources).not.toContain(path.join(home, '.claude.json'));
+    });
+
+    it('stages the Claude config seed as a private directory the gateway owns', () => {
+      const entry = makeEntry(tmpDir);
+      manager.injectAgentService(entry);
+
+      const composePath = path.join(entry.installPath, 'docker-compose.yml');
+      const composed = yaml.load(fs.readFileSync(composePath, 'utf-8')) as Record<string, unknown>;
+      const services = composed['services'] as Record<string, unknown>;
+      const agentSvc = services['agent'] as Record<string, unknown>;
+      const volumes = agentSvc['volumes'] as string[];
+      const home = os.homedir();
+
+      // Staged next to the agent's media dir, outside the app's install path so an
+      // app service's own compose can never mount it.
+      const seedDir = path.join(tmpDir, 'agents', 'my-agent', '.claude-seed');
+      expect(fs.statSync(seedDir).isDirectory()).toBe(true);
+      expect(fs.statSync(seedDir).mode & 0o777).toBe(0o700);
+
+      // The host ~/.claude.json is copied in, not mounted, and stays private.
+      const staged = path.join(seedDir, '.claude.json');
+      expect(fs.readFileSync(staged, 'utf-8')).toBe(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8'));
+      expect(fs.statSync(staged).mode & 0o777).toBe(0o600);
+
+      // Mounted read-only as a directory, so Docker resolves entries per access.
+      const seedMount = volumes.find((v) => v.split(':')[1] === `${home}/.claude-seed`);
+      expect(seedMount).toBeDefined();
+      expect(seedMount!.endsWith(':ro')).toBe(true);
+      expect(seedMount!.split(':')[0]).toBe(fs.realpathSync(seedDir));
     });
 
     it('seeds a writable ~/.claude.json via copy instead of a read-only mount at its real path (regression: app-agent "Not logged in")', () => {
@@ -147,8 +222,8 @@ describe('AgentManager', () => {
       // rename over the target). Bind-mounting the host file at its real container
       // path makes that rename fail with EBUSY, so auth state is never persisted
       // and every app-agent turn returns "Not logged in · Please run /login".
-      // Fix: mount the host file read-only to a seed path (host file untouched) and
-      // copy it into a writable ~/.claude.json at container start.
+      // Fix: stage the host file in a read-only seed dir and copy it into a
+      // writable ~/.claude.json at container start.
       const entry = makeEntry(tmpDir);
       manager.injectAgentService(entry);
 
@@ -164,15 +239,27 @@ describe('AgentManager', () => {
       const realPathMount = volumes.find((v) => v.split(':')[1] === `${home}/.claude.json`);
       expect(realPathMount).toBeUndefined();
 
-      // It is mounted read-only to a seed path, sourced from the host file.
-      const seedMount = volumes.find((v) => v.split(':')[1] === `${home}/.claude.json.seed`);
-      expect(seedMount).toBeDefined();
-      expect(seedMount!.endsWith(':ro')).toBe(true);
-      expect(seedMount!.split(':')[0]).toBe(`${home}/.claude.json`);
-
       // The container copies the seed into a writable ~/.claude.json at start.
       const command = agentSvc['command'] as string;
-      expect(command).toContain(`cp ${home}/.claude.json.seed ${home}/.claude.json`);
+      expect(command).toContain(`cp ${home}/.claude-seed/.claude.json ${home}/.claude.json`);
+      // `;` not `&&`: a failed copy must not stop the container from starting.
+      expect(command).toContain('; exec sleep infinity');
+    });
+
+    it('omits the seed copy when the host has no ~/.claude.json', () => {
+      fs.rmSync(path.join(mockHomeDir!, '.claude.json'));
+      const entry = makeEntry(tmpDir);
+      manager.injectAgentService(entry);
+
+      const composePath = path.join(entry.installPath, 'docker-compose.yml');
+      const composed = yaml.load(fs.readFileSync(composePath, 'utf-8')) as Record<string, unknown>;
+      const services = composed['services'] as Record<string, unknown>;
+      const agentSvc = services['agent'] as Record<string, unknown>;
+
+      // No dangling `cp` of a file that does not exist — the container still idles.
+      const command = agentSvc['command'] as string;
+      expect(command).not.toContain('cp ');
+      expect(command).toContain('sleep infinity');
     });
 
     it('mounts the agent media dir at the identical host path (:rw) and pre-creates it', () => {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -2979,6 +2979,44 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
     }
   });
 
+  it('U-SP-AUTH6: a credential in settings.json blocks the env from adding a second one', async () => {
+    // Credentials resolve as a group. If the file proves an identity, the
+    // gateway env must not contribute a *different* one — a file OAuth token
+    // forwarded alongside an env ANTHROPIC_API_KEY hands the container two
+    // identities and lets the CLI silently pick between them. A base URL only
+    // selects an endpoint, so it still falls through independently.
+    process.env.ANTHROPIC_API_KEY = 'key-from-gateway-env';
+    process.env.ANTHROPIC_BASE_URL = 'https://from-gateway-env.invalid';
+    try {
+      await withFakeAuthHome({ CLAUDE_CODE_OAUTH_TOKEN: 'token-from-settings' }, async () => {
+        const appAgent = makeAgentConfig({
+          workspace: agentConfig.workspace,
+          type: 'app-agent',
+          container: 'my-app-container',
+        });
+        const sp = makeSp('chat:auth6', 'telegram', appAgent, gatewayConfig, sessionStore);
+        await sp.start();
+
+        const [, spawnArgs, spawnOpts] = spawnMock.mock.calls[0] as [
+          string,
+          string[],
+          { env: Record<string, string> },
+        ];
+        expect(spawnOpts.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('token-from-settings');
+        // The competing env credential is neither forwarded nor announced to docker.
+        expect(spawnArgs).not.toContain('ANTHROPIC_API_KEY');
+        // Endpoint routing is not an identity, so it still falls through.
+        expect(spawnOpts.env.ANTHROPIC_BASE_URL).toBe('https://from-gateway-env.invalid');
+        expect(spawnArgs).toContain('ANTHROPIC_BASE_URL');
+
+        await sp.stop();
+      });
+    } finally {
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.ANTHROPIC_BASE_URL;
+    }
+  });
+
   // --------------------------------------------------------------------------
   // U-SP-BIN5: a genuinely unresolvable binary surfaces as an ENOENT `error`  // event (NOT on stderr). It must still be captured into lastStderrLine so the
   // fatal max-restarts log can name the cause and fire the CLAUDE_BIN hint.

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -2915,7 +2915,16 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
 
   it('U-SP-AUTH3: a malformed credential in settings.json is not forwarded', async () => {
     await withFakeAuthHome(
-      { CLAUDE_CODE_OAUTH_TOKEN: '', ANTHROPIC_API_KEY: 42, ANTHROPIC_AUTH_TOKEN: 'bad\nvalue' },
+      {
+        CLAUDE_CODE_OAUTH_TOKEN: '',
+        ANTHROPIC_API_KEY: 42,
+        ANTHROPIC_AUTH_TOKEN: 'bad\nvalue',
+        // A well-formed value alongside the bad ones, to anchor the negative
+        // assertions below: without it, "not forwarded" also holds when nothing
+        // is forwarded at all — the pre-fix behaviour — and this spec would pass
+        // on the very bug it guards.
+        ANTHROPIC_BASE_URL: 'https://example.invalid',
+      },
       async () => {
         const appAgent = makeAgentConfig({
           workspace: agentConfig.workspace,
@@ -2925,11 +2934,19 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
         const sp = makeSp('chat:auth3', 'telegram', appAgent, gatewayConfig, sessionStore);
         await sp.start();
 
-        const [, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]];
+        const [, spawnArgs, spawnOpts] = spawnMock.mock.calls[0] as [
+          string,
+          string[],
+          { env: Record<string, string> },
+        ];
         // Empty, non-string and newline-bearing values are all rejected at the boundary.
         expect(spawnArgs).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
         expect(spawnArgs).not.toContain('ANTHROPIC_API_KEY');
         expect(spawnArgs).not.toContain('ANTHROPIC_AUTH_TOKEN');
+        // ...while the clean value in the same file did make it through, proving
+        // the resolver ran and rejected only the malformed keys.
+        expect(spawnArgs).toContain('ANTHROPIC_BASE_URL');
+        expect(spawnOpts.env.ANTHROPIC_BASE_URL).toBe('https://example.invalid');
 
         await sp.stop();
       },
@@ -2945,8 +2962,23 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
       const [spawnBin, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]];
       expect(spawnBin).not.toBe('docker');
       expect(spawnArgs).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
-
       await sp.stop();
+
+      // Anchor: the same settings.json DOES produce the flag for an app-agent, so
+      // the assertion above is about the host path rather than about nothing being
+      // forwarded anywhere — which is what the pre-fix code did, and would have
+      // passed this spec.
+      const appAgent = makeAgentConfig({
+        workspace: agentConfig.workspace,
+        type: 'app-agent',
+        container: 'my-app-container',
+      });
+      const spContainer = makeSp('chat:auth4b', 'telegram', appAgent, gatewayConfig, sessionStore);
+      await spContainer.start();
+      const [, containerArgs] = spawnMock.mock.calls[1] as [string, string[]];
+      expect(containerArgs).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+
+      await spContainer.stop();
     });
   });
 
@@ -3014,6 +3046,71 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
     } finally {
       delete process.env.ANTHROPIC_API_KEY;
       delete process.env.ANTHROPIC_BASE_URL;
+    }
+  });
+
+  it('U-SP-AUTH7: the Telegram bot token is forwarded by name, never on the docker argv', async () => {
+    // Same threat model as the Claude credential: /proc/<pid>/cmdline is
+    // world-readable on a stock kernel while /proc/<pid>/environ is owner-only,
+    // so a `-e KEY=value` here would expose a bot-account bearer token to every
+    // local user via `ps`.
+    await withFakeAuthHome({ CLAUDE_CODE_OAUTH_TOKEN: 'tok' }, async () => {
+      const appAgent = makeAgentConfig({
+        workspace: agentConfig.workspace,
+        type: 'app-agent',
+        container: 'my-app-container',
+        telegram: { botToken: 'bot-secret-12345' },
+      });
+      const sp = makeSp('chat:auth7', 'telegram', appAgent, gatewayConfig, sessionStore);
+      await sp.start();
+
+      const [, spawnArgs, spawnOpts] = spawnMock.mock.calls[0] as [
+        string,
+        string[],
+        { env: Record<string, string> },
+      ];
+      expect(spawnArgs.some((a) => a.includes('bot-secret-12345'))).toBe(false);
+      // Anchor: announced by name and present in the env docker inherits, so the
+      // container still receives it.
+      expect(spawnArgs).toContain('TELEGRAM_BOT_TOKEN');
+      expect(spawnOpts.env.TELEGRAM_BOT_TOKEN).toBe('bot-secret-12345');
+
+      await sp.stop();
+    });
+  });
+
+  it('U-SP-AUTH8: a container agent with no resolvable credential warns instead of failing silently', async () => {
+    // The bug this path exists to fix presented as a container that looked
+    // healthy while telling real users "Not logged in". A malformed token that
+    // silently forwards nothing would reproduce exactly that, so it must be
+    // announced. Presence-not-validity means the empty token still owns the
+    // group and blocks the env from substituting a different identity.
+    process.env.ANTHROPIC_API_KEY = 'key-from-gateway-env';
+    try {
+      await withFakeAuthHome({ CLAUDE_CODE_OAUTH_TOKEN: '' }, async () => {
+        const appAgent = makeAgentConfig({
+          workspace: agentConfig.workspace,
+          type: 'app-agent',
+          container: 'my-app-container',
+        });
+        const sp = makeSp('chat:auth8', 'telegram', appAgent, gatewayConfig, sessionStore);
+        const warn = jest.spyOn((sp as unknown as { logger: { warn: (...a: unknown[]) => void } }).logger, 'warn');
+        await sp.start();
+
+        const [, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]];
+        expect(spawnArgs).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+        expect(spawnArgs).not.toContain('ANTHROPIC_API_KEY');
+
+        const warned = warn.mock.calls.find((c) => String(c[0]).includes('No Claude credential'));
+        expect(warned).toBeDefined();
+        // The reason is reported without ever logging the value itself.
+        expect(JSON.stringify(warned?.[1])).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+        expect(JSON.stringify(warned?.[1])).toContain('empty');
+
+        await sp.stop();
+      });
+    } finally {
+      delete process.env.ANTHROPIC_API_KEY;
     }
   });
 

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -2842,8 +2842,145 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
   });
 
   // --------------------------------------------------------------------------
-  // U-SP-BIN5: a genuinely unresolvable binary surfaces as an ENOENT `error`
-  // event (NOT on stderr). It must still be captured into lastStderrLine so the
+  // U-SP-AUTH1/2/3: app-agent containers get their Claude credentials as
+  // `docker exec` env resolved from the live host settings.json each spawn.
+  //
+  // Regression: credentials used to reach the container as a read-only bind
+  // mount of ~/.claude/settings.json. A Docker *file* bind mount pins an inode,
+  // not a path, and Claude Code rewrites that file by atomic rename — so the
+  // first host settings change left every long-lived container reading a
+  // deleted inode. Claude Code silently ignores a settings.json whose inode is
+  // unlinked, so the agent stayed healthy and answered every real user
+  // "Not logged in · Please run /login".
+  // --------------------------------------------------------------------------
+  function withFakeAuthHome(env: Record<string, unknown>, fn: () => Promise<void>): Promise<void> {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-authhome-'));
+    fs.mkdirSync(path.join(fakeHome, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(fakeHome, '.claude', 'settings.json'), JSON.stringify({ env }));
+    mockHomeDir = fakeHome;
+    return fn().finally(() => fs.rmSync(fakeHome, { recursive: true, force: true }));
+  }
+
+  it('U-SP-AUTH1: app-agent forwards host settings.json credentials into the container', async () => {
+    await withFakeAuthHome(
+      { CLAUDE_CODE_OAUTH_TOKEN: 'tok-from-settings', ANTHROPIC_BASE_URL: 'https://example.invalid' },
+      async () => {
+        const appAgent = makeAgentConfig({
+          workspace: agentConfig.workspace,
+          type: 'app-agent',
+          container: 'my-app-container',
+        });
+        const sp = makeSp('chat:auth1', 'telegram', appAgent, gatewayConfig, sessionStore);
+        await sp.start();
+
+        const [, spawnArgs, spawnOpts] = spawnMock.mock.calls[0] as [string, string[], { env: Record<string, string> }];
+
+        // Passed by NAME only, so Docker inherits the value from the gateway's env.
+        expect(spawnArgs).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+        expect(spawnArgs).toContain('ANTHROPIC_BASE_URL');
+        expect(spawnOpts.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('tok-from-settings');
+        expect(spawnOpts.env.ANTHROPIC_BASE_URL).toBe('https://example.invalid');
+
+        await sp.stop();
+      },
+    );
+  });
+
+  it('U-SP-AUTH2: the credential value never appears on the docker argv', async () => {
+    await withFakeAuthHome({ CLAUDE_CODE_OAUTH_TOKEN: 'super-secret-token' }, async () => {
+      const appAgent = makeAgentConfig({
+        workspace: agentConfig.workspace,
+        type: 'app-agent',
+        container: 'my-app-container',
+      });
+      const sp = makeSp('chat:auth2', 'telegram', appAgent, gatewayConfig, sessionStore);
+      await sp.start();
+
+      // `-e KEY=value` would expose the token to any local user via `ps`.
+      const [, spawnArgs, spawnOpts] = spawnMock.mock.calls[0] as [
+        string,
+        string[],
+        { env: Record<string, string> },
+      ];
+      expect(spawnArgs.some((a) => a.includes('super-secret-token'))).toBe(false);
+      // Anchor the assertion above: the token must be genuinely forwarded (via
+      // the process env docker inherits), just never written onto argv. Without
+      // this, "not on argv" also holds when nothing is forwarded at all — the
+      // pre-fix behaviour — and the spec would pass on the very bug it guards.
+      expect(spawnOpts.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('super-secret-token');
+
+      await sp.stop();
+    });
+  });
+
+  it('U-SP-AUTH3: a malformed credential in settings.json is not forwarded', async () => {
+    await withFakeAuthHome(
+      { CLAUDE_CODE_OAUTH_TOKEN: '', ANTHROPIC_API_KEY: 42, ANTHROPIC_AUTH_TOKEN: 'bad\nvalue' },
+      async () => {
+        const appAgent = makeAgentConfig({
+          workspace: agentConfig.workspace,
+          type: 'app-agent',
+          container: 'my-app-container',
+        });
+        const sp = makeSp('chat:auth3', 'telegram', appAgent, gatewayConfig, sessionStore);
+        await sp.start();
+
+        const [, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]];
+        // Empty, non-string and newline-bearing values are all rejected at the boundary.
+        expect(spawnArgs).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+        expect(spawnArgs).not.toContain('ANTHROPIC_API_KEY');
+        expect(spawnArgs).not.toContain('ANTHROPIC_AUTH_TOKEN');
+
+        await sp.stop();
+      },
+    );
+  });
+
+  it('U-SP-AUTH4: a host session gets no container credential flags', async () => {
+    await withFakeAuthHome({ CLAUDE_CODE_OAUTH_TOKEN: 'tok-from-settings' }, async () => {
+      const sp = makeSp('chat:auth4', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+
+      // Non-app-agents run claude directly; the credential plumbing is container-only.
+      const [spawnBin, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]];
+      expect(spawnBin).not.toBe('docker');
+      expect(spawnArgs).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+
+      await sp.stop();
+    });
+  });
+
+  it('U-SP-AUTH5: settings.json wins over the gateway env, which is only a fallback', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://from-gateway-env.invalid';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'tok-from-gateway-env';
+    try {
+      // The file carries the base URL but not the auth token.
+      await withFakeAuthHome({ ANTHROPIC_BASE_URL: 'https://from-settings.invalid' }, async () => {
+        const appAgent = makeAgentConfig({
+          workspace: agentConfig.workspace,
+          type: 'app-agent',
+          container: 'my-app-container',
+        });
+        const sp = makeSp('chat:auth5', 'telegram', appAgent, gatewayConfig, sessionStore);
+        await sp.start();
+
+        const [, , spawnOpts] = spawnMock.mock.calls[0] as [string, string[], { env: Record<string, string> }];
+        // The live file is the source of truth, so rotating it takes effect without
+        // restarting a long-lived gateway that was started with an exported value.
+        expect(spawnOpts.env.ANTHROPIC_BASE_URL).toBe('https://from-settings.invalid');
+        // Keys the file does not carry still fall through to the gateway env.
+        expect(spawnOpts.env.ANTHROPIC_AUTH_TOKEN).toBe('tok-from-gateway-env');
+
+        await sp.stop();
+      });
+    } finally {
+      delete process.env.ANTHROPIC_BASE_URL;
+      delete process.env.ANTHROPIC_AUTH_TOKEN;
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // U-SP-BIN5: a genuinely unresolvable binary surfaces as an ENOENT `error`  // event (NOT on stderr). It must still be captured into lastStderrLine so the
   // fatal max-restarts log can name the cause and fire the CLAUDE_BIN hint.
   // --------------------------------------------------------------------------
   it('U-SP-BIN5: captures a spawn ENOENT error into lastStderrLine', async () => {

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -3114,6 +3114,43 @@ describe('SessionProcess — corrupted thinking-block recovery', () => {
     }
   });
 
+  it('U-SP-AUTH9: credentials are read from CLAUDE_CONFIG_DIR when the operator relocated it', async () => {
+    // The gateway already honours CLAUDE_CONFIG_DIR everywhere else it reads
+    // settings.json (model catalog, image module). A resolver that hardcoded
+    // ~/.claude would read a path that does not exist for such an operator and
+    // forward no credential at all — the exact "Not logged in" failure this
+    // forwarding was added to prevent, just reached from a different direction.
+    const relocated = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-cfgdir-'));
+    fs.writeFileSync(
+      path.join(relocated, 'settings.json'),
+      JSON.stringify({ env: { CLAUDE_CODE_OAUTH_TOKEN: 'tok-from-relocated-dir' } }),
+    );
+    // A home that deliberately holds NO .claude/settings.json, so a pass can
+    // only come from the relocated directory.
+    const bareHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-barehome-'));
+    mockHomeDir = bareHome;
+    process.env.CLAUDE_CONFIG_DIR = relocated;
+    try {
+      const appAgent = makeAgentConfig({
+        workspace: agentConfig.workspace,
+        type: 'app-agent',
+        container: 'my-app-container',
+      });
+      const sp = makeSp('chat:auth9', 'telegram', appAgent, gatewayConfig, sessionStore);
+      await sp.start();
+
+      const [, spawnArgs, spawnOpts] = spawnMock.mock.calls[0] as [string, string[], { env: Record<string, string> }];
+      expect(spawnArgs).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+      expect(spawnOpts.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('tok-from-relocated-dir');
+
+      await sp.stop();
+    } finally {
+      delete process.env.CLAUDE_CONFIG_DIR;
+      fs.rmSync(relocated, { recursive: true, force: true });
+      fs.rmSync(bareHome, { recursive: true, force: true });
+    }
+  });
+
   // --------------------------------------------------------------------------
   // U-SP-BIN5: a genuinely unresolvable binary surfaces as an ENOENT `error`  // event (NOT on stderr). It must still be captured into lastStderrLine so the
   // fatal max-restarts log can name the cause and fire the CLAUDE_BIN hint.


### PR DESCRIPTION
## Summary

A Docker **file** bind mount pins an inode, not a path. Claude Code rewrites `~/.claude/settings.json` by atomic rename, so the first host settings change left every long-lived app-agent container reading the old, now-unlinked inode. Claude Code **silently ignores** a `settings.json` whose inode is unlinked — so the container stayed healthy, logged nothing useful, and answered every real end user `Not logged in · Please run /login` until someone recreated it by hand.

This fixes it in two layers: at the **boundary**, so containers that are already broken recover on their next turn with no restart, and at the **source**, so the whole class stops being possible for future containers.

## Related Issue

Closes #442

## Changes Made

- `src/session/process.ts`: added `CONTAINER_AUTH_ENV_KEYS` and `resolveContainerAuthEnv()`, a sibling of the existing `readUserScopedMcp()`. It resolves the Claude credentials **by path, once per spawn**, and forwards them into the container. Because it resolves by path on every turn, it is immune to the inode problem by construction.
  - Credentials are passed as **bare `-e KEY` names** (no `=value`), so docker reads each value from the gateway's own environment. The token never lands on the docker argv, where any local user could read it out of `ps`.
  - `settings.json` **wins over** the gateway's own environment, which is only a fallback. This matches Claude Code, which applies the file's `env` block over whatever it inherited, and keeps the live file the single source of truth — otherwise a long-lived gateway started with an exported token would pin containers to a credential that can never be rotated without restarting the service, reintroducing the very staleness class being fixed here.
  - `settings.json` is treated as untrusted input: only clean, non-empty strings are forwarded (a NUL byte throws at spawn; a newline is never legitimate in a credential or a base URL).

- `src/apps/agent-manager.ts`: `injectAgentService()` no longer bind-mounts individual host config files.
  - `~/.claude.json` is staged into a gateway-owned seed **directory** (mode `0700`, staged file `0600`) mounted read-only. Directory bind mounts resolve entries per access, so a host-side rename is picked up by the next (re)start without recreating the container.
  - The seed indirection itself is deliberately preserved: Claude Code rewrites `~/.claude.json` *inside* the container, and a mountpoint cannot be replaced via rename (`Device or resource busy`), so the container still needs a writable copy rather than a mount.
  - The container-start copy is now `;`-separated rather than `&&`, so a failed copy surfaces on stderr (visible in `docker logs`) instead of preventing the container from starting. The copy is omitted entirely when the host has no `~/.claude.json`.
  - The `~/.claude/settings.json` mount is **dropped**. Credentials now arrive as env; the file's remaining keys (plugins, marketplaces, statusLine) are host-scoped and point at paths that were never mounted into the container anyway.
  - The comment claiming `cp` on every (re)start "always picks up the current host auth" was factually false once the host file had been replaced by rename. It now describes what the code actually does.

## Testing

- `npm run typecheck`: pass
- `npm test`: 236 suites / 4308 tests pass, zero failures

### Regression tests — proven to fail on the pre-fix code

Verified by reverting only the two source files and re-running; 7 specs go red:

`tests/unit/apps/agent-manager.test.ts`
- `never bind-mounts an individual host Claude config file (regression: stale inode => "Not logged in")` — the primary guard
- `stages the Claude config seed as a private directory the gateway owns`
- `seeds a writable ~/.claude.json via copy instead of a read-only mount at its real path`
- `omits the seed copy when the host has no ~/.claude.json`
- `mounts binaries, auth files, and workspace as volumes` (updated for the new shape)

`tests/unit/session-process.test.ts`
- `U-SP-AUTH1`: an app-agent forwards the host `settings.json` credentials into the container
- `U-SP-AUTH2`: the credential value never appears on the docker argv — and *is* present in the spawn env, so the assertion cannot pass vacuously on the pre-fix code
- `U-SP-AUTH5`: `settings.json` wins over the gateway env, which is only a fallback

`U-SP-AUTH3` (a malformed credential is not forwarded) and `U-SP-AUTH4` (a host session gets no container credential flags) are negative guards and correctly hold both before and after the fix.

## Docs

No change needed — this touches no HTTP API surface. The one `~/.claude/settings.json` reference in `API.md` (models-catalog token resolution) is host-side and untouched.

## Out of Scope

The `claude` and `node` binary mounts carry the same latent hazard — a `claude` self-update replaces the binary by rename, so a long-lived container could keep executing a deleted binary. Verified **not** currently stale, so it is latent rather than an active bug; worth a follow-up issue.