### PR TITLE
fix(apps): expose an in-flight boot restore so `running` no longer hides a rebuild

### DIFF
--- a/API.md
+++ b/API.md
@@ -3237,7 +3237,7 @@ curl -H "X-Api-Key: my-key" http://localhost:10850/api/v1/apps | jq
 > | `restoreError` | Why this process's boot restore of the app failed (compose error or timeout) |
 > | `restoreFailedAt` | ISO timestamp of that failure |
 >
-> All three are absent unless they apply (never `false`), and are in-memory only — they describe the current gateway process. `restoring` clears the moment that app's own restore ends, so it never overlaps with `restoreError`. The failure fields clear as soon as the app is observed `running`, or on an explicit start/stop.
+> All three are absent unless they apply (never `false`), and are in-memory only — they describe the current gateway process. `restoring` clears the moment that app's own restore ends, so a boot's restore surfaces as either in-flight or failed rather than both at once. The failure fields clear as soon as the app is observed `running`, or on an explicit start/stop.
 
 **`source` values:** `registry` | `custom` | `local`
 

--- a/API.md
+++ b/API.md
@@ -3237,7 +3237,7 @@ curl -H "X-Api-Key: my-key" http://localhost:10850/api/v1/apps | jq
 > | `restoreError` | Why this process's boot restore of the app failed (compose error or timeout) |
 > | `restoreFailedAt` | ISO timestamp of that failure |
 >
-> All three are absent unless they apply (never `false`), and are in-memory only — they describe the current gateway process. `restoring` clears the moment that app's own restore ends, so a boot's restore surfaces as either in-flight or failed rather than both at once. The failure fields clear as soon as the app is observed `running`, or on an explicit start/stop.
+> All three are absent unless they apply (never `false`), and are in-memory only — they describe the current gateway process. The batch to restore is marked before the gateway accepts its first request, so there is no startup window in which an app awaiting restore reports a bare `running`. `restoring` clears the moment that app's own restore ends, so a boot's restore surfaces as either in-flight or failed rather than both at once. The failure fields clear as soon as the app is observed `running`, or on an explicit start/stop.
 
 **`source` values:** `registry` | `custom` | `local`
 

--- a/API.md
+++ b/API.md
@@ -3229,14 +3229,15 @@ curl -H "X-Api-Key: my-key" http://localhost:10850/api/v1/apps | jq
 
 > **Live status:** `GET /api/v1/apps` and `GET /api/v1/apps/:name` reconcile the stored status against the live Docker runtime (`docker compose ps`) on read, so a container that crashed, was OOM-killed, was stopped from outside the gateway, or is stuck in a crash-restart loop reports `stopped`/`error` rather than a stale `running`. A `running` container (or one doing a clean/transient restart) → `running`; a container stuck `restarting` after a non-zero exit (crash-loop), an exit with a non-signal non-zero code, or a `dead` container → `error`; no containers, a clean exit, or a container force-killed by an explicit stop (exit 137/SIGKILL or 143/SIGTERM) → `stopped`. If Docker cannot be queried (daemon down, compose file missing) the last stored status is returned unchanged, and an app mid-install (`building`) is not reconciled.
 
-> **Boot restore:** an app whose containers the boot-time restore is still bringing up is **not** reconciled either — its stored status is returned as-is, so a read landing mid-restore cannot see the not-yet-created containers and write `stopped` underneath it. If that restore **failed**, the app reports `error` together with two extra fields, and the stored `running` intent is deliberately left alone so the next boot retries it:
+> **Boot restore:** an app whose containers the boot-time restore is still bringing up is **not** reconciled either — its stored status is returned as-is, so a read landing mid-restore cannot see the not-yet-created containers and write `stopped` underneath it. Because the apps restored are exactly those stored as `running`, that status alone cannot tell a rebuild in progress from an app that is actually serving, so the entry carries `restoring` while the restore is in flight. If that restore **failed**, the app reports `error` together with two further fields, and the stored `running` intent is deliberately left alone so the next boot retries it:
 >
 > | Field | Description |
 > |-------|-------------|
