### PR TITLE
fix: set OOMPolicy=continue to stop OOM-kill cascade restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ pass `--force` to install anyway.
 
 The systemd path writes `~/.config/systemd/user/claude-gateway.service`. Run
 `loginctl enable-linger $USER` once if it must keep running while you're logged out.
+The unit sets `OOMPolicy=continue` so that an OOM-killed child process (e.g. a dev server an
+agent spawned on its own) doesn't take the whole gateway down with it — only `Restart=always`
+restarting the *gateway's own* process is intended. Installs from before this was added need to
+re-run `claude-gateway service install` to regenerate the unit file and pick up the directive; it
+is not applied retroactively to an already-installed unit.
 Prefer [PM2](https://pm2.keymetrics.io)? `claude-gateway service install --manager pm2` registers
 and saves the process instead (run `pm2 startup` separately for boot-time start).
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ The systemd path writes `~/.config/systemd/user/claude-gateway.service`. Run
 The unit sets `OOMPolicy=continue` so that an OOM-killed child process (e.g. a dev server an
 agent spawned on its own) doesn't take the whole gateway down with it — only `Restart=always`
 restarting the *gateway's own* process is intended. Installs from before this was added need to
-re-run `claude-gateway service install` to regenerate the unit file and pick up the directive; it
-is not applied retroactively to an already-installed unit.
+re-run `claude-gateway service install` to regenerate the unit file *and then*
+`systemctl --user restart claude-gateway.service` — reinstalling alone reloads systemd's unit
+definition but does not restart an already-running unit, so the live process keeps the old
+`OOMPolicy` until it's explicitly restarted (or the host reboots).
 Prefer [PM2](https://pm2.keymetrics.io)? `claude-gateway service install --manager pm2` registers
 and saves the process instead (run `pm2 startup` separately for boot-time start).
 

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -148,6 +148,12 @@ Environment="GATEWAY_CONFIG=${q(spec.config)}"
 ExecStart="${q(spec.node)}" "${q(spec.entry)}" gateway start --config "${q(spec.config)}"
 Restart=always
 RestartSec=5
+# Without this, systemd's default OOMPolicy=stop treats an OOM-killed
+# process ANYWHERE in this unit's cgroup (e.g. a dev server an agent spawned
+# on its own) as the whole unit failing, and Restart=always then restarts
+# the entire gateway — dropping every agent's session for an OOM kill that
+# had nothing to do with gateway health.
+OOMPolicy=continue
 
 [Install]
 WantedBy=default.target

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -109,6 +109,16 @@ describe('service — generated launch configuration', () => {
     expect(unit).not.toContain('Restart=on-failure');
   });
 
+  it('sets OOMPolicy=continue so an OOM-killed child process cannot take the whole gateway down', () => {
+    // systemd's default OOMPolicy=stop treats an OOM-killed process anywhere
+    // in this unit's cgroup as the unit failing, which combined with
+    // Restart=always restarts the entire gateway for an OOM kill of, say, an
+    // agent's own dev server — dropping every other agent's session too
+    // (issue #454). `continue` logs the kill without restarting the unit.
+    const unit = renderSystemdUnit(resolveLaunchSpec({})!);
+    expect(unit).toContain('OOMPolicy=continue');
+  });
+
   it('never writes a secret into the unit — only paths', () => {
     const unit = renderSystemdUnit(resolveLaunchSpec({})!);
     for (const line of unit.split('\n').filter((l) => l.startsWith('Environment='))) {


### PR DESCRIPTION
## Summary
An OOM-killed child process anywhere in the `claude-gateway.service` cgroup currently cascades into a full restart of the entire gateway, dropping every agent's live session. This sets `OOMPolicy=continue` on the systemd unit so only the actually-OOM-killed process dies.

## Related Issue
Closes #454

## Changes Made
- `src/cli/commands/service.ts`: `renderSystemdUnit()` now emits `OOMPolicy=continue` in the `[Service]` section, alongside the existing `Restart=always` / `RestartSec=5`.
- `tests/unit/cli-service.test.ts`: new test asserting the rendered unit contains `OOMPolicy=continue`; proven to fail on the pre-fix renderer (reverted the source line, confirmed red, restored).
- `README.md`: notes that `OOMPolicy=continue` is now part of the generated unit, and that existing installs must re-run `claude-gateway service install` to pick it up (not applied retroactively).

## Testing
- `npm run typecheck`: pass
- `npm run gen-cli:check`: up to date (no CLI surface changed)
- `npm test`: 237 suites / 4395 tests pass on the final tree (3 unrelated tests flaked once earlier under heavy host CPU/memory load from concurrent unrelated processes — a full clean rerun on the settled tree was 4395/4395 green)
