### PR TITLE
fix(apps): run docker compose build/up on the async spawn seam

### DIFF
--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -960,7 +960,7 @@ export class AppInstaller {
       if (wasRunning) {
         try {
           log(`Restarting "${appName}"`);
-          this.composeUp(appName, appDir);
+          await this.composeUp(appName, appDir);
         } catch (restartErr) {
           log(
             `WARNING: failed to restart "${appName}" after backup: ${
@@ -1073,7 +1073,7 @@ export class AppInstaller {
       this.copyIfExists(path.join(staging, 'config', '.env'), path.join(appDir, '.env'));
 
       log(`Starting "${appName}" on restored data`);
-      this.composeUp(appName, appDir);
+      await this.composeUp(appName, appDir);
       await this.registry.updateStatus(appName, 'running').catch(() => {});
 
       log(`Restore of "${backupId}" complete`);
@@ -1353,7 +1353,7 @@ export class AppInstaller {
         await this.registry.updateStatus(appName, 'stopped');
       } else {
         // start / restart: stop conflicting containers and wait for healthcheck
-        this.composeUp(appName, entry.installPath);
+        await this.composeUp(appName, entry.installPath);
         await this.registry.updateStatus(appName, 'running');
       }
       // An explicit operator action supersedes this boot's restore attempt: a
@@ -1869,11 +1869,11 @@ export class AppInstaller {
     try {
       // ── docker compose build ──────────────────────────────────────────────
       this.log(job, 'Building images');
-      this.run(['docker', 'compose', '-p', appName, 'build'], appDir, 600_000);
+      await this.runAsync(['docker', 'compose', '-p', appName, 'build'], appDir, 600_000);
 
       // ── docker compose up -d ──────────────────────────────────────────────
       this.log(job, 'Starting containers');
-      this.composeUp(appName, appDir, job);
+      await this.composeUp(appName, appDir, job);
     } catch (err) {
       this.log(job, 'Build/start failed — rolling back');
       throw err; // outer catch handles full cleanup
@@ -2055,7 +2055,7 @@ export class AppInstaller {
 
       // ── Build new images in tmp dir ───────────────────────────────────────
       this.log(job, 'Building new images');
-      this.run(['docker', 'compose', '-p', appName, 'build'], tmpDir, 600_000);
+      await this.runAsync(['docker', 'compose', '-p', appName, 'build'], tmpDir, 600_000);
 
       // ── Backup MEMORY.md before any disruption ────────────────────────────
       let memoryBackup: string | null = null;
@@ -2115,7 +2115,7 @@ export class AppInstaller {
         // ── Start new containers ────────────────────────────────────────────
         this.log(job, 'Starting new containers');
         reachedContainerStart = true;
-        this.composeUp(appName, finalDir, job);
+        await this.composeUp(appName, finalDir, job);
       } catch (upErr) {
         // The catch spans the whole swap, so a failure here is not necessarily a
         // container failure — saying it is sends diagnosis to the wrong
@@ -2442,7 +2442,7 @@ export class AppInstaller {
       // compose does not detect an env_file content change on its own. This is an
       // `up`, not a `down -v`, so named volumes (and their data) survive.
       this.log(job, 'Recreating container');
-      this.composeUp(appName, appDir, job, { forceRecreate: true });
+      await this.composeUp(appName, appDir, job, { forceRecreate: true });
 
       await this.registry.updateStatus(appName, 'running');
 
@@ -2481,7 +2481,7 @@ export class AppInstaller {
         if (hasPortChange && oldComposeContent !== null) {
           fs.writeFileSync(composePath, oldComposeContent);
         }
-        this.composeUp(appName, appDir, job, { forceRecreate: true });
+        await this.composeUp(appName, appDir, job, { forceRecreate: true });
         if (hasPortChange) {
           this.callbacks.registerRoutes(
             appName,
@@ -3055,19 +3055,27 @@ export class AppInstaller {
    * Stop conflicting containers then run `docker compose up -d --wait`.
    * Captures container logs into the job on failure before rethrowing.
    * job is optional — when omitted (e.g. startStopRestart) logs go to stderr.
+   *
+   * Uses the async spawn seam for the `up` itself (which can legitimately run
+   * for minutes waiting on a healthcheck), so this never freezes the gateway
+   * event loop while a container starts — every caller (install/update/
+   * reconfigure/backup/restore/startStopRestart) is on the request-serving
+   * path. `stopConflictingContainers` stays on the sync seam: it is a handful
+   * of short, bounded `docker ps`/`stop`/`rm` calls, not the long-running step
+   * this fix targets.
    */
-  private composeUp(appName: string, dir: string, job?: JobState, opts?: { forceRecreate?: boolean }): void {
+  private async composeUp(appName: string, dir: string, job?: JobState, opts?: { forceRecreate?: boolean }): Promise<void> {
     this.stopConflictingContainers(appName);
     const args = ['docker', 'compose', '-p', appName, 'up', '-d', '--wait'];
     if (opts?.forceRecreate) {
       args.push('--force-recreate');
     }
     try {
-      this.run(args, dir, 600_000);
+      await this.runAsync(args, dir, 600_000);
     } catch (upErr) {
       if (job) {
         try {
-          const { stdout } = this.run(
+          const { stdout } = await this.runAsync(
             ['docker', 'compose', '-p', appName, 'logs', '--no-color', '--tail=50'],
             dir,
             10_000,

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -1848,7 +1848,7 @@ export class AppInstaller {
       // Pre-pull the agent base image so compose up --wait doesn't time out during pull
       this.log(job, 'Pre-pulling agent base image');
       try {
-        this.run(['docker', 'pull', 'debian:stable-slim'], appDir, 300_000);
+        await this.runAsync(['docker', 'pull', 'debian:stable-slim'], appDir, 300_000);
       } catch {
         // non-fatal — compose up will attempt its own pull
       }

--- a/src/apps/installer.ts
+++ b/src/apps/installer.ts
@@ -2162,7 +2162,7 @@ export class AppInstaller {
           }
           const upArgs = ['docker', 'compose', '-p', appName, 'up', '-d'];
           if (rebuild) upArgs.push('--build');
-          this.run(upArgs, finalDir, rebuild ? 600_000 : 120_000);
+          await this.runAsync(upArgs, finalDir, rebuild ? 600_000 : 120_000);
           this.callbacks.registerRoutes(appName, entry.ports.map((p) => ({
             name: p.name,
             service: p.service,

--- a/tests/unit/api/apps-router.test.ts
+++ b/tests/unit/api/apps-router.test.ts
@@ -47,9 +47,13 @@ function makeInstaller(
   registry: AppsRegistry,
   appsDir?: string,
   spawn?: (cmd: string, args: string[], opts?: object) => { stdout: string; stderr: string; status: number },
-  // Boot restore runs through the async seam, not the sync one, so a test that
-  // drives restoreRunningApps() has to be able to substitute it (#446).
-  // Omitted → the constructor's real default, i.e. unchanged for every caller.
+  // Boot restore, and now composeUp()'s `up`/`build` steps too (#452), run
+  // through the async seam, not the sync one. A test that needs the two seams
+  // to disagree (e.g. driving restoreRunningApps() per #446) passes this
+  // explicitly. Omitted → derived from `spawn` so a caller that only mocks
+  // the sync side still gets a matching, always-resolving async mock instead
+  // of silently falling through to the constructor's real default (which
+  // would spawn an actual `docker` child process from a unit test).
   asyncSpawn?: (cmd: string, args: string[], opts?: object) => Promise<{ stdout: string; stderr: string; status: number }>,
 ): { installer: AppInstaller; callbacks: InstallerCallbacks } {
   const callbacks: InstallerCallbacks = {
@@ -58,14 +62,15 @@ function makeInstaller(
     startSocket: jest.fn((_socketPath: string, _socket: ComposeSocket) => Promise.resolve()),
     stopSockets: jest.fn((_appName: string) => {}),
   };
+  const syncSpawn = spawn ?? jest.fn().mockReturnValue({ stdout: '', stderr: '', status: 0 });
   const installer = new AppInstaller(
     registry,
     new RegistryClient(),
     callbacks,
-    (spawn ?? jest.fn().mockReturnValue({ stdout: '', stderr: '', status: 0 })) as ConstructorParameters<typeof AppInstaller>[3],
+    syncSpawn as ConstructorParameters<typeof AppInstaller>[3],
     appsDir ?? makeTmpDir(),
     undefined,
-    asyncSpawn as ConstructorParameters<typeof AppInstaller>[6],
+    (asyncSpawn ?? (async (cmd: string, args: string[], opts?: object) => syncSpawn(cmd, args, opts))) as ConstructorParameters<typeof AppInstaller>[6],
   );
   return { installer, callbacks };
 }

--- a/tests/unit/apps/backup.test.ts
+++ b/tests/unit/apps/backup.test.ts
@@ -108,8 +108,20 @@ function backupSpawn(
   });
 }
 
-/** async seam: returning status 1 makes queryRuntimeStatus fall back to the stored status. */
-const keepStoredAsyncSpawn = jest.fn(async () => ({ stdout: '', stderr: '', status: 1 }));
+/**
+ * Async seam for backup/restore's AppInstaller. `docker compose ps` fails
+ * (status 1) so `queryRuntimeStatus` falls back to the stored status, never
+ * driving these tests off a live-status side channel. Everything else —
+ * notably `compose up --wait`, which composeUp() now runs on this same seam
+ * (issue #452) — delegates to the same sync mock backup/restore already
+ * assert against, so a test's `calls` log still sees the restart/start step.
+ */
+function makeAsyncSpawn(spawnFn: jest.Mock) {
+  return jest.fn(async (cmd: string, args: string[], opts?: object) => {
+    if (args.includes('ps')) return { stdout: '', stderr: '', status: 1 };
+    return spawnFn(cmd, args, opts);
+  });
+}
 
 describe('AppInstaller — backup/restore', () => {
   let tmpDir: string;
@@ -133,7 +145,7 @@ describe('AppInstaller — backup/restore', () => {
       spawnFn as unknown as ConstructorParameters<typeof AppInstaller>[3],
       appsDir,
       undefined,
-      keepStoredAsyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
+      makeAsyncSpawn(spawnFn) as unknown as ConstructorParameters<typeof AppInstaller>[6],
       undefined, // housekeepingConfig
       cfg,
       backupsDir,
@@ -224,14 +236,15 @@ describe('AppInstaller — backup/restore', () => {
     const { calls } = makeCallLog();
     // Construct without the injected backupsDir so the default (derived from
     // appsDir) is exercised — locks the user-specified `apps/.backups/<app>` layout.
+    const spawnFn = backupSpawn(calls, { volumes: ['data'] });
     const installer = new AppInstaller(
       registry,
       new RegistryClient(),
       makeCallbacks(),
-      backupSpawn(calls, { volumes: ['data'] }) as unknown as ConstructorParameters<typeof AppInstaller>[3],
+      spawnFn as unknown as ConstructorParameters<typeof AppInstaller>[3],
       appsDir,
       undefined,
-      keepStoredAsyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
+      makeAsyncSpawn(spawnFn) as unknown as ConstructorParameters<typeof AppInstaller>[6],
       undefined, // housekeepingConfig
       undefined, // appBackupConfig
       // no backupsDir arg → default under <appsDir>/.backups

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -2173,6 +2173,87 @@ services:
       expect(job.logs.some((l) => l.includes('was not preserved'))).toBe(true);
     });
 
+    it('runs the rollback "compose up --build" through the async spawn seam, not spawnSync', async () => {
+      // Found in manual review of #452's fix: the rebuild-on-rollback branch
+      // above (previous test) still called `this.run()` (spawnSync) directly
+      // instead of the async seam composeUp()'s own `up`/`build` steps moved
+      // to, so a rollback that needs to rebuild could block the event loop for
+      // up to 10 minutes — the exact failure #452 reports, but during error
+      // recovery, which is the worst moment for the gateway to stop serving.
+      const appName = 'rollback-async-app';
+      const state = { head: 'a'.repeat(40), version: '1.0.0', upCalls: 0, failNewUp: false };
+      const dockerRespond = (args: string[], spawnOpts?: { cwd?: string }) => {
+        if (args.includes('config') && args.includes('--format') && spawnOpts?.cwd) {
+          return { stdout: JSON.stringify({ services: { app: { volumes: [] } } }), stderr: '', status: 0 };
+        }
+        if (args.includes('images') && args.includes('json')) {
+          const row = { ID: 'previmageid0000', Repository: `${appName}-app`, Tag: 'latest' };
+          return { stdout: JSON.stringify([row]), stderr: '', status: 0 };
+        }
+        // `docker image tag` fails, so the preserved image has no backup ref —
+        // restorePreservedImages() can't put it back, forcing a rebuild.
+        if (args[0] === 'image' && args[1] === 'tag') {
+          return { stdout: '', stderr: 'No such image', status: 1 };
+        }
+        if (args.includes('up')) {
+          state.upCalls += 1;
+          if (state.failNewUp && state.upCalls === 1) {
+            return { stdout: '', stderr: 'new stack failed', status: 1 };
+          }
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      };
+      const syncCalls: string[][] = [];
+      const spawn = jest.fn((cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${state.head}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && spawnOpts?.cwd) {
+          fs.writeFileSync(path.join(spawnOpts.cwd, 'app.yaml'), `
+apiVersion: apps.getpod.ai/v1
+name: ${appName}
+version: ${state.version}
+commit: "${state.head}"
+services:
+  app:
+    build: .
+    ports:
+      - name: api
+        host: 5413
+        container: 5413
+        type: api
+    healthcheck:
+      test: exit 0
+      interval: 30s
+`.trim(), 'utf-8');
+        }
+        if (cmd !== 'docker') return { stdout: '', stderr: '', status: 0 };
+        syncCalls.push(args);
+        return dockerRespond(args, spawnOpts);
+      });
+      const asyncCalls: string[][] = [];
+      const asyncSpawn = jest.fn(async (cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
+        if (cmd !== 'docker') return { stdout: '', stderr: '', status: 0 };
+        asyncCalls.push(args);
+        return dockerRespond(args, spawnOpts);
+      });
+      const installer = makeInstaller(spawn, asyncSpawn);
+      await waitForJob(installer, installer.install({ githubUrl: `https://github.com/test/${appName}` }), 5000);
+
+      state.head = 'b'.repeat(40);
+      state.version = '2.0.0';
+      state.failNewUp = true;
+      state.upCalls = 0;
+      syncCalls.length = 0;
+      asyncCalls.length = 0;
+      const job = await waitForJob(installer, installer.update(appName), 5000);
+      expect(job.status).toBe('failed');
+
+      const isRollbackUp = (a: string[]) => a.includes('up') && !a.includes('--wait') && a.includes('--build');
+      expect(syncCalls.some(isRollbackUp)).toBe(false);
+      expect(asyncCalls.some(isRollbackUp)).toBe(true);
+    });
+
     it('updates an app whose on-disk dir name ≠ app.yaml name (legacy install, issue #275)', async () => {
       // Legacy installs named the on-disk dir after the source repo basename,
       // so installPath basename can differ from the app name. The dir-swap must

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -154,7 +154,16 @@ describe('AppInstaller', () => {
 
   function makeInstaller(
     spawnFn = successSpawn,
-    asyncSpawnFn = successAsyncSpawn,
+    // Derived from spawnFn by default (not a bare successAsyncSpawn) so a
+    // caller that only overrides the sync mock — e.g. to simulate a failing
+    // `docker compose build`/`up`, both of which now run on the async seam —
+    // still sees that behavior on the async path instead of silently
+    // succeeding. Callers that need the async and sync paths to disagree
+    // (e.g. the boot-restore tests) pass an explicit second argument, which
+    // this default never overrides.
+    asyncSpawnFn = jest.fn(
+      async (cmd: string, args: string[], opts?: object) => spawnFn(cmd, args, opts),
+    ),
     restoreConfig?: { buildTimeoutMs?: number; waitTimeoutMs?: number },
   ) {
     return new AppInstaller(
@@ -176,6 +185,12 @@ describe('AppInstaller', () => {
     spawn: typeof successSpawn,
     agentMgr: ReturnType<typeof makeAgentMgr>,
   ) {
+    // Same rationale as makeInstaller's default: derive the async mock from
+    // the sync one so a `compose build`/`up` failure simulated on the sync
+    // side (both now run on the async seam) is not silently swallowed.
+    const asyncSpawn = jest.fn(
+      async (cmd: string, args: string[], opts?: object) => spawn(cmd, args, opts),
+    );
     return new AppInstaller(
       registry,
       new RegistryClient(),
@@ -183,7 +198,7 @@ describe('AppInstaller', () => {
       spawn,
       appsDir,
       agentMgr as unknown as ConstructorParameters<typeof AppInstaller>[5],
-      successAsyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
+      asyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
     );
   }
 
@@ -730,6 +745,42 @@ services:
 
       expect(job2.status).toBe('failed');
       expect(job2.error).toMatch(/already installed/);
+    });
+  });
+
+  // ─── docker compose build/up — async spawn seam (#452) ──────────────────
+
+  describe('install() — docker compose build/up run non-blocking', () => {
+    it('runs "docker compose build" and "compose up --wait" through the async spawn seam, never spawnSync', async () => {
+      // Regression for #452: install used the spawnSync-backed seam for both
+      // `docker compose build` and `docker compose up -d --wait`, freezing the
+      // gateway's event loop (verified live: /health did not respond for 85s
+      // during a real build) for the whole duration. Two independently-tracked
+      // mocks — one sync, one async — pin which seam each command travels
+      // through: on the pre-fix code every `docker` call, including build/up,
+      // arrives on the sync mock and the async mock never sees them.
+      const appDir = makeAppDir(srcDir, 'async-app');
+      const syncCalls: string[][] = [];
+      const asyncCalls: string[][] = [];
+      const spawn = jest.fn((_cmd: string, args: string[], _opts?: object) => {
+        syncCalls.push(args);
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const asyncSpawn = jest.fn(async (_cmd: string, args: string[], _opts?: object) => {
+        asyncCalls.push(args);
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = makeInstaller(spawn, asyncSpawn);
+      const job = await waitForJob(installer, installer.install({ localPath: appDir }), 5000);
+      expect(job.status).toBe('completed');
+
+      const isComposeBuild = (a: string[]) => a[0] === 'compose' && a.includes('build');
+      const isComposeUp = (a: string[]) => a[0] === 'compose' && a.includes('up') && a.includes('--wait');
+
+      expect(syncCalls.some(isComposeBuild)).toBe(false);
+      expect(syncCalls.some(isComposeUp)).toBe(false);
+      expect(asyncCalls.some(isComposeBuild)).toBe(true);
+      expect(asyncCalls.some(isComposeUp)).toBe(true);
     });
   });
 

--- a/tests/unit/apps/installer.test.ts
+++ b/tests/unit/apps/installer.test.ts
@@ -782,6 +782,75 @@ services:
       expect(asyncCalls.some(isComposeBuild)).toBe(true);
       expect(asyncCalls.some(isComposeUp)).toBe(true);
     });
+
+    it('runs the agent pre-pull ("docker pull debian:stable-slim") through the async spawn seam too', async () => {
+      // Found in independent review of #452's fix: an app that declares an
+      // agent service triggers a pre-pull of the agent base image inside the
+      // same install job, still issued on `this.run()` (spawnSync) even after
+      // build/up moved to the async seam — up to a 300s block on a host
+      // without the image cached.
+      const agentMgr = makeAgentMgr('never-conflicts');
+      const syncCalls: string[][] = [];
+      const asyncCalls: string[][] = [];
+      const spawn = jest.fn((cmd: string, args: string[], opts?: { cwd?: string }) => {
+        syncCalls.push(args);
+        if (cmd === 'git' && args[0] === 'ls-remote') {
+          return { stdout: `${'a'.repeat(40)}\tHEAD\n`, stderr: '', status: 0 };
+        }
+        if (cmd === 'git' && args[0] === 'checkout' && opts?.cwd) {
+          fs.writeFileSync(
+            path.join(opts.cwd, 'app.yaml'),
+            `
+apiVersion: apps.getpod.ai/v1
+name: agent-prepull-app
+version: 1.0.0
+commit: "${'a'.repeat(40)}"
+services:
+  app:
+    image: nginx:1.25
+    ports:
+      - name: api
+        host: 5702
+        container: 5702
+        type: api
+    healthcheck:
+      test: wget -qO- http://localhost:5702/health
+      interval: 30s
+  agent:
+    path: ./agent
+    name: prepull-bot
+`.trim(),
+            'utf-8',
+          );
+          fs.mkdirSync(path.join(opts.cwd, 'agent'), { recursive: true });
+        }
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const asyncSpawn = jest.fn(async (_cmd: string, args: string[], _opts?: object) => {
+        asyncCalls.push(args);
+        return { stdout: '', stderr: '', status: 0 };
+      });
+      const installer = new AppInstaller(
+        registry,
+        new RegistryClient(),
+        callbacks,
+        spawn as unknown as ConstructorParameters<typeof AppInstaller>[3],
+        appsDir,
+        agentMgr as unknown as ConstructorParameters<typeof AppInstaller>[5],
+        asyncSpawn as unknown as ConstructorParameters<typeof AppInstaller>[6],
+      );
+
+      const job = await waitForJob(
+        installer,
+        installer.install({ githubUrl: 'https://github.com/test/agent-prepull-app' }),
+        5000,
+      );
+      expect(job.status).toBe('completed');
+
+      const isPrepull = (a: string[]) => a[0] === 'pull' && a.includes('debian:stable-slim');
+      expect(syncCalls.some(isPrepull)).toBe(false);
+      expect(asyncCalls.some(isPrepull)).toBe(true);
+    });
   });
 
   // ─── getJob() ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Installing, updating, reconfiguring, backing up/restoring, or starting/stopping an app ran `docker compose build` and `docker compose up -d --wait` through the spawnSync-backed sync seam, freezing the gateway's Node.js event loop for the whole build/start duration — during which the gateway could not serve any request (HTTP API, Telegram, cron, other running apps).

## Related Issue
Closes #452

## Changes Made
- `src/apps/installer.ts`: `composeUp()` — used by all 6 callers (install, update, reconfigure ×2, backup restart, restore, start/stop/restart) — now uses the async spawn seam that already existed for the boot-time container restore path (`spawnAsync`/`runAsync`), instead of the sync `run()`/`spawnSync`. The `docker compose build` step in `runInstall()` and `runUpdate()` switches to the same async seam.
- `tests/unit/apps/installer.test.ts`: `makeInstaller()`/`makeInstallerWithAgent()` now derive the default async spawn mock from the sync one (instead of a bare always-succeed mock), so a test that only overrides the sync mock — e.g. to simulate a failing `compose build`/`up` — still sees that behavior on the async path. Added a regression test proving `compose build`/`up` run on the async seam, not `spawnSync`.
- `tests/unit/apps/backup.test.ts`: same fix for the backup/restore installer helper — the async mock now delegates to the sync one (still failing `docker compose ps` only, for `queryRuntimeStatus`'s fallback behavior).
- `tests/unit/api/apps-router.test.ts`: same fix for the router test's installer helper — an omitted async spawn mock now derives from the sync one instead of silently falling through to the constructor's real default (which would spawn an actual `docker` child process from a unit test).

## Testing
- `npm run typecheck`: pass
- `npm test`: 237 suites / 4392 tests pass
- Regression test proven to fail on the pre-fix code (reverted `src/apps/installer.ts`, confirmed red, restored)