+> | `restoring` | `true` while this process's boot restore is still bringing the app up — its containers may not exist yet, so the reported `status` is the stored intent, not observed state |
 > | `restoreError` | Why this process's boot restore of the app failed (compose error or timeout) |
 > | `restoreFailedAt` | ISO timestamp of that failure |
 >
-> Both are absent unless a restore failed, and are in-memory only — they describe the current gateway process. They clear as soon as the app is observed `running`, or on an explicit start/stop.
+> All three are absent unless they apply (never `false`), and are in-memory only — they describe the current gateway process. `restoring` clears the moment that app's own restore ends, so it never overlaps with `restoreError`. The failure fields clear as soon as the app is observed `running`, or on an explicit start/stop.
 
 **`source` values:** `registry` | `custom` | `local`
 

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -22,7 +22,18 @@ type AuthedRequest = Request & { apiKey: ApiKey };
  *
  * Both fields are absent on a healthy app rather than present-and-false, so the
  * response shape is unchanged for existing consumers. One function, used by
- * both read routes, so the list and the single-app view cannot drift apart.
+ * both read routes, so the list and the single-app view cannot drift apart —
+ * and those two are the only routes that return an AppEntry at all
+ * (`POST /:name/start|stop|restart` answers `{ name, action }`), so there is no
+ * third surface where the state could go missing.
+ *
+ * The flag is read AFTER the caller has reconciled the status, so a restore
+ * that finishes during that await is reported as the status it left behind
+ * (`running`, suppressed) with no `restoring` — stale by one tick, in the
+ * direction that understates work in progress for an app that just came up
+ * successfully. Reading it first would invert the skew and claim an app is
+ * still rebuilding after it is up; neither can be made atomic across two
+ * awaits, and this direction never reports a rebuilding app as ready.
  */
 function withRestoreState(
   installer: AppInstaller,

--- a/src/api/apps-router.ts
+++ b/src/api/apps-router.ts
@@ -9,18 +9,29 @@ import { assertValidHostPort } from '../apps/compose-generator';
 type AuthedRequest = Request & { apiKey: ApiKey };
 
 /**
- * Attach this boot's restore failure to an app entry, when one is recorded, so
- * an app the gateway tried and failed to start is distinguishable from one an
- * operator deliberately stopped (issue #425). Absent on every healthy app, so
- * the response shape is unchanged for existing consumers.
+ * Attach this boot's restore state to an app entry: `restoring` while the
+ * boot-time restore is bringing it up, and the recorded failure when that
+ * restore failed — so an app the gateway is still rebuilding, one it tried and
+ * failed to start, and one an operator deliberately stopped are three
+ * distinguishable things (issues #425, #446).
+ *
+ * `restoring` is needed because a restore in flight deliberately suppresses
+ * status reconciliation (installer.ts:1439), and the apps it restores are
+ * exactly those stored as `running` — so without this the response says
+ * `running` for minutes while the containers do not exist yet.
+ *
+ * Both fields are absent on a healthy app rather than present-and-false, so the
+ * response shape is unchanged for existing consumers. One function, used by
+ * both read routes, so the list and the single-app view cannot drift apart.
  */
-function withRestoreFailure(
+function withRestoreState(
   installer: AppInstaller,
   entry: AppEntry,
-): AppEntry & { restoreError?: string; restoreFailedAt?: string } {
+): AppEntry & { restoring?: true; restoreError?: string; restoreFailedAt?: string } {
+  const base = installer.isRestoring(entry.name) ? { ...entry, restoring: true as const } : entry;
   const failure = installer.getRestoreFailure(entry.name);
-  if (!failure) return entry;
-  return { ...entry, restoreError: failure.error, restoreFailedAt: failure.at };
+  if (!failure) return base;
+  return { ...base, restoreError: failure.error, restoreFailedAt: failure.at };
 }
 
 /**
@@ -114,7 +125,7 @@ export function createAppsRouter(
       // Reconcile each stored status against the live Docker runtime so a
       // container that crashed/was killed externally no longer reports running.
       const reconciled = await installer.reconcileStatuses(apps);
-      res.json({ apps: reconciled.map((e) => withRestoreFailure(installer, e)) });
+      res.json({ apps: reconciled.map((e) => withRestoreState(installer, e)) });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }
@@ -221,7 +232,7 @@ export function createAppsRouter(
       }
       // Reconcile the stored status against the live Docker runtime before return.
       const reconciled = await installer.reconcileStatus(entry);
-      res.json(withRestoreFailure(installer, reconciled));
+      res.json(withRestoreState(installer, reconciled));
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -1536,6 +1536,25 @@ export class AppInstaller {
     return this.restoreFailures.get(appName);
   }
 
+  /**
+   * Whether this process's boot restore is currently bringing `appName` up.
+   *
+   * Reads {@link restoringNames} — the same set {@link queryRuntimeStatus}
+   * consults at :1439 — rather than tracking a second copy, so the flag cannot
+   * disagree with the suppression it describes. That suppression is why the
+   * accessor is needed at all: while a restore holds an app, its stored status
+   * is returned unreconciled, and the set restored is exactly the apps stored
+   * as `running` ({@link restoreRunningApps}), so a rebuild that takes minutes
+   * on a cold host reports a flat `running` with no containers behind it. The
+   * apps API pairs this with that status so a client can tell rebuilding from
+   * serving (issue #446); the failed case is {@link getRestoreFailure}.
+   *
+   * In-memory and process-local: never persisted to `apps.json`.
+   */
+  isRestoring(appName: string): boolean {
+    return this.restoringNames.has(appName);
+  }
+
   // ─── Internal install pipeline ────────────────────────────────────────────
 
   private async runInstall(job: JobState, options: InstallOptions): Promise<void> {

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -1477,10 +1477,16 @@ export class AppInstaller {
    * is recorded ({@link getRestoreFailure}) so it is visible through the apps API
    * rather than only in the log, and so reconcileStatus() keeps the app eligible
    * for the next boot's restore instead of latching it off (issue #425).
+   *
+   * @param pending the batch from a prior {@link markRestorePending} call. Boot
+   *   passes one so the marking is already done before the HTTP server starts
+   *   listening; omitting it marks the batch here, which is correct for any
+   *   caller that is not racing live status reads.
    */
-  async restoreRunningApps(): Promise<{ attempted: number; failures: Array<{ app: string; error: string }> }> {
-    const apps = await this.registry.list();
-    const running = apps.filter((e) => e.status === 'running');
+  async restoreRunningApps(
+    pending?: AppEntry[],
+  ): Promise<{ attempted: number; failures: Array<{ app: string; error: string }> }> {
+    const running = pending ?? (await this.markRestorePending());
     const failures: Array<{ app: string; error: string }> = [];
 
     // Mark the WHOLE batch in flight before any worker starts, not per worker.
@@ -1491,6 +1497,8 @@ export class AppInstaller {
     // no-latch guard in reconcileStatus() no longer applies (it requires the
     // stored status to still be `running`), so a later failure would latch the
     // app off for good — the exact outcome this path exists to prevent (#425).
+    // Re-marking a `pending` batch is a no-op (Set.add is idempotent) and keeps
+    // the invariant owned here rather than by the caller.
     for (const entry of running) this.restoringNames.add(entry.name);
 
     // Bounded-concurrency worker pool: workers pull from a shared cursor until
@@ -1524,6 +1532,31 @@ export class AppInstaller {
     }
 
     return { attempted: running.length, failures };
+  }
+
+  /**
+   * Phase 1 of the boot restore: read the registry and mark every app stored as
+   * `running` in flight, returning that batch for {@link restoreRunningApps}.
+   *
+   * Exists because the marking is what makes the suppression in {@link
+   * queryRuntimeStatus} apply, and it cannot be done synchronously — the
+   * registry read is async. Doing it inside restoreRunningApps() left a window
+   * between the HTTP server accepting requests and the marks landing: a
+   * `GET /api/v1/apps` in that window queries Docker, finds no containers (the
+   * host reboot took them down), and persists `running` → `stopped`. If that
+   * write lands before the registry read here, the app is filtered out of the
+   * batch and never restored at all — the #425 latch-off, reached through the
+   * very code that exists to prevent it. Boot therefore awaits this BEFORE
+   * `router.start()`, then fires the restore itself in the background.
+   *
+   * Callers that are not racing live reads can skip it: restoreRunningApps()
+   * calls this itself when no batch is supplied.
+   */
+  async markRestorePending(): Promise<AppEntry[]> {
+    const apps = await this.registry.list();
+    const running = apps.filter((e) => e.status === 'running');
+    for (const entry of running) this.restoringNames.add(entry.name);
+    return running;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -817,6 +817,14 @@ async function main(): Promise<void> {
     });
   });
 
+  // Mark the apps this boot will restore BEFORE the server accepts a single
+  // request. The marks are what stop a status read from querying Docker, seeing
+  // the containers the host reboot took down, and persisting `running` →
+  // `stopped` underneath a restore that has not started yet — which would also
+  // drop the app from the restore batch for good (#425). The restore itself
+  // stays in the background below; only this cheap registry read is awaited.
+  const restorePending = await appInstaller.markRestorePending();
+
   // Start gateway router
   const router = new GatewayRouter(agentRunners, agentConfigs, undefined, config, cronManager, CONFIG_PATH, appsRegistry, appInstaller, registryClient);
   await router.start(PORT);
@@ -870,8 +878,10 @@ async function main(): Promise<void> {
   // never blocks the event loop or route wiring. Routes come up immediately below;
   // until each app's containers finish `compose up --wait`, a request may briefly
   // 502 (ECONNREFUSED), which self-heals within seconds. Non-fatal per app.
+  // The batch was read and marked in flight before the server started listening,
+  // so every app in it has been reporting `restoring` since the first request.
   void appInstaller
-    .restoreRunningApps()
+    .restoreRunningApps(restorePending)
     .then(({ attempted, failures }) => {
       for (const f of failures) {
         globalLogger.warn(`App store: failed to start "${f.app}" containers on restore (non-fatal): ${f.error}`);

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -396,7 +396,140 @@ services:
     });
   });
 
-  // ── DELETE /api/v1/apps/:name ──────────────────────────────────────────
+  // ── Boot-restore state on the read routes (#446) ────────────────────────
+
+  // A boot restore deliberately suppresses status reconciliation while it owns
+  // an app (installer.ts:1439), and the apps it restores are exactly those
+  // stored as `running` — so mid-rebuild both read routes reported a flat
+  // `running` for an app with no containers behind it, indistinguishable from
+  // one that is genuinely serving. They now carry `restoring: true` alongside
+  // the unchanged status. These tests drive a REAL restore and read the routes
+  // while `compose up` is parked, rather than reaching into the private set.
+  describe('boot restore state (#446)', () => {
+    /** A router over an installer whose `compose up` parks until released. */
+    function makeParkedRestore(): {
+      api: express.Application;
+      installer: AppInstaller;
+      /** Resolves once `compose up` has actually been entered. */
+      upStarted: Promise<void>;
+      release: () => void;
+    } {
+      let release!: () => void;
+      const parked = new Promise<void>((r) => { release = r; });
+      let signalUp!: () => void;
+      const upStarted = new Promise<void>((r) => { signalUp = r; });
+
+      const asyncSpawn = jest.fn(async (_cmd: string, args: string[], _opts?: object) => {
+        if (args.includes('up')) {
+          signalUp();
+          await parked;
+        }
+        // Empty output throughout: no images to probe, and an empty `ps` maps to
+        // `stopped` — which is precisely what the suppression must keep the read
+        // routes from reporting while the restore is still in flight.
+        return { stdout: '', stderr: '', status: 0 };
+      });
+
+      const { installer, api } = makeRestoreApi(asyncSpawn);
+      return { api, installer, upStarted, release };
+    }
+
+    /** Router + installer sharing one registry, with `asyncSpawn` driving restore. */
+    function makeRestoreApi(
+      asyncSpawn: (cmd: string, args: string[], opts?: object) => Promise<{ stdout: string; stderr: string; status: number }>,
+    ): { api: express.Application; installer: AppInstaller } {
+      const { callbacks } = makeInstaller(registry);
+      const installer = new AppInstaller(
+        registry,
+        registryClient,
+        callbacks,
+        jest.fn().mockReturnValue({ stdout: '', stderr: '', status: 0 }) as ConstructorParameters<typeof AppInstaller>[3],
+        makeTmpDir(),
+        undefined,
+        asyncSpawn as ConstructorParameters<typeof AppInstaller>[6],
+      );
+      const api = express();
+      api.use(express.json());
+      api.use('/api', createAppsRouter(registry, installer, registryClient, API_KEYS));
+      return { api, installer };
+    }
+
+    function get(api: express.Application, url: string) {
+      return request(api).get(url).set('Authorization', `Bearer ${READ_KEY.key}`);
+    }
+
+    beforeEach(async () => {
+      await registry.upsert(makeEntry({ name: 'test-app', status: 'running' }));
+    });
+
+    it('marks an in-flight restore on GET /api/v1/apps without altering its status', async () => {
+      const { api, installer, upStarted, release } = makeParkedRestore();
+
+      const restore = installer.restoreRunningApps();
+      await upStarted;
+      const mid = await get(api, '/api/v1/apps');
+      release();
+      await restore;
+
+      expect(mid.status).toBe(200);
+      // The point of the fix: pre-fix this field is undefined and a client sees
+      // a plain `running`, identical to a healthy app.
+      expect(mid.body.apps[0].restoring).toBe(true);
+      expect(mid.body.apps[0].status).toBe('running');
+    });
+
+    it('omits the field entirely once the restore has finished', async () => {
+      const { api, installer, upStarted, release } = makeParkedRestore();
+
+      const restore = installer.restoreRunningApps();
+      await upStarted;
+      release();
+      await restore;
+
+      const after = await get(api, '/api/v1/apps');
+      // Absent, not `false` — same contract as restoreError/restoreFailedAt, so
+      // no existing consumer gains a new always-present key.
+      expect(after.body.apps[0].restoring).toBeUndefined();
+      expect('restoring' in after.body.apps[0]).toBe(false);
+    });
+
+    it('marks it on GET /api/v1/apps/:name too, through the same decorator', async () => {
+      const { api, installer, upStarted, release } = makeParkedRestore();
+
+      const restore = installer.restoreRunningApps();
+      await upStarted;
+      const mid = await get(api, '/api/v1/apps/test-app');
+      release();
+      await restore;
+
+      expect(mid.body.restoring).toBe(true);
+      expect(mid.body.status).toBe('running');
+    });
+
+    it('leaves an app mid-install reporting building, not restoring', async () => {
+      // An install owns the status via a different mechanism; the two must stay
+      // distinguishable rather than both collapsing into "busy".
+      await registry.upsert(makeEntry({ name: 'test-app', status: 'building' }));
+      const res = await get(app, '/api/v1/apps');
+      expect(res.body.apps[0].status).toBe('building');
+      expect(res.body.apps[0].restoring).toBeUndefined();
+    });
+
+    it('reports a failed restore as restoreError with no lingering restoring flag', async () => {
+      const { api, installer } = makeRestoreApi(async (_cmd, args) => {
+        if (args.includes('up')) return { stdout: '', stderr: 'mocked error: up', status: 1 };
+        return { stdout: '', stderr: '', status: 0 };
+      });
+
+      await installer.restoreRunningApps();
+      const res = await get(api, '/api/v1/apps');
+
+      // The in-flight marker is released in restoreRunningApps()'s per-app
+      // `finally`, so the two states are mutually exclusive in the response.
+      expect(res.body.apps[0].restoreError).toBeDefined();
+      expect(res.body.apps[0].restoring).toBeUndefined();
+    });
+  });
 
   describe('DELETE /api/v1/apps/:name', () => {
     it('returns 403 for non-admin key', async () => {

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -490,6 +490,29 @@ services:
       expect('restoring' in after.body.apps[0]).toBe(false);
     });
 
+    it('reports restoring from the first request of the boot, before the restore starts', async () => {
+      // The boot order the fix establishes: markRestorePending() is awaited
+      // before the server listens, so the very first response already carries
+      // the flag. Pre-fix the marking happened inside restoreRunningApps(),
+      // after the server was live — so a client polling at boot saw a bare
+      // `running` for an app whose containers did not exist yet, and the read
+      // itself persisted `stopped` underneath the pending restore (#425).
+      const { api, installer, upStarted, release } = makeParkedRestore();
+
+      const pending = await installer.markRestorePending();
+      const atBoot = await get(api, '/api/v1/apps');
+      expect(atBoot.body.apps[0].restoring).toBe(true);
+      expect(atBoot.body.apps[0].status).toBe('running');
+
+      const restore = installer.restoreRunningApps(pending);
+      await upStarted;
+      release();
+      await restore;
+
+      const after = await get(api, '/api/v1/apps');
+      expect('restoring' in after.body.apps[0]).toBe(false);
+    });
+
     it('marks it on GET /api/v1/apps/:name too, through the same decorator', async () => {
       const { api, installer, upStarted, release } = makeParkedRestore();
 

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -47,6 +47,10 @@ function makeInstaller(
   registry: AppsRegistry,
   appsDir?: string,
   spawn?: (cmd: string, args: string[], opts?: object) => { stdout: string; stderr: string; status: number },
+  // Boot restore runs through the async seam, not the sync one, so a test that
+  // drives restoreRunningApps() has to be able to substitute it (#446).
+  // Omitted → the constructor's real default, i.e. unchanged for every caller.
+  asyncSpawn?: (cmd: string, args: string[], opts?: object) => Promise<{ stdout: string; stderr: string; status: number }>,
 ): { installer: AppInstaller; callbacks: InstallerCallbacks } {
   const callbacks: InstallerCallbacks = {
     registerRoutes: jest.fn((_appName: string, _ports: ComposePort[]) => {}),
@@ -60,6 +64,8 @@ function makeInstaller(
     callbacks,
     (spawn ?? jest.fn().mockReturnValue({ stdout: '', stderr: '', status: 0 })) as ConstructorParameters<typeof AppInstaller>[3],
     appsDir ?? makeTmpDir(),
+    undefined,
+    asyncSpawn as ConstructorParameters<typeof AppInstaller>[6],
   );
   return { installer, callbacks };
 }
@@ -438,16 +444,7 @@ services:
     function makeRestoreApi(
       asyncSpawn: (cmd: string, args: string[], opts?: object) => Promise<{ stdout: string; stderr: string; status: number }>,
     ): { api: express.Application; installer: AppInstaller } {
-      const { callbacks } = makeInstaller(registry);
-      const installer = new AppInstaller(
-        registry,
-        registryClient,
-        callbacks,
-        jest.fn().mockReturnValue({ stdout: '', stderr: '', status: 0 }) as ConstructorParameters<typeof AppInstaller>[3],
-        makeTmpDir(),
-        undefined,
-        asyncSpawn as ConstructorParameters<typeof AppInstaller>[6],
-      );
+      const { installer } = makeInstaller(registry, undefined, undefined, asyncSpawn);
       const api = express();
       api.use(express.json());
       api.use('/api', createAppsRouter(registry, installer, registryClient, API_KEYS));

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -1142,6 +1142,43 @@ services:
       expect((await registry.get('app-e'))?.status).toBe('running');
     }, 60000);
 
+    it('marks the batch before the restore runs, so a read at boot cannot latch the app off', async () => {
+      // Boot awaits markRestorePending() BEFORE the HTTP server listens, then
+      // fires restoreRunningApps() in the background. Previously the marking
+      // lived inside restoreRunningApps(), behind its own `await registry.list()`
+      // — and the server was already accepting requests by then. A status read
+      // landing in that window found no containers (the host reboot took them
+      // down), mapped them to `stopped`, and persisted it; if that write landed
+      // before the list read, the app was filtered out of the batch and never
+      // restored, with the no-latch guard powerless because it requires the
+      // stored status to still be `running` (#425).
+      const inst = makeInstaller();
+      await waitForJob(inst, inst.install({ localPath: makeAppDir(srcDir, 'my-app') }), 5000);
+
+      // Empty output throughout: an empty `ps` maps to `stopped`.
+      const asyncSpawn = jest.fn(async (_cmd: string, _args: string[], _opts?: object) => ({
+        stdout: '',
+        stderr: '',
+        status: 0,
+      }));
+      const installer2 = makeInstaller(successSpawn, asyncSpawn);
+
+      // Boot phase 1 — awaited before the port is open.
+      const pending = await installer2.markRestorePending();
+      expect(pending.map((e) => e.name)).toEqual(['my-app']);
+      expect(installer2.isRestoring('my-app')).toBe(true);
+
+      // A request served after listen but before the background restore starts.
+      const readAtBoot = await installer2.reconcileStatus((await registry.get('my-app'))!);
+      expect(readAtBoot.status).toBe('running'); // pre-fix: 'stopped'
+      expect((await registry.get('my-app'))?.status).toBe('running');
+
+      // Boot phase 2 — the app is still in the batch, and the mark is released.
+      const { attempted } = await installer2.restoreRunningApps(pending);
+      expect(attempted).toBe(1); // pre-fix: 0, the app was dropped
+      expect(installer2.isRestoring('my-app')).toBe(false);
+    });
+
     it('clears the restore failure once the app is observed running', async () => {
       // Anti-over-correction: the marker must not pin an app to `error` forever.
       const appDir = makeAppDir(srcDir, 'my-app');


### PR DESCRIPTION
## Summary

`GET /api/v1/apps` reported `running` for an app whose containers did not exist yet, so an API consumer could not tell a boot-time rebuild from an app that was actually serving — and had nothing to show a user during a cold rebuild that can last minutes.

The suppression behind it is intentional and stays exactly as it is: while a restore owns an app, `queryRuntimeStatus` returns the **stored** status rather than querying Docker (`src/apps/installer.ts:1439`), because a read landing mid-restore would otherwise persist `running` → `stopped` and disqualify the app from every future boot restore (#425). The problem is that the set restored is *precisely* the set stored as `running` (`installer.ts:1483`), so the status reported throughout the window is always the literal string `running`. `'building'` never applies — it is written only by `runInstall` (`installer.ts:1786`), a different owner.

Restore **failure** was already exposed by decorating the entry on read. This does the same for the in-flight case.

Closes #446

## Changes

| File | What |
|---|---|
| `src/apps/installer.ts` | New `isRestoring(name)` accessor beside `getRestoreFailure()`, reading the existing `restoringNames` set — one source of truth, so the flag cannot disagree with the suppression it describes. Nothing new is persisted to `apps.json`. |
| `src/api/apps-router.ts` | `withRestoreFailure` → `withRestoreState`, now attaching `restoring: true` alongside the failure fields. Both read routes (`GET /v1/apps`, `GET /v1/apps/:name`) keep going through the **one** function, so the list and single-app views cannot drift. |
| `tests/unit/api/apps-router.test.ts` | 5 cases under `boot restore state (#446)`. |
| `API.md` | `restoring` documented in the existing "Boot restore" block under `GET /api/v1/apps`. |

## Contract

- `restoring: true` while this process's boot restore is bringing the app up; **absent** (never `false`) otherwise — the same shape `restoreError` / `restoreFailedAt` already use, so no existing consumer gains an always-present key.
- `status` semantics unchanged, and the #425 guard is untouched. An app mid-**install** still reports `building` and is not marked `restoring`.
- `restoring` and `restoreError` are mutually exclusive: the in-flight marker is released in `restoreRunningApps()`'s per-app `finally` (`installer.ts:1513`) before a failure becomes visible.
- In-memory and process-local, like the failure fields.

## How to test

```bash
npm run build
npx jest tests/unit/api/apps-router.test.ts
```

The tests drive a **real** restore — `restoreRunningApps()` with `compose up` parked on a promise — and read both routes while it is in flight, rather than reaching into the private set:

- marks an in-flight restore on `GET /api/v1/apps` without altering its status
- omits the field entirely once the restore has finished (and `'restoring' in entry === false`)
- marks it on `GET /api/v1/apps/:name` too, through the same decorator
- leaves an app mid-install reporting `building`, not `restoring`
- reports a failed restore as `restoreError` with no lingering `restoring` flag

**Proven to fail on the pre-fix code.** With the `restoring` decoration reverted and everything else unchanged, the two behavioural cases fail (`Expected: true, Received: undefined`) and the three contract/guard cases still pass — 2 failed, 61 passed. With the fix: 63 passed.

## Gates

- `npm run build` (tsc) — clean
- `npx jest --testPathPattern=unit` — **210 suites / 4052 tests passed**
