### PR TITLE
fix(service): restart on graceful update-exit, refuse conflicting units

### DIFF
--- a/API.md
+++ b/API.md
@@ -3865,7 +3865,7 @@ curl -H "X-Api-Key: admin-secret" \
 
 Installs the latest version of the specified package. `:name` accepts `claude-gateway` or `claude-code`.
 
-- **claude-gateway**: runs `npm install -g @0xmaxma/claude-gateway@latest` then calls `process.exit(0)` so the process manager (systemd/pm2) restarts the service.
+- **claude-gateway**: runs `npm install -g @0xmaxma/claude-gateway@latest` then sends itself `SIGTERM`, requesting a non-zero (`EX_TEMPFAIL`) exit code so a `Restart=on-failure` unit restarts it too — a graceful `exit(0)` reads as success to `on-failure` and never restarts (issue #450). `Restart=always` units and pm2's `autorestart` restart on any exit code regardless.
 - **claude-code**: runs the native updater (`claude update`) so the actual binary on PATH is updated. No restart needed. (npm install is not used — Claude Code ships via the native installer, so an npm-global copy would not be the running binary.)
 
 If the package is already on the latest version the call is a no-op (`updated: false`).

--- a/CLI.md
+++ b/CLI.md
@@ -93,7 +93,7 @@ never mistaken for one.
 
 | Command | Description |
 |---------|-------------|
-| `claude-gateway service install [--manager systemd\|pm2] [--config <path>] [--yes] [--print]` | Generate and start a service |
+| `claude-gateway service install [--manager systemd\|pm2] [--config <path>] [--yes] [--print] [--force]` | Generate and start a service |
 | `claude-gateway service status [--manager systemd\|pm2]` | Report installed/enabled/active state as JSON |
 | `claude-gateway service uninstall [--manager systemd\|pm2] [--yes]` | Stop and remove the service |
 
@@ -108,6 +108,9 @@ never mistaken for one.
   and refuse to run non-interactively without it.
 - `install` verifies `/health` on the **local bind address**, and `uninstall` reports the state the
   manager actually reports afterwards — never the state that was intended.
+- (systemd) `install` refuses by default if a `claude-gateway.service` unit already exists and is
+  enabled or active at *system* scope (e.g. from provisioning outside this CLI) — it prints the exact
+  `sudo systemctl disable --now claude-gateway.service` to resolve it; pass `--force` to install anyway.
 - After installing, `gateway restart`/`stop` detect and drive that same service.
 
 ## Versions & updates

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ claude-gateway service uninstall            # asks first — this stops a runnin
 ```
 
 Install and uninstall both prompt before acting; pass `--yes` in scripts (without it, a
-non-interactive run is refused rather than left hanging).
+non-interactive run is refused rather than left hanging). Always stop the gateway through
+`service uninstall` or `systemctl --user stop claude-gateway.service` — a bare `kill <pid>` bypasses
+systemd's own stop tracking, so `Restart=always` brings it right back regardless of exit code.
 
 `install` also refuses (rather than just warning) if a `claude-gateway.service` unit already
 exists and is enabled or active at *system* scope (e.g. one written by provisioning outside this

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ claude-gateway service uninstall            # asks first — this stops a runnin
 Install and uninstall both prompt before acting; pass `--yes` in scripts (without it, a
 non-interactive run is refused rather than left hanging).
 
+`install` also refuses (rather than just warning) if a `claude-gateway.service` unit already
+exists and is enabled or active at *system* scope (e.g. one written by provisioning outside this
+CLI) — installing a second, independent unit alongside it would race for the port on the next
+reboot. It prints the exact `sudo systemctl disable --now claude-gateway.service` to resolve it;
+pass `--force` to install anyway.
+
 The systemd path writes `~/.config/systemd/user/claude-gateway.service`. Run
 `loginctl enable-linger $USER` once if it must keep running while you're logged out.
 Prefer [PM2](https://pm2.keymetrics.io)? `claude-gateway service install --manager pm2` registers

--- a/scripts/gen-cli.ts
+++ b/scripts/gen-cli.ts
@@ -164,7 +164,7 @@ never mistaken for one.
 
 | Command | Description |
 |---------|-------------|
-| \`claude-gateway service install [--manager systemd\\|pm2] [--config <path>] [--yes] [--print]\` | Generate and start a service |
+| \`claude-gateway service install [--manager systemd\\|pm2] [--config <path>] [--yes] [--print] [--force]\` | Generate and start a service |
 | \`claude-gateway service status [--manager systemd\\|pm2]\` | Report installed/enabled/active state as JSON |
 | \`claude-gateway service uninstall [--manager systemd\\|pm2] [--yes]\` | Stop and remove the service |
 
@@ -179,6 +179,9 @@ never mistaken for one.
   and refuse to run non-interactively without it.
 - \`install\` verifies \`/health\` on the **local bind address**, and \`uninstall\` reports the state the
   manager actually reports afterwards — never the state that was intended.
+- (systemd) \`install\` refuses by default if a \`claude-gateway.service\` unit already exists and is
+  enabled or active at *system* scope (e.g. from provisioning outside this CLI) — it prints the exact
+  \`sudo systemctl disable --now claude-gateway.service\` to resolve it; pass \`--force\` to install anyway.
 - After installing, \`gateway restart\`/\`stop\` detect and drive that same service.
 
 ## Versions & updates

--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -181,8 +181,16 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
         // exit as failure-worth-restarting; `Restart=always` and pm2's
         // `autorestart` already restart on any exit code, so this is a no-op
         // for them. See issue #450.
-        requestExitCode(EX_TEMPFAIL);
-        setTimeout(() => process.kill(process.pid, 'SIGTERM'), 500);
+        //
+        // Requested inside the timeout, immediately before the signal — not
+        // right after the response — so the window in which an unrelated
+        // shutdown (an operator's own `kill`/Ctrl-C landing in the same
+        // 500ms) could consume this process's pending code instead of its
+        // own is as close to zero as this signal-based handoff allows.
+        setTimeout(() => {
+          requestExitCode(EX_TEMPFAIL);
+          process.kill(process.pid, 'SIGTERM');
+        }, 500);
       } else {
         res.json({ package: packageName, from, to, updated: true, warning: null });
       }

--- a/src/api/packages.ts
+++ b/src/api/packages.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { ApiKey } from '../types';
 import { createApiAuthMiddleware, isAdmin } from './auth';
+import { EX_TEMPFAIL, requestExitCode } from '../shutdown-signals';
 import {
   PACKAGES,
   PackageInfo,
@@ -174,6 +175,13 @@ export function createPackagesRouter(apiKeys?: ApiKey[]): Router {
           warning: isManaged ? 'service will restart' : 'process will stop — restart manually',
         });
 
+        // A graceful `exit(0)` reads as success to `Restart=on-failure` systemd
+        // units — including ones this same codebase generates — so it never
+        // restarts. Request EX_TEMPFAIL so an `on-failure` unit treats this
+        // exit as failure-worth-restarting; `Restart=always` and pm2's
+        // `autorestart` already restart on any exit code, so this is a no-op
+        // for them. See issue #450.
+        requestExitCode(EX_TEMPFAIL);
         setTimeout(() => process.kill(process.pid, 'SIGTERM'), 500);
       } else {
         res.json({ package: packageName, from, to, updated: true, warning: null });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -30,6 +30,12 @@ function looksLikeFlag(token: string): boolean {
  * parser has no schema of its own, so it can only be told which names are
  * boolean by the caller. Flags not in this set keep the default heuristic
  * (consume the next token unless it looks like another flag).
+ *
+ * A declared boolean flag's `--flag=value` form is parsed as a boolean too
+ * (`value !== 'false'`), not left as a raw string — otherwise `--force=true`
+ * silently reads as truthy-but-not-`true`, and a strict `flags.force === true`
+ * check downstream (as `service install` does) refuses despite the explicit
+ * override. `--force=false` is the one form that's meant to read as off.
  */
 export function parseCliArgs(tokens: string[], booleanFlags: ReadonlySet<string> = new Set()): ParsedArgs {
   const positionals: string[] = [];
@@ -40,7 +46,9 @@ export function parseCliArgs(tokens: string[], booleanFlags: ReadonlySet<string>
       const body = tok.startsWith('--') ? tok.slice(2) : SHORT_ALIASES[tok.slice(1)];
       const eq = body.indexOf('=');
       if (eq !== -1) {
-        flags[body.slice(0, eq)] = body.slice(eq + 1);
+        const key = body.slice(0, eq);
+        const value = body.slice(eq + 1);
+        flags[key] = booleanFlags.has(key) ? value !== 'false' : value;
         continue;
       }
       if (booleanFlags.has(body)) {

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -146,7 +146,7 @@ Environment="HOME=${q(spec.home)}"
 Environment="PATH=${q(spec.pathEnv)}"
 Environment="GATEWAY_CONFIG=${q(spec.config)}"
 ExecStart="${q(spec.node)}" "${q(spec.entry)}" gateway start --config "${q(spec.config)}"
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 [Install]
@@ -254,6 +254,29 @@ function systemdStatus(flags: Record<string, string | boolean>): number {
   return state.active ? 0 : 1;
 }
 
+/**
+ * True when a same-named unit already exists and is enabled or active at
+ * *system* scope (`/etc/systemd/system/`) — e.g. from an externally
+ * provisioned image. Installing the user-scope unit alongside it would leave
+ * both `enabled`, racing for the port on the next reboot (see issue #450).
+ *
+ * Reading system scope needs no privileges: `systemctl is-enabled`/`is-active`
+ * without `--user` queries it as any user, so this check costs nothing extra.
+ */
+function systemScopeConflict(): boolean {
+  try {
+    if (capture('systemctl', ['is-enabled', UNIT_NAME]).trim() === 'enabled') return true;
+  } catch {
+    /* disabled, static, or not installed at system scope */
+  }
+  try {
+    if (capture('systemctl', ['is-active', UNIT_NAME]).trim() === 'active') return true;
+  } catch {
+    /* inactive, or not installed at system scope */
+  }
+  return false;
+}
+
 async function systemdInstall(
   flags: Record<string, string | boolean>,
   config: CliConfigView,
@@ -266,6 +289,24 @@ async function systemdInstall(
   // stderr, not stdout: stdout carries the JSON result (see printJson).
   printFilePreview(file, unit, (line) => process.stderr.write(line + '\n'));
   if (flags.print === true) return 0;
+
+  // Refuse by default rather than only warning: a warning a user proceeds
+  // past (or never reads) still ends up with two enabled units. Disabling the
+  // conflicting unit automatically would need sudo — deliberately outside
+  // this command's scope (see the file-level comment) — and it may belong to
+  // a provisioning system this installer has no context on, so this stops
+  // and hands back the exact command to resolve it instead.
+  if (flags.force !== true && systemScopeConflict()) {
+    process.stderr.write(
+      `A ${UNIT_NAME} unit already exists at system scope (/etc/systemd/system/${UNIT_NAME}) and is enabled or active.\n` +
+        `Installing a second, independent unit at user scope would race it for the port on the next reboot.\n` +
+        `Disable the existing one first, then re-run this command:\n` +
+        `  sudo systemctl disable --now ${UNIT_NAME}\n` +
+        'Pass --force to install anyway.\n',
+    );
+    return 1;
+  }
+
   if (!(await confirm(flags, 'install', `Install and start ${UNIT_NAME} for user ${os.userInfo().username}?`))) {
     process.stderr.write('Aborted — nothing was written.\n');
     return 1;
@@ -467,7 +508,7 @@ async function pm2Uninstall(flags: Record<string, string | boolean>): Promise<nu
 // ─── entry point ──────────────────────────────────────────────────────────────
 
 const USAGE_LINE =
-  'claude-gateway service <install|status|uninstall> [--manager systemd|pm2] [--config <path>] [--yes] [--print]';
+  'claude-gateway service <install|status|uninstall> [--manager systemd|pm2] [--config <path>] [--yes] [--print] [--force]';
 
 /** Pick the manager to act on when `--manager` is omitted. `status`/`uninstall`
  *  act on whatever is actually installed; `install` always defaults to systemd
@@ -504,7 +545,11 @@ export async function runService(
       'service',
       'run the gateway as a systemd-user or PM2 service',
       USAGE_LINE,
-      ['  systemd installs a user unit in ~/.config/systemd/user (no sudo).'],
+      [
+        '  systemd installs a user unit in ~/.config/systemd/user (no sudo).',
+        '  install refuses if a claude-gateway unit already exists at system scope;',
+        '  --force overrides that check.',
+      ],
     );
     return flags.help === true ? 0 : 1;
   }

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -232,12 +232,14 @@ async function waitForHealth(config: CliConfigView, flags: Record<string, string
 
 // ─── systemd (user scope) ─────────────────────────────────────────────────────
 
-/** `is-enabled`/`is-active` for `UNIT_NAME` at whatever scope `scopeArgs`
- *  selects (`['--user']` or `[]` for system scope) — the query both
- *  `systemdState()` (user scope, for `service status`) and
+/** `is-enabled`/`is-active` for `UNIT_NAME` at the given scope — the query
+ *  both `systemdState()` (user scope, for `service status`) and
  *  `systemScopeConflict()` (system scope, for the install-time check below)
- *  need, differing only in scope. */
-function unitFlagState(scopeArgs: readonly string[]): { enabled: boolean; active: boolean } {
+ *  need, differing only in scope. A named boolean rather than a raw argv
+ *  fragment (`['--user']`/`[]`) so a future call site passing the wrong array
+ *  fails to compile instead of silently querying the wrong scope. */
+function unitFlagState(userScope: boolean): { enabled: boolean; active: boolean } {
+  const scopeArgs = userScope ? ['--user'] : [];
   let enabled = false;
   let active = false;
   try {
@@ -254,7 +256,7 @@ function unitFlagState(scopeArgs: readonly string[]): { enabled: boolean; active
 }
 
 function systemdState(): { installed: boolean; enabled: boolean; active: boolean } {
-  return { installed: fs.existsSync(unitPath()), ...unitFlagState(['--user']) };
+  return { installed: fs.existsSync(unitPath()), ...unitFlagState(true) };
 }
 
 function systemdStatus(flags: Record<string, string | boolean>): number {
@@ -273,8 +275,21 @@ function systemdStatus(flags: Record<string, string | boolean>): number {
  * without `--user` queries it as any user, so this check costs nothing extra.
  */
 function systemScopeConflict(): boolean {
-  const { enabled, active } = unitFlagState([]);
+  const { enabled, active } = unitFlagState(false);
   return enabled || active;
+}
+
+/** Written to stderr when `systemScopeConflict()` refuses an install — shared
+ *  by both the pre-prompt check and the re-check right after `confirm()`
+ *  below, so the two call sites can't drift into different wording. */
+function writeSystemScopeConflictRefusal(): void {
+  process.stderr.write(
+    `A ${UNIT_NAME} unit already exists at system scope (/etc/systemd/system/${UNIT_NAME}) and is enabled or active.\n` +
+      `Installing a second, independent unit at user scope would race it for the port on the next reboot.\n` +
+      `Disable the existing one first, then re-run this command:\n` +
+      `  sudo systemctl disable --now ${UNIT_NAME}\n` +
+      'Pass --force to install anyway.\n',
+  );
 }
 
 async function systemdInstall(
@@ -297,18 +312,20 @@ async function systemdInstall(
   // a provisioning system this installer has no context on, so this stops
   // and hands back the exact command to resolve it instead.
   if (flags.force !== true && systemScopeConflict()) {
-    process.stderr.write(
-      `A ${UNIT_NAME} unit already exists at system scope (/etc/systemd/system/${UNIT_NAME}) and is enabled or active.\n` +
-        `Installing a second, independent unit at user scope would race it for the port on the next reboot.\n` +
-        `Disable the existing one first, then re-run this command:\n` +
-        `  sudo systemctl disable --now ${UNIT_NAME}\n` +
-        'Pass --force to install anyway.\n',
-    );
+    writeSystemScopeConflictRefusal();
     return 1;
   }
 
   if (!(await confirm(flags, 'install', `Install and start ${UNIT_NAME} for user ${os.userInfo().username}?`))) {
     process.stderr.write('Aborted — nothing was written.\n');
+    return 1;
+  }
+
+  // `confirm()` can block indefinitely on the y/N prompt — re-check right
+  // before writing anything, in case a conflicting unit appeared while it
+  // was waiting on the operator.
+  if (flags.force !== true && systemScopeConflict()) {
+    writeSystemScopeConflictRefusal();
     return 1;
   }
 

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -232,20 +232,29 @@ async function waitForHealth(config: CliConfigView, flags: Record<string, string
 
 // ─── systemd (user scope) ─────────────────────────────────────────────────────
 
-function systemdState(): { installed: boolean; enabled: boolean; active: boolean } {
+/** `is-enabled`/`is-active` for `UNIT_NAME` at whatever scope `scopeArgs`
+ *  selects (`['--user']` or `[]` for system scope) — the query both
+ *  `systemdState()` (user scope, for `service status`) and
+ *  `systemScopeConflict()` (system scope, for the install-time check below)
+ *  need, differing only in scope. */
+function unitFlagState(scopeArgs: readonly string[]): { enabled: boolean; active: boolean } {
   let enabled = false;
   let active = false;
   try {
-    enabled = capture('systemctl', ['--user', 'is-enabled', UNIT_NAME]).trim() === 'enabled';
+    enabled = capture('systemctl', [...scopeArgs, 'is-enabled', UNIT_NAME]).trim() === 'enabled';
   } catch {
     /* systemctl absent, or the unit is disabled/missing */
   }
   try {
-    active = capture('systemctl', ['--user', 'is-active', UNIT_NAME]).trim() === 'active';
+    active = capture('systemctl', [...scopeArgs, 'is-active', UNIT_NAME]).trim() === 'active';
   } catch {
     /* systemctl absent, or the unit is inactive */
   }
-  return { installed: fs.existsSync(unitPath()), enabled, active };
+  return { enabled, active };
+}
+
+function systemdState(): { installed: boolean; enabled: boolean; active: boolean } {
+  return { installed: fs.existsSync(unitPath()), ...unitFlagState(['--user']) };
 }
 
 function systemdStatus(flags: Record<string, string | boolean>): number {
@@ -264,17 +273,8 @@ function systemdStatus(flags: Record<string, string | boolean>): number {
  * without `--user` queries it as any user, so this check costs nothing extra.
  */
 function systemScopeConflict(): boolean {
-  try {
-    if (capture('systemctl', ['is-enabled', UNIT_NAME]).trim() === 'enabled') return true;
-  } catch {
-    /* disabled, static, or not installed at system scope */
-  }
-  try {
-    if (capture('systemctl', ['is-active', UNIT_NAME]).trim() === 'active') return true;
-  } catch {
-    /* inactive, or not installed at system scope */
-  }
-  return false;
+  const { enabled, active } = unitFlagState([]);
+  return enabled || active;
 }
 
 async function systemdInstall(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,8 +17,11 @@ import { runChannels } from './commands/channels';
  *  token as a value (see parseCliArgs). `follow` is here rather than in the
  *  gateway command because the verb is a positional: `gateway --follow logs`
  *  would otherwise parse `logs` as the flag's value and leave no command at all.
- *  No generated resource command declares a `--follow` value flag. */
-const GLOBAL_BOOLEAN_FLAGS = new Set(['help', 'json', 'yes', 'print', 'follow']);
+ *  No generated resource command declares a `--follow` value flag. `force` is
+ *  here for the same reason: `service --force install` (flag before the verb)
+ *  would otherwise swallow `install` as `--force`'s value and leave `service`
+ *  with no verb at all — see issue #450. */
+const GLOBAL_BOOLEAN_FLAGS = new Set(['help', 'json', 'yes', 'print', 'follow', 'force']);
 /** Flags every command accepts, on top of whatever the generated manifest
  *  declares for that command. Anything outside this set and the command's own
  *  flags is a typo, and is reported rather than dropped: a resource command

--- a/src/shutdown-signals.ts
+++ b/src/shutdown-signals.ts
@@ -26,30 +26,6 @@
  */
 export const SHUTDOWN_SIGNALS: readonly NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP'];
 
-/**
- * sysexits.h `EX_TEMPFAIL` — "temporary failure, user is invited to retry".
- * Used by callers that trigger their own shutdown (see `requestExitCode`) but
- * need `Restart=on-failure` systemd units to treat the exit as failure-worth-
- * restarting, rather than the default clean-shutdown code 0. See issue #450:
- * an API-triggered update SIGTERMs the gateway itself expecting the
- * supervisor to bring it back, but `on-failure` only restarts on a non-zero
- * exit or a signal kill, not on a graceful `exit(0)`.
- */
-export const EX_TEMPFAIL = 75;
-
-let pendingExitCode = 0;
-
-/**
- * Overrides the exit code the *next* signal-driven shutdown uses, then resets
- * to 0 (the default clean-exit code) once consumed — so a caller that
- * triggers its own shutdown (e.g. the package updater sending itself
- * SIGTERM) can request `on-failure` supervisors restart it, without pinning
- * every future shutdown to the same code.
- */
-export function requestExitCode(code: number): void {
-  pendingExitCode = code;
-}
-
 export interface ShutdownSignalOptions {
   /** The teardown itself. Invoked at most once, no matter how many signals arrive. */
   run: (signal: string) => Promise<void>;
@@ -92,13 +68,8 @@ export function registerShutdownSignals(
       // signal — holding its port and its children — which is a worse outcome
       // than an unclean exit. Exit non-zero so the failure stays visible.
       void shutdown(signal).then(
-        () => {
-          const code = pendingExitCode;
-          pendingExitCode = 0;
-          exit(code);
-        },
+        () => exit(0),
         (err) => {
-          pendingExitCode = 0;
           onError(err);
           exit(1);
         },

--- a/src/shutdown-signals.ts
+++ b/src/shutdown-signals.ts
@@ -26,6 +26,30 @@
  */
 export const SHUTDOWN_SIGNALS: readonly NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP'];
 
+/**
+ * sysexits.h `EX_TEMPFAIL` — "temporary failure, user is invited to retry".
+ * Used by callers that trigger their own shutdown (see `requestExitCode`) but
+ * need `Restart=on-failure` systemd units to treat the exit as failure-worth-
+ * restarting, rather than the default clean-shutdown code 0. See issue #450:
+ * an API-triggered update SIGTERMs the gateway itself expecting the
+ * supervisor to bring it back, but `on-failure` only restarts on a non-zero
+ * exit or a signal kill, not on a graceful `exit(0)`.
+ */
+export const EX_TEMPFAIL = 75;
+
+let pendingExitCode = 0;
+
+/**
+ * Overrides the exit code the *next* signal-driven shutdown uses, then resets
+ * to 0 (the default clean-exit code) once consumed — so a caller that
+ * triggers its own shutdown (e.g. the package updater sending itself
+ * SIGTERM) can request `on-failure` supervisors restart it, without pinning
+ * every future shutdown to the same code.
+ */
+export function requestExitCode(code: number): void {
+  pendingExitCode = code;
+}
+
 export interface ShutdownSignalOptions {
   /** The teardown itself. Invoked at most once, no matter how many signals arrive. */
   run: (signal: string) => Promise<void>;
@@ -68,8 +92,13 @@ export function registerShutdownSignals(
       // signal — holding its port and its children — which is a worse outcome
       // than an unclean exit. Exit non-zero so the failure stays visible.
       void shutdown(signal).then(
-        () => exit(0),
+        () => {
+          const code = pendingExitCode;
+          pendingExitCode = 0;
+          exit(code);
+        },
         (err) => {
+          pendingExitCode = 0;
           onError(err);
           exit(1);
         },

--- a/src/shutdown-signals.ts
+++ b/src/shutdown-signals.ts
@@ -77,9 +77,18 @@ export function registerShutdownSignals(
   const target = opts.target ?? process;
 
   let inFlight: Promise<void> | null = null;
+  // Captured once, by whichever signal actually starts the teardown — not
+  // re-read when it resolves. A second signal that merely joins an
+  // already-in-flight shutdown (e.g. an operator's own `kill <pid>` landing
+  // while an update-triggered self-restart is still draining connections)
+  // must not let an unrelated `requestExitCode()` call made in that window
+  // change the exit code of a shutdown it didn't start.
+  let exitCode = 0;
 
   const shutdown = (signal: string): Promise<void> => {
     if (inFlight) return inFlight;
+    exitCode = pendingExitCode;
+    pendingExitCode = 0;
     opts.onBegin?.(signal);
     inFlight = opts.run(signal);
     return inFlight;
@@ -92,13 +101,8 @@ export function registerShutdownSignals(
       // signal — holding its port and its children — which is a worse outcome
       // than an unclean exit. Exit non-zero so the failure stays visible.
       void shutdown(signal).then(
-        () => {
-          const code = pendingExitCode;
-          pendingExitCode = 0;
-          exit(code);
-        },
+        () => exit(exitCode),
         (err) => {
-          pendingExitCode = 0;
           onError(err);
           exit(1);
         },

--- a/tests/unit/cli-args.test.ts
+++ b/tests/unit/cli-args.test.ts
@@ -37,8 +37,17 @@ describe('cli args parseCliArgs', () => {
     });
   });
 
-  it('--flag=value form still wins over a declared boolean set', () => {
-    expect(parseCliArgs(['--force=true'], new Set(['force']))).toEqual({ positionals: [], flags: { force: 'true' } });
+  // Issue #450: `service install --force=true` used to refuse anyway, because
+  // the `=` form returned the raw string `'true'` and `service.ts`'s strict
+  // `flags.force !== true` check rejected it. Declared boolean flags now parse
+  // their `=` form as a boolean too.
+  it('a declared boolean flag\'s --flag=value form parses as a boolean, not a string', () => {
+    expect(parseCliArgs(['--force=true'], new Set(['force']))).toEqual({ positionals: [], flags: { force: true } });
+    expect(parseCliArgs(['--force=false'], new Set(['force']))).toEqual({ positionals: [], flags: { force: false } });
+  });
+
+  it('--flag=value stays a string for a flag not declared boolean', () => {
+    expect(parseCliArgs(['--force=true'])).toEqual({ positionals: [], flags: { force: 'true' } });
   });
 
   // `-h` used to fall through to positionals, so `crons -h` reported

--- a/tests/unit/cli-service-force-flag.test.ts
+++ b/tests/unit/cli-service-force-flag.test.ts
@@ -64,4 +64,13 @@ describe('`service --force install` — --force placed before the verb (issue #4
     expect(code).toBe(0);
     expect(mockWriteFileSync).toHaveBeenCalled();
   });
+
+  it('`--force=true` (equals form) also installs despite the conflict', async () => {
+    // parseCliArgs used to return the raw string 'true' for a declared
+    // boolean flag's `--flag=value` form; service.ts's strict
+    // `flags.force !== true` check then refused as if --force were absent.
+    const code = await runCli(['service', 'install', '--force=true', '--yes', '--manager', 'systemd']);
+    expect(code).toBe(0);
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
 });

--- a/tests/unit/cli-service-force-flag.test.ts
+++ b/tests/unit/cli-service-force-flag.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `--force` (added for `service install`, issue #450) has to survive real CLI
+ * parsing, not just the pre-parsed `flags` object `cli-service.test.ts` hands
+ * `runService` directly. `runCli` parses raw argv through `GLOBAL_BOOLEAN_FLAGS`
+ * before any command sees a `flags` object at all — if `force` isn't declared
+ * boolean there, a `--force` placed before the verb (`service --force install`)
+ * swallows `install` as its value instead of leaving it as the positional verb.
+ */
+jest.mock('child_process', () => ({ execFileSync: jest.fn() }));
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  unlinkSync: jest.fn(),
+}));
+jest.mock('../../src/cli/http-client', () => ({
+  ...jest.requireActual('../../src/cli/http-client'),
+  loadCliConfig: () => ({ keys: [] }),
+}));
+
+import * as fs from 'fs';
+import { execFileSync } from 'child_process';
+import { runCli } from '../../src/cli';
+
+const mockExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
+const mockWriteFileSync = fs.writeFileSync as jest.MockedFunction<typeof fs.writeFileSync>;
+
+let stderr: string[];
+let errSpy: jest.SpyInstance;
+let ttyDescriptor: PropertyDescriptor | undefined;
+let fetchSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (fs.existsSync as jest.Mock).mockReturnValue(true);
+  stderr = [];
+  jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  errSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    stderr.push(chunk.toString());
+    return true;
+  });
+  ttyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+  Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+  fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+  // A same-named unit already exists at system scope and is enabled — only
+  // `--force` should get past this.
+  mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+    if (file === 'systemctl' && !args.includes('--user') && args[0] === 'is-enabled') {
+      return Buffer.from('enabled\n');
+    }
+    return Buffer.from('');
+  }) as unknown as typeof execFileSync);
+});
+
+afterEach(() => {
+  errSpy.mockRestore();
+  fetchSpy.mockRestore();
+  if (ttyDescriptor) Object.defineProperty(process.stdin, 'isTTY', ttyDescriptor);
+});
+
+describe('`service --force install` — --force placed before the verb (issue #450)', () => {
+  it('does not swallow `install` as --force\'s value — the install proceeds', async () => {
+    const code = await runCli(['service', '--force', 'install', '--yes', '--manager', 'systemd']);
+    expect(code).toBe(0);
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -101,7 +101,12 @@ describe('service — generated launch configuration', () => {
     // is a valid launch target, so the shape is what this asserts.
     expect(execStart).toMatch(/^ExecStart="\/.*" "\/.*(entry|index)\.js" gateway start --config "\/.*"$/);
     expect(unit).toContain('WantedBy=default.target');
-    expect(unit).toContain('Restart=on-failure');
+    // `on-failure` treats a graceful exit(0) as success and never restarts —
+    // exactly the failure mode in issue #450 (an API-triggered update
+    // SIGTERMs the gateway expecting a restart it never gets). `always`
+    // restarts unconditionally, which also covers the update-triggered exit.
+    expect(unit).toContain('Restart=always');
+    expect(unit).not.toContain('Restart=on-failure');
   });
 
   it('never writes a secret into the unit — only paths', () => {
@@ -224,6 +229,74 @@ describe('service install — confirmation gate', () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+});
+
+describe('service install — system-scope conflict (issue #450)', () => {
+  /** A same-named unit already exists at *system* scope and is enabled. */
+  function systemUnitEnabled(): void {
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && !args.includes('--user') && args[0] === 'is-enabled') {
+        return Buffer.from('enabled\n');
+      }
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+  }
+
+  it('refuses to install — writes nothing, runs no systemctl mutation — when a system-scope unit is enabled', async () => {
+    systemUnitEnabled();
+    const code = await runService(['install'], { manager: 'systemd', yes: true });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/system scope/);
+    expect(stderr.join('')).toMatch(/sudo systemctl disable --now claude-gateway\.service/);
+  });
+
+  it('--force installs anyway despite the conflict', async () => {
+    systemUnitEnabled();
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true, force: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(unitPath, expect.stringContaining('gateway start'), expect.objectContaining({ mode: 0o600 }));
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('does not refuse when a system-scope unit exists but is only "static", not "enabled"', async () => {
+    // A unit can exist and answer `is-enabled` successfully without being
+    // `enabled` (e.g. a static unit with no [Install] section) — the check
+    // must compare the literal value, not just whether the command succeeded.
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && !args.includes('--user') && args[0] === 'is-enabled') {
+        return Buffer.from('static\n');
+      }
+      if (file === 'systemctl' && !args.includes('--user') && args[0] === 'is-active') {
+        return Buffer.from('inactive\n');
+      }
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('checks system scope, not user scope, for the conflict', async () => {
+    systemUnitEnabled();
+    await runService(['install'], { manager: 'systemd', yes: true });
+    // The system-scope check must not be confused with (or piggyback on) the
+    // user-scope `systemdState()` reads used elsewhere in this file.
+    const isChecks = (mockExecFileSync.mock.calls as unknown as Array<[string, string[]]>).filter(
+      ([file, args]) => file === 'systemctl' && (args[0] === 'is-enabled' || args[0] === 'is-active'),
+    );
+    expect(isChecks.length).toBeGreaterThan(0);
+    for (const [, args] of isChecks) expect(args).not.toContain('--user');
   });
 });
 

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -265,6 +265,28 @@ describe('service install — system-scope conflict (issue #450)', () => {
     }
   });
 
+  it('re-checks for a conflict right before writing — a unit that appears while confirm() was waiting on the operator still refuses', async () => {
+    // Simulates the TOCTOU window: no conflict at the pre-prompt check, but
+    // one has appeared by the time confirm() resolves and the code is about
+    // to write. `is-enabled` is queried once per systemScopeConflict() call —
+    // once before the prompt, once again right after — so the first call
+    // reports no conflict and every call after reports one.
+    let isEnabledCalls = 0;
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && !args.includes('--user') && args[0] === 'is-enabled') {
+        isEnabledCalls++;
+        return Buffer.from(isEnabledCalls === 1 ? 'disabled\n' : 'enabled\n');
+      }
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+
+    const code = await runService(['install'], { manager: 'systemd', yes: true });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(stderr.join('')).toMatch(/system scope/);
+    expect(isEnabledCalls).toBeGreaterThanOrEqual(2);
+  });
+
   it('does not refuse when a system-scope unit exists but is only "static", not "enabled"', async () => {
     // A unit can exist and answer `is-enabled` successfully without being
     // `enabled` (e.g. a static unit with no [Install] section) — the check

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -30,6 +30,8 @@
  * T25: GET — current newer than registry latest → hasUpdate:false (no false positive)
  * T26: update when current is ahead of latest → updated:false, native updater not invoked
  * T27: native updater runs but version unchanged (no-op) → updated:false (honest)
+ * T28: claude-gateway self-restart requests EX_TEMPFAIL so an on-failure unit
+ *      still restarts on a graceful exit (issue #450)
  */
 
 import express from 'express';
@@ -39,13 +41,19 @@ import { ApiKey } from '../../src/types';
 // Must mock child_process and fs before importing the module under test
 jest.mock('child_process', () => ({ execSync: jest.fn() }));
 jest.mock('fs', () => ({ readdirSync: jest.fn(), rmSync: jest.fn() }));
+jest.mock('../../src/shutdown-signals', () => ({
+  ...jest.requireActual('../../src/shutdown-signals'),
+  requestExitCode: jest.fn(),
+}));
 
 import { execSync } from 'child_process';
 import { readdirSync, rmSync } from 'fs';
 import { createPackagesRouter, _resetCache, _resetLock, _setLock } from '../../src/api/packages';
+import { EX_TEMPFAIL, requestExitCode } from '../../src/shutdown-signals';
 
 const mockReaddirSync = readdirSync as jest.MockedFunction<typeof readdirSync>;
 const mockRmSync = rmSync as jest.MockedFunction<typeof rmSync>;
+const mockRequestExitCode = requestExitCode as jest.MockedFunction<typeof requestExitCode>;
 
 const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
 
@@ -314,6 +322,25 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
 
     if (savedInvocationId !== undefined) process.env.INVOCATION_ID = savedInvocationId;
     else delete process.env.INVOCATION_ID;
+  });
+
+  it('T28: requests EX_TEMPFAIL before self-killing, so an on-failure unit restarts on a graceful exit', async () => {
+    mockReaddirSync.mockReturnValue([] as unknown as ReturnType<typeof readdirSync>);
+    mockNpmList('@0xmaxma/claude-gateway', '1.2.0');
+    mockFetch({ '@0xmaxma/claude-gateway': '1.3.1' });
+
+    await request(makeApp())
+      .post('/api/v1/packages/claude-gateway/update')
+      .set('X-Api-Key', ADMIN_KEY);
+
+    // Requested synchronously, before the kill is even scheduled — a graceful
+    // exit(0) reads as success to `Restart=on-failure`, so systemd (or any
+    // other on-failure supervisor) never restarts it without this.
+    expect(mockRequestExitCode).toHaveBeenCalledWith(EX_TEMPFAIL);
+    expect(killSpy).not.toHaveBeenCalled();
+
+    jest.runAllTimers();
+    expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
   });
 
   it('T12: npm install fails → 500 with stderr', async () => {

--- a/tests/unit/packages-router.test.ts
+++ b/tests/unit/packages-router.test.ts
@@ -333,14 +333,16 @@ describe('T7-T15: POST /api/v1/packages/:name/update', () => {
       .post('/api/v1/packages/claude-gateway/update')
       .set('X-Api-Key', ADMIN_KEY);
 
-    // Requested synchronously, before the kill is even scheduled — a graceful
-    // exit(0) reads as success to `Restart=on-failure`, so systemd (or any
-    // other on-failure supervisor) never restarts it without this.
-    expect(mockRequestExitCode).toHaveBeenCalledWith(EX_TEMPFAIL);
+    // Requested atomically with the kill (inside the timer), not right after
+    // the response — narrowing the window where an unrelated shutdown could
+    // consume the pending code instead of this one.
+    expect(mockRequestExitCode).not.toHaveBeenCalled();
     expect(killSpy).not.toHaveBeenCalled();
 
     jest.runAllTimers();
+    expect(mockRequestExitCode).toHaveBeenCalledWith(EX_TEMPFAIL);
     expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
+    expect(mockRequestExitCode.mock.invocationCallOrder[0]).toBeLessThan(killSpy.mock.invocationCallOrder[0]);
   });
 
   it('T12: npm install fails → 500 with stderr', async () => {

--- a/tests/unit/shutdown-signals.test.ts
+++ b/tests/unit/shutdown-signals.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { SHUTDOWN_SIGNALS, registerShutdownSignals } from '../../src/shutdown-signals';
+import { EX_TEMPFAIL, SHUTDOWN_SIGNALS, registerShutdownSignals, requestExitCode } from '../../src/shutdown-signals';
 
 describe('shutdown signal wiring (issue #405)', () => {
   // ── U-SD-405a: the defect itself ───────────────────────────────────────────
@@ -122,5 +122,67 @@ describe('shutdown signal wiring (issue #405)', () => {
     // and still holding its port and its children.
     expect(exits).toEqual([1]);
     expect((errors[0] as Error).message).toBe('router.stop() blew up');
+  });
+});
+
+describe('requestExitCode (issue #450)', () => {
+  it('overrides the exit code for the very next signal-driven shutdown', async () => {
+    const target = new EventEmitter();
+    const exits: number[] = [];
+
+    registerShutdownSignals({ run: async () => {}, exit: (code) => exits.push(code), target });
+
+    requestExitCode(EX_TEMPFAIL);
+    target.emit('SIGTERM');
+    await new Promise((r) => setImmediate(r));
+
+    expect(exits).toEqual([EX_TEMPFAIL]);
+  });
+
+  it('defaults to exit 0 when nothing requested a code', async () => {
+    const target = new EventEmitter();
+    const exits: number[] = [];
+
+    registerShutdownSignals({ run: async () => {}, exit: (code) => exits.push(code), target });
+
+    target.emit('SIGTERM');
+    await new Promise((r) => setImmediate(r));
+
+    expect(exits).toEqual([0]);
+  });
+
+  it('is consumed once — a requested code does not leak into a later shutdown', async () => {
+    const targetA = new EventEmitter();
+    const exitsA: number[] = [];
+    requestExitCode(EX_TEMPFAIL);
+    registerShutdownSignals({ run: async () => {}, exit: (code) => exitsA.push(code), target: targetA });
+    targetA.emit('SIGTERM');
+    await new Promise((r) => setImmediate(r));
+    expect(exitsA).toEqual([EX_TEMPFAIL]);
+
+    const targetB = new EventEmitter();
+    const exitsB: number[] = [];
+    registerShutdownSignals({ run: async () => {}, exit: (code) => exitsB.push(code), target: targetB });
+    targetB.emit('SIGTERM');
+    await new Promise((r) => setImmediate(r));
+    expect(exitsB).toEqual([0]);
+  });
+
+  it('a shutdown that throws still exits 1, ignoring any requested code', async () => {
+    const target = new EventEmitter();
+    const exits: number[] = [];
+    requestExitCode(EX_TEMPFAIL);
+
+    registerShutdownSignals({
+      run: async () => { throw new Error('boom'); },
+      exit: (code) => exits.push(code),
+      onError: () => {},
+      target,
+    });
+
+    target.emit('SIGTERM');
+    await new Promise((r) => setImmediate(r));
+
+    expect(exits).toEqual([1]);
   });
 });

--- a/tests/unit/shutdown-signals.test.ts
+++ b/tests/unit/shutdown-signals.test.ts
@@ -185,4 +185,39 @@ describe('requestExitCode (issue #450)', () => {
 
     expect(exits).toEqual([1]);
   });
+
+  // A second, unrelated `requestExitCode()` call landing *after* a teardown
+  // has already started (but before it resolves) must not change that
+  // teardown's exit code — e.g. an operator's own `kill <pid>` starts the
+  // shutdown with nothing pending, and the update endpoint's timer (racing
+  // to self-restart) calls `requestExitCode(EX_TEMPFAIL)` while it's still
+  // draining. The operator's deliberate stop must still exit 0, not inherit
+  // a code requested for a shutdown it didn't start.
+  it('a requestExitCode() call made after a shutdown has already started does not affect it', async () => {
+    const target = new EventEmitter();
+    const exits: number[] = [];
+    let releaseShutdown!: () => void;
+    const teardownDone = new Promise<void>((resolve) => { releaseShutdown = resolve; });
+
+    registerShutdownSignals({
+      run: async () => { await teardownDone; },
+      exit: (code) => exits.push(code),
+      target,
+    });
+
+    // Nothing pending yet — this teardown starts wanting exit 0.
+    target.emit('SIGTERM');
+    await new Promise((r) => setImmediate(r));
+    expect(exits).toEqual([]);
+
+    // A later, unrelated request while the teardown above is still running.
+    requestExitCode(EX_TEMPFAIL);
+
+    releaseShutdown();
+    await new Promise((r) => setImmediate(r));
+
+    // The already-started teardown must exit with the code it began with (0),
+    // not the EX_TEMPFAIL requested after it was already under way.
+    expect(exits).toEqual([0]);
+  });
 });


### PR DESCRIPTION
## Summary
An API-triggered gateway update SIGTERMs the process expecting a supervisor restart, but a graceful `exit(0)` reads as success to `Restart=on-failure` systemd units -- including the one `service install` writes -- so it never comes back on its own (Part A). `service install` also had no awareness of a same-named unit at a different systemd scope, so it could silently write a second, independent, also-enabled unit alongside one already present, racing for the port on the next reboot (Part B).

## Related Issue
Closes #450

## Changes Made
- `src/shutdown-signals.ts`: adds `EX_TEMPFAIL` (75, sysexits.h) and `requestExitCode()` -- overrides the exit code of the *next* signal-driven shutdown, consumed once then reset to 0.
- `src/api/packages.ts`: calls `requestExitCode(EX_TEMPFAIL)` before self-SIGTERM on a `claude-gateway` update, so an `on-failure` unit treats the exit as failure-worth-restarting. No-op for `Restart=always` and pm2 `autorestart`, which already restart on any exit code.
- `src/cli/commands/service.ts`: `renderSystemdUnit()` now emits `Restart=always` for new installs; `systemdInstall()` checks (read-only, no privileges needed) whether a `claude-gateway.service` unit is enabled/active at *system* scope before the confirm prompt, and refuses by default with the exact `sudo systemctl disable --now claude-gateway.service` fix if one is found -- `--force` overrides.
- `README.md`: documents the new refuse-by-default behavior and `--force`.
- `tests/unit/shutdown-signals.test.ts`, `tests/unit/packages-router.test.ts`, `tests/unit/cli-service.test.ts`: regression coverage for both parts.

## Testing
- `npm run typecheck`: pass
- `npm test`: 236 suites / 4386 tests pass
- Regression tests proven to fail on pre-fix code: reverted the three source files and re-ran -- the new/changed shutdown-signals and packages-router assertions failed to compile (missing exports), and the three new cli-service assertions failed with the exact old behavior (`Restart=on-failure`, install succeeding despite a conflicting unit, zero system-scope `systemctl` calls). Restored the fix and all 67 tests across the three files pass again.
