### PR TITLE
feat(share): allow documents through the share bridge and rename the image-only surface to file

### DIFF
--- a/API.md
+++ b/API.md
@@ -217,18 +217,21 @@ Boot restore (`gateway.appRestore`): at startup every app stored as `running` is
 Short-lived public image shares + private image artifacts (enabled only when
 `gateway.publicUrl` is set). A token IS the capability — only its SHA-256 hash is
 stored, and shares are unenumerable (there is no list endpoint by design).
-**Phase-1 supports raster images only (PNG / JPEG / WebP);** any other type is
-rejected with `415 unsupported_image_type` at both mint and fetch time. `agent_id`
-and `session_id` must be valid identifiers (same charset as elsewhere) or the
-request is `400` before any path resolution.
+**The default allowlist is raster images only (PNG / JPEG / WebP);** any other
+type is rejected with `415 unsupported_image_type` at both mint and fetch time.
+A mint may pass `allow_documents: true` to widen the allowlist to PDF for that
+request; the allow-kind is recorded per share and the file is **re-sniffed on
+every fetch**, so replacing the file behind a live share never widens what it
+serves. `agent_id` and `session_id` must be valid identifiers (same charset as
+elsewhere) or the request is `400` before any path resolution.
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| `POST` | `/api/v1/shares` | Key (agent-scoped) | Mint one or more shares for artifact refs / media paths → `{ items: [{ share_id, token, url?, expires_at, task_id?, provider?, prior_prompt? }] }` (order preserved; TTL 10s–24h, default 30 min; idempotent within a 60s window). `token` is a host-agnostic capability and is always present; `url` is a convenience built from `gateway.publicUrl` and is omitted when that is unset — callers with their own public base (e.g. LINE) build `<base>/shared/<token>` themselves. `task_id`/`provider`/`prior_prompt` are echoed **only for artifact refs** (never path refs) and only when the artifact's generation recorded them — `task_id`/`provider` are the provider-side handle a resume-capable backend needs (absent when the generating provider has no resume concept), and `prior_prompt` is the prompt that produced the artifact; `generate_image`'s `continue_from` consumes these to resume or hand off an edit session |
+| `POST` | `/api/v1/shares` | Key (agent-scoped) | Mint one or more shares for artifact refs / media paths → `{ items: [{ share_id, token, url?, expires_at, task_id?, provider?, prior_prompt? }] }` (order preserved; TTL 10s–24h, default 30 min; idempotent within a 60s window, keyed by allow-kind as well as ref). Optional `allow_documents: true` widens this request's allowlist to PDF; anything non-boolean is `400`. `token` is a host-agnostic capability and is always present; `url` is a convenience built from `gateway.publicUrl` and is omitted when that is unset — callers with their own public base (e.g. LINE) build `<base>/shared/<token>` themselves. `task_id`/`provider`/`prior_prompt` are echoed **only for artifact refs** (never path refs) and only when the artifact's generation recorded them — `task_id`/`provider` are the provider-side handle a resume-capable backend needs (absent when the generating provider has no resume concept), and `prior_prompt` is the prompt that produced the artifact; `generate_image`'s `continue_from` consumes these to resume or hand off an edit session |
 | `DELETE` | `/api/v1/shares/:shareId` | Key (owner/admin) | Revoke a share (uniform `404` when the key can't access the owner) |
 | `POST` | `/api/v1/image-artifacts` | Key (agent-scoped) | Register generated images as private artifacts (registration never makes a file public) |
 | `GET` | `/api/v1/image-catalog?agent_id=&session_id=` | Key (agent-scoped) | Deterministic per-session image list (oldest first); mints nothing, returns no token |
-| `GET`/`HEAD` | `/shared/:token` | None (token IS the capability) | Stream a shared image inline; uniform `404` for unknown/expired/revoked/traversal; per-IP rate limited. This is the single public share primitive — the gateway, MCP subprocesses, and LINE image delivery all mint through `/api/v1/shares` and serve here |
+| `GET`/`HEAD` | `/shared/:token` | None (token IS the capability) | Stream the shared file — images `inline`, documents as an `attachment` (sanitised RFC 5987 filename), always `X-Content-Type-Options: nosniff`; uniform `404` for unknown/expired/revoked/traversal/type-mismatch; per-IP rate limited. This is the single public share primitive — the gateway, MCP subprocesses, and LINE image delivery all mint through `/api/v1/shares` and serve here |
 
 ### PTY Shell API
 

--- a/API.md
+++ b/API.md
@@ -220,9 +220,11 @@ stored, and shares are unenumerable (there is no list endpoint by design).
 **The default allowlist is raster images only (PNG / JPEG / WebP);** any other
 type is rejected with `415 unsupported_file_type` at both mint and fetch time.
 A mint may pass `allow_documents: true` to widen the allowlist to PDF for that
-request; the allow-kind is recorded per share and the file is **re-sniffed on
-every fetch**, so replacing the file behind a live share never widens what it
-serves. `agent_id` and `session_id` must be valid identifiers (same charset as
+request; the allow-kind is then recorded **per share, narrowed to what the ref
+actually validated as** — a PNG in an `allow_documents` batch is still stored as
+image-only — and the file is **re-sniffed on every fetch**, so replacing the file
+behind a live share never widens what it serves. `agent_id` and `session_id`
+must be valid identifiers (same charset as
 elsewhere) or the request is `400` before any path resolution.
 
 | Method | Path | Auth | Description |

--- a/API.md
+++ b/API.md
@@ -224,8 +224,8 @@ request; the allow-kind is then recorded **per share, narrowed to what the ref
 actually validated as** — a PNG in an `allow_documents` batch is still stored as
 image-only — and the file is **re-sniffed on every fetch**, so replacing the file
 behind a live share never widens what it serves. `agent_id` and `session_id`
-must be valid identifiers (same charset as
-elsewhere) or the request is `400` before any path resolution.
+must be valid identifiers (same charset as elsewhere) or the request is `400`
+before any path resolution.
 
 > **Upgrade / rollback note (#444).** The share table was renamed
 > `image_shares` → `file_shares`. Upgrading renames in place, so shares minted

--- a/API.md
+++ b/API.md
@@ -227,13 +227,22 @@ behind a live share never widens what it serves. `agent_id` and `session_id`
 must be valid identifiers (same charset as
 elsewhere) or the request is `400` before any path resolution.
 
+> **Upgrade / rollback note (#444).** The share table was renamed
+> `image_shares` → `file_shares`. Upgrading renames in place, so shares minted
+> before the upgrade keep resolving. **Rolling back across #444 does not:** the
+> older build recreates an empty `image_shares` and every still-live share URL
+> returns `404` until it expires (bounded by the 24 h max TTL — nothing durable
+> is lost, since shares are ephemeral by design). Rolling forward again folds
+> any rows the older build minted back into `file_shares` and drops the orphan
+> table, logging `[share] migrated legacy image_shares:` with the row counts.
+
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `POST` | `/api/v1/shares` | Key (agent-scoped) | Mint one or more shares for artifact refs / media paths → `{ items: [{ share_id, token, url?, expires_at, task_id?, provider?, prior_prompt? }] }` (order preserved; TTL 10s–24h, default 30 min; idempotent within a 60s window, keyed by allow-kind as well as ref). Optional `allow_documents: true` widens this request's allowlist to PDF; anything non-boolean is `400`. `token` is a host-agnostic capability and is always present; `url` is a convenience built from `gateway.publicUrl` and is omitted when that is unset — callers with their own public base (e.g. LINE) build `<base>/shared/<token>` themselves. `task_id`/`provider`/`prior_prompt` are echoed **only for artifact refs** (never path refs) and only when the artifact's generation recorded them — `task_id`/`provider` are the provider-side handle a resume-capable backend needs (absent when the generating provider has no resume concept), and `prior_prompt` is the prompt that produced the artifact; `generate_image`'s `continue_from` consumes these to resume or hand off an edit session |
 | `DELETE` | `/api/v1/shares/:shareId` | Key (owner/admin) | Revoke a share (uniform `404` when the key can't access the owner) |
 | `POST` | `/api/v1/image-artifacts` | Key (agent-scoped) | Register generated images as private artifacts (registration never makes a file public) |
 | `GET` | `/api/v1/image-catalog?agent_id=&session_id=` | Key (agent-scoped) | Deterministic per-session image list (oldest first); mints nothing, returns no token |
-| `GET`/`HEAD` | `/shared/:token` | None (token IS the capability) | Stream the shared file — images `inline`, documents as an `attachment` whose filename is sanitised (RFC 5987) and whose **extension is forced to match the sniffed type**, not the agent-chosen basename (so `%PDF-` bytes named `invoice.html` download as `invoice.pdf`); always `X-Content-Type-Options: nosniff`; uniform `404` for unknown/expired/revoked/traversal/type-mismatch; per-IP rate limited. This is the single public share primitive — the gateway, MCP subprocesses, and LINE image delivery all mint through `/api/v1/shares` and serve here |
+| `GET`/`HEAD` | `/shared/:token` | None (token IS the capability) | Stream the shared file — images `inline`, documents as an `attachment` whose filename is sanitised (RFC 8187) and whose **extension is forced to match the sniffed type**, not the agent-chosen basename (so `%PDF-` bytes named `invoice.html` download as `invoice.pdf`); always `X-Content-Type-Options: nosniff`; uniform `404` for unknown/expired/revoked/traversal/type-mismatch; per-IP rate limited. This is the single public share primitive — the gateway, MCP subprocesses, and LINE image delivery all mint through `/api/v1/shares` and serve here |
 
 **Renamed in #444** (the bridge is no longer image-only):
 

--- a/API.md
+++ b/API.md
@@ -212,13 +212,13 @@ Boot restore (`gateway.appRestore`): at startup every app stored as `running` is
 | `POST` | `/api/v1/agents/:agentId/media` | Key | Upload a media file (image/* or PDF) — returns `mediaPath` |
 | `GET` | `/api/v1/agents/:agentId/media/*` | Key | Serve a media file by path |
 
-### Image Share Bridge API
+### File Share Bridge API
 
-Short-lived public image shares + private image artifacts (enabled only when
+Short-lived public file shares + private image artifacts (enabled only when
 `gateway.publicUrl` is set). A token IS the capability — only its SHA-256 hash is
 stored, and shares are unenumerable (there is no list endpoint by design).
 **The default allowlist is raster images only (PNG / JPEG / WebP);** any other
-type is rejected with `415 unsupported_image_type` at both mint and fetch time.
+type is rejected with `415 unsupported_file_type` at both mint and fetch time.
 A mint may pass `allow_documents: true` to widen the allowlist to PDF for that
 request; the allow-kind is recorded per share and the file is **re-sniffed on
 every fetch**, so replacing the file behind a live share never widens what it
@@ -232,6 +232,20 @@ elsewhere) or the request is `400` before any path resolution.
 | `POST` | `/api/v1/image-artifacts` | Key (agent-scoped) | Register generated images as private artifacts (registration never makes a file public) |
 | `GET` | `/api/v1/image-catalog?agent_id=&session_id=` | Key (agent-scoped) | Deterministic per-session image list (oldest first); mints nothing, returns no token |
 | `GET`/`HEAD` | `/shared/:token` | None (token IS the capability) | Stream the shared file — images `inline`, documents as an `attachment` (sanitised RFC 5987 filename), always `X-Content-Type-Options: nosniff`; uniform `404` for unknown/expired/revoked/traversal/type-mismatch; per-IP rate limited. This is the single public share primitive — the gateway, MCP subprocesses, and LINE image delivery all mint through `/api/v1/shares` and serve here |
+
+**Renamed in #444** (the bridge is no longer image-only):
+
+| Kind | Was | Now |
+|------|-----|-----|
+| Error code | `image_ref_not_found` | `share_ref_not_found` |
+| Error code | `image_too_large` | `file_too_large` |
+| Error code | `unsupported_image_type` | `unsupported_file_type` |
+| MCP tool | `share_image` | `share_file` (old name kept as a deprecated alias) |
+| Env vars | `IMAGE_SHARE_*` | `SHARE_*` (legacy names still read as a fallback) |
+| SQLite table | `image_shares` | `file_shares` (renamed in place on first open) |
+
+The error codes are the only breaking part: `code` values in `4xx` bodies changed.
+HTTP statuses, request/response shapes and the token format are unchanged.
 
 ### PTY Shell API
 

--- a/API.md
+++ b/API.md
@@ -231,7 +231,7 @@ elsewhere) or the request is `400` before any path resolution.
 | `DELETE` | `/api/v1/shares/:shareId` | Key (owner/admin) | Revoke a share (uniform `404` when the key can't access the owner) |
 | `POST` | `/api/v1/image-artifacts` | Key (agent-scoped) | Register generated images as private artifacts (registration never makes a file public) |
 | `GET` | `/api/v1/image-catalog?agent_id=&session_id=` | Key (agent-scoped) | Deterministic per-session image list (oldest first); mints nothing, returns no token |
-| `GET`/`HEAD` | `/shared/:token` | None (token IS the capability) | Stream the shared file — images `inline`, documents as an `attachment` (sanitised RFC 5987 filename), always `X-Content-Type-Options: nosniff`; uniform `404` for unknown/expired/revoked/traversal/type-mismatch; per-IP rate limited. This is the single public share primitive — the gateway, MCP subprocesses, and LINE image delivery all mint through `/api/v1/shares` and serve here |
+| `GET`/`HEAD` | `/shared/:token` | None (token IS the capability) | Stream the shared file — images `inline`, documents as an `attachment` whose filename is sanitised (RFC 5987) and whose **extension is forced to match the sniffed type**, not the agent-chosen basename (so `%PDF-` bytes named `invoice.html` download as `invoice.pdf`); always `X-Content-Type-Options: nosniff`; uniform `404` for unknown/expired/revoked/traversal/type-mismatch; per-IP rate limited. This is the single public share primitive — the gateway, MCP subprocesses, and LINE image delivery all mint through `/api/v1/shares` and serve here |
 
 **Renamed in #444** (the bridge is no longer image-only):
 
@@ -240,7 +240,7 @@ elsewhere) or the request is `400` before any path resolution.
 | Error code | `image_ref_not_found` | `share_ref_not_found` |
 | Error code | `image_too_large` | `file_too_large` |
 | Error code | `unsupported_image_type` | `unsupported_file_type` |
-| MCP tool | `share_image` | `share_file` (old name kept as a deprecated alias) |
+| MCP tool | `share_image` | `share_file` (old name kept as a deprecated alias, still image-only — only `share_file` opts into documents) |
 | Env vars | `IMAGE_SHARE_*` | `SHARE_*` (legacy names still read as a fallback) |
 | SQLite table | `image_shares` | `file_shares` (renamed in place on first open) |
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Config lives at `~/.claude-gateway/config.json` (or set `GATEWAY_CONFIG` env var
 
 The externally reachable gateway base URL. Set it manually to enable short-lived
 public file shares used by `generate_image` reference edits and `share_file`
-(formerly `share_image`, which still works as a deprecated alias).
+(formerly `share_image`, which still works as a deprecated image-only alias).
 The URL must end in `/gateway`; changing it requires a gateway restart.
 
 ```json

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ Config lives at `~/.claude-gateway/config.json` (or set `GATEWAY_CONFIG` env var
 ### `gateway.publicUrl` (optional)
 
 The externally reachable gateway base URL. Set it manually to enable short-lived
-public image shares used by `generate_image` reference edits and `share_image`.
+public file shares used by `generate_image` reference edits and `share_file`
+(formerly `share_image`, which still works as a deprecated alias).
 The URL must end in `/gateway`; changing it requires a gateway restart.
 
 ```json

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -21,7 +21,7 @@ import { SkillsModule } from './tools/skills/module';
 import { AgentModule } from './tools/agent/module';
 import { BrowserModule } from './tools/browser/module';
 import { ImageModule } from './tools/image/module';
-import { ShareImageModule } from './tools/share-image/module';
+import { ShareFileModule } from './tools/share-file/module';
 import { AppsModule } from './tools/apps/module';
 import { ApiModule } from './tools/api/module';
 import { MemoryModule } from './tools/memory/module';
@@ -46,7 +46,7 @@ const modules: AnyModule[] = [
   new AgentModule(),
   new BrowserModule(),
   new ImageModule(),
-  new ShareImageModule(),
+  new ShareFileModule(),
   new AppsModule(),
   new ApiModule(),
   new MemoryModule(),

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -456,7 +456,11 @@ export class ImageModule implements ToolModule {
       error: { content: [{ type: 'text', text }], isError: true },
     });
     const maxRefs = (() => {
-      const n = Number(process.env.IMAGE_SHARE_MAX_REFS);
+      // #444: the neutral SHARE_* name wins; IMAGE_SHARE_* is the legacy
+      // fallback. Both are forwarded to this subprocess, and unset vars arrive
+      // as '' — so treat empty as unset rather than letting it shadow the other.
+      const raw = process.env.SHARE_MAX_REFS || process.env.IMAGE_SHARE_MAX_REFS;
+      const n = Number(raw);
       return Number.isFinite(n) && n > 0 ? Math.floor(n) : 5;
     })();
     if (refs.length > maxRefs) {
@@ -493,8 +497,11 @@ export class ImageModule implements ToolModule {
         minted = await createShares(localRefs.map((e) => e.ref), { purpose: 'codex_ref' });
       } catch (err) {
         if (err instanceof ShareClientError) {
-          if (err.code === 'image_ref_not_found') {
-            return fail('generate_image: image_ref_not_found: the referenced image/artifact does not exist in this session.');
+          // #444 renamed this gateway error code image_ref_not_found ->
+          // share_ref_not_found. Match both: this subprocess can be talking to
+          // a gateway that predates the rename.
+          if (err.code === 'share_ref_not_found' || err.code === 'image_ref_not_found') {
+            return fail(`generate_image: ${err.code}: the referenced image/artifact does not exist in this session.`);
           }
           return fail(`generate_image: ${err.code}: ${err.message}`);
         }

--- a/mcp/tools/share-file/module.ts
+++ b/mcp/tools/share-file/module.ts
@@ -131,6 +131,19 @@ const shareFileInputSchema = {
   required: [],
 };
 
+// The alias is image-only, so it must not advertise the PDF example: an agent
+// reading its schema would be told a document is acceptable and get a 415.
+// Same shape, image wording — a separate object costs nothing, since both defs
+// are serialized in full either way.
+const shareImageInputSchema = {
+  ...shareFileInputSchema,
+  properties: {
+    ...shareFileInputSchema.properties,
+    path: { type: 'string', description: 'One media path (e.g. "media/session-1/chart.png") or "artifact:<id>" to share.' },
+    paths: { type: 'array', items: { type: 'string' }, description: 'Multiple media image paths / artifact refs (max 5).' },
+  },
+};
+
 const shareFileToolDefs: McpToolDefinition[] = [
   {
     name: 'share_file',
@@ -148,10 +161,9 @@ const shareFileToolDefs: McpToolDefinition[] = [
     // name keep working — and kept IMAGE-ONLY, which is what those instructions
     // meant and what the name still promises. Description is deliberately one
     // line: it must not cost a second copy of the real tool's context budget.
-    // Same schema object — these defs are only ever serialized, never mutated.
     name: LEGACY_TOOL_NAME,
     description:
       'Deprecated image-only alias for share_file — use share_file instead, which also shares PDFs.',
-    inputSchema: shareFileInputSchema,
+    inputSchema: shareImageInputSchema,
   },
 ];

--- a/mcp/tools/share-file/module.ts
+++ b/mcp/tools/share-file/module.ts
@@ -8,14 +8,19 @@ import {
 } from '../shared/share-client';
 
 /**
- * Standalone share_image MCP tool (#70, plan §15) — explicit create/revoke of
- * short-lived public image URLs. There is deliberately NO list action (shares
- * are unenumerable, §10). generate_image auto-normalizes refs through the same
- * gateway API, so normal image editing never needs this tool; it exists for
- * explicit workflows (e.g. handing a temporary URL to an external service).
+ * Standalone share_file MCP tool (#70, plan §15) — explicit create/revoke of
+ * short-lived public URLs for a file in the agent's media directory. There is
+ * deliberately NO list action (shares are unenumerable, §10). generate_image
+ * auto-normalizes refs through the same gateway API, so normal image editing
+ * never needs this tool; it exists for explicit workflows (e.g. handing a
+ * temporary URL to an external service).
+ *
+ * #444: was `share_image` back when the bridge could only carry images. The
+ * old name stays registered as a thin alias — it is baked into agent
+ * workspaces (AGENTS.md, skills, memories) that we do not get to rewrite.
  */
-export class ShareImageModule implements ToolModule {
-  id = 'share-image';
+export class ShareFileModule implements ToolModule {
+  id = 'share-file';
   toolVisibility: ToolVisibility = 'all-configured';
 
   isEnabled(): boolean {
@@ -23,11 +28,11 @@ export class ShareImageModule implements ToolModule {
   }
 
   getTools(): McpToolDefinition[] {
-    return shareImageToolDefs;
+    return shareFileToolDefs;
   }
 
   async handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
-    if (name !== 'share_image') {
+    if (name !== 'share_file' && name !== LEGACY_TOOL_NAME) {
       return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
     }
     const action = typeof args.action === 'string' ? args.action : 'create';
@@ -38,7 +43,7 @@ export class ShareImageModule implements ToolModule {
         return this.handleRevoke(args);
       default:
         return {
-          content: [{ type: 'text', text: `share_image: unknown action "${action}" (expected create | revoke)` }],
+          content: [{ type: 'text', text: `share_file: unknown action "${action}" (expected create | revoke)` }],
           isError: true,
         };
     }
@@ -50,11 +55,11 @@ export class ShareImageModule implements ToolModule {
       ? (args.paths.filter((p) => typeof p === 'string' && p.trim()) as string[])
       : [];
     if (single.length && many.length) {
-      return { content: [{ type: 'text', text: 'share_image: pass either "path" or "paths", not both.' }], isError: true };
+      return { content: [{ type: 'text', text: 'share_file: pass either "path" or "paths", not both.' }], isError: true };
     }
     const paths = single.length ? single : many;
     if (!paths.length) {
-      return { content: [{ type: 'text', text: 'share_image: action="create" requires "path" or "paths".' }], isError: true };
+      return { content: [{ type: 'text', text: 'share_file: action="create" requires "path" or "paths".' }], isError: true };
     }
     const refs: ShareRef[] = paths.map((p) =>
       p.startsWith('artifact:') ? { artifact_id: p.slice('artifact:'.length) } : { path: p },
@@ -79,7 +84,7 @@ export class ShareImageModule implements ToolModule {
   private async handleRevoke(args: Record<string, unknown>): Promise<McpToolResult> {
     const shareId = typeof args.share_id === 'string' ? args.share_id.trim() : '';
     if (!shareId) {
-      return { content: [{ type: 'text', text: 'share_image: action="revoke" requires "share_id".' }], isError: true };
+      return { content: [{ type: 'text', text: 'share_file: action="revoke" requires "share_id".' }], isError: true };
     }
     try {
       await revokeShare(shareId);
@@ -91,36 +96,49 @@ export class ShareImageModule implements ToolModule {
 
   private mapError(err: unknown): McpToolResult {
     if (err instanceof ShareClientError) {
-      return { content: [{ type: 'text', text: `share_image: ${err.code}: ${err.message}` }], isError: true };
+      return { content: [{ type: 'text', text: `share_file: ${err.code}: ${err.message}` }], isError: true };
     }
     return {
-      content: [{ type: 'text', text: `share_image: gateway unavailable: ${(err as Error).message}` }],
+      content: [{ type: 'text', text: `share_file: gateway unavailable: ${(err as Error).message}` }],
       isError: true,
     };
   }
 }
 
-const shareImageToolDefs: McpToolDefinition[] = [
+const LEGACY_TOOL_NAME = 'share_image';
+
+const shareFileInputSchema = {
+  type: 'object',
+  properties: {
+    action: { type: 'string', enum: ['create', 'revoke'], description: 'create (default) | revoke' },
+    path: { type: 'string', description: 'One media path (e.g. "media/session-1/report.pdf") or "artifact:<id>" to share.' },
+    paths: { type: 'array', items: { type: 'string' }, description: 'Multiple media paths / artifact refs (max 5).' },
+    ttl_seconds: { type: 'number', description: 'Optional lifetime in seconds (default 1800).' },
+    purpose: { type: 'string', description: 'Optional purpose tag (default "codex_ref").' },
+    share_id: { type: 'string', description: 'Share id to revoke (required for action="revoke").' },
+  },
+  required: [],
+};
+
+const shareFileToolDefs: McpToolDefinition[] = [
   {
-    name: 'share_image',
+    name: 'share_file',
     description:
-      'Create or revoke a SHORT-LIVED public URL for an image in this agent\'s media directory. ' +
+      'Create or revoke a SHORT-LIVED public URL for a file in this agent\'s media directory (PNG, JPEG, WebP or PDF). ' +
       'action="create" takes "path" (one media path or artifact:<id>) or "paths" (up to 5) and returns ' +
-      '{ share_id, url, expires_at } per image — the URL needs no auth and expires automatically (default 30 min). ' +
+      '{ share_id, url, expires_at } per file — the URL needs no auth and expires automatically (default 30 min). ' +
       'action="revoke" takes "share_id" and invalidates the URL immediately. ' +
       'You normally do NOT need this for image editing: generate_image converts local/artifact references ' +
       'to share URLs automatically. There is no list action.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        action: { type: 'string', enum: ['create', 'revoke'], description: 'create (default) | revoke' },
-        path: { type: 'string', description: 'One media path (e.g. "media/session-1/image.png") or "artifact:<id>" to share.' },
-        paths: { type: 'array', items: { type: 'string' }, description: 'Multiple media paths / artifact refs (max 5).' },
-        ttl_seconds: { type: 'number', description: 'Optional lifetime in seconds (default 1800).' },
-        purpose: { type: 'string', description: 'Optional purpose tag (default "codex_ref").' },
-        share_id: { type: 'string', description: 'Share id to revoke (required for action="revoke").' },
-      },
-      required: [],
-    },
+    inputSchema: shareFileInputSchema,
+  },
+  {
+    // Deprecated #444 alias, kept so agent instructions written against the old
+    // name keep working. Description is deliberately one line: it must not cost
+    // a second copy of the real tool's context budget. Same schema object —
+    // these defs are only ever serialized, never mutated.
+    name: LEGACY_TOOL_NAME,
+    description: 'Deprecated alias for share_file — use share_file instead. Identical behaviour.',
+    inputSchema: shareFileInputSchema,
   },
 ];

--- a/mcp/tools/share-file/module.ts
+++ b/mcp/tools/share-file/module.ts
@@ -35,10 +35,11 @@ export class ShareFileModule implements ToolModule {
     if (name !== 'share_file' && name !== LEGACY_TOOL_NAME) {
       return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
     }
+    const legacy = name === LEGACY_TOOL_NAME;
     const action = typeof args.action === 'string' ? args.action : 'create';
     switch (action) {
       case 'create':
-        return this.handleCreate(args);
+        return this.handleCreate(args, legacy);
       case 'revoke':
         return this.handleRevoke(args);
       default:
@@ -49,7 +50,7 @@ export class ShareFileModule implements ToolModule {
     }
   }
 
-  private async handleCreate(args: Record<string, unknown>): Promise<McpToolResult> {
+  private async handleCreate(args: Record<string, unknown>, legacy: boolean): Promise<McpToolResult> {
     const single = typeof args.path === 'string' && args.path.trim() ? [args.path.trim()] : [];
     const many = Array.isArray(args.paths)
       ? (args.paths.filter((p) => typeof p === 'string' && p.trim()) as string[])
@@ -65,11 +66,15 @@ export class ShareFileModule implements ToolModule {
       p.startsWith('artifact:') ? { artifact_id: p.slice('artifact:'.length) } : { path: p },
     );
     const opts: { purpose?: string; ttlSeconds?: number; allowDocuments: boolean } = {
-      // The standalone tool is the agent's explicit "publish this file" verb, so
-      // it opts into the full share allowlist (images + PDF). The narrow image
-      // consumers — line_image, generate_image ref normalization — deliberately
-      // do NOT, and keep rejecting anything that is not a raster image.
-      allowDocuments: true,
+      // share_file is the agent's explicit "publish this file" verb, so it opts
+      // into the full share allowlist (images + PDF). The legacy share_image
+      // name does NOT: an instruction written against it meant "share an
+      // image", and widening it would retroactively change what an existing
+      // call site's live token can serve — a share minted on chart.png would
+      // start serving a PDF if the file were later overwritten, where before it
+      // failed closed with a 404. The narrow image consumers (line_image,
+      // generate_image ref normalization) stay strict for the same reason.
+      allowDocuments: !legacy,
     };
     if (typeof args.purpose === 'string' && args.purpose.trim()) opts.purpose = args.purpose.trim();
     if (typeof args.ttl_seconds === 'number' && args.ttl_seconds > 0) opts.ttlSeconds = args.ttl_seconds;
@@ -77,7 +82,7 @@ export class ShareFileModule implements ToolModule {
       const items = await createShares(refs, opts);
       return { content: [{ type: 'text', text: JSON.stringify({ items }, null, 2) }] };
     } catch (err) {
-      return this.mapError(err);
+      return this.mapError(err, legacy);
     }
   }
 
@@ -94,9 +99,15 @@ export class ShareFileModule implements ToolModule {
     }
   }
 
-  private mapError(err: unknown): McpToolResult {
+  private mapError(err: unknown, legacy = false): McpToolResult {
     if (err instanceof ShareClientError) {
-      return { content: [{ type: 'text', text: `share_file: ${err.code}: ${err.message}` }], isError: true };
+      // Without this the agent hits a dead end: it asked the image-only name to
+      // share a PDF and gets a bare 415 with no hint that a wider tool exists.
+      const hint =
+        legacy && err.code === 'unsupported_file_type'
+          ? ' — share_image is image-only; call share_file for documents.'
+          : '';
+      return { content: [{ type: 'text', text: `share_file: ${err.code}: ${err.message}${hint}` }], isError: true };
     }
     return {
       content: [{ type: 'text', text: `share_file: gateway unavailable: ${(err as Error).message}` }],
@@ -134,11 +145,13 @@ const shareFileToolDefs: McpToolDefinition[] = [
   },
   {
     // Deprecated #444 alias, kept so agent instructions written against the old
-    // name keep working. Description is deliberately one line: it must not cost
-    // a second copy of the real tool's context budget. Same schema object —
-    // these defs are only ever serialized, never mutated.
+    // name keep working — and kept IMAGE-ONLY, which is what those instructions
+    // meant and what the name still promises. Description is deliberately one
+    // line: it must not cost a second copy of the real tool's context budget.
+    // Same schema object — these defs are only ever serialized, never mutated.
     name: LEGACY_TOOL_NAME,
-    description: 'Deprecated alias for share_file — use share_file instead. Identical behaviour.',
+    description:
+      'Deprecated image-only alias for share_file — use share_file instead, which also shares PDFs.',
     inputSchema: shareFileInputSchema,
   },
 ];

--- a/mcp/tools/share-image/module.ts
+++ b/mcp/tools/share-image/module.ts
@@ -59,7 +59,13 @@ export class ShareImageModule implements ToolModule {
     const refs: ShareRef[] = paths.map((p) =>
       p.startsWith('artifact:') ? { artifact_id: p.slice('artifact:'.length) } : { path: p },
     );
-    const opts: { purpose?: string; ttlSeconds?: number } = {};
+    const opts: { purpose?: string; ttlSeconds?: number; allowDocuments: boolean } = {
+      // The standalone tool is the agent's explicit "publish this file" verb, so
+      // it opts into the full share allowlist (images + PDF). The narrow image
+      // consumers — line_image, generate_image ref normalization — deliberately
+      // do NOT, and keep rejecting anything that is not a raster image.
+      allowDocuments: true,
+    };
     if (typeof args.purpose === 'string' && args.purpose.trim()) opts.purpose = args.purpose.trim();
     if (typeof args.ttl_seconds === 'number' && args.ttl_seconds > 0) opts.ttlSeconds = args.ttl_seconds;
     try {

--- a/mcp/tools/shared/share-client.ts
+++ b/mcp/tools/shared/share-client.ts
@@ -1,6 +1,7 @@
 /**
- * Image share bridge client (#70) — the ONLY way MCP subprocesses touch the
- * share/artifact store. They call the authenticated local Gateway HTTP API
+ * File share bridge client (#70, widened past images in #444) — the ONLY way
+ * MCP subprocesses touch the share/artifact store. They call the authenticated
+ * local Gateway HTTP API
  * (GATEWAY_API_URL + GATEWAY_API_KEY, both already injected into the session
  * subprocess env) and NEVER open the SQLite DB themselves (plan §9/§10).
  *

--- a/mcp/tools/shared/share-client.ts
+++ b/mcp/tools/shared/share-client.ts
@@ -109,7 +109,7 @@ async function callGateway(
 /** Mint short-lived share URLs for local/artifact refs — order preserved. */
 export async function createShares(
   refs: ShareRef[],
-  opts: { purpose?: string; ttlSeconds?: number } = {},
+  opts: { purpose?: string; ttlSeconds?: number; allowDocuments?: boolean } = {},
 ): Promise<ShareItem[]> {
   const body: Record<string, unknown> = {
     agent_id: process.env.GATEWAY_AGENT_ID,
@@ -118,6 +118,9 @@ export async function createShares(
     refs,
   };
   if (opts.ttlSeconds !== undefined) body.ttl_seconds = opts.ttlSeconds;
+  // Opt-in only: image callers (line_image, generate_image refs) must keep
+  // getting a hard rejection for a non-image ref.
+  if (opts.allowDocuments) body.allow_documents = true;
   const { status, json } = await callGateway('POST', '/api/v1/shares', body);
   if (status !== 201) {
     const code = typeof json.code === 'string' ? json.code : 'share_failed';

--- a/mcp/tools/shared/share-client.ts
+++ b/mcp/tools/shared/share-client.ts
@@ -53,7 +53,7 @@ export type CatalogItem = {
   desc?: string;
 };
 
-/** Error carrying the gateway's stable machine-readable code (e.g. image_ref_not_found). */
+/** Error carrying the gateway's stable machine-readable code (e.g. share_ref_not_found). */
 export class ShareClientError extends Error {
   readonly code: string;
   readonly status: number;

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1324,7 +1324,7 @@ export class AgentRunner extends EventEmitter {
    * returned — the ui-upload STAGING paths. promoteUiUploads then MOVES those
    * files into per-session storage, so a note or history row built from the
    * raw params would hand out dead paths (the agent's generate_image call
-   * fails image_ref_not_found and has to guess its way to the real file).
+   * fails share_ref_not_found and has to guess its way to the real file).
    * Substitute every ref that matches a promoted staging path with its new
    * session path; refs that were never staged (catalog refs, artifact:<id>)
    * pass through untouched. (#74)

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -45,7 +45,7 @@ import {
   createSharesPublicRouter,
   createSharesPrivateRouter,
 } from './share-router';
-import { ShareStore } from '../share/share-store';
+import { ShareStore, shareEnv } from '../share/share-store';
 
 const APP_NAME_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
 
@@ -636,7 +636,7 @@ export class GatewayRouter {
     // trailing slash can't produce "//shared/<token>" in mint URLs.
     try {
       const dbPath =
-        process.env.IMAGE_SHARE_DB_PATH ||
+        shareEnv('DB_PATH') ||
         path.join(os.homedir(), '.claude-gateway', 'shares.db');
       const store = new ShareStore(dbPath);
       this.app.use(createSharesPublicRouter(store, this.agentsRoot()));

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -71,6 +71,13 @@ function rfc5987(value: string): string {
   );
 }
 
+/** The extension a download is given, keyed by the mime we SNIFFED — never by
+ *  the name the agent chose. `invoice.html` holding `%PDF-…` is served as
+ *  `application/pdf`; saved under its own name it would be a .html file that
+ *  the browser renders from `file://`, running whatever script follows the PDF
+ *  magic (reflected file download). The extension must describe the bytes. */
+const EXT_FOR_MIME: Record<string, string> = { 'application/pdf': 'pdf' };
+
 /**
  * Build the `Content-Disposition` for a non-image share (#444). The basename
  * comes from `relative_path`, which is agent-controlled, so the quoted
@@ -78,22 +85,29 @@ function rfc5987(value: string): string {
  * alone rules out the CR/LF that would split the header — and the real name
  * rides along percent-encoded in `filename*`.
  */
-export function attachmentDisposition(basename: string): string {
-  // Cap first: a media filename is agent-controlled and a 4 KB one would bloat
-  // (or, behind some proxies, break) the response header. Cap by CODE POINT,
-  // not code unit — a plain `.slice()` can cut a surrogate pair in half, and
-  // encodeURIComponent throws URIError on the lone surrogate that leaves
-  // behind. That throw lands in the serve handler's catch and turns a
-  // perfectly good share into a uniform 404. The `\p{Surrogate}` scrub is the
-  // belt to that braces: after a code-point slice it can only ever match a
-  // surrogate that was already unpaired on the way in.
-  const name = [...basename]
-    .slice(0, MAX_DISPOSITION_NAME_CHARS)
+export function attachmentDisposition(basename: string, mime: string): string {
+  const ext = EXT_FOR_MIME[mime];
+  // Drop whatever extension the agent picked; the sniffed one replaces it. An
+  // unmapped mime can't happen today (PDF is the only non-image on the
+  // allowlist) but falls through to the name as-given rather than guessing.
+  const suffix = ext ? `.${ext}` : '';
+  const rawStem = ext ? basename.replace(/\.[^./\\]*$/, '') : basename;
+  // Cap the STEM, so the extension survives truncation — a 4 KB agent-chosen
+  // title must not cost the user a file their OS can no longer open (and must
+  // not bloat, or behind some proxies break, the response header). Cap by CODE
+  // POINT, not code unit — a plain `.slice()` can cut a surrogate pair in half,
+  // and encodeURIComponent throws URIError on the lone surrogate that leaves
+  // behind. That throw lands in the serve handler's catch and turns a perfectly
+  // good share into a uniform 404. The `\p{Surrogate}` scrub is the belt to
+  // that braces: after a code-point slice it can only ever match a surrogate
+  // that was already unpaired on the way in.
+  const stem = [...rawStem]
+    .slice(0, MAX_DISPOSITION_NAME_CHARS - suffix.length)
     .join('')
     .replace(/\p{Surrogate}/gu, '_');
-  const ascii = name.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_').trim();
-  const fallback = ascii || 'download';
-  return `attachment; filename="${fallback}"; filename*=UTF-8''${rfc5987(name)}`;
+  const asciiStem = stem.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_').trim();
+  const fallback = `${asciiStem || 'download'}${suffix}`;
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${rfc5987(`${stem}${suffix}`)}`;
 }
 
 export type PublicShareRouterOpts = {
@@ -187,7 +201,7 @@ export function createSharesPublicRouter(
       res.status(200).set({
         'Content-Type': mime,
         'Content-Length': String(stat.size),
-        'Content-Disposition': isImage ? 'inline' : attachmentDisposition(path.basename(share.relativePath)),
+        'Content-Disposition': isImage ? 'inline' : attachmentDisposition(path.basename(share.relativePath), mime),
         'X-Content-Type-Options': 'nosniff',
         'Cache-Control': 'private, no-store',
       });

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -101,13 +101,22 @@ export function attachmentDisposition(basename: string, mime: string): string {
   // good share into a uniform 404. The `\p{Surrogate}` scrub is the belt to
   // that braces: after a code-point slice it can only ever match a surrogate
   // that was already unpaired on the way in.
-  const stem = [...rawStem]
-    .slice(0, MAX_DISPOSITION_NAME_CHARS - suffix.length)
-    .join('')
-    .replace(/\p{Surrogate}/gu, '_');
-  const asciiStem = stem.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_').trim();
-  const fallback = `${asciiStem || 'download'}${suffix}`;
-  return `attachment; filename="${fallback}"; filename*=UTF-8''${rfc5987(`${stem}${suffix}`)}`;
+  // Trim and default ONCE, before the two forms diverge. RFC 6266 §4.3 says a
+  // recipient SHOULD prefer `filename*`, and every current browser does, so a
+  // guard applied only to the ASCII fallback is a guard no user ever gets: a
+  // basename of `.pdf` would save as a hidden, name-less file while the
+  // fallback nobody reads politely said `download.pdf`.
+  const stem =
+    [...rawStem]
+      .slice(0, MAX_DISPOSITION_NAME_CHARS - suffix.length)
+      .join('')
+      .replace(/\p{Surrogate}/gu, '_')
+      .trim() || 'download';
+  // Substitution is 1:1 and never yields whitespace, so a non-empty `stem`
+  // cannot ASCII-fold to nothing; the `|| 'download'` is kept as a guard on the
+  // sanitiser rather than a reachable branch.
+  const asciiStem = stem.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_').trim() || 'download';
+  return `attachment; filename="${asciiStem}${suffix}"; filename*=UTF-8''${rfc5987(`${stem}${suffix}`)}`;
 }
 
 export type PublicShareRouterOpts = {
@@ -310,6 +319,7 @@ export function createSharesPrivateRouter(
       dedupeRef: string;
       relativePath: string;
       size: number;
+      allowKind: ShareAllowKind;
       taskId?: string;
       provider?: string;
       priorPrompt?: string;
@@ -372,6 +382,16 @@ export function createSharesPrivateRouter(
         dedupeRef,
         relativePath: validated.relativePath,
         size: validated.size,
+        // Persist the kind this ref ACTUALLY validated as, not the request's
+        // ceiling. `allow_documents` is the caller's permission to include a
+        // PDF in the batch, not a declaration that every ref is one — the
+        // share_file tool sends it unconditionally. Recording 'any' on a file
+        // that sniffed as an image would widen exactly the hole the fetch-time
+        // re-sniff exists to close: overwrite the shared PNG with a PDF inside
+        // the TTL and the live token starts serving it, where before the swap
+        // failed closed with a 404. Narrowing per ref keeps the PDF feature and
+        // restores fail-closed for images.
+        allowKind: validated.mime.startsWith('image/') ? 'image' : allowKind,
         taskId,
         provider: refProvider,
         priorPrompt,
@@ -390,7 +410,7 @@ export function createSharesPrivateRouter(
         dedupeRef: r.dedupeRef,
         purpose,
         ttlSeconds,
-        allowKind,
+        allowKind: r.allowKind,
       });
       console.log(`[share] mint share=${mint.shareId} purpose=${purpose} deduped=${mint.deduped}`);
       return {

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -90,11 +90,16 @@ const EXT_FOR_MIME: Record<string, string> = { 'application/pdf': 'pdf' };
  */
 export function attachmentDisposition(basename: string, mime: string): string {
   const ext = EXT_FOR_MIME[mime];
-  // Drop whatever extension the agent picked; the sniffed one replaces it. An
-  // unmapped mime can't happen today (PDF is the only non-image on the
-  // allowlist) but falls through to the name as-given rather than guessing.
+  // Drop whatever extension the agent picked, ALWAYS — the sniffed one replaces
+  // it, and when the mime maps to no extension the name simply ships without
+  // one. Keeping the agent's extension in that case would be the RFD hole this
+  // function exists to close: an unmapped mime is precisely the case where we
+  // cannot vouch for what the bytes are, so it must fail closed, not fall back
+  // to the attacker-chosen `.html`. (No unmapped mime reaches here today —
+  // images are served inline and PDF is the only other allowlisted type — so
+  // this is the guard for whatever gets allowlisted next.)
   const suffix = ext ? `.${ext}` : '';
-  const rawStem = ext ? basename.replace(/\.[^./\\]*$/, '') : basename;
+  const rawStem = basename.replace(/\.[^./\\]*$/, '');
   // Cap the STEM, so the extension survives truncation — a 4 KB agent-chosen
   // title must not cost the user a file their OS can no longer open (and must
   // not bloat, or behind some proxies break, the response header). Cap by CODE

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -11,6 +11,7 @@ import {
   ShareLimits,
   ShareAllowKind,
   mimeDetectorFor,
+  shareEnv,
   shareLimitsFromEnv,
   validateShareFile,
   DEFAULT_SHARE_TTL_SECONDS,
@@ -47,10 +48,10 @@ const DEFAULT_PUBLIC_RATE_PER_MIN = 60;
 
 function errStatus(code: string): number {
   switch (code) {
-    case 'image_ref_not_found': return 404;
-    case 'image_too_large': return 413;
+    case 'share_ref_not_found': return 404;
+    case 'file_too_large': return 413;
     case 'total_size_exceeded': return 413;
-    case 'unsupported_image_type': return 415;
+    case 'unsupported_file_type': return 415;
     default: return 400;
   }
 }
@@ -98,7 +99,7 @@ export function createSharesPublicRouter(
   opts: PublicShareRouterOpts = {},
 ): Router {
   const router = Router();
-  const envRate = Number(process.env.IMAGE_SHARE_PUBLIC_RATE_PER_MIN);
+  const envRate = Number(shareEnv('PUBLIC_RATE_PER_MIN'));
   const ratePerMinute =
     opts.ratePerMinute ?? (Number.isFinite(envRate) && envRate > 0 ? envRate : DEFAULT_PUBLIC_RATE_PER_MIN);
   const limits = shareLimitsFromEnv();
@@ -216,7 +217,7 @@ export function createSharesPrivateRouter(
   const auth = createApiAuthMiddleware(apiKeys);
   const limits = limitsOverride ?? shareLimitsFromEnv();
   const defaultTtl = (() => {
-    const n = Number(process.env.IMAGE_SHARE_CODEX_TTL_SECONDS);
+    const n = Number(shareEnv('CODEX_TTL_SECONDS'));
     return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_SHARE_TTL_SECONDS;
   })();
 
@@ -307,7 +308,7 @@ export function createSharesPrivateRouter(
       if (typeof ref.artifact_id === 'string' && ref.artifact_id.trim()) {
         const artifact = store.resolveArtifact(agentId, sessionId, ref.artifact_id.trim());
         if (!artifact) {
-          res.status(404).json({ error: 'referenced artifact was not found in this agent/session', code: 'image_ref_not_found' });
+          res.status(404).json({ error: 'referenced artifact was not found in this agent/session', code: 'share_ref_not_found' });
           return;
         }
         dedupeRef = `artifact:${artifact.artifactId}`;

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -62,12 +62,14 @@ function publicNotFound(res: Response): void {
   res.status(404).type('text/plain').send('Not Found');
 }
 
-/** RFC 8187 (which obsoletes RFC 5987) `attr-char`: everything
- *  encodeURIComponent leaves alone EXCEPT `!`, `'`, `(`, `)` and `*`, which are
- *  not attr-char and must be escaped. */
+/** Percent-encode for an RFC 8187 `ext-value` (the `filename*` form). RFC 8187
+ *  — which obsoletes RFC 5987 — defines attr-char as ALPHA / DIGIT / any of
+ *  `!#$&+-.^_\`|~`. encodeURIComponent already escapes everything outside that
+ *  set except `'`, `(`, `)` and `*`, so those four are all this has to add.
+ *  (`!` and `~` are left raw on purpose: both ARE attr-char.) */
 function rfc8187(value: string): string {
   return encodeURIComponent(value).replace(
-    /['()*!]/g,
+    /['()*]/g,
     (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
   );
 }

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -80,8 +80,17 @@ function rfc5987(value: string): string {
  */
 export function attachmentDisposition(basename: string): string {
   // Cap first: a media filename is agent-controlled and a 4 KB one would bloat
-  // (or, behind some proxies, break) the response header.
-  const name = basename.slice(0, MAX_DISPOSITION_NAME_CHARS);
+  // (or, behind some proxies, break) the response header. Cap by CODE POINT,
+  // not code unit — a plain `.slice()` can cut a surrogate pair in half, and
+  // encodeURIComponent throws URIError on the lone surrogate that leaves
+  // behind. That throw lands in the serve handler's catch and turns a
+  // perfectly good share into a uniform 404. The `\p{Surrogate}` scrub is the
+  // belt to that braces: after a code-point slice it can only ever match a
+  // surrogate that was already unpaired on the way in.
+  const name = [...basename]
+    .slice(0, MAX_DISPOSITION_NAME_CHARS)
+    .join('')
+    .replace(/\p{Surrogate}/gu, '_');
   const ascii = name.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_').trim();
   const fallback = ascii || 'download';
   return `attachment; filename="${fallback}"; filename*=UTF-8''${rfc5987(name)}`;

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import * as fs from 'fs';
+import * as path from 'path';
 import { createApiAuthMiddleware, canAccessAgent } from './auth';
 import { isValidAgentId, isValidSessionId } from './router';
 import { MediaStore } from '../history/media-store';
@@ -8,7 +9,8 @@ import {
   ShareStore,
   ShareError,
   ShareLimits,
-  detectImageMime,
+  ShareAllowKind,
+  mimeDetectorFor,
   shareLimitsFromEnv,
   validateShareFile,
   DEFAULT_SHARE_TTL_SECONDS,
@@ -40,6 +42,7 @@ const MIN_TTL_SECONDS = 10;
 const MAX_TTL_SECONDS = 86_400;
 const MAX_ARTIFACT_FILES = 10;
 const MAX_ARTIFACT_PROMPT_CHARS = 500;
+const MAX_DISPOSITION_NAME_CHARS = 200;
 const DEFAULT_PUBLIC_RATE_PER_MIN = 60;
 
 function errStatus(code: string): number {
@@ -56,6 +59,31 @@ function errStatus(code: string): number {
  *  deleted / forbidden so the response never leaks WHY (§11). */
 function publicNotFound(res: Response): void {
   res.status(404).type('text/plain').send('Not Found');
+}
+
+/** RFC 5987 `attr-char`: everything encodeURIComponent leaves alone EXCEPT
+ *  `!`, `'`, `(`, `)` and `*`, which are not attr-char and must be escaped. */
+function rfc5987(value: string): string {
+  return encodeURIComponent(value).replace(
+    /['()*!]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/**
+ * Build the `Content-Disposition` for a non-image share (#444). The basename
+ * comes from `relative_path`, which is agent-controlled, so the quoted
+ * `filename=` fallback keeps only printable ASCII minus `"` and `\` — that
+ * alone rules out the CR/LF that would split the header — and the real name
+ * rides along percent-encoded in `filename*`.
+ */
+export function attachmentDisposition(basename: string): string {
+  // Cap first: a media filename is agent-controlled and a 4 KB one would bloat
+  // (or, behind some proxies, break) the response header.
+  const name = basename.slice(0, MAX_DISPOSITION_NAME_CHARS);
+  const ascii = name.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_').trim();
+  const fallback = ascii || 'download';
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${rfc5987(name)}`;
 }
 
 export type PublicShareRouterOpts = {
@@ -135,13 +163,21 @@ export function createSharesPublicRouter(
       if (!stat.isFile() || stat.size > limits.maxFileBytes) throw new Error('invalid file');
       const header = Buffer.alloc(12);
       fs.readSync(fd, header, 0, 12, 0);
-      const mime = detectImageMime(header);
+      // Always re-sniff. The share row records the ALLOW-KIND it was minted
+      // under, never a mime: the file can be replaced between mint and fetch,
+      // so the kind only picks the detector and the bytes on disk decide the
+      // Content-Type (§12.9/§12.10, #444).
+      const mime = mimeDetectorFor(share.allowKind)(header);
       if (!mime) throw new Error('unsupported type');
 
+      // Images keep the exact `inline` they have always had. Anything else is
+      // offered as a download — the share origin must never invite a browser to
+      // render a non-image it just sniffed.
+      const isImage = mime.startsWith('image/');
       res.status(200).set({
         'Content-Type': mime,
         'Content-Length': String(stat.size),
-        'Content-Disposition': 'inline',
+        'Content-Disposition': isImage ? 'inline' : attachmentDisposition(path.basename(share.relativePath)),
         'X-Content-Type-Options': 'nosniff',
         'Cache-Control': 'private, no-store',
       });
@@ -186,11 +222,13 @@ export function createSharesPrivateRouter(
 
   /**
    * POST /api/v1/shares — mint one or more shares (§10).
-   * Body: { agent_id, session_id, purpose?, ttl_seconds?, refs: [{artifact_id}|{path}] }
+   * Body: { agent_id, session_id, purpose?, ttl_seconds?, allow_documents?, refs: [{artifact_id}|{path}] }
    * Response: { items: [{ share_id, token, url?, expires_at }] } — order preserved.
    * `token` is always present (host-agnostic capability); `url` is a convenience
    * built from `gateway.publicUrl` and is omitted when that is unset — callers
    * with their own public base (e.g. LINE) build the URL from `token`.
+   * `allow_documents` widens the allowlist to PDF for THIS request only and is
+   * recorded on each minted row (#444); without it a PDF is still 415.
    */
   router.post('/v1/shares', auth, (req: Request, res: Response) => {
     const apiKey = (req as AuthedRequest).apiKey;
@@ -199,6 +237,7 @@ export function createSharesPrivateRouter(
       session_id?: unknown;
       purpose?: unknown;
       ttl_seconds?: unknown;
+      allow_documents?: unknown;
       refs?: unknown;
     };
     const agentId = typeof body.agent_id === 'string' ? body.agent_id.trim() : '';
@@ -224,6 +263,11 @@ export function createSharesPrivateRouter(
       }
       ttlSeconds = Math.min(Math.max(Math.floor(body.ttl_seconds), MIN_TTL_SECONDS), MAX_TTL_SECONDS);
     }
+    if (body.allow_documents !== undefined && typeof body.allow_documents !== 'boolean') {
+      res.status(400).json({ error: 'allow_documents must be a boolean' });
+      return;
+    }
+    const allowKind: ShareAllowKind = body.allow_documents === true ? 'any' : 'image';
     const refs = body.refs;
     if (!Array.isArray(refs) || refs.length === 0) {
       res.status(400).json({ error: 'refs must be a non-empty array' });
@@ -280,7 +324,7 @@ export function createSharesPrivateRouter(
       }
       let validated;
       try {
-        validated = validateShareFile(agentsBaseDir, agentId, candidatePath, limits.maxFileBytes);
+        validated = validateShareFile(agentsBaseDir, agentId, candidatePath, limits.maxFileBytes, allowKind);
       } catch (err) {
         if (err instanceof ShareError) {
           res.status(errStatus(err.code)).json({ error: err.message, code: err.code });
@@ -322,6 +366,7 @@ export function createSharesPrivateRouter(
         dedupeRef: r.dedupeRef,
         purpose,
         ttlSeconds,
+        allowKind,
       });
       console.log(`[share] mint share=${mint.shareId} purpose=${purpose} deduped=${mint.deduped}`);
       return {
@@ -413,6 +458,9 @@ export function createSharesPrivateRouter(
       const file = (files as string[])[index]!;
       let validated;
       try {
+        // Deliberately NOT widened by #444: this registry feeds the session
+        // IMAGE catalog (generate_image refs, "the second image"), so it takes
+        // the default 'image' allow-kind and a PDF here is still a 415.
         validated = validateShareFile(agentsBaseDir, agentId, file, limits.maxFileBytes);
       } catch (err) {
         const code = err instanceof ShareError ? err.code : 'invalid_path';

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -62,9 +62,10 @@ function publicNotFound(res: Response): void {
   res.status(404).type('text/plain').send('Not Found');
 }
 
-/** RFC 5987 `attr-char`: everything encodeURIComponent leaves alone EXCEPT
- *  `!`, `'`, `(`, `)` and `*`, which are not attr-char and must be escaped. */
-function rfc5987(value: string): string {
+/** RFC 8187 (which obsoletes RFC 5987) `attr-char`: everything
+ *  encodeURIComponent leaves alone EXCEPT `!`, `'`, `(`, `)` and `*`, which are
+ *  not attr-char and must be escaped. */
+function rfc8187(value: string): string {
   return encodeURIComponent(value).replace(
     /['()*!]/g,
     (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
@@ -116,7 +117,7 @@ export function attachmentDisposition(basename: string, mime: string): string {
   // cannot ASCII-fold to nothing; the `|| 'download'` is kept as a guard on the
   // sanitiser rather than a reachable branch.
   const asciiStem = stem.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_').trim() || 'download';
-  return `attachment; filename="${asciiStem}${suffix}"; filename*=UTF-8''${rfc5987(`${stem}${suffix}`)}`;
+  return `attachment; filename="${asciiStem}${suffix}"; filename*=UTF-8''${rfc8187(`${stem}${suffix}`)}`;
 }
 
 export type PublicShareRouterOpts = {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -563,6 +563,11 @@ export class SessionProcess extends EventEmitter {
             IMAGE_API_KEY: process.env.IMAGE_API_KEY ?? process.env.ANTHROPIC_AUTH_TOKEN ?? '',
             IMAGE_DISABLED: process.env.IMAGE_DISABLED ?? '',
             IMAGE_POLL_TIMEOUT_MS: process.env.IMAGE_POLL_TIMEOUT_MS ?? '',
+            // #444: the share bridge's env vars were renamed IMAGE_SHARE_* ->
+            // SHARE_* when it stopped being image-only. Forward BOTH so an
+            // operator who set either name keeps working; the MCP side reads
+            // the neutral name first and falls back to the legacy one.
+            SHARE_MAX_REFS: process.env.SHARE_MAX_REFS ?? '',
             IMAGE_SHARE_MAX_REFS: process.env.IMAGE_SHARE_MAX_REFS ?? '',
             // Short-lived public media URLs (LINE image delivery). line_image
             // mints a share token via the gateway share bridge (using

--- a/src/share/share-store.ts
+++ b/src/share/share-store.ts
@@ -60,7 +60,10 @@ export class ShareError extends Error {
   }
 }
 
-/** Phase-1 formats: PNG / JPEG / WebP only (§11). GIF/SVG/PDF are rejected. */
+/** Raster image formats: PNG / JPEG / WebP (§11). GIF/SVG/PDF are NOT images
+ *  here — callers that genuinely need "is this an image" (LINE image messages,
+ *  provider image-edit refs, the session image catalog) must keep using this
+ *  one rather than the wider detectShareMime below. */
 export function detectImageMime(header: Buffer): 'image/png' | 'image/jpeg' | 'image/webp' | null {
   if (header.length >= 3 && header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff) return 'image/jpeg';
   if (header.length >= 8 && header[0] === 0x89 && header[1] === 0x50 && header[2] === 0x4e && header[3] === 0x47) return 'image/png';
@@ -70,6 +73,46 @@ export function detectImageMime(header: Buffer): 'image/png' | 'image/jpeg' | 'i
     header[8] === 0x57 && header[9] === 0x45 && header[10] === 0x42 && header[11] === 0x50
   ) return 'image/webp';
   return null;
+}
+
+/**
+ * What a share is allowed to carry. Persisted per share row and re-checked at
+ * fetch time — it is NOT a cached mime (#444). The file behind a live share can
+ * be replaced between mint and fetch, so serving always re-sniffs the magic
+ * bytes; this kind only selects WHICH detector runs. That keeps both directions
+ * safe: an `image` share whose file became a PDF still 404s, and an `any` share
+ * whose file became HTML still 404s.
+ */
+export type ShareAllowKind = 'image' | 'any';
+
+export const SHARE_ALLOW_KINDS: readonly ShareAllowKind[] = ['image', 'any'];
+
+export function isShareAllowKind(v: unknown): v is ShareAllowKind {
+  return typeof v === 'string' && (SHARE_ALLOW_KINDS as readonly string[]).includes(v);
+}
+
+/** `%PDF-` — the only non-image format on the share allowlist (#444). */
+function isPdf(header: Buffer): boolean {
+  return (
+    header.length >= 5 &&
+    header[0] === 0x25 && header[1] === 0x50 && header[2] === 0x44 && header[3] === 0x46 && header[4] === 0x2d
+  );
+}
+
+/**
+ * The full share allowlist: the three raster image types plus PDF. Deliberately
+ * limited to inert binary formats — `text/html`, `image/svg+xml` and
+ * `application/octet-stream` are NOT here and must not be added, because the
+ * share origin serves them to a browser and they would turn it into an XSS
+ * surface (§11).
+ */
+export function detectShareMime(header: Buffer): string | null {
+  return detectImageMime(header) ?? (isPdf(header) ? 'application/pdf' : null);
+}
+
+/** Pick the sniffer that matches a share's allow-kind. */
+export function mimeDetectorFor(allow: ShareAllowKind): (header: Buffer) => string | null {
+  return allow === 'any' ? detectShareMime : detectImageMime;
 }
 
 export type ValidatedShareFile = {
@@ -85,12 +128,16 @@ export type ValidatedShareFile = {
  * escapes, require a regular file, validate magic bytes and the per-file cap.
  * Returns only the media-root-relative path — client-supplied absolute paths
  * are never persisted. Throws ShareError with a stable code.
+ *
+ * `allow` defaults to 'image' so every existing caller keeps today's behaviour;
+ * only a caller that has explicitly opted into documents passes 'any' (#444).
  */
 export function validateShareFile(
   agentsBaseDir: string,
   agentId: string,
   ref: string,
   maxFileBytes: number = DEFAULT_MAX_FILE_BYTES,
+  allow: ShareAllowKind = 'image',
 ): ValidatedShareFile {
   const root = MediaStore.agentMediaRoot(agentsBaseDir, agentId);
   let resolved: string;
@@ -127,9 +174,14 @@ export function validateShareFile(
   } finally {
     fs.closeSync(fd);
   }
-  const mime = detectImageMime(header);
+  const mime = mimeDetectorFor(allow)(header);
   if (!mime) {
-    throw new ShareError('unsupported_image_type', 'only PNG, JPEG and WebP can be shared');
+    throw new ShareError(
+      'unsupported_image_type',
+      allow === 'any'
+        ? 'only PNG, JPEG, WebP and PDF can be shared'
+        : 'only PNG, JPEG and WebP can be shared',
+    );
   }
   const relativePath = path.relative(root, resolved);
   if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
@@ -153,6 +205,9 @@ export type ShareRow = {
   sessionId: string;
   relativePath: string;
   purpose: string;
+  /** What this share was minted to carry. Serving re-sniffs the file and uses
+   *  this only to pick the detector — never as a cached mime (#444). */
+  allowKind: ShareAllowKind;
 };
 
 export type ArtifactRow = {
@@ -199,7 +254,8 @@ export class ShareStore {
         purpose       TEXT NOT NULL,
         created_at    INTEGER NOT NULL,
         expires_at    INTEGER NOT NULL,
-        revoked_at    INTEGER
+        revoked_at    INTEGER,
+        allow_kind    TEXT NOT NULL DEFAULT 'image'
       );
       CREATE INDEX IF NOT EXISTS image_shares_expiry ON image_shares(expires_at);
 
@@ -224,6 +280,13 @@ export class ShareStore {
     const cols = this.db.prepare(`PRAGMA table_info(image_artifacts)`).all() as Array<{ name: string }>;
     if (!cols.some((c) => c.name === 'prompt')) {
       this.db.exec('ALTER TABLE image_artifacts ADD COLUMN prompt TEXT');
+    }
+    // Same story for `allow_kind` (#444): DBs minted before documents were
+    // allowed carry image-only shares, and 'image' is exactly their existing
+    // behaviour, so the default backfills them correctly.
+    const shareCols = this.db.prepare(`PRAGMA table_info(image_shares)`).all() as Array<{ name: string }>;
+    if (!shareCols.some((c) => c.name === 'allow_kind')) {
+      this.db.exec(`ALTER TABLE image_shares ADD COLUMN allow_kind TEXT NOT NULL DEFAULT 'image'`);
     }
   }
 
@@ -315,8 +378,10 @@ export class ShareStore {
   /**
    * Mint a share. `dedupeRef` is the caller-facing identity of the ref
    * (e.g. "artifact:img_x" or "path:<relative>") — an identical mint for the
-   * same (agent, session, ref, purpose) within MINT_DEDUPE_WINDOW_MS returns
-   * the SAME token (§17.4) so provider-side dedupe keeps working.
+   * same (agent, session, ref, purpose, allowKind) within MINT_DEDUPE_WINDOW_MS
+   * returns the SAME token (§17.4) so provider-side dedupe keeps working.
+   * `allowKind` is part of the key because two mints of the same file under
+   * different allow-kinds are different capabilities and must not collapse.
    */
   mintShare(a: {
     agentId: string;
@@ -325,8 +390,10 @@ export class ShareStore {
     dedupeRef: string;
     purpose: string;
     ttlSeconds: number;
+    allowKind?: ShareAllowKind;
   }): MintedShare {
-    const key = [a.agentId, a.sessionId, a.dedupeRef, a.purpose].join(' ');
+    const allowKind: ShareAllowKind = a.allowKind ?? 'image';
+    const key = [a.agentId, a.sessionId, a.dedupeRef, a.purpose, allowKind].join('\0');
     const now = Date.now();
     const cached = this.mintCache.get(key);
     if (cached && now - cached.mintedAtMs < MINT_DEDUPE_WINDOW_MS && cached.expiresAtMs > now) {
@@ -337,9 +404,9 @@ export class ShareStore {
     const shareId = `shr_${randomBytes(9).toString('base64url')}`;
     const expiresAtMs = now + a.ttlSeconds * 1000;
     this.db.prepare(
-      `INSERT INTO image_shares (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(shareId, tokenHash, a.agentId, a.sessionId, a.relativePath, a.purpose, now, expiresAtMs);
+      `INSERT INTO image_shares (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at, allow_kind)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(shareId, tokenHash, a.agentId, a.sessionId, a.relativePath, a.purpose, now, expiresAtMs, allowKind);
     this.mintCache.set(key, { shareId, token, expiresAtMs, deduped: false, mintedAtMs: now });
     this.pruneMintCache(now);
     return { shareId, token, expiresAtMs, deduped: false };
@@ -350,11 +417,18 @@ export class ShareStore {
     if (!SHARE_TOKEN_RE.test(token)) return null;
     const tokenHash = createHash('sha256').update(token).digest();
     const row = this.db.prepare(
-      `SELECT id, agent_id, session_id, relative_path, purpose
+      `SELECT id, agent_id, session_id, relative_path, purpose, allow_kind
        FROM image_shares
        WHERE token_hash = ? AND revoked_at IS NULL AND expires_at > ?`,
     ).get(tokenHash, Date.now()) as
-      | { id: string; agent_id: string; session_id: string; relative_path: string; purpose: string }
+      | {
+          id: string;
+          agent_id: string;
+          session_id: string;
+          relative_path: string;
+          purpose: string;
+          allow_kind: string | null;
+        }
       | undefined;
     if (!row) return null;
     return {
@@ -363,6 +437,9 @@ export class ShareStore {
       sessionId: row.session_id,
       relativePath: row.relative_path,
       purpose: row.purpose,
+      // Anything unrecognised (or a legacy NULL) falls back to the strictest
+      // kind — an unknown value must never widen what a share can serve.
+      allowKind: isShareAllowKind(row.allow_kind) ? row.allow_kind : 'image',
     };
   }
 

--- a/src/share/share-store.ts
+++ b/src/share/share-store.ts
@@ -39,15 +39,27 @@ export type ShareLimits = {
   maxTotalBytes: number;
 };
 
+/**
+ * Read a share setting, preferring the neutral `SHARE_*` name and falling back
+ * to the legacy `IMAGE_SHARE_*` one (#444). Both names are forwarded to session
+ * subprocesses, so an operator who set either keeps working. An empty value
+ * counts as unset — `src/session/process.ts` forwards unset vars as `''`, and
+ * without this an empty new name would shadow a real legacy one.
+ */
+export function shareEnv(suffix: string): string | undefined {
+  const pick = (v: string | undefined): string | undefined => (v !== undefined && v !== '' ? v : undefined);
+  return pick(process.env[`SHARE_${suffix}`]) ?? pick(process.env[`IMAGE_SHARE_${suffix}`]);
+}
+
 export function shareLimitsFromEnv(): ShareLimits {
   const num = (v: string | undefined, dflt: number): number => {
     const n = Number(v);
     return Number.isFinite(n) && n > 0 ? Math.floor(n) : dflt;
   };
   return {
-    maxRefs: num(process.env.IMAGE_SHARE_MAX_REFS, DEFAULT_MAX_REFS),
-    maxFileBytes: num(process.env.IMAGE_SHARE_MAX_FILE_BYTES, DEFAULT_MAX_FILE_BYTES),
-    maxTotalBytes: num(process.env.IMAGE_SHARE_MAX_TOTAL_BYTES, DEFAULT_MAX_TOTAL_BYTES),
+    maxRefs: num(shareEnv('MAX_REFS'), DEFAULT_MAX_REFS),
+    maxFileBytes: num(shareEnv('MAX_FILE_BYTES'), DEFAULT_MAX_FILE_BYTES),
+    maxTotalBytes: num(shareEnv('MAX_TOTAL_BYTES'), DEFAULT_MAX_TOTAL_BYTES),
   };
 }
 
@@ -159,13 +171,13 @@ export function validateShareFile(
   try {
     stat = fs.lstatSync(resolved); // realpath already followed links; lstat guards devices/FIFOs
   } catch {
-    throw new ShareError('image_ref_not_found', 'referenced image file does not exist');
+    throw new ShareError('share_ref_not_found', 'referenced file does not exist');
   }
   if (!stat.isFile()) {
     throw new ShareError('invalid_path', 'referenced path is not a regular file');
   }
   if (stat.size > maxFileBytes) {
-    throw new ShareError('image_too_large', `image exceeds ${maxFileBytes} bytes`);
+    throw new ShareError('file_too_large', `file exceeds ${maxFileBytes} bytes`);
   }
   const header = Buffer.alloc(12);
   const fd = fs.openSync(resolved, 'r');
@@ -177,7 +189,7 @@ export function validateShareFile(
   const mime = mimeDetectorFor(allow)(header);
   if (!mime) {
     throw new ShareError(
-      'unsupported_image_type',
+      'unsupported_file_type',
       allow === 'any'
         ? 'only PNG, JPEG, WebP and PDF can be shared'
         : 'only PNG, JPEG and WebP can be shared',
@@ -244,8 +256,22 @@ export class ShareStore {
     this.db.exec('PRAGMA journal_mode=WAL');
     this.db.exec('PRAGMA busy_timeout=5000');
     this.db.exec('PRAGMA foreign_keys=ON');
+    // #444: the table was `image_shares` back when the bridge could only carry
+    // images. Rename in place — and BEFORE the CREATE TABLE IF NOT EXISTS
+    // below, which would otherwise create an empty `file_shares` beside the
+    // real data and silently 404 every live share. Shares are ephemeral (TTL
+    // <= 24h, swept by cleanupExpired) so nothing durable is at stake, but
+    // renaming keeps shares minted before the upgrade resolving after it.
+    const hasTable = (name: string): boolean =>
+      !!this.db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(name);
+    if (hasTable('image_shares') && !hasTable('file_shares')) {
+      this.db.exec('ALTER TABLE image_shares RENAME TO file_shares');
+      // RENAME TO carries indexes over under their OLD names, so drop the old
+      // one rather than let CREATE INDEX IF NOT EXISTS add a duplicate.
+      this.db.exec('DROP INDEX IF EXISTS image_shares_expiry');
+    }
     this.db.exec(`
-      CREATE TABLE IF NOT EXISTS image_shares (
+      CREATE TABLE IF NOT EXISTS file_shares (
         id            TEXT PRIMARY KEY,
         token_hash    BLOB NOT NULL UNIQUE,
         agent_id      TEXT NOT NULL,
@@ -257,7 +283,7 @@ export class ShareStore {
         revoked_at    INTEGER,
         allow_kind    TEXT NOT NULL DEFAULT 'image'
       );
-      CREATE INDEX IF NOT EXISTS image_shares_expiry ON image_shares(expires_at);
+      CREATE INDEX IF NOT EXISTS file_shares_expiry ON file_shares(expires_at);
 
       CREATE TABLE IF NOT EXISTS image_artifacts (
         id            TEXT PRIMARY KEY,
@@ -284,9 +310,9 @@ export class ShareStore {
     // Same story for `allow_kind` (#444): DBs minted before documents were
     // allowed carry image-only shares, and 'image' is exactly their existing
     // behaviour, so the default backfills them correctly.
-    const shareCols = this.db.prepare(`PRAGMA table_info(image_shares)`).all() as Array<{ name: string }>;
+    const shareCols = this.db.prepare(`PRAGMA table_info(file_shares)`).all() as Array<{ name: string }>;
     if (!shareCols.some((c) => c.name === 'allow_kind')) {
-      this.db.exec(`ALTER TABLE image_shares ADD COLUMN allow_kind TEXT NOT NULL DEFAULT 'image'`);
+      this.db.exec(`ALTER TABLE file_shares ADD COLUMN allow_kind TEXT NOT NULL DEFAULT 'image'`);
     }
   }
 
@@ -404,7 +430,7 @@ export class ShareStore {
     const shareId = `shr_${randomBytes(9).toString('base64url')}`;
     const expiresAtMs = now + a.ttlSeconds * 1000;
     this.db.prepare(
-      `INSERT INTO image_shares (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at, allow_kind)
+      `INSERT INTO file_shares (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at, allow_kind)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(shareId, tokenHash, a.agentId, a.sessionId, a.relativePath, a.purpose, now, expiresAtMs, allowKind);
     this.mintCache.set(key, { shareId, token, expiresAtMs, deduped: false, mintedAtMs: now });
@@ -418,7 +444,7 @@ export class ShareStore {
     const tokenHash = createHash('sha256').update(token).digest();
     const row = this.db.prepare(
       `SELECT id, agent_id, session_id, relative_path, purpose, allow_kind
-       FROM image_shares
+       FROM file_shares
        WHERE token_hash = ? AND revoked_at IS NULL AND expires_at > ?`,
     ).get(tokenHash, Date.now()) as
       | {
@@ -445,7 +471,7 @@ export class ShareStore {
 
   getShareOwner(shareId: string): { agentId: string; sessionId: string; purpose: string } | null {
     const row = this.db.prepare(
-      `SELECT agent_id, session_id, purpose FROM image_shares WHERE id = ? AND revoked_at IS NULL`,
+      `SELECT agent_id, session_id, purpose FROM file_shares WHERE id = ? AND revoked_at IS NULL`,
     ).get(shareId) as { agent_id: string; session_id: string; purpose: string } | undefined;
     return row ? { agentId: row.agent_id, sessionId: row.session_id, purpose: row.purpose } : null;
   }
@@ -454,7 +480,7 @@ export class ShareStore {
    *  it so a post-revoke mint issues a FRESH token. Returns false when unknown. */
   revokeShare(shareId: string): boolean {
     const res = this.db.prepare(
-      `UPDATE image_shares SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`,
+      `UPDATE file_shares SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`,
     ).run(Date.now(), shareId);
     for (const [key, entry] of this.mintCache) {
       if (entry.shareId === shareId) this.mintCache.delete(key);
@@ -465,7 +491,7 @@ export class ShareStore {
   /** Lazy cleanup — delete expired rows. Safe to call opportunistically. */
   cleanupExpired(): void {
     try {
-      this.db.prepare(`DELETE FROM image_shares WHERE expires_at <= ?`).run(Date.now());
+      this.db.prepare(`DELETE FROM file_shares WHERE expires_at <= ?`).run(Date.now());
     } catch {
       /* best-effort */
     }

--- a/src/share/share-store.ts
+++ b/src/share/share-store.ts
@@ -314,6 +314,25 @@ export class ShareStore {
     if (!shareCols.some((c) => c.name === 'allow_kind')) {
       this.db.exec(`ALTER TABLE file_shares ADD COLUMN allow_kind TEXT NOT NULL DEFAULT 'image'`);
     }
+    // `image_shares` surviving THIS far means a downgrade recreated it (the
+    // pre-#444 release runs its own CREATE TABLE IF NOT EXISTS) and minted
+    // into it, and we have now rolled forward. The rename guard above no
+    // longer fires — both tables exist — so without this those shares would
+    // 404 until their TTL ran out while the orphan table stayed in the file
+    // forever. Fold the rows in (they are image-only by definition: the
+    // release that wrote them knew nothing else) and drop the orphan, so the
+    // migration is idempotent across a rollback rather than one-shot. Runs
+    // after the ALTER above so `allow_kind` is guaranteed to exist.
+    if (hasTable('image_shares')) {
+      this.db.exec(`
+        INSERT OR IGNORE INTO file_shares
+          (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at, revoked_at, allow_kind)
+        SELECT id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at, revoked_at, 'image'
+          FROM image_shares
+      `);
+      // DROP TABLE takes the table's indexes with it.
+      this.db.exec('DROP TABLE image_shares');
+    }
   }
 
   // ── artifacts (§8) ────────────────────────────────────────────────────────

--- a/src/share/share-store.ts
+++ b/src/share/share-store.ts
@@ -269,6 +269,7 @@ export class ShareStore {
       // RENAME TO carries indexes over under their OLD names, so drop the old
       // one rather than let CREATE INDEX IF NOT EXISTS add a duplicate.
       this.db.exec('DROP INDEX IF EXISTS image_shares_expiry');
+      console.log('[share] renamed legacy image_shares table to file_shares');
     }
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS file_shares (
@@ -324,14 +325,27 @@ export class ShareStore {
     // migration is idempotent across a rollback rather than one-shot. Runs
     // after the ALTER above so `allow_kind` is guaranteed to exist.
     if (hasTable('image_shares')) {
+      const legacy = this.db.prepare(`SELECT COUNT(*) AS n FROM image_shares`).get() as { n: number };
+      const before = this.db.prepare(`SELECT COUNT(*) AS n FROM file_shares`).get() as { n: number };
       this.db.exec(`
         INSERT OR IGNORE INTO file_shares
           (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at, revoked_at, allow_kind)
         SELECT id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at, revoked_at, 'image'
           FROM image_shares
       `);
+      const after = this.db.prepare(`SELECT COUNT(*) AS n FROM file_shares`).get() as { n: number };
       // DROP TABLE takes the table's indexes with it.
       this.db.exec('DROP TABLE image_shares');
+      // Say so. Reaching here at all means this deployment was rolled back
+      // across #444 and rolled forward again — rare, and worth a line in the
+      // log rather than a database that quietly changed shape. `skipped` is
+      // non-zero only when OR IGNORE hit the token_hash UNIQUE, i.e. the same
+      // token exists in both tables; the file_shares row wins because it is the
+      // one this build minted. No token or path is logged (§19).
+      const folded = after.n - before.n;
+      console.log(
+        `[share] migrated legacy image_shares: rows=${legacy.n} folded=${folded} skipped=${legacy.n - folded}`,
+      );
     }
   }
 

--- a/tests/unit/share-file-module.test.ts
+++ b/tests/unit/share-file-module.test.ts
@@ -88,6 +88,22 @@ describe('share_file MCP module', () => {
       expect(alias!.description).toContain('share_file');
       expect(alias!.description.length).toBeLessThan(primary!.description.length / 3);
     });
+
+    // The alias is image-only, so its schema must not hold up a PDF as an
+    // example — an agent reading it would be told a document is acceptable and
+    // get a 415 back.
+    test('the alias schema advertises an image example, not a PDF', () => {
+      const [primary, alias] = new ShareFileModule().getTools();
+      const aliasSchema = JSON.stringify(alias!.inputSchema);
+      expect(aliasSchema).not.toContain('.pdf');
+      expect(aliasSchema).toContain('.png');
+      // The primary keeps the PDF example — it really does share them.
+      expect(JSON.stringify(primary!.inputSchema)).toContain('.pdf');
+      // Same shape otherwise: only the wording differs.
+      expect(Object.keys(JSON.parse(aliasSchema).properties)).toEqual(
+        Object.keys(JSON.parse(JSON.stringify(primary!.inputSchema)).properties),
+      );
+    });
   });
 
   describe('create', () => {

--- a/tests/unit/share-file-module.test.ts
+++ b/tests/unit/share-file-module.test.ts
@@ -1,10 +1,11 @@
 /**
- * Unit tests for the standalone share_image MCP tool (#70) —
- * mcp/tools/share-image/module.ts. Locks in: gateway-context gating, create/revoke
- * plumbing through the authenticated gateway API, and the DELIBERATE absence
- * of any list action (plan §15).
+ * Unit tests for the standalone share_file MCP tool (#70, renamed from
+ * share_image in #444) — mcp/tools/share-file/module.ts. Locks in:
+ * gateway-context gating, create/revoke plumbing through the authenticated
+ * gateway API, the deprecated share_image alias, and the DELIBERATE absence of
+ * any list action (plan §15).
  */
-import { ShareImageModule } from '../../mcp/tools/share-image/module';
+import { ShareFileModule } from '../../mcp/tools/share-file/module';
 
 const GATEWAY = 'http://127.0.0.1:19999';
 
@@ -17,7 +18,7 @@ const ENV_KEYS = [
 
 type Captured = { url: string; method: string; body?: Record<string, unknown> };
 
-describe('share_image MCP module', () => {
+describe('share_file MCP module', () => {
   const saved: Record<string, string | undefined> = {};
   const realFetch = global.fetch;
   let calls: Captured[];
@@ -64,24 +65,34 @@ describe('share_image MCP module', () => {
 
   describe('gating', () => {
     test('enabled only when the full gateway API context is present', () => {
-      expect(new ShareImageModule().isEnabled()).toBe(true);
+      expect(new ShareFileModule().isEnabled()).toBe(true);
       delete process.env.GATEWAY_SESSION_ID;
-      expect(new ShareImageModule().isEnabled()).toBe(false);
+      expect(new ShareFileModule().isEnabled()).toBe(false);
     });
 
-    test('exposes exactly one tool and NO list action', () => {
-      const tools = new ShareImageModule().getTools();
-      expect(tools).toHaveLength(1);
-      expect(tools[0]!.name).toBe('share_image');
-      const schema = JSON.stringify(tools[0]!.inputSchema);
-      expect(schema).not.toContain('"list"');
-      expect((JSON.parse(schema).properties.action.enum as string[])).toEqual(['create', 'revoke']);
+    test('exposes share_file plus the deprecated alias, and NO list action', () => {
+      const tools = new ShareFileModule().getTools();
+      expect(tools.map((t) => t.name)).toEqual(['share_file', 'share_image']);
+      for (const tool of tools) {
+        const schema = JSON.stringify(tool.inputSchema);
+        expect(schema).not.toContain('"list"');
+        expect((JSON.parse(schema).properties.action.enum as string[])).toEqual(['create', 'revoke']);
+      }
+    });
+
+    // #444: the alias exists to keep agent instructions written against the old
+    // name working — it must not cost a second copy of the real description.
+    test('the alias description is a one-liner pointing at share_file', () => {
+      const [primary, alias] = new ShareFileModule().getTools();
+      expect(alias!.description).toContain('Deprecated');
+      expect(alias!.description).toContain('share_file');
+      expect(alias!.description.length).toBeLessThan(primary!.description.length / 3);
     });
   });
 
   describe('create', () => {
     test('single path → POST /api/v1/shares with identity from env', async () => {
-      const res = await new ShareImageModule().handleTool('share_image', {
+      const res = await new ShareFileModule().handleTool('share_file', {
         action: 'create',
         path: 'media/session-1/image.png',
         ttl_seconds: 900,
@@ -101,7 +112,7 @@ describe('share_image MCP module', () => {
     });
 
     test('batch paths + artifact refs are classified correctly', async () => {
-      await new ShareImageModule().handleTool('share_image', {
+      await new ShareFileModule().handleTool('share_file', {
         action: 'create',
         paths: ['media/session-1/a.png', 'artifact:img_x'],
       });
@@ -109,7 +120,7 @@ describe('share_image MCP module', () => {
     });
 
     test('path AND paths together → error, no call', async () => {
-      const res = await new ShareImageModule().handleTool('share_image', {
+      const res = await new ShareFileModule().handleTool('share_file', {
         action: 'create',
         path: 'a.png',
         paths: ['b.png'],
@@ -122,7 +133,7 @@ describe('share_image MCP module', () => {
     // opts into the full share allowlist (images + PDF). The narrow image
     // consumers (line_image, generate_image ref normalization) must NOT.
     test('always opts into documents so a PDF can be shared', async () => {
-      await new ShareImageModule().handleTool('share_image', {
+      await new ShareFileModule().handleTool('share_file', {
         action: 'create',
         path: 'media/session-1/report.pdf',
       });
@@ -130,30 +141,57 @@ describe('share_image MCP module', () => {
     });
 
     test('gateway error code is surfaced', async () => {
-      responder = () => new Response(JSON.stringify({ error: 'nope', code: 'image_ref_not_found' }), { status: 404 });
-      const res = await new ShareImageModule().handleTool('share_image', { action: 'create', path: 'gone.png' });
+      responder = () => new Response(JSON.stringify({ error: 'nope', code: 'share_ref_not_found' }), { status: 404 });
+      const res = await new ShareFileModule().handleTool('share_file', { action: 'create', path: 'gone.png' });
       expect(res.isError).toBe(true);
-      expect(res.content[0]!.text).toContain('image_ref_not_found');
+      expect(res.content[0]!.text).toContain('share_ref_not_found');
     });
   });
 
   describe('revoke', () => {
     test('DELETE /api/v1/shares/:id', async () => {
-      const res = await new ShareImageModule().handleTool('share_image', { action: 'revoke', share_id: 'shr_1' });
+      const res = await new ShareFileModule().handleTool('share_file', { action: 'revoke', share_id: 'shr_1' });
       expect(res.isError).toBeUndefined();
       expect(calls[0]!.method).toBe('DELETE');
       expect(calls[0]!.url).toBe(`${GATEWAY}/api/v1/shares/shr_1`);
     });
 
     test('missing share_id → error, no call', async () => {
-      const res = await new ShareImageModule().handleTool('share_image', { action: 'revoke' });
+      const res = await new ShareFileModule().handleTool('share_file', { action: 'revoke' });
       expect(res.isError).toBe(true);
       expect(calls).toHaveLength(0);
     });
   });
 
+  // #444: agent workspaces (AGENTS.md, skills, memories) still say share_image,
+  // and we do not get to rewrite them — the old name must keep working.
+  describe('deprecated share_image alias', () => {
+    test('create behaves identically to share_file', async () => {
+      const res = await new ShareFileModule().handleTool('share_image', {
+        action: 'create',
+        path: 'media/session-1/report.pdf',
+      });
+      expect(res.isError).toBeUndefined();
+      expect(calls[0]!.url).toBe(`${GATEWAY}/api/v1/shares`);
+      expect(calls[0]!.body!.allow_documents).toBe(true);
+    });
+
+    test('revoke behaves identically to share_file', async () => {
+      const res = await new ShareFileModule().handleTool('share_image', { action: 'revoke', share_id: 'shr_1' });
+      expect(res.isError).toBeUndefined();
+      expect(calls[0]!.method).toBe('DELETE');
+    });
+  });
+
+  test('unknown tool name → error, no call', async () => {
+    const res = await new ShareFileModule().handleTool('share_document', { action: 'create', path: 'a.png' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('Unknown tool');
+    expect(calls).toHaveLength(0);
+  });
+
   test('unknown action (including "list") → error, no call', async () => {
-    const res = await new ShareImageModule().handleTool('share_image', { action: 'list' });
+    const res = await new ShareFileModule().handleTool('share_file', { action: 'list' });
     expect(res.isError).toBe(true);
     expect(calls).toHaveLength(0);
   });

--- a/tests/unit/share-file-module.test.ts
+++ b/tests/unit/share-file-module.test.ts
@@ -164,22 +164,47 @@ describe('share_file MCP module', () => {
   });
 
   // #444: agent workspaces (AGENTS.md, skills, memories) still say share_image,
-  // and we do not get to rewrite them — the old name must keep working.
+  // and we do not get to rewrite them — the old name must keep working. It stays
+  // IMAGE-ONLY though: those instructions meant "share an image", and widening
+  // them would change what an already-handed-out token can serve.
   describe('deprecated share_image alias', () => {
-    test('create behaves identically to share_file', async () => {
+    test('create works, but does NOT opt into documents', async () => {
       const res = await new ShareFileModule().handleTool('share_image', {
         action: 'create',
-        path: 'media/session-1/report.pdf',
+        path: 'media/session-1/chart.png',
       });
       expect(res.isError).toBeUndefined();
       expect(calls[0]!.url).toBe(`${GATEWAY}/api/v1/shares`);
-      expect(calls[0]!.body!.allow_documents).toBe(true);
+      // Absent, not false — the gateway defaults to image-only.
+      expect(calls[0]!.body!.allow_documents).toBeUndefined();
     });
 
     test('revoke behaves identically to share_file', async () => {
       const res = await new ShareFileModule().handleTool('share_image', { action: 'revoke', share_id: 'shr_1' });
       expect(res.isError).toBeUndefined();
       expect(calls[0]!.method).toBe('DELETE');
+    });
+
+    test('a 415 through the old name points the agent at share_file', async () => {
+      responder = () =>
+        new Response(JSON.stringify({ error: 'file type is not allowed', code: 'unsupported_file_type' }), { status: 415 });
+      const res = await new ShareFileModule().handleTool('share_image', {
+        action: 'create',
+        path: 'media/session-1/report.pdf',
+      });
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text).toContain('call share_file for documents');
+    });
+
+    test('the same 415 through share_file carries no such hint', async () => {
+      responder = () =>
+        new Response(JSON.stringify({ error: 'file type is not allowed', code: 'unsupported_file_type' }), { status: 415 });
+      const res = await new ShareFileModule().handleTool('share_file', {
+        action: 'create',
+        path: 'media/session-1/report.pdf',
+      });
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text).not.toContain('call share_file for documents');
     });
   });
 

--- a/tests/unit/share-image-module.test.ts
+++ b/tests/unit/share-image-module.test.ts
@@ -118,6 +118,17 @@ describe('share_image MCP module', () => {
       expect(calls).toHaveLength(0);
     });
 
+    // #444: this tool is the agent's explicit "publish this file" verb, so it
+    // opts into the full share allowlist (images + PDF). The narrow image
+    // consumers (line_image, generate_image ref normalization) must NOT.
+    test('always opts into documents so a PDF can be shared', async () => {
+      await new ShareImageModule().handleTool('share_image', {
+        action: 'create',
+        path: 'media/session-1/report.pdf',
+      });
+      expect(calls[0]!.body!.allow_documents).toBe(true);
+    });
+
     test('gateway error code is surfaced', async () => {
       responder = () => new Response(JSON.stringify({ error: 'nope', code: 'image_ref_not_found' }), { status: 404 });
       const res = await new ShareImageModule().handleTool('share_image', { action: 'create', path: 'gone.png' });

--- a/tests/unit/share-normalize.test.ts
+++ b/tests/unit/share-normalize.test.ts
@@ -27,6 +27,7 @@ const ENV_KEYS = [
   'ANTHROPIC_AUTH_TOKEN',
   'IMAGE_DISABLED',
   'IMAGE_POLL_TIMEOUT_MS',
+  'SHARE_MAX_REFS',
   'IMAGE_SHARE_MAX_REFS',
   'GATEWAY_API_URL',
   'GATEWAY_API_KEY',
@@ -333,13 +334,58 @@ describe('generate_image share-bridge normalization (#70)', () => {
       expect(calls).toHaveLength(0);
     });
 
-    test('missing artifact → deterministic image_ref_not_found, no submit', async () => {
+    test('missing artifact → deterministic share_ref_not_found, no submit', async () => {
+      shareStatus = 404;
+      shareErrorBody = { error: 'referenced artifact was not found in this agent/session', code: 'share_ref_not_found' };
+      const res = await generate({ image: 'artifact:img_gone' });
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text).toContain('share_ref_not_found');
+      expect(submitCall()).toBeUndefined();
+    });
+
+    // #444 renamed this code. The MCP subprocess can be talking to a gateway
+    // that predates the rename, so the legacy code must still produce the same
+    // deterministic "does not exist" message rather than a generic failure.
+    test('a pre-#444 gateway still answering image_ref_not_found is handled the same', async () => {
       shareStatus = 404;
       shareErrorBody = { error: 'referenced artifact was not found in this agent/session', code: 'image_ref_not_found' };
       const res = await generate({ image: 'artifact:img_gone' });
       expect(res.isError).toBe(true);
       expect(res.content[0]!.text).toContain('image_ref_not_found');
+      expect(res.content[0]!.text).toContain('does not exist in this session');
       expect(submitCall()).toBeUndefined();
+    });
+
+    // #444: the neutral name wins, but the legacy one still tunes the cap so an
+    // existing deployment does not silently jump back to the default of 5.
+    describe('max-refs env dual-read', () => {
+      test('legacy IMAGE_SHARE_MAX_REFS still caps the ref count', async () => {
+        process.env.IMAGE_SHARE_MAX_REFS = '2';
+        const res = await generate({ images: ['a.png', 'b.png', 'c.png'] });
+        expect(res.isError).toBe(true);
+        expect(res.content[0]!.text).toContain('max 2');
+        expect(calls).toHaveLength(0);
+      });
+
+      test('neutral SHARE_MAX_REFS wins over the legacy name', async () => {
+        process.env.SHARE_MAX_REFS = '3';
+        process.env.IMAGE_SHARE_MAX_REFS = '2';
+        const res = await generate({ images: ['a.png', 'b.png', 'c.png', 'd.png'] });
+        expect(res.isError).toBe(true);
+        expect(res.content[0]!.text).toContain('max 3');
+        expect(calls).toHaveLength(0);
+      });
+
+      // Unset vars reach this subprocess as '' — that must not shadow the
+      // legacy name and silently restore the default cap.
+      test('an empty neutral name falls through to the legacy one', async () => {
+        process.env.SHARE_MAX_REFS = '';
+        process.env.IMAGE_SHARE_MAX_REFS = '2';
+        const res = await generate({ images: ['a.png', 'b.png', 'c.png'] });
+        expect(res.isError).toBe(true);
+        expect(res.content[0]!.text).toContain('max 2');
+        expect(calls).toHaveLength(0);
+      });
     });
 
     test('submit failure → freshly minted shares are best-effort revoked (§18)', async () => {

--- a/tests/unit/share-normalize.test.ts
+++ b/tests/unit/share-normalize.test.ts
@@ -173,6 +173,9 @@ describe('generate_image share-bridge normalization (#70)', () => {
         refs: [{ path: 'media/session-1/duck.png' }],
       });
       expect(sc[0]!.headers['Authorization']).toBe('Bearer gw-key');
+      // #444: ref normalization feeds an image-editing provider, so it must NOT
+      // opt into documents — a PDF ref here has to keep failing at the gateway.
+      expect(sc[0]!.body!.allow_documents).toBeUndefined();
       expect(submitCall()!.body!.image).toBe('https://vm.example.com/gateway/shared/tok1');
     });
 

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -45,7 +45,7 @@ const AUTH_A1 = { Authorization: 'Bearer a1-key' };
 const AUTH_B1 = { Authorization: 'Bearer b1-key' };
 const AUTH_STAR = { Authorization: 'Bearer star-key' };
 
-describe('image share router', () => {
+describe('file share router', () => {
   let baseDir: string;
   let mediaDir: string;
   let store: ShareStore;
@@ -678,6 +678,23 @@ describe('image share router', () => {
         // 4 KB of filename must not become a 4 KB header.
         const long = attachmentDisposition(`${'n'.repeat(4096)}.pdf`);
         expect(long).toBe(`attachment; filename="${'n'.repeat(200)}"; filename*=UTF-8''${'n'.repeat(200)}`);
+      });
+
+      test('the length cap never splits a surrogate pair into an unencodable half', () => {
+        // A code-unit slice would cut this emoji in half at the 200-char cap and
+        // leave a lone surrogate, which encodeURIComponent rejects with
+        // URIError — inside the serve handler's try, that becomes a bogus 404
+        // on a share whose file is perfectly fine. Cap by code point instead.
+        const straddling = `${'a'.repeat(199)}\u{1F389}.pdf`;
+        const cd = attachmentDisposition(straddling);
+        // 199 'a' + the whole emoji = 200 code points; '.pdf' is past the cap.
+        // The ASCII fallback substitutes per code UNIT, so the emoji shows as __.
+        expect(cd).toBe(
+          `attachment; filename="${'a'.repeat(199)}__"; filename*=UTF-8''${'a'.repeat(199)}${encodeURIComponent('\u{1F389}')}`,
+        );
+        // An already-unpaired surrogate (never produced by fs, but the header
+        // must not be able to throw on any input) degrades instead of throwing.
+        expect(() => attachmentDisposition('x\uD800.pdf')).not.toThrow();
       });
     });
   });

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -643,6 +643,32 @@ describe('file share router', () => {
         expect(res.status).toBe(404);
         expect(res.text).toBe('Not Found');
       });
+
+      test('allow_documents does NOT widen a ref that validated as an image', async () => {
+        // share_file sends allow_documents unconditionally, so the flag is the
+        // caller's permission to include a PDF in the batch — not a claim that
+        // every ref is one. Persisting 'any' on a file that sniffed as an image
+        // would let this exact swap succeed, reopening the hole the re-sniff
+        // exists to close.
+        const item = await mintOne(`${SESSION}/ok.png`, { allow_documents: true });
+        expect((await request().get(sharedPath(item.url))).status).toBe(200);
+        expect(store.lookupByToken(item.token)?.allowKind).toBe('image');
+        fs.writeFileSync(path.join(mediaDir, 'ok.png'), PDF);
+        const res = await request().get(sharedPath(item.url));
+        expect(res.status).toBe(404);
+        expect(res.text).toBe('Not Found');
+      });
+
+      test('a mixed batch narrows per ref — the PDF keeps its wider kind', async () => {
+        const res = await post({
+          refs: [{ path: `${SESSION}/ok.png` }, { path: `${SESSION}/doc.pdf` }],
+          allow_documents: true,
+        });
+        expect(res.status).toBe(201);
+        const [img, pdf] = res.body.items as Array<{ token: string }>;
+        expect(store.lookupByToken(img!.token)?.allowKind).toBe('image');
+        expect(store.lookupByToken(pdf!.token)?.allowKind).toBe('any');
+      });
     });
 
     describe('Content-Disposition filename safety', () => {
@@ -675,9 +701,16 @@ describe('file share router', () => {
           `attachment; filename="______.pdf"; filename*=UTF-8''${encodeURIComponent('รายงาน.pdf')}`,
         );
         // A name that sanitizes away entirely still yields a usable fallback —
-        // with the extension, so the download is still openable.
+        // with the extension, so the download is still openable. BOTH forms get
+        // it: browsers prefer filename*, so a guard applied only to the ASCII
+        // fallback is a guard the user never sees.
         expect(attachmentDisposition('   ', PDF_MIME)).toBe(
-          `attachment; filename="download.pdf"; filename*=UTF-8''%20%20%20.pdf`,
+          `attachment; filename="download.pdf"; filename*=UTF-8''download.pdf`,
+        );
+        // A bare extension leaves no stem at all — without the shared default
+        // filename* would say `.pdf` and the browser would save a hidden file.
+        expect(attachmentDisposition('.pdf', PDF_MIME)).toBe(
+          `attachment; filename="download.pdf"; filename*=UTF-8''download.pdf`,
         );
         // 4 KB of filename must not become a 4 KB header — and truncating it
         // must not eat the extension, or the saved file no longer opens.

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -12,6 +12,7 @@ import * as supertest from 'supertest';
 import {
   createSharesPublicRouter,
   createSharesPrivateRouter,
+  attachmentDisposition,
 } from '../../src/api/share-router';
 import { resolveGatewayPublicUrl } from '../../src/config/public-url';
 import { ShareStore } from '../../src/share/share-store';
@@ -23,6 +24,8 @@ const PNG = Buffer.concat([
   Buffer.alloc(64, 1),
 ]);
 const JPEG = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), Buffer.alloc(80, 2)]);
+const PDF = Buffer.concat([Buffer.from('%PDF-1.7\n'), Buffer.alloc(96, 5)]);
+const HTML = Buffer.from('<!DOCTYPE html><html><body>hi</body></html>');
 
 const AGENT = 'a1';
 const SESSION = 'session-1';
@@ -545,6 +548,137 @@ describe('image share router', () => {
         const keys = Object.keys(item).filter((k) => k !== 'desc').sort();
         expect(keys).toEqual(['available', 'index', 'origin', 'ref', 'relative_path', 'ts']);
       }
+    });
+  });
+
+  // #444 — the share bridge carries documents (PDF) when the caller opts in.
+  // The whole point of the opt-in is that everything which did NOT ask keeps
+  // rejecting non-images exactly as before.
+  describe('documents (#444)', () => {
+    beforeEach(() => {
+      fs.writeFileSync(path.join(mediaDir, 'doc.pdf'), PDF);
+    });
+
+    const post = (body: Record<string, unknown>) =>
+      request().post('/api/v1/shares').set(AUTH_A1).send({ agent_id: AGENT, session_id: SESSION, ...body });
+
+    test('a PDF without allow_documents is still rejected with 415', async () => {
+      const res = await post({ refs: [{ path: `${SESSION}/doc.pdf` }] });
+      expect(res.status).toBe(415);
+      expect(res.body.code).toBe('unsupported_image_type');
+    });
+
+    test('allow_documents mints a PDF share and serves it as an attachment', async () => {
+      const item = await mintOne(`${SESSION}/doc.pdf`, { allow_documents: true });
+      const res = await request().get(sharedPath(item.url));
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('application/pdf');
+      expect(res.headers['content-length']).toBe(String(PDF.length));
+      // A non-image is offered as a download, never rendered inline.
+      expect(res.headers['content-disposition']).toBe(
+        `attachment; filename="doc.pdf"; filename*=UTF-8''doc.pdf`,
+      );
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.headers['cache-control']).toBe('private, no-store');
+      expect(Buffer.compare(res.body as Buffer, PDF)).toBe(0);
+    });
+
+    test('HEAD on a PDF share carries the same headers without a body', async () => {
+      const item = await mintOne(`${SESSION}/doc.pdf`, { allow_documents: true });
+      const res = await request().head(sharedPath(item.url));
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('application/pdf');
+      expect(res.headers['content-length']).toBe(String(PDF.length));
+      expect(res.headers['content-disposition']).toContain('attachment;');
+    });
+
+    test('an IMAGE minted with allow_documents is still served inline', async () => {
+      // allow_documents widens what MAY be shared; it must not change how an
+      // image that is still an image gets delivered.
+      const item = await mintOne(`${SESSION}/ok.png`, { allow_documents: true });
+      const res = await request().get(sharedPath(item.url));
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('image/png');
+      expect(res.headers['content-disposition']).toBe('inline');
+    });
+
+    test('allow_documents must be a boolean — anything else is 400 before minting', async () => {
+      for (const bad of ['true', 1, {}, []]) {
+        const res = await post({ refs: [{ path: `${SESSION}/ok.png` }], allow_documents: bad });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('allow_documents must be a boolean');
+      }
+      // Explicit false is valid and means image-only.
+      const off = await post({ refs: [{ path: `${SESSION}/doc.pdf` }], allow_documents: false });
+      expect(off.status).toBe(415);
+    });
+
+    test('the artifact registry is NOT widened — a PDF there is still 415', async () => {
+      const res = await request()
+        .post('/api/v1/image-artifacts')
+        .set(AUTH_A1)
+        .send({ agent_id: AGENT, session_id: SESSION, provider: 'p', model: 'm', files: [`${SESSION}/doc.pdf`] });
+      expect(res.status).toBe(415);
+      expect(res.body.code).toBe('unsupported_image_type');
+    });
+
+    // The allow-kind is persisted, the MIME is not: serving always re-sniffs the
+    // bytes on disk, so swapping the file under a live share fails closed in
+    // BOTH directions.
+    describe('TOCTOU — the file is re-sniffed at fetch time, not trusted from mint', () => {
+      test('an image share whose file became a PDF serves 404, not the PDF', async () => {
+        const item = await mintOne(`${SESSION}/ok.png`);
+        expect((await request().get(sharedPath(item.url))).status).toBe(200);
+        fs.writeFileSync(path.join(mediaDir, 'ok.png'), PDF);
+        const res = await request().get(sharedPath(item.url));
+        expect(res.status).toBe(404);
+        expect(res.text).toBe('Not Found');
+      });
+
+      test('an allow_documents share whose file became HTML serves 404', async () => {
+        const item = await mintOne(`${SESSION}/doc.pdf`, { allow_documents: true });
+        expect((await request().get(sharedPath(item.url))).status).toBe(200);
+        fs.writeFileSync(path.join(mediaDir, 'doc.pdf'), HTML);
+        const res = await request().get(sharedPath(item.url));
+        expect(res.status).toBe(404);
+        expect(res.text).toBe('Not Found');
+      });
+    });
+
+    describe('Content-Disposition filename safety', () => {
+      const rfc5987 = (v: string) =>
+        encodeURIComponent(v).replace(/['()*!]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+
+      test('a hostile basename still produces one well-formed header line', async () => {
+        // The basename comes from relative_path, which is agent-controlled, so a
+        // CRLF in it would otherwise split the response header outright.
+        const hostile = ['a"b', '\\c', '\r\n', 'X-Injected: 1 ', '\u00e9', '.pdf'].join('');
+        fs.writeFileSync(path.join(mediaDir, hostile), PDF);
+        const item = await mintOne(`${SESSION}/${hostile}`, { allow_documents: true });
+        const res = await request().get(sharedPath(item.url));
+        expect(res.status).toBe(200);
+        const cd = res.headers['content-disposition'] as string;
+        expect(cd).not.toMatch(/[\r\n]/);
+        expect(res.headers['x-injected']).toBeUndefined();
+        // Quoted fallback: printable ASCII only, minus " and \.
+        expect(cd).toBe(`attachment; filename="a_b_c__X-Injected: 1 _.pdf"; filename*=UTF-8''${rfc5987(hostile)}`);
+      });
+
+      test('attachmentDisposition escapes the non-attr-char set and caps the length', () => {
+        // encodeURIComponent leaves !'()* alone; they are not RFC 5987 attr-char.
+        expect(attachmentDisposition(`x!'()*.pdf`)).toBe(
+          `attachment; filename="x!'()*.pdf"; filename*=UTF-8''x%21%27%28%29%2A.pdf`,
+        );
+        // Non-ASCII survives only in filename*; the fallback degrades to _.
+        expect(attachmentDisposition('รายงาน.pdf')).toBe(
+          `attachment; filename="______.pdf"; filename*=UTF-8''${encodeURIComponent('รายงาน.pdf')}`,
+        );
+        // A name that sanitizes away entirely still yields a usable fallback.
+        expect(attachmentDisposition('   ')).toBe(`attachment; filename="download"; filename*=UTF-8''%20%20%20`);
+        // 4 KB of filename must not become a 4 KB header.
+        const long = attachmentDisposition(`${'n'.repeat(4096)}.pdf`);
+        expect(long).toBe(`attachment; filename="${'n'.repeat(200)}"; filename*=UTF-8''${'n'.repeat(200)}`);
+      });
     });
   });
 

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -297,7 +297,7 @@ describe('image share router', () => {
         .set(AUTH_A1)
         .send({ agent_id: AGENT, session_id: 'other-session', refs: [{ artifact_id: artifact.artifact_id }] });
       expect(wrongSession.status).toBe(404);
-      expect(wrongSession.body.code).toBe('image_ref_not_found');
+      expect(wrongSession.body.code).toBe('share_ref_not_found');
     });
 
     // a mint from an artifact_id ref whose registration
@@ -565,7 +565,7 @@ describe('image share router', () => {
     test('a PDF without allow_documents is still rejected with 415', async () => {
       const res = await post({ refs: [{ path: `${SESSION}/doc.pdf` }] });
       expect(res.status).toBe(415);
-      expect(res.body.code).toBe('unsupported_image_type');
+      expect(res.body.code).toBe('unsupported_file_type');
     });
 
     test('allow_documents mints a PDF share and serves it as an attachment', async () => {
@@ -619,7 +619,7 @@ describe('image share router', () => {
         .set(AUTH_A1)
         .send({ agent_id: AGENT, session_id: SESSION, provider: 'p', model: 'm', files: [`${SESSION}/doc.pdf`] });
       expect(res.status).toBe(415);
-      expect(res.body.code).toBe('unsupported_image_type');
+      expect(res.body.code).toBe('unsupported_file_type');
     });
 
     // The allow-kind is persisted, the MIME is not: serving always re-sniffs the

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -669,11 +669,24 @@ describe('file share router', () => {
         expect(store.lookupByToken(img!.token)?.allowKind).toBe('image');
         expect(store.lookupByToken(pdf!.token)?.allowKind).toBe('any');
       });
+
+      // The allow-kind is part of the 60s mint-dedupe key (§17.4), so before
+      // per-ref narrowing the SAME image requested with and without
+      // allow_documents produced two tokens and two rows. Narrowing makes the
+      // flag irrelevant to a file that is an image either way, which is what
+      // lets the same picture dedupe no matter which tool asked for it.
+      test('an image dedupes across allow_documents — the flag does not split it', async () => {
+        const strict = await mintOne(`${SESSION}/ok.png`);
+        const wide = await mintOne(`${SESSION}/ok.png`, { allow_documents: true });
+        expect(wide.token).toBe(strict.token);
+        expect(wide.share_id).toBe(strict.share_id);
+        expect(store.lookupByToken(wide.token)?.allowKind).toBe('image');
+      });
     });
 
     describe('Content-Disposition filename safety', () => {
       const rfc8187 = (v: string) =>
-        encodeURIComponent(v).replace(/['()*!]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+        encodeURIComponent(v).replace(/['()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 
       test('a hostile basename still produces one well-formed header line', async () => {
         // The basename comes from relative_path, which is agent-controlled, so a
@@ -692,9 +705,10 @@ describe('file share router', () => {
 
       test('attachmentDisposition escapes the non-attr-char set and caps the length', () => {
         const PDF_MIME = 'application/pdf';
-        // encodeURIComponent leaves !'()* alone; they are not RFC 8187 attr-char.
-        expect(attachmentDisposition(`x!'()*.pdf`, PDF_MIME)).toBe(
-          `attachment; filename="x!'()*.pdf"; filename*=UTF-8''x%21%27%28%29%2A.pdf`,
+        // Of the punctuation encodeURIComponent leaves raw, only ' ( ) * fall
+        // outside RFC 8187 attr-char. `!` and `~` are attr-char and stay raw.
+        expect(attachmentDisposition(`x!~'()*.pdf`, PDF_MIME)).toBe(
+          `attachment; filename="x!~'()*.pdf"; filename*=UTF-8''x!~%27%28%29%2A.pdf`,
         );
         // Non-ASCII survives only in filename*; the fallback degrades to _.
         expect(attachmentDisposition('รายงาน.pdf', PDF_MIME)).toBe(

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -746,6 +746,25 @@ describe('file share router', () => {
         expect(attachmentDisposition('report', 'application/pdf')).toContain('filename="report.pdf"');
       });
 
+      // A mime with no entry in EXT_FOR_MIME is the case where we cannot vouch
+      // for what the bytes are — so it must fail CLOSED. Handing back the
+      // agent's own `.html` there would reopen exactly the reflected-file-
+      // download hole the mapped path closes. Nothing reaches this branch today
+      // (images go out inline, PDF is the only other allowlisted type); this
+      // pins the behaviour for whatever type is allowlisted next.
+      test('an unmapped mime drops the extension instead of trusting the basename', () => {
+        expect(attachmentDisposition('invoice.html', 'application/zip')).toBe(
+          `attachment; filename="invoice"; filename*=UTF-8''invoice`,
+        );
+        expect(attachmentDisposition('payload.svg', 'application/octet-stream')).toBe(
+          `attachment; filename="payload"; filename*=UTF-8''payload`,
+        );
+        // Nothing left after the strip still yields a usable name, not "".
+        expect(attachmentDisposition('.html', 'application/zip')).toBe(
+          `attachment; filename="download"; filename*=UTF-8''download`,
+        );
+      });
+
       test('a PDF disguised with an .html basename is served as .pdf end to end', async () => {
         fs.writeFileSync(path.join(mediaDir, 'invoice.html'), PDF);
         const item = await mintOne(`${SESSION}/invoice.html`, { allow_documents: true });

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -665,36 +665,67 @@ describe('file share router', () => {
       });
 
       test('attachmentDisposition escapes the non-attr-char set and caps the length', () => {
+        const PDF_MIME = 'application/pdf';
         // encodeURIComponent leaves !'()* alone; they are not RFC 5987 attr-char.
-        expect(attachmentDisposition(`x!'()*.pdf`)).toBe(
+        expect(attachmentDisposition(`x!'()*.pdf`, PDF_MIME)).toBe(
           `attachment; filename="x!'()*.pdf"; filename*=UTF-8''x%21%27%28%29%2A.pdf`,
         );
         // Non-ASCII survives only in filename*; the fallback degrades to _.
-        expect(attachmentDisposition('รายงาน.pdf')).toBe(
+        expect(attachmentDisposition('รายงาน.pdf', PDF_MIME)).toBe(
           `attachment; filename="______.pdf"; filename*=UTF-8''${encodeURIComponent('รายงาน.pdf')}`,
         );
-        // A name that sanitizes away entirely still yields a usable fallback.
-        expect(attachmentDisposition('   ')).toBe(`attachment; filename="download"; filename*=UTF-8''%20%20%20`);
-        // 4 KB of filename must not become a 4 KB header.
-        const long = attachmentDisposition(`${'n'.repeat(4096)}.pdf`);
-        expect(long).toBe(`attachment; filename="${'n'.repeat(200)}"; filename*=UTF-8''${'n'.repeat(200)}`);
+        // A name that sanitizes away entirely still yields a usable fallback —
+        // with the extension, so the download is still openable.
+        expect(attachmentDisposition('   ', PDF_MIME)).toBe(
+          `attachment; filename="download.pdf"; filename*=UTF-8''%20%20%20.pdf`,
+        );
+        // 4 KB of filename must not become a 4 KB header — and truncating it
+        // must not eat the extension, or the saved file no longer opens.
+        const long = attachmentDisposition(`${'n'.repeat(4096)}.pdf`, PDF_MIME);
+        expect(long).toBe(`attachment; filename="${'n'.repeat(196)}.pdf"; filename*=UTF-8''${'n'.repeat(196)}.pdf`);
+        expect((long.match(/filename="([^"]*)"/)![1]!).length).toBe(200);
+      });
+
+      // The bytes decide the extension, not the agent-chosen name. Serving
+      // `%PDF-`-prefixed bytes as `invoice.html` would hand the user a file the
+      // browser renders from file://, running whatever script trails the PDF
+      // magic — the reflected-file-download shape.
+      test('the extension describes the SNIFFED type, not the basename', () => {
+        expect(attachmentDisposition('invoice.html', 'application/pdf')).toBe(
+          `attachment; filename="invoice.pdf"; filename*=UTF-8''invoice.pdf`,
+        );
+        expect(attachmentDisposition('payload.svg', 'application/pdf')).toContain('filename="payload.pdf"');
+        // No extension at all still gets the right one appended.
+        expect(attachmentDisposition('report', 'application/pdf')).toContain('filename="report.pdf"');
+      });
+
+      test('a PDF disguised with an .html basename is served as .pdf end to end', async () => {
+        fs.writeFileSync(path.join(mediaDir, 'invoice.html'), PDF);
+        const item = await mintOne(`${SESSION}/invoice.html`, { allow_documents: true });
+        const res = await request().get(sharedPath(item.url));
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toBe('application/pdf');
+        expect(res.headers['content-disposition']).toBe(
+          `attachment; filename="invoice.pdf"; filename*=UTF-8''invoice.pdf`,
+        );
       });
 
       test('the length cap never splits a surrogate pair into an unencodable half', () => {
-        // A code-unit slice would cut this emoji in half at the 200-char cap and
+        // A code-unit slice would cut this emoji in half at the stem cap and
         // leave a lone surrogate, which encodeURIComponent rejects with
         // URIError — inside the serve handler's try, that becomes a bogus 404
         // on a share whose file is perfectly fine. Cap by code point instead.
-        const straddling = `${'a'.repeat(199)}\u{1F389}.pdf`;
-        const cd = attachmentDisposition(straddling);
-        // 199 'a' + the whole emoji = 200 code points; '.pdf' is past the cap.
+        // 195 'a' + the emoji = 196 code points = exactly the stem budget, so a
+        // code-UNIT slice would land mid-pair.
+        const straddling = `${'a'.repeat(195)}\u{1F389}.pdf`;
+        const cd = attachmentDisposition(straddling, 'application/pdf');
         // The ASCII fallback substitutes per code UNIT, so the emoji shows as __.
         expect(cd).toBe(
-          `attachment; filename="${'a'.repeat(199)}__"; filename*=UTF-8''${'a'.repeat(199)}${encodeURIComponent('\u{1F389}')}`,
+          `attachment; filename="${'a'.repeat(195)}__.pdf"; filename*=UTF-8''${'a'.repeat(195)}${encodeURIComponent('\u{1F389}')}.pdf`,
         );
         // An already-unpaired surrogate (never produced by fs, but the header
         // must not be able to throw on any input) degrades instead of throwing.
-        expect(() => attachmentDisposition('x\uD800.pdf')).not.toThrow();
+        expect(() => attachmentDisposition('x\uD800.pdf', 'application/pdf')).not.toThrow();
       });
     });
   });

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -672,7 +672,7 @@ describe('file share router', () => {
     });
 
     describe('Content-Disposition filename safety', () => {
-      const rfc5987 = (v: string) =>
+      const rfc8187 = (v: string) =>
         encodeURIComponent(v).replace(/['()*!]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 
       test('a hostile basename still produces one well-formed header line', async () => {
@@ -687,12 +687,12 @@ describe('file share router', () => {
         expect(cd).not.toMatch(/[\r\n]/);
         expect(res.headers['x-injected']).toBeUndefined();
         // Quoted fallback: printable ASCII only, minus " and \.
-        expect(cd).toBe(`attachment; filename="a_b_c__X-Injected: 1 _.pdf"; filename*=UTF-8''${rfc5987(hostile)}`);
+        expect(cd).toBe(`attachment; filename="a_b_c__X-Injected: 1 _.pdf"; filename*=UTF-8''${rfc8187(hostile)}`);
       });
 
       test('attachmentDisposition escapes the non-attr-char set and caps the length', () => {
         const PDF_MIME = 'application/pdf';
-        // encodeURIComponent leaves !'()* alone; they are not RFC 5987 attr-char.
+        // encodeURIComponent leaves !'()* alone; they are not RFC 8187 attr-char.
         expect(attachmentDisposition(`x!'()*.pdf`, PDF_MIME)).toBe(
           `attachment; filename="x!'()*.pdf"; filename*=UTF-8''x%21%27%28%29%2A.pdf`,
         );

--- a/tests/unit/share-store.test.ts
+++ b/tests/unit/share-store.test.ts
@@ -17,6 +17,9 @@ import {
   validateShareFile,
   detectImageMime,
   detectShareMime,
+  shareEnv,
+  shareLimitsFromEnv,
+  DEFAULT_MAX_REFS,
 } from '../../src/share/share-store';
 
 const PNG = Buffer.concat([
@@ -34,6 +37,68 @@ const PDF = Buffer.concat([Buffer.from('%PDF-1.7\n'), Buffer.alloc(64, 5)]);
 
 const AGENT = 'a1';
 const SESSION = 'session-1';
+
+// #444: the share bridge's env vars were renamed IMAGE_SHARE_* -> SHARE_*.
+// Both names stay readable so an existing deployment does not silently lose its
+// tuning on upgrade, and the neutral name wins when both are set.
+describe('shareEnv dual-read (#444)', () => {
+  const KEYS = ['SHARE_MAX_REFS', 'IMAGE_SHARE_MAX_REFS'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test('neither set → undefined, and the limit falls back to its default', () => {
+    expect(shareEnv('MAX_REFS')).toBeUndefined();
+    expect(shareLimitsFromEnv().maxRefs).toBe(DEFAULT_MAX_REFS);
+  });
+
+  test('only the legacy name set → legacy value is used', () => {
+    process.env.IMAGE_SHARE_MAX_REFS = '3';
+    expect(shareEnv('MAX_REFS')).toBe('3');
+    expect(shareLimitsFromEnv().maxRefs).toBe(3);
+  });
+
+  test('only the neutral name set → neutral value is used', () => {
+    process.env.SHARE_MAX_REFS = '7';
+    expect(shareEnv('MAX_REFS')).toBe('7');
+    expect(shareLimitsFromEnv().maxRefs).toBe(7);
+  });
+
+  test('both set → the neutral name wins', () => {
+    process.env.SHARE_MAX_REFS = '7';
+    process.env.IMAGE_SHARE_MAX_REFS = '3';
+    expect(shareEnv('MAX_REFS')).toBe('7');
+    expect(shareLimitsFromEnv().maxRefs).toBe(7);
+  });
+
+  // src/session/process.ts forwards UNSET vars to the MCP subprocess as '',
+  // so an empty neutral name must not shadow a genuinely-set legacy one.
+  test('empty neutral name does not shadow a set legacy name', () => {
+    process.env.SHARE_MAX_REFS = '';
+    process.env.IMAGE_SHARE_MAX_REFS = '3';
+    expect(shareEnv('MAX_REFS')).toBe('3');
+    expect(shareLimitsFromEnv().maxRefs).toBe(3);
+  });
+
+  test('both empty → undefined, not the empty string', () => {
+    process.env.SHARE_MAX_REFS = '';
+    process.env.IMAGE_SHARE_MAX_REFS = '';
+    expect(shareEnv('MAX_REFS')).toBeUndefined();
+    expect(shareLimitsFromEnv().maxRefs).toBe(DEFAULT_MAX_REFS);
+  });
+});
 
 describe('image share store', () => {
   let baseDir: string; // agentsBaseDir
@@ -83,7 +148,7 @@ describe('image share store', () => {
       const m = mint();
       const raw = new DatabaseSync(dbPath);
       const row = raw
-        .prepare('SELECT token_hash, id, agent_id, session_id, relative_path, purpose FROM image_shares')
+        .prepare('SELECT token_hash, id, agent_id, session_id, relative_path, purpose FROM file_shares')
         .get() as Record<string, unknown>;
       raw.close();
       const expectedHash = createHash('sha256').update(m.token).digest();
@@ -134,7 +199,7 @@ describe('image share store', () => {
       expect(store.lookupByToken(m.token)).toBeNull();
       store.cleanupExpired();
       const raw = new DatabaseSync(dbPath);
-      const cnt = raw.prepare('SELECT COUNT(*) AS c FROM image_shares').get() as { c: number };
+      const cnt = raw.prepare('SELECT COUNT(*) AS c FROM file_shares').get() as { c: number };
       raw.close();
       expect(Number(cnt.c)).toBe(0);
     });
@@ -265,16 +330,16 @@ describe('image share store', () => {
         path.join(mediaDir, 'anim.gif'),
         Buffer.concat([Buffer.from('GIF89a'), Buffer.alloc(32, 4)]),
       );
-      expect(codeOf(() => validate(`${SESSION}/note.txt`))).toBe('unsupported_image_type');
-      expect(codeOf(() => validate(`${SESSION}/anim.gif`))).toBe('unsupported_image_type');
+      expect(codeOf(() => validate(`${SESSION}/note.txt`))).toBe('unsupported_file_type');
+      expect(codeOf(() => validate(`${SESSION}/anim.gif`))).toBe('unsupported_file_type');
     });
 
     test('rejects a file over the per-file cap', () => {
-      expect(codeOf(() => validate(`${SESSION}/ok.png`, 16))).toBe('image_too_large');
+      expect(codeOf(() => validate(`${SESSION}/ok.png`, 16))).toBe('file_too_large');
     });
 
-    test('missing file → deterministic image_ref_not_found', () => {
-      expect(codeOf(() => validate(`${SESSION}/gone.png`))).toBe('image_ref_not_found');
+    test('missing file → deterministic share_ref_not_found', () => {
+      expect(codeOf(() => validate(`${SESSION}/gone.png`))).toBe('share_ref_not_found');
     });
   });
 
@@ -328,7 +393,7 @@ describe('image share store', () => {
 
     test('validateShareFile rejects a PDF by default and accepts it with allow="any"', () => {
       expect(codeOf(() => validateShareFile(baseDir, AGENT, `${SESSION}/doc.pdf`))).toBe(
-        'unsupported_image_type',
+        'unsupported_file_type',
       );
       const ok = validateShareFile(baseDir, AGENT, `${SESSION}/doc.pdf`, undefined, 'any');
       expect(ok.mime).toBe('application/pdf');
@@ -342,12 +407,12 @@ describe('image share store', () => {
       fs.symlinkSync(outside, path.join(mediaDir, 'sneaky.pdf'));
       const any = (ref: string, cap?: number) => validateShareFile(baseDir, AGENT, ref, cap, 'any');
 
-      expect(codeOf(() => any(`${SESSION}/page.html`))).toBe('unsupported_image_type');
+      expect(codeOf(() => any(`${SESSION}/page.html`))).toBe('unsupported_file_type');
       expect(codeOf(() => any('../../outside.pdf'))).toBe('invalid_path');
       expect(codeOf(() => any(`${SESSION}/sneaky.pdf`))).toBe('invalid_path');
       expect(codeOf(() => any(SESSION))).toBe('invalid_path');
-      expect(codeOf(() => any(`${SESSION}/doc.pdf`, 16))).toBe('image_too_large');
-      expect(codeOf(() => any(`${SESSION}/gone.pdf`))).toBe('image_ref_not_found');
+      expect(codeOf(() => any(`${SESSION}/doc.pdf`, 16))).toBe('file_too_large');
+      expect(codeOf(() => any(`${SESSION}/gone.pdf`))).toBe('share_ref_not_found');
     });
 
     test('the allow-kind is persisted per share and round-trips through lookup', () => {
@@ -374,7 +439,7 @@ describe('image share store', () => {
     test('an unrecognised persisted allow_kind falls back to the STRICTEST kind', () => {
       const m = mint();
       const raw = new DatabaseSync(dbPath);
-      raw.prepare('UPDATE image_shares SET allow_kind = ? WHERE id = ?').run('everything', m.shareId);
+      raw.prepare('UPDATE file_shares SET allow_kind = ? WHERE id = ?').run('everything', m.shareId);
       raw.close();
       expect(store.lookupByToken(m.token)!.allowKind).toBe('image');
     });
@@ -382,9 +447,11 @@ describe('image share store', () => {
 
   // The `allow_kind` column is added in place, exactly like `prompt` on
   // image_artifacts: CREATE TABLE IF NOT EXISTS leaves an existing DB untouched.
-  describe('allow_kind migration on a pre-#444 database', () => {
-    test('an old DB opens, gains the column defaulted to image, and keeps its live shares', () => {
-      const legacyPath = path.join(baseDir, 'legacy.db');
+  // The table itself is renamed image_shares -> file_shares, and that rename
+  // MUST run before the CREATE TABLE IF NOT EXISTS, or the store would sit on an
+  // empty new table and 404 every share minted before the upgrade.
+  describe('migration from a pre-#444 database', () => {
+    const seedLegacy = (legacyPath: string, token: string): void => {
       const legacy = new DatabaseSync(legacyPath);
       legacy.exec(`
         CREATE TABLE image_shares (
@@ -398,8 +465,8 @@ describe('image share store', () => {
           expires_at    INTEGER NOT NULL,
           revoked_at    INTEGER
         );
+        CREATE INDEX IF NOT EXISTS image_shares_expiry ON image_shares(expires_at);
       `);
-      const token = 'L'.repeat(32);
       legacy
         .prepare(
           `INSERT INTO image_shares (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at)
@@ -416,6 +483,12 @@ describe('image share store', () => {
           Date.now() + 600_000,
         );
       legacy.close();
+    };
+
+    test('an old DB opens, gains the column defaulted to image, and keeps its live shares', () => {
+      const legacyPath = path.join(baseDir, 'legacy.db');
+      const token = 'L'.repeat(32);
+      seedLegacy(legacyPath, token);
 
       const migrated = new ShareStore(legacyPath);
       try {
@@ -434,6 +507,36 @@ describe('image share store', () => {
         expect(reopened.lookupByToken(token)!.allowKind).toBe('image');
       } finally {
         reopened.close();
+      }
+    });
+
+    test('the table is RENAMED, not shadowed by an empty new one', () => {
+      const legacyPath = path.join(baseDir, 'legacy-rename.db');
+      const token = 'R'.repeat(32);
+      seedLegacy(legacyPath, token);
+
+      const migrated = new ShareStore(legacyPath);
+      migrated.close();
+
+      const raw = new DatabaseSync(legacyPath);
+      try {
+        const tables = (
+          raw.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`).all() as Array<{ name: string }>
+        ).map((r) => r.name);
+        expect(tables).toContain('file_shares');
+        expect(tables).not.toContain('image_shares');
+        // The row survived the rename rather than being left behind.
+        const cnt = raw.prepare('SELECT COUNT(*) AS c FROM file_shares').get() as { c: number };
+        expect(cnt.c).toBe(1);
+        // RENAME TO carries indexes over under their OLD names — the old one is
+        // dropped so the new CREATE INDEX cannot leave a duplicate behind.
+        const indexes = (
+          raw.prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'file_shares'`).all() as Array<{ name: string }>
+        ).map((r) => r.name);
+        expect(indexes).toContain('file_shares_expiry');
+        expect(indexes).not.toContain('image_shares_expiry');
+      } finally {
+        raw.close();
       }
     });
   });

--- a/tests/unit/share-store.test.ts
+++ b/tests/unit/share-store.test.ts
@@ -100,7 +100,7 @@ describe('shareEnv dual-read (#444)', () => {
   });
 });
 
-describe('image share store', () => {
+describe('file share store', () => {
   let baseDir: string; // agentsBaseDir
   let mediaDir: string; // agents/a1/media/session-1
   let dbPath: string;

--- a/tests/unit/share-store.test.ts
+++ b/tests/unit/share-store.test.ts
@@ -539,5 +539,77 @@ describe('image share store', () => {
         raw.close();
       }
     });
+
+    // The rename guard only fires when file_shares does NOT yet exist, so a
+    // downgrade that recreates image_shares and mints into it would otherwise
+    // strand those rows behind a guard that can never fire again.
+    test('a downgrade/re-upgrade folds the recreated old table back in', () => {
+      const dbPath2 = path.join(baseDir, 'rollback.db');
+      const preToken = 'P'.repeat(32);
+      seedLegacy(dbPath2, preToken); // pre-#444 release, one live share
+
+      new ShareStore(dbPath2).close(); // upgrade: renames to file_shares
+
+      // Downgrade: the old release recreates its own table and mints into it.
+      const rollbackToken = 'B'.repeat(32);
+      const old = new DatabaseSync(dbPath2);
+      old.exec(`
+        CREATE TABLE IF NOT EXISTS image_shares (
+          id            TEXT PRIMARY KEY,
+          token_hash    BLOB NOT NULL UNIQUE,
+          agent_id      TEXT NOT NULL,
+          session_id    TEXT NOT NULL,
+          relative_path TEXT NOT NULL,
+          purpose       TEXT NOT NULL,
+          created_at    INTEGER NOT NULL,
+          expires_at    INTEGER NOT NULL,
+          revoked_at    INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS image_shares_expiry ON image_shares(expires_at);
+      `);
+      old
+        .prepare(
+          `INSERT INTO image_shares (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'shr_rollback',
+          createHash('sha256').update(rollbackToken).digest(),
+          AGENT,
+          SESSION,
+          `${SESSION}/ok.png`,
+          'codex_ref',
+          Date.now(),
+          Date.now() + 600_000,
+        );
+      old.close();
+
+      // Roll forward again.
+      const rolledForward = new ShareStore(dbPath2);
+      try {
+        // Both the pre-downgrade share AND the one minted during the rollback
+        // window resolve, and the rollback one is image-only as it was minted.
+        expect(rolledForward.lookupByToken(preToken)!.shareId).toBe('shr_legacy');
+        const back = rolledForward.lookupByToken(rollbackToken);
+        expect(back).not.toBeNull();
+        expect(back!.shareId).toBe('shr_rollback');
+        expect(back!.allowKind).toBe('image');
+      } finally {
+        rolledForward.close();
+      }
+
+      const raw = new DatabaseSync(dbPath2);
+      try {
+        const tables = (
+          raw.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`).all() as Array<{ name: string }>
+        ).map((r) => r.name);
+        // The orphan is gone rather than lingering in the file forever.
+        expect(tables).not.toContain('image_shares');
+        const cnt = raw.prepare('SELECT COUNT(*) AS c FROM file_shares').get() as { c: number };
+        expect(cnt.c).toBe(2);
+      } finally {
+        raw.close();
+      }
+    });
   });
 });

--- a/tests/unit/share-store.test.ts
+++ b/tests/unit/share-store.test.ts
@@ -16,6 +16,7 @@ import {
   SHARE_TOKEN_RE,
   validateShareFile,
   detectImageMime,
+  detectShareMime,
 } from '../../src/share/share-store';
 
 const PNG = Buffer.concat([
@@ -29,6 +30,7 @@ const WEBP = Buffer.concat([
   Buffer.from('WEBP'),
   Buffer.alloc(64, 3),
 ]);
+const PDF = Buffer.concat([Buffer.from('%PDF-1.7\n'), Buffer.alloc(64, 5)]);
 
 const AGENT = 'a1';
 const SESSION = 'session-1';
@@ -283,6 +285,156 @@ describe('image share store', () => {
       expect(detectImageMime(WEBP)).toBe('image/webp');
       expect(detectImageMime(Buffer.from('GIF89a-not-allowed'))).toBeNull();
       expect(detectImageMime(Buffer.from('%PDF-1.4'))).toBeNull();
+    });
+  });
+
+  // #444 — the wider share allowlist. detectImageMime stays image-only for the
+  // callers that genuinely need an image (line_image, generate_image refs, the
+  // session image catalog); detectShareMime is what the share bridge uses when
+  // the caller opted into documents.
+  describe('detectShareMime (#444)', () => {
+    test('classifies the image formats AND PDF', () => {
+      expect(detectShareMime(PNG)).toBe('image/png');
+      expect(detectShareMime(JPEG)).toBe('image/jpeg');
+      expect(detectShareMime(WEBP)).toBe('image/webp');
+      expect(detectShareMime(PDF)).toBe('application/pdf');
+    });
+
+    test('still rejects everything off the allowlist — HTML/SVG are never shareable', () => {
+      expect(detectShareMime(Buffer.from('GIF89a-not-allowed'))).toBeNull();
+      expect(detectShareMime(Buffer.from('<!DOCTYPE html><html>'))).toBeNull();
+      expect(detectShareMime(Buffer.from('<svg xmlns="http://'))).toBeNull();
+      expect(detectShareMime(Buffer.from('plain text, no magic'))).toBeNull();
+      // A near-miss on the PDF magic must not slip through.
+      expect(detectShareMime(Buffer.from('%PDF+1.7'))).toBeNull();
+      expect(detectShareMime(Buffer.from('%PDF'))).toBeNull();
+    });
+  });
+
+  describe('document shares (#444)', () => {
+    beforeEach(() => {
+      fs.writeFileSync(path.join(mediaDir, 'doc.pdf'), PDF);
+    });
+
+    const codeOf = (fn: () => unknown): string => {
+      try {
+        fn();
+      } catch (err) {
+        if (err instanceof ShareError) return err.code;
+        return `unexpected:${(err as Error).message}`;
+      }
+      return 'no-error';
+    };
+
+    test('validateShareFile rejects a PDF by default and accepts it with allow="any"', () => {
+      expect(codeOf(() => validateShareFile(baseDir, AGENT, `${SESSION}/doc.pdf`))).toBe(
+        'unsupported_image_type',
+      );
+      const ok = validateShareFile(baseDir, AGENT, `${SESSION}/doc.pdf`, undefined, 'any');
+      expect(ok.mime).toBe('application/pdf');
+      expect(ok.relativePath).toBe(`${SESSION}/doc.pdf`);
+    });
+
+    test('allow="any" does NOT relax anything else — containment, size and the allowlist still bite', () => {
+      fs.writeFileSync(path.join(mediaDir, 'page.html'), '<!DOCTYPE html><html>x</html>');
+      const outside = path.join(baseDir, 'outside.pdf');
+      fs.writeFileSync(outside, PDF);
+      fs.symlinkSync(outside, path.join(mediaDir, 'sneaky.pdf'));
+      const any = (ref: string, cap?: number) => validateShareFile(baseDir, AGENT, ref, cap, 'any');
+
+      expect(codeOf(() => any(`${SESSION}/page.html`))).toBe('unsupported_image_type');
+      expect(codeOf(() => any('../../outside.pdf'))).toBe('invalid_path');
+      expect(codeOf(() => any(`${SESSION}/sneaky.pdf`))).toBe('invalid_path');
+      expect(codeOf(() => any(SESSION))).toBe('invalid_path');
+      expect(codeOf(() => any(`${SESSION}/doc.pdf`, 16))).toBe('image_too_large');
+      expect(codeOf(() => any(`${SESSION}/gone.pdf`))).toBe('image_ref_not_found');
+    });
+
+    test('the allow-kind is persisted per share and round-trips through lookup', () => {
+      const img = mint();
+      expect(store.lookupByToken(img.token)!.allowKind).toBe('image');
+
+      const doc = mint({
+        relativePath: `${SESSION}/doc.pdf`,
+        dedupeRef: `path:${SESSION}/doc.pdf`,
+        allowKind: 'any',
+      });
+      expect(store.lookupByToken(doc.token)!.allowKind).toBe('any');
+    });
+
+    test('two mints of the SAME ref under different allow-kinds do not collapse', () => {
+      // They are different capabilities: one may serve a PDF, the other may not.
+      const strict = mint();
+      const wide = mint({ allowKind: 'any' });
+      expect(wide.token).not.toBe(strict.token);
+      expect(store.lookupByToken(strict.token)!.allowKind).toBe('image');
+      expect(store.lookupByToken(wide.token)!.allowKind).toBe('any');
+    });
+
+    test('an unrecognised persisted allow_kind falls back to the STRICTEST kind', () => {
+      const m = mint();
+      const raw = new DatabaseSync(dbPath);
+      raw.prepare('UPDATE image_shares SET allow_kind = ? WHERE id = ?').run('everything', m.shareId);
+      raw.close();
+      expect(store.lookupByToken(m.token)!.allowKind).toBe('image');
+    });
+  });
+
+  // The `allow_kind` column is added in place, exactly like `prompt` on
+  // image_artifacts: CREATE TABLE IF NOT EXISTS leaves an existing DB untouched.
+  describe('allow_kind migration on a pre-#444 database', () => {
+    test('an old DB opens, gains the column defaulted to image, and keeps its live shares', () => {
+      const legacyPath = path.join(baseDir, 'legacy.db');
+      const legacy = new DatabaseSync(legacyPath);
+      legacy.exec(`
+        CREATE TABLE image_shares (
+          id            TEXT PRIMARY KEY,
+          token_hash    BLOB NOT NULL UNIQUE,
+          agent_id      TEXT NOT NULL,
+          session_id    TEXT NOT NULL,
+          relative_path TEXT NOT NULL,
+          purpose       TEXT NOT NULL,
+          created_at    INTEGER NOT NULL,
+          expires_at    INTEGER NOT NULL,
+          revoked_at    INTEGER
+        );
+      `);
+      const token = 'L'.repeat(32);
+      legacy
+        .prepare(
+          `INSERT INTO image_shares (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'shr_legacy',
+          createHash('sha256').update(token).digest(),
+          AGENT,
+          SESSION,
+          `${SESSION}/ok.png`,
+          'codex_ref',
+          Date.now(),
+          Date.now() + 600_000,
+        );
+      legacy.close();
+
+      const migrated = new ShareStore(legacyPath);
+      try {
+        const row = migrated.lookupByToken(token);
+        expect(row).not.toBeNull();
+        expect(row!.shareId).toBe('shr_legacy');
+        expect(row!.relativePath).toBe(`${SESSION}/ok.png`);
+        expect(row!.allowKind).toBe('image');
+      } finally {
+        migrated.close();
+      }
+
+      // Opening it again is a no-op, not a duplicate-column error.
+      const reopened = new ShareStore(legacyPath);
+      try {
+        expect(reopened.lookupByToken(token)!.allowKind).toBe('image');
+      } finally {
+        reopened.close();
+      }
     });
   });
 });

--- a/tests/unit/share-store.test.ts
+++ b/tests/unit/share-store.test.ts
@@ -451,6 +451,18 @@ describe('image share store', () => {
   // MUST run before the CREATE TABLE IF NOT EXISTS, or the store would sit on an
   // empty new table and 404 every share minted before the upgrade.
   describe('migration from a pre-#444 database', () => {
+    let logSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    const logLines = (): string[] => logSpy.mock.calls.map((c) => String(c[0]));
+
     const seedLegacy = (legacyPath: string, token: string): void => {
       const legacy = new DatabaseSync(legacyPath);
       legacy.exec(`
@@ -610,6 +622,63 @@ describe('image share store', () => {
       } finally {
         raw.close();
       }
+    });
+
+    // A schema migration that changes what the database holds must leave a
+    // trace an operator can find afterwards — "no silent failures" covers the
+    // silent recovery too, not just the silent break.
+    test('both migration paths announce themselves in the log', () => {
+      const renamePath = path.join(baseDir, 'log-rename.db');
+      seedLegacy(renamePath, 'R'.repeat(32));
+      new ShareStore(renamePath).close();
+      expect(logLines()).toContain('[share] renamed legacy image_shares table to file_shares');
+
+      // A fresh database migrates nothing and must stay quiet.
+      logSpy.mockClear();
+      new ShareStore(path.join(baseDir, 'log-fresh.db')).close();
+      expect(logLines().filter((l) => l.startsWith('[share]'))).toEqual([]);
+    });
+
+    test('the rollback fold reports how many rows it moved', () => {
+      const dbPath3 = path.join(baseDir, 'log-fold.db');
+      seedLegacy(dbPath3, 'F'.repeat(32));
+      new ShareStore(dbPath3).close();
+
+      // Downgrade window: the old release recreates its table and mints one row.
+      const old = new DatabaseSync(dbPath3);
+      old.exec(`
+        CREATE TABLE IF NOT EXISTS image_shares (
+          id            TEXT PRIMARY KEY,
+          token_hash    BLOB NOT NULL UNIQUE,
+          agent_id      TEXT NOT NULL,
+          session_id    TEXT NOT NULL,
+          relative_path TEXT NOT NULL,
+          purpose       TEXT NOT NULL,
+          created_at    INTEGER NOT NULL,
+          expires_at    INTEGER NOT NULL,
+          revoked_at    INTEGER
+        );
+      `);
+      old
+        .prepare(
+          `INSERT INTO image_shares (id, token_hash, agent_id, session_id, relative_path, purpose, created_at, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'shr_logged',
+          createHash('sha256').update('G'.repeat(32)).digest(),
+          AGENT,
+          SESSION,
+          `${SESSION}/ok.png`,
+          'codex_ref',
+          Date.now(),
+          Date.now() + 600_000,
+        );
+      old.close();
+
+      logSpy.mockClear();
+      new ShareStore(dbPath3).close();
+      expect(logLines()).toContain('[share] migrated legacy image_shares: rows=1 folded=1 skipped=0');
     });
   });
 });


### PR DESCRIPTION
Closes #444

Eight commits. The first two are the substance and are separately revertible —
the feature, then the rename. The rest are review fixes on top of them
(disposition hardening, per-ref allow-kind narrowing, migration logging, and the
attr-char/dedupe corrections).

## 1. `feat` — allow documents (PDF) through the share bridge

The bridge only accepted PNG/JPEG/WebP, so an agent that produced a PDF had no
way to hand it to a LINE user — LINE has no outbound `file` message type, and a
share link, the standard workaround, was refused with `unsupported_image_type`.

- `detectShareMime()` adds `application/pdf` (`%PDF-` magic). `detectImageMime()`
  is left alone for the callers that genuinely mean "is this an image"
  (`line_image`, `generate_image` ref normalisation, the session image catalog).
- `validateShareFile(..., allow: 'image' | 'any' = 'image')` — the default keeps
  every existing caller on today's behaviour.
- `POST /api/v1/shares` accepts optional `allow_documents: true`. Without it a
  PDF is still `415`. Non-boolean is `400`.
- The MCP `share_file` tool always opts in — it is the agent's explicit "publish
  this file" verb. The narrow image consumers deliberately do not.

### What is persisted is the allow-KIND, not the mime

The issue's original proposal was to persist the resolved mime "so serving does
not have to guess". Serving is not guessing — the fetch-time re-sniff is a
deliberate TOCTOU control, and the file behind a live share can be replaced
between mint and fetch. Persisting a mime would let anyone who can write into
the media root swap a shared PNG and have the gateway serve it under the mime
recorded at mint time.

So the row carries `allow_kind` (`image` | `any`), added with the same in-place
`PRAGMA table_info` + `ALTER TABLE ADD COLUMN` migration already used for
`image_artifacts.prompt`. The re-sniff still runs on every fetch; the kind only
selects which detector runs. That fails closed in both directions, and both
directions are tested:

- an image share whose file becomes a valid PDF still `404`s;
- a document share whose file becomes HTML still `404`s.

`allow_kind` is also part of the 60s idempotent-mint key — two mints of the same
file under different kinds are different capabilities and must not collapse.

### The persisted kind is narrowed PER REF, not per request

`allow_documents: true` is the caller's permission to *include* a PDF in a
batch; it is not a claim that every ref in that batch is one. So each row stores
what its own ref actually validated as — a PNG minted in an `allow_documents`
batch is persisted as `image`, not `any`. Storing the request-level ceiling on
an image row would have quietly reopened the TOCTOU hole for exactly the mixed
batch the flag makes possible: swap that PNG for a PDF and the widened row would
have served it.

### Serving

Images stay exactly `inline`. Documents get
`Content-Disposition: attachment; filename="<ascii>"; filename*=UTF-8''<pct>`.
The basename is agent-controlled, so it is sanitised on three axes:

- **Header integrity** — the quoted fallback keeps printable ASCII only, minus
  `"` and `\`; that alone rules out the CR/LF that would split the response
  header. The real name rides along percent-encoded in `filename*`, where the
  RFC 8187 `ext-value` form escapes `'`, `(`, `)` and `*` — the four characters
  `encodeURIComponent` leaves raw that are not `attr-char`. (`!` and `~` are
  attr-char and stay raw.)
- **Length** — the stem is capped at 200 **code points**, not code units, so a
  4 KB agent-chosen title cannot bloat the header and the cap can never split a
  surrogate pair into a half that makes `encodeURIComponent` throw. The
  extension survives truncation, so the saved file still opens.
- **Type honesty** — the extension is derived from the mime we *sniffed*, never
  from the name the agent chose. `invoice.html` holding `%PDF-` is served as
  `invoice.pdf`; saved under its own name it would be an `.html` file the
  browser renders from `file://`, running whatever script trails the PDF magic
  (reflected file download). A mime that maps to no extension fails **closed** —
  the name ships with no extension rather than falling back to the agent's.

`POST /api/v1/image-artifacts` keeps the `image` default deliberately — it feeds
the session image catalog, and a PDF there is still `415`. HTML, SVG and unknown
magic remain rejected at both mint and fetch; the allowlist stays inert binary
formats so the share origin does not become an XSS surface.

## 2. `refactor` — rename the image-only share surface to file

Every name on the bridge still said "image". Renamed in one pass:

| Kind | Was | Now |
|------|-----|-----|
| Error code | `image_ref_not_found` | `share_ref_not_found` |
| Error code | `image_too_large` | `file_too_large` |
| Error code | `unsupported_image_type` | `unsupported_file_type` |
| Env vars | `IMAGE_SHARE_*` | `SHARE_*` |
| MCP tool / module | `share_image` / `share-image` | `share_file` / `share-file` |
| SQLite table | `image_shares` | `file_shares` |

Deliberately **not** renamed, because those names are correct: `image_artifacts`,
`/api/v1/image-artifacts`, `/api/v1/image-catalog`, `detectImageMime()`,
`generate_image`, `line_image`.

### Compatibility, so the upgrade is not a silent outage

- **`shareEnv()`** reads `SHARE_*` first, falls back to `IMAGE_SHARE_*`. Empty
  counts as unset: `src/session/process.ts` forwards unset vars to MCP
  subprocesses as `''`, so a plain `??` chain would let an empty new name shadow
  a real legacy one. Both names are now forwarded to the subprocess. Missing that
  passthrough would have made the setting silently stop applying inside the agent
  — no error, no failing test.
- **`share_image` stays registered** as a thin alias of `share_file`, with a
  one-line description so it costs almost nothing. Agent workspaces (AGENTS.md,
  skills, memories) reference the old name and we do not get to rewrite them.
  The alias is **image-only** (`allowDocuments: !legacy`): a caller reaching for
  the old name is a caller written before documents existed, and the alias's job
  is to keep it working, not to silently widen what it can publish. New
  capability goes through the new name.
- **`generate_image` matches both** the old and new "ref not found" code — the
  subprocess can be talking to a gateway that predates the rename.
- `errStatus()` maps only the new codes: after the rename nothing in-repo throws
  the old ones, so old cases would be unreachable branches. Compatibility belongs
  on the consumer side, which is where version skew actually happens.

### The table rename

`ALTER TABLE image_shares RENAME TO file_shares`, guarded by `sqlite_master`
lookups, and run **before** the `CREATE TABLE IF NOT EXISTS` — otherwise an empty
`file_shares` is created beside the live data and every share minted before the
upgrade silently `404`s. `RENAME TO` carries indexes over under their OLD names,
so `image_shares_expiry` is dropped rather than left as a duplicate of
`file_shares_expiry`. The rename logs a single line when it fires, so an operator
watching an upgrade can see it happen instead of inferring it.

Renaming the share table is safe specifically because share rows are ephemeral:
TTL is capped at 24 h and expired rows are swept by `cleanupExpired()`. That is
**not** true of `image_artifacts` (30-day retention), which is one more reason it
is out of scope.

Rolling **back** to a pre-#444 build folds `file_shares` back to `image_shares`
if the old table is absent; if a downgrade and a re-upgrade interleave, the
newer rows win. Documented in `API.md`.

## Breaking change

The error `code` values in `4xx` bodies changed. HTTP statuses, request/response
shapes and the token format are unchanged. Documented in `API.md` with a full
rename table.

## Also fixed

`src/share/share-store.ts` contained a raw NUL byte written as a literal control
character instead of `'\0'` in the mint dedupe key. Functionally correct, but it
made `grep`/`rg` classify the whole file as binary and silently return zero
matches — anyone searching the share layer got a false "not found". Byte-identical
join key, no behaviour change, and the key's field order is now pinned by a test
so a future edit cannot reorder it and silently split the dedupe window.

## Tests

`tests/unit/share-image-module.test.ts` → `share-file-module.test.ts`. New
coverage across the four share suites:

- `detectShareMime` allowlist, PDF mint/serve, and the two TOCTOU swaps
- the artifact registry staying image-only
- `Content-Disposition`: hostile basename, attr-char escaping, the code-point
  length cap and its surrogate-pair edge, the sniffed-type extension end to end,
  and the fail-closed unmapped-mime fallback
- allow-kind idempotency (same ref, different kinds, different tokens), the
  per-ref narrowing in a mixed batch, and the fail-closed fallback for an
  unrecognised persisted `allow_kind`
- pre-#444 DB migration: live share survives, `image_shares` is gone, exactly one
  expiry index, idempotent reopen
- `shareEnv` precedence including the `''`-as-unset case, end to end through
  `generate_image`'s max-refs cap
- the `share_image` alias staying image-only, and a pre-rename gateway still
  answering `image_ref_not_found`

Revert-proven: with `src/` and `mcp/` reverted to the pre-change source, all four
share suites fail (two fail to even resolve their imports; `share-router` and
`share-normalize` fail on the renamed codes and env precedence). Each later
review fix was revert-proven individually as well.

## Gates

- `npx tsc --noEmit` — clean
- `npm test` — **236 suites / 4355 tests, all passing**
