### PR TITLE
feat: native MCP connectors — built-in + custom, per-agent enablement, managed & generic OAuth

### DIFF
--- a/e2e-connectors.cjs
+++ b/e2e-connectors.cjs
@@ -1,0 +1,82 @@
+/* Real e2e for the connectors feature — uses the COMPILED dist modules, a real
+ * HTTP server on a test port, real files in a temp HOME. No systemd, no mocks. */
+const express = require('express');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-e2e-'));
+const tokenEnv = path.join(tmp, 'mcp-token.env');
+const configPath = path.join(tmp, 'config.json');
+process.env.GATEWAY_MCP_TOKEN_ENV = tokenEnv;
+fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2));
+
+const { createConnectorsRouter } = require('./dist/api/connectors-router');
+const { resolveEnabledConnectors } = require('./dist/connectors/resolve');
+
+const ADMIN = 'admin-key-e2e';
+const apiKeys = [{ key: ADMIN, agents: '*', admin: true }];
+
+const app = express();
+app.use(express.json());
+app.use('/api', createConnectorsRouter(apiKeys, configPath));
+const server = app.listen(19099);
+
+const TOKEN = process.env.E2E_GH_TOKEN || 'ghp_dummy_e2e_test_token';
+const base = 'http://127.0.0.1:19099/api/v1';
+const H = { 'Content-Type': 'application/json', 'X-Api-Key': ADMIN };
+const log = (...a) => console.log(...a);
+
+(async () => {
+  try {
+    log('\n=== 1. GET /connectors (catalog, before connect) ===');
+    let r = await fetch(`${base}/connectors`, { headers: H });
+    log('status', r.status, JSON.stringify(await r.json()));
+
+    log('\n=== 2. auth: missing key rejected ===');
+    r = await fetch(`${base}/connectors`);
+    log('no key ->', r.status);
+
+    log('\n=== 3. POST /connectors/github/connect (real token write) ===');
+    r = await fetch(`${base}/connectors/github/connect`, { method: 'POST', headers: H, body: JSON.stringify({ token: TOKEN }) });
+    log('status', r.status, JSON.stringify(await r.json()));
+
+    log('\n=== 4. real files on disk ===');
+    log('mcp-token.env:', JSON.stringify(fs.readFileSync(tokenEnv, 'utf-8')));
+    log('mode:', '0' + (fs.statSync(tokenEnv).mode & 0o777).toString(8));
+    log('config.json gateway.connectors:', JSON.stringify(JSON.parse(fs.readFileSync(configPath, 'utf-8')).gateway.connectors));
+
+    log('\n=== 5. GET status ===');
+    r = await fetch(`${base}/connectors/github/status`, { headers: H });
+    log('status', r.status, JSON.stringify(await r.json()));
+
+    log('\n=== 6. INJECTION: what a session would get (resolveEnabledConnectors) ===');
+    const injected = resolveEnabledConnectors({ connectors: { github: { enabled: true } } });
+    log(JSON.stringify(injected, null, 2));
+    const disabled = resolveEnabledConnectors({ connectors: {} });
+    log('disabled agent ->', JSON.stringify(disabled));
+
+    log('\n=== 7. REAL GitHub MCP reachability with the connected token ===');
+    const ghEntry = injected.github;
+    const mcpInit = { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'e2e', version: '0' } } };
+    const gr = await fetch(ghEntry.url, { method: 'POST', headers: { ...ghEntry.headers, 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' }, body: JSON.stringify(mcpInit) });
+    log('GitHub MCP status:', gr.status);
+    log('www-authenticate:', gr.headers.get('www-authenticate') || '(none)');
+    const bodyText = (await gr.text()).slice(0, 300);
+    log('body (first 300):', bodyText.replace(/\n/g, ' '));
+
+    log('\n=== 8. DELETE /connectors/github (disconnect) ===');
+    r = await fetch(`${base}/connectors/github`, { method: 'DELETE', headers: H });
+    log('status', r.status, JSON.stringify(await r.json()));
+    log('mcp-token.env after delete:', JSON.stringify(fs.readFileSync(tokenEnv, 'utf-8')));
+    log('config.json connectors after delete:', JSON.stringify(JSON.parse(fs.readFileSync(configPath, 'utf-8')).gateway.connectors));
+
+    log('\n=== DONE ===');
+  } catch (e) {
+    console.error('E2E ERROR:', e);
+    process.exitCode = 1;
+  } finally {
+    server.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+})();

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2712,8 +2712,9 @@ export class AgentRunner extends EventEmitter {
   }
 
   /**
-   * Called after a connector's secret changes: either services/api pushed a
-   * fresh access_token for a managed connector (POST /oauth/receive), or the
+   * Called after a connector's secret changes: either an external control
+   * plane pushed a fresh access_token for a managed connector (POST
+   * /oauth/receive), or the
    * background refresh sweep in oauth-refresh-sweep.ts (invoked from
    * gateway-router.ts's 60s interval) rotated one for a user's own oauth:true
    * custom connector. A no-op when this agent doesn't actually resolve that

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -2712,9 +2712,12 @@ export class AgentRunner extends EventEmitter {
   }
 
   /**
-   * Called after a connector's secret changes (most commonly: the background
-   * OAuth refresher in index.ts rotated an access token). A no-op when this
-   * agent doesn't actually resolve that connector — restarting a long-lived
+   * Called after a connector's secret changes: either services/api pushed a
+   * fresh access_token for a managed connector (POST /oauth/receive), or the
+   * background refresh sweep in oauth-refresh-sweep.ts (invoked from
+   * gateway-router.ts's 60s interval) rotated one for a user's own oauth:true
+   * custom connector. A no-op when this agent doesn't actually resolve that
+   * connector — restarting a long-lived
    * session that never uses the connector would be pure disruption. Otherwise
    * reuses restartOrDefer's lossless defer-idle path: the stdio MCP subprocess
    * only reads its env once at spawn (see session/process.ts's writeMcpConfig

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -42,6 +42,7 @@ import { scheduleCleanup, resolveRetentionDays } from '../history/cleanup';
 import type { HistorySource, ChatChannel, ChatChannelOrApi } from '../history/types';
 import type { SkillLearningManager } from './skill-learning';
 import { spawnArchiveReindex } from './knowledge';
+import { resolveEnabledConnectors } from '../connectors/resolve';
 
 const DEFAULT_IDLE_TIMEOUT_MINUTES = 30;
 const DEFAULT_MAX_CONCURRENT = 20;
@@ -2708,6 +2709,27 @@ export class AgentRunner extends EventEmitter {
     }
     this.logger.info('restartOrDefer: sessions restarted', { immediate, deferred, skipped });
     return { immediate, deferred, skipped };
+  }
+
+  /**
+   * Called after a connector's secret changes (most commonly: the background
+   * OAuth refresher in index.ts rotated an access token). A no-op when this
+   * agent doesn't actually resolve that connector — restarting a long-lived
+   * session that never uses the connector would be pure disruption. Otherwise
+   * reuses restartOrDefer's lossless defer-idle path: the stdio MCP subprocess
+   * only reads its env once at spawn (see session/process.ts's writeMcpConfig
+   * comment), so a session with the connector enabled genuinely needs a
+   * respawn to pick up the new token — there's no way to hot-patch a running
+   * child process's env.
+   */
+  async restartSessionsUsingConnector(connectorId: string): Promise<{ restarted: boolean }> {
+    const resolved = resolveEnabledConnectors(
+      this.agentConfig,
+      this.gatewayConfig?.gateway?.customConnectors,
+    );
+    if (!(connectorId in resolved)) return { restarted: false };
+    await this.restartOrDefer({ skipBusy: false, deferIdle: true });
+    return { restarted: true };
   }
 
   /**

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -1,0 +1,137 @@
+import { Router, Request, Response } from 'express';
+import * as fsp from 'fs/promises';
+import { randomUUID } from 'crypto';
+import { ApiKey } from '../types';
+import { createApiAuthMiddleware, isAdmin } from './auth';
+import { getConnectorSpec } from '../connectors/catalog';
+import { listConnectorStatus } from '../connectors/resolve';
+import { secretEnvOf } from '../connectors/types';
+import { setSecret, deleteSecret, hasSecret } from '../connectors/token-env';
+
+type AuthedRequest = Request & { apiKey: ApiKey };
+
+/**
+ * Connector management API. The gateway acts as catalog + secret manager + config
+ * injector: connecting a connector stores its secret in mcp-token.env and records the
+ * non-secret wiring in config.json (gateway.connectors). The actual MCP server is
+ * injected into each session by SessionProcess (see resolveEnabledConnectors).
+ *
+ * Routes (mounted under /api):
+ *   GET    /v1/connectors            — catalog + connected state
+ *   GET    /v1/connectors/:id/status — connected boolean (for polling)
+ *   POST   /v1/connectors/:id/connect — store a secret (admin)
+ *   DELETE /v1/connectors/:id        — clear a secret (admin)
+ */
+export function createConnectorsRouter(apiKeys?: ApiKey[], configPath?: string): Router {
+  const router = Router();
+  if (apiKeys?.length) router.use(createApiAuthMiddleware(apiKeys));
+
+  // Serialise read-modify-write of config.json's gateway.connectors subtree.
+  let writeLock: Promise<void> = Promise.resolve();
+  async function mutateGatewayConnectors(
+    fn: (connectors: Record<string, { secretEnv: string }>) => void,
+  ): Promise<void> {
+    if (!configPath) return; // no persistence target (e.g. tests) — secret store is authoritative
+    const run = writeLock.catch(() => {}).then(async () => {
+      const raw = await fsp.readFile(configPath, 'utf-8');
+      const config = JSON.parse(raw) as {
+        gateway?: { connectors?: Record<string, { secretEnv: string }> };
+        [k: string]: unknown;
+      };
+      config.gateway = config.gateway ?? {};
+      config.gateway.connectors = config.gateway.connectors ?? {};
+      fn(config.gateway.connectors);
+      const tmp = `${configPath}.tmp.${randomUUID()}`;
+      await fsp.writeFile(tmp, JSON.stringify(config, null, 2), 'utf-8');
+      await fsp.rename(tmp, configPath);
+    });
+    writeLock = run.catch(() => {});
+    return run;
+  }
+
+  function requireAdmin(req: Request, res: Response): boolean {
+    if (!apiKeys?.length) return true; // no auth configured — allow
+    if (!isAdmin((req as AuthedRequest).apiKey)) {
+      res.status(403).json({ error: 'Connector management requires an admin API key' });
+      return false;
+    }
+    return true;
+  }
+
+  // List catalog + connected state
+  router.get('/v1/connectors', (_req: Request, res: Response) => {
+    res.json({ connectors: listConnectorStatus() });
+  });
+
+  // Single connector status (used by the web to poll)
+  router.get('/v1/connectors/:id/status', (req: Request, res: Response) => {
+    const spec = getConnectorSpec(req.params.id);
+    if (!spec) {
+      res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
+      return;
+    }
+    const envName = secretEnvOf(spec);
+    const connected = envName === null ? true : hasSecret(envName);
+    res.json({ id: spec.id, connected });
+  });
+
+  // Connect — store the secret (iteration 1: auth kind 'secret')
+  router.post('/v1/connectors/:id/connect', async (req: Request, res: Response) => {
+    const spec = getConnectorSpec(req.params.id);
+    if (!spec) {
+      res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
+      return;
+    }
+    if (!requireAdmin(req, res)) return;
+
+    if (spec.auth.kind === 'none') {
+      res.json({ id: spec.id, connected: true });
+      return;
+    }
+
+    if (spec.auth.kind !== 'secret') {
+      res.status(501).json({ error: `Auth kind '${spec.auth.kind}' not yet implemented` });
+      return;
+    }
+
+    const token = (req.body as { token?: unknown })?.token;
+    if (typeof token !== 'string' || !token.trim()) {
+      res.status(400).json({ error: 'token is required and must be a non-empty string' });
+      return;
+    }
+
+    const envName = spec.auth.secretEnv;
+    try {
+      setSecret(envName, token.trim());
+      await mutateGatewayConnectors((c) => {
+        c[spec.id] = { secretEnv: envName };
+      });
+      res.json({ id: spec.id, connected: true });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Disconnect — clear the secret + wiring
+  router.delete('/v1/connectors/:id', async (req: Request, res: Response) => {
+    const spec = getConnectorSpec(req.params.id);
+    if (!spec) {
+      res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
+      return;
+    }
+    if (!requireAdmin(req, res)) return;
+
+    const envName = secretEnvOf(spec);
+    try {
+      if (envName) deleteSecret(envName);
+      await mutateGatewayConnectors((c) => {
+        delete c[spec.id];
+      });
+      res.json({ id: spec.id, connected: false });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  return router;
+}

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -159,7 +159,7 @@ export function createConnectorsRouter(
 
     if (spec.auth.kind === 'oauth') {
       res.status(400).json({
-        error: `'${spec.id}' is connected via getpod-ai (Google OAuth), not a pasted token`,
+        error: `'${spec.id}' is connected via getpod-ai (OAuth), not a pasted token`,
       });
       return;
     }

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -49,12 +49,13 @@ type AuthedRequest = Request & { apiKey: ApiKey };
  * retired.)
  *
  * 'oauth'-kind connectors (Gmail/Drive/Calendar) never do the actual OAuth
- * dance here — getpod-ai's services/api owns the client_secret, the token
- * exchange, and the refresh loop (this gateway runs inside the user's own VM,
- * reachable by that user's own shell/SSH, so a shared client_secret can't live
- * here safely — see types.ts's 'oauth' kind doc comment). services/api pushes
- * the resulting short-lived access_token here via /oauth/receive, over the
- * internal network, authenticated the same way any other admin API caller is.
+ * dance here — an external control plane the deployer runs owns the
+ * client_secret, the token exchange, and the refresh loop (this gateway runs
+ * inside the user's own VM, reachable by that user's own shell/SSH, so a
+ * shared client_secret can't live here safely — see types.ts's 'oauth' kind
+ * doc comment). That control plane pushes the resulting short-lived
+ * access_token here via /oauth/receive, over the internal network,
+ * authenticated the same way any other admin API caller is.
  *
  * `agents` (all live AgentRunners) is only needed so /oauth/receive can
  * restart sessions using the connector — every other route works the same
@@ -180,18 +181,18 @@ export function createConnectorsRouter(
     }
   });
 
-  // Receive a fresh access_token + full connector shape pushed by getpod-ai's
-  // services/api for a GetPod-managed OAuth connector (github/gmail/
-  // google-drive/google-calendar) — this is how those connect (and stay fresh
-  // on refresh) now. Admin-gated exactly like /connect; the caller is
-  // services/api itself, reaching this over the internal network with the
+  // Receive a fresh access_token + full connector shape pushed by an external
+  // control plane for a managed OAuth connector (github/gmail/google-drive/
+  // google-calendar, say) — this is how those connect (and stay fresh on
+  // refresh) now. Admin-gated exactly like /connect; the caller is that
+  // control plane itself, reaching this over the internal network with the
   // same admin API key any other admin caller would use.
   //
   // Unlike /connect, there's no catalog lookup here — CONNECTOR_CATALOG is
   // empty by default, and these ids are never in it (see catalog.ts's doc
   // comment). The entry is written into gateway.customConnectors instead,
   // same storage a user-pasted custom connector uses, with `managed: true` +
-  // `authKind: 'oauth'` marking it as services/api's, not the user's (see
+  // `authKind: 'oauth'` marking it as that control plane's, not the user's (see
   // CustomConnectorEntry's doc comment). `secretNames` is never trusted from
   // the request body — derived from `config` via extractPlaceholders, the
   // same helper /custom's add route uses, and required to be exactly
@@ -336,11 +337,11 @@ export function createConnectorsRouter(
       // (click Disconnect, row stays "Connected"), so fall through to a real
       // delete instead — there's nothing to preserve for a reconnect anyway.
       //
-      // Managed entries (github/gmail/etc., pushed by services/api) keep the
-      // old delete-the-entry behavior: their definition lives in the
-      // services/api-owned managed catalog instead, which the web panel
-      // already falls back to for the "not connected" row, and reconnecting
-      // re-pushes a full entry via /oauth/receive regardless.
+      // Managed entries (github/gmail/etc., pushed by an external control
+      // plane) keep the old delete-the-entry behavior: their definition
+      // lives in that control plane's own catalog instead, which the web
+      // panel already falls back to for the "not connected" row, and
+      // reconnecting re-pushes a full entry via /oauth/receive regardless.
       if (!entry.managed && entry.secretNames.length > 0) {
         res.json({ id, connected: false });
         return;

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -1,12 +1,14 @@
 import { Router, Request, Response } from 'express';
 import * as fsp from 'fs/promises';
 import { randomUUID } from 'crypto';
-import { ApiKey } from '../types';
+import { ApiKey, CustomConnectorEntry } from '../types';
 import { createApiAuthMiddleware, isAdmin } from './auth';
 import { getConnectorSpec } from '../connectors/catalog';
 import { listConnectorStatus } from '../connectors/resolve';
 import { secretEnvOf } from '../connectors/types';
 import { setSecret, deleteSecret, hasSecret } from '../connectors/token-env';
+import { slugify, extractPlaceholders, customSecretKey } from '../connectors/custom';
+import type { AgentRunner } from '../agent/runner';
 
 type AuthedRequest = Request & { apiKey: ApiKey };
 
@@ -17,12 +19,31 @@ type AuthedRequest = Request & { apiKey: ApiKey };
  * injected into each session by SessionProcess (see resolveEnabledConnectors).
  *
  * Routes (mounted under /api):
- *   GET    /v1/connectors            — catalog + connected state
- *   GET    /v1/connectors/:id/status — connected boolean (for polling)
- *   POST   /v1/connectors/:id/connect — store a secret (admin)
- *   DELETE /v1/connectors/:id        — clear a secret (admin)
+ *   GET    /v1/connectors                    — built-in + custom catalog, connected state
+ *   GET    /v1/connectors/:id/status         — connected boolean (for polling)
+ *   POST   /v1/connectors/:id/connect        — store a secret (admin, auth kind 'secret' only)
+ *   POST   /v1/connectors/:id/oauth/receive  — store a pushed access_token (admin, auth kind 'oauth' only)
+ *   DELETE /v1/connectors/:id                — clear a secret (admin, built-in only)
+ *   POST   /v1/connectors/custom             — add a user-pasted connector (admin)
+ *   DELETE /v1/connectors/custom/:id         — remove one (admin)
+ *
+ * 'oauth'-kind connectors (Gmail/Drive/Calendar) never do the actual OAuth
+ * dance here — getpod-ai's services/api owns the client_secret, the token
+ * exchange, and the refresh loop (this gateway runs inside the user's own VM,
+ * reachable by that user's own shell/SSH, so a shared client_secret can't live
+ * here safely — see types.ts's 'oauth' kind doc comment). services/api pushes
+ * the resulting short-lived access_token here via /oauth/receive, over the
+ * internal network, authenticated the same way any other admin API caller is.
+ *
+ * `agents` (all live AgentRunners) is only needed so /oauth/receive can
+ * restart sessions using the connector — every other route works the same
+ * without it (e.g. in tests).
  */
-export function createConnectorsRouter(apiKeys?: ApiKey[], configPath?: string): Router {
+export function createConnectorsRouter(
+  apiKeys?: ApiKey[],
+  configPath?: string,
+  agents?: Map<string, AgentRunner>,
+): Router {
   const router = Router();
   if (apiKeys?.length) router.use(createApiAuthMiddleware(apiKeys));
 
@@ -49,6 +70,44 @@ export function createConnectorsRouter(apiKeys?: ApiKey[], configPath?: string):
     return run;
   }
 
+  // Same read-modify-write-tmp-rename pattern as mutateGatewayConnectors above,
+  // targeting gateway.customConnectors instead. Shares the same writeLock so a
+  // built-in connect and a custom add can't race each other's read-modify-write.
+  async function mutateCustomConnectors(
+    fn: (connectors: Record<string, CustomConnectorEntry>) => void,
+  ): Promise<void> {
+    if (!configPath) return;
+    const run = writeLock.catch(() => {}).then(async () => {
+      const raw = await fsp.readFile(configPath, 'utf-8');
+      const config = JSON.parse(raw) as {
+        gateway?: { customConnectors?: Record<string, CustomConnectorEntry> };
+        [k: string]: unknown;
+      };
+      config.gateway = config.gateway ?? {};
+      config.gateway.customConnectors = config.gateway.customConnectors ?? {};
+      fn(config.gateway.customConnectors);
+      const tmp = `${configPath}.tmp.${randomUUID()}`;
+      await fsp.writeFile(tmp, JSON.stringify(config, null, 2), 'utf-8');
+      await fsp.rename(tmp, configPath);
+    });
+    writeLock = run.catch(() => {});
+    return run;
+  }
+
+  /** Fresh read of gateway.customConnectors — mirrors token-env.ts's "no caching" stance. */
+  async function readCustomConnectors(): Promise<Record<string, CustomConnectorEntry>> {
+    if (!configPath) return {};
+    try {
+      const raw = await fsp.readFile(configPath, 'utf-8');
+      const config = JSON.parse(raw) as {
+        gateway?: { customConnectors?: Record<string, CustomConnectorEntry> };
+      };
+      return config.gateway?.customConnectors ?? {};
+    } catch {
+      return {};
+    }
+  }
+
   function requireAdmin(req: Request, res: Response): boolean {
     if (!apiKeys?.length) return true; // no auth configured — allow
     if (!isAdmin((req as AuthedRequest).apiKey)) {
@@ -58,21 +117,30 @@ export function createConnectorsRouter(apiKeys?: ApiKey[], configPath?: string):
     return true;
   }
 
-  // List catalog + connected state
-  router.get('/v1/connectors', (_req: Request, res: Response) => {
-    res.json({ connectors: listConnectorStatus() });
+  // List catalog + connected state (built-in + custom)
+  router.get('/v1/connectors', async (_req: Request, res: Response) => {
+    res.json({ connectors: listConnectorStatus(await readCustomConnectors()) });
   });
 
-  // Single connector status (used by the web to poll)
-  router.get('/v1/connectors/:id/status', (req: Request, res: Response) => {
+  // Single connector status (used by the web to poll) — built-in first, custom fallback
+  router.get('/v1/connectors/:id/status', async (req: Request, res: Response) => {
     const spec = getConnectorSpec(req.params.id);
-    if (!spec) {
+    if (spec) {
+      const envName = secretEnvOf(spec);
+      const connected = envName === null ? true : hasSecret(envName);
+      res.json({ id: spec.id, connected });
+      return;
+    }
+
+    const custom = (await readCustomConnectors())[req.params.id];
+    if (!custom) {
       res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
       return;
     }
-    const envName = secretEnvOf(spec);
-    const connected = envName === null ? true : hasSecret(envName);
-    res.json({ id: spec.id, connected });
+    const connected = custom.secretNames.every((name: string) =>
+      hasSecret(customSecretKey(req.params.id, name)),
+    );
+    res.json({ id: req.params.id, connected });
   });
 
   // Connect — store the secret (iteration 1: auth kind 'secret')
@@ -86,6 +154,13 @@ export function createConnectorsRouter(apiKeys?: ApiKey[], configPath?: string):
 
     if (spec.auth.kind === 'none') {
       res.json({ id: spec.id, connected: true });
+      return;
+    }
+
+    if (spec.auth.kind === 'oauth') {
+      res.status(400).json({
+        error: `'${spec.id}' is connected via getpod-ai (Google OAuth), not a pasted token`,
+      });
       return;
     }
 
@@ -112,6 +187,53 @@ export function createConnectorsRouter(apiKeys?: ApiKey[], configPath?: string):
     }
   });
 
+  // Receive a fresh access_token pushed by getpod-ai's services/api for an
+  // 'oauth'-kind connector — this is how Google connectors get connected (and
+  // kept fresh on refresh) now. Admin-gated exactly like /connect; the caller
+  // is services/api itself, reaching this over the internal network with the
+  // same admin API key any other admin caller would use.
+  router.post('/v1/connectors/:id/oauth/receive', async (req: Request, res: Response) => {
+    const spec = getConnectorSpec(req.params.id);
+    if (!spec) {
+      res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
+      return;
+    }
+    if (!requireAdmin(req, res)) return;
+    if (spec.auth.kind !== 'oauth') {
+      res.status(400).json({ error: `'${spec.id}' does not use managed OAuth` });
+      return;
+    }
+
+    const accessToken = (req.body as { access_token?: unknown })?.access_token;
+    if (typeof accessToken !== 'string' || !accessToken.trim()) {
+      res.status(400).json({ error: 'access_token is required and must be a non-empty string' });
+      return;
+    }
+
+    const envName = spec.auth.secretEnv;
+    try {
+      setSecret(envName, accessToken.trim());
+      await mutateGatewayConnectors((c) => {
+        c[spec.id] = { secretEnv: envName };
+      });
+
+      // A live session already resolved this connector with the stale (or
+      // absent) token baked into its MCP subprocess's env — restart it so the
+      // next spawn picks up the fresh one (session/process.ts resolves
+      // connector secrets fresh on every spawn, but a running subprocess
+      // can't be hot-patched).
+      if (agents) {
+        await Promise.all(
+          [...agents.values()].map((runner) => runner.restartSessionsUsingConnector(spec.id)),
+        );
+      }
+
+      res.json({ id: spec.id, connected: true });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   // Disconnect — clear the secret + wiring
   router.delete('/v1/connectors/:id', async (req: Request, res: Response) => {
     const spec = getConnectorSpec(req.params.id);
@@ -128,6 +250,106 @@ export function createConnectorsRouter(apiKeys?: ApiKey[], configPath?: string):
         delete c[spec.id];
       });
       res.json({ id: spec.id, connected: false });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Add a custom (user-pasted) connector — raw mcpServers-entry JSON with
+  // {placeholder} tokens standing in for secrets. Admin-trusted, NOT
+  // code-reviewed (see CustomConnectorEntry's doc comment for the tradeoff).
+  router.post('/v1/connectors/custom', async (req: Request, res: Response) => {
+    if (!requireAdmin(req, res)) return;
+
+    const body = req.body as {
+      label?: unknown;
+      description?: unknown;
+      config?: unknown;
+      secrets?: unknown;
+      sourceUrl?: unknown;
+    };
+
+    if (typeof body.label !== 'string' || !body.label.trim()) {
+      res.status(400).json({ error: 'label is required and must be a non-empty string' });
+      return;
+    }
+    if (
+      typeof body.config !== 'object' ||
+      body.config === null ||
+      Array.isArray(body.config)
+    ) {
+      res.status(400).json({ error: 'config is required and must be a JSON object' });
+      return;
+    }
+    if (body.description !== undefined && typeof body.description !== 'string') {
+      res.status(400).json({ error: 'description must be a string' });
+      return;
+    }
+    if (body.sourceUrl !== undefined && typeof body.sourceUrl !== 'string') {
+      res.status(400).json({ error: 'sourceUrl must be a string' });
+      return;
+    }
+    let secrets: Record<string, string> = {};
+    if (body.secrets !== undefined) {
+      if (typeof body.secrets !== 'object' || body.secrets === null || Array.isArray(body.secrets)) {
+        res.status(400).json({ error: 'secrets must be an object of string values' });
+        return;
+      }
+      for (const v of Object.values(body.secrets as Record<string, unknown>)) {
+        if (typeof v !== 'string') {
+          res.status(400).json({ error: 'secrets values must all be strings' });
+          return;
+        }
+      }
+      secrets = body.secrets as Record<string, string>;
+    }
+
+    const existing = await readCustomConnectors();
+    const id = slugify(body.label, Object.keys(existing));
+    const secretNames = extractPlaceholders(body.config);
+
+    try {
+      for (const name of secretNames) {
+        const value = secrets[name];
+        if (value?.trim()) setSecret(customSecretKey(id, name), value.trim());
+      }
+      const entry: CustomConnectorEntry = {
+        label: body.label.trim(),
+        description: typeof body.description === 'string' ? body.description : undefined,
+        config: body.config as Record<string, unknown>,
+        secretNames,
+        sourceUrl:
+          typeof body.sourceUrl === 'string' && body.sourceUrl.trim()
+            ? body.sourceUrl.trim()
+            : undefined,
+      };
+      await mutateCustomConnectors((c) => {
+        c[id] = entry;
+      });
+      const connected = secretNames.every((name: string) => hasSecret(customSecretKey(id, name)));
+      res.json({ id, label: entry.label, connected });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Remove a custom connector — clears its namespaced secrets + config entry.
+  router.delete('/v1/connectors/custom/:id', async (req: Request, res: Response) => {
+    if (!requireAdmin(req, res)) return;
+
+    const existing = await readCustomConnectors();
+    const entry = existing[req.params.id];
+    if (!entry) {
+      res.status(404).json({ error: `Unknown custom connector '${req.params.id}'` });
+      return;
+    }
+
+    try {
+      for (const name of entry.secretNames) deleteSecret(customSecretKey(req.params.id, name));
+      await mutateCustomConnectors((c) => {
+        delete c[req.params.id];
+      });
+      res.json({ id: req.params.id, connected: false });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -24,7 +24,10 @@ type AuthedRequest = Request & { apiKey: ApiKey };
  *   GET    /v1/connectors/:id/status         — connected boolean (for polling)
  *   POST   /v1/connectors/:id/connect        — store a secret (admin, auth kind 'secret' only)
  *   POST   /v1/connectors/:id/oauth/receive  — store a pushed access_token (admin, auth kind 'oauth' only)
- *   DELETE /v1/connectors/:id                — clear a secret (admin, built-in only)
+ *   DELETE /v1/connectors/:id                — clear a secret (admin); a genuinely
+ *                                              user-added custom connector keeps its
+ *                                              entry (config/label intact, just
+ *                                              disconnected) — see the handler below
  *   POST   /v1/connectors/custom             — add a user-pasted connector (admin)
  *   DELETE /v1/connectors/custom/:id         — remove one (admin)
  *
@@ -274,6 +277,22 @@ export function createConnectorsRouter(
     }
     try {
       for (const name of entry.secretNames) deleteSecret(customSecretKey(id, name));
+      // A genuinely user-added custom connector (not entry.managed) has no
+      // catalog to fall back on — its config/label/description IS the
+      // customConnectors entry, so wiping the whole entry here used to mean
+      // "Disconnect" silently discarded everything the user pasted, with no
+      // way back short of re-adding it from scratch. Clearing only the
+      // secret (leaving the entry, and thus the row, in place as "not
+      // connected") lets the user reconnect without retyping the config.
+      // Managed entries (github/gmail/etc., pushed by services/api) keep the
+      // old delete-the-entry behavior: their definition lives in the
+      // services/api-owned managed catalog instead, which the web panel
+      // already falls back to for the "not connected" row, and reconnecting
+      // re-pushes a full entry via /oauth/receive regardless.
+      if (!entry.managed) {
+        res.json({ id, connected: false });
+        return;
+      }
       await store.mutate((c) => {
         delete c[id];
       });

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -1,6 +1,4 @@
 import { Router, Request, Response } from 'express';
-import * as fsp from 'fs/promises';
-import { randomUUID } from 'crypto';
 import { ApiKey, CustomConnectorEntry } from '../types';
 import { createApiAuthMiddleware, isAdmin } from './auth';
 import { getConnectorSpec } from '../connectors/catalog';
@@ -9,15 +7,23 @@ import { secretEnvOf } from '../connectors/types';
 import { setSecret, deleteSecret, hasSecret } from '../connectors/token-env';
 import { slugify, extractPlaceholders, customSecretKey } from '../connectors/custom';
 import { createCustomConnectorsStore, type CustomConnectorsStore } from '../connectors/custom-connectors-store';
+import {
+  refreshTokenSecretKey,
+  clientIdSecretKey,
+  expiresAtSecretKey,
+  refreshFailCountSecretKey,
+  refreshBackoffUntilSecretKey,
+} from '../connectors/oauth-refresh-sweep';
 import type { AgentRunner } from '../agent/runner';
 
 type AuthedRequest = Request & { apiKey: ApiKey };
 
 /**
  * Connector management API. The gateway acts as catalog + secret manager + config
- * injector: connecting a connector stores its secret in mcp-token.env and records the
- * non-secret wiring in config.json (gateway.connectors). The actual MCP server is
- * injected into each session by SessionProcess (see resolveEnabledConnectors).
+ * injector: connecting a connector stores its secret in mcp-token.env — that store
+ * alone is authoritative for "connected" (see resolve.ts's listConnectorStatus). The
+ * actual MCP server is injected into each session by SessionProcess (see
+ * resolveEnabledConnectors).
  *
  * Routes (mounted under /api):
  *   GET    /v1/connectors                    — built-in + custom catalog, connected state
@@ -35,7 +41,12 @@ type AuthedRequest = Request & { apiKey: ApiKey };
  *                                              to clear ("No auth"), in which case the
  *                                              whole entry is removed — see the handler below
  *   POST   /v1/connectors/custom             — add a user-pasted connector (admin)
- *   DELETE /v1/connectors/custom/:id         — remove one (admin)
+ *
+ * (Removal of a custom connector is NOT a separate route — it's the same
+ * unified DELETE /v1/connectors/:id above, which falls back to
+ * customConnectors when the id isn't a built-in catalog entry. See the note
+ * at the bottom of this file for why the old dedicated /custom/:id route was
+ * retired.)
  *
  * 'oauth'-kind connectors (Gmail/Drive/Calendar) never do the actual OAuth
  * dance here — getpod-ai's services/api owns the client_secret, the token
@@ -58,29 +69,6 @@ export function createConnectorsRouter(
   const router = Router();
   if (apiKeys?.length) router.use(createApiAuthMiddleware(apiKeys));
   const store = customConnectorsStore ?? createCustomConnectorsStore(configPath);
-
-  // Serialise read-modify-write of config.json's gateway.connectors subtree.
-  let writeLock: Promise<void> = Promise.resolve();
-  async function mutateGatewayConnectors(
-    fn: (connectors: Record<string, { secretEnv: string }>) => void,
-  ): Promise<void> {
-    if (!configPath) return; // no persistence target (e.g. tests) — secret store is authoritative
-    const run = writeLock.catch(() => {}).then(async () => {
-      const raw = await fsp.readFile(configPath, 'utf-8');
-      const config = JSON.parse(raw) as {
-        gateway?: { connectors?: Record<string, { secretEnv: string }> };
-        [k: string]: unknown;
-      };
-      config.gateway = config.gateway ?? {};
-      config.gateway.connectors = config.gateway.connectors ?? {};
-      fn(config.gateway.connectors);
-      const tmp = `${configPath}.tmp.${randomUUID()}`;
-      await fsp.writeFile(tmp, JSON.stringify(config, null, 2), 'utf-8');
-      await fsp.rename(tmp, configPath);
-    });
-    writeLock = run.catch(() => {});
-    return run;
-  }
 
   function requireAdmin(req: Request, res: Response): boolean {
     if (!apiKeys?.length) return true; // no auth configured — allow
@@ -149,9 +137,6 @@ export function createConnectorsRouter(
       const envName = spec.auth.secretEnv;
       try {
         setSecret(envName, token.trim());
-        await mutateGatewayConnectors((c) => {
-          c[spec.id] = { secretEnv: envName };
-        });
         res.json({ id: spec.id, connected: true });
       } catch (err) {
         res.status(500).json({ error: (err as Error).message });
@@ -164,9 +149,11 @@ export function createConnectorsRouter(
       res.status(404).json({ error: `Unknown connector '${id}'` });
       return;
     }
-    if (entry.oauth) {
+    if (entry.oauth || entry.managed) {
       res.status(400).json({
-        error: `Connector '${id}' uses OAuth sign-in — start it via POST /v1/connectors/custom/${id}/oauth/start instead`,
+        error: entry.managed
+          ? `Connector '${id}' is managed externally — its token is pushed via POST /v1/connectors/${id}/oauth/receive, not set here.`
+          : `Connector '${id}' uses OAuth sign-in — start it via POST /v1/connectors/custom/${id}/oauth/start instead`,
       });
       return;
     }
@@ -304,9 +291,6 @@ export function createConnectorsRouter(
       const envName = secretEnvOf(spec);
       try {
         if (envName) deleteSecret(envName);
-        await mutateGatewayConnectors((c) => {
-          delete c[spec.id];
-        });
         res.json({ id: spec.id, connected: false });
       } catch (err) {
         res.status(500).json({ error: (err as Error).message });
@@ -322,6 +306,20 @@ export function createConnectorsRouter(
     }
     try {
       for (const name of entry.secretNames) deleteSecret(customSecretKey(id, name));
+      // An oauth:true entry's refresh_token/client_id/expiry (and any
+      // recorded failure backoff) live outside secretNames — they're
+      // sweep-internal bookkeeping, not a {placeholder} from the pasted
+      // config (see oauth-refresh-sweep.ts's storage note), so the loop
+      // above never touches them. Left alone, the still-valid refresh_token
+      // would let refreshExpiringOAuthConnectors silently mint a fresh
+      // access_token and resurrect a connector the user just disconnected.
+      if (entry.oauth) {
+        deleteSecret(refreshTokenSecretKey(id));
+        deleteSecret(clientIdSecretKey(id));
+        deleteSecret(expiresAtSecretKey(id));
+        deleteSecret(refreshFailCountSecretKey(id));
+        deleteSecret(refreshBackoffUntilSecretKey(id));
+      }
       // A genuinely user-added custom connector (not entry.managed) has no
       // catalog to fall back on — its config/label/description IS the
       // customConnectors entry, so wiping the whole entry here used to mean

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -31,7 +31,9 @@ type AuthedRequest = Request & { apiKey: ApiKey };
  *   DELETE /v1/connectors/:id                — clear a secret (admin); a genuinely
  *                                              user-added custom connector keeps its
  *                                              entry (config/label intact, just
- *                                              disconnected) — see the handler below
+ *                                              disconnected) UNLESS it has no secret
+ *                                              to clear ("No auth"), in which case the
+ *                                              whole entry is removed — see the handler below
  *   POST   /v1/connectors/custom             — add a user-pasted connector (admin)
  *   DELETE /v1/connectors/custom/:id         — remove one (admin)
  *
@@ -327,12 +329,21 @@ export function createConnectorsRouter(
       // way back short of re-adding it from scratch. Clearing only the
       // secret (leaving the entry, and thus the row, in place as "not
       // connected") lets the user reconnect without retyping the config.
+      //
+      // That soft-disconnect only makes sense when there's a secret to
+      // clear. A "No auth" custom connector (secretNames: []) has none —
+      // listConnectorStatus's `secretNames.every(...)` is vacuously true on
+      // an empty array, so it reports connected forever no matter what this
+      // route does. Soft-disconnecting it is a no-op that looks like a bug
+      // (click Disconnect, row stays "Connected"), so fall through to a real
+      // delete instead — there's nothing to preserve for a reconnect anyway.
+      //
       // Managed entries (github/gmail/etc., pushed by services/api) keep the
       // old delete-the-entry behavior: their definition lives in the
       // services/api-owned managed catalog instead, which the web panel
       // already falls back to for the "not connected" row, and reconnecting
       // re-pushes a full entry via /oauth/receive regardless.
-      if (!entry.managed) {
+      if (!entry.managed && entry.secretNames.length > 0) {
         res.json({ id, connected: false });
         return;
       }

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -22,7 +22,11 @@ type AuthedRequest = Request & { apiKey: ApiKey };
  * Routes (mounted under /api):
  *   GET    /v1/connectors                    — built-in + custom catalog, connected state
  *   GET    /v1/connectors/:id/status         — connected boolean (for polling)
- *   POST   /v1/connectors/:id/connect        — store a secret (admin, auth kind 'secret' only)
+ *   POST   /v1/connectors/:id/connect        — store a secret (admin); built-in catalog
+ *                                              first, falls back to a single-secret
+ *                                              customConnectors entry (e.g. reconnecting
+ *                                              a paste-token connector after DELETE
+ *                                              soft-disconnected it) — see the handler
  *   POST   /v1/connectors/:id/oauth/receive  — store a pushed access_token (admin, auth kind 'oauth' only)
  *   DELETE /v1/connectors/:id                — clear a secret (admin); a genuinely
  *                                              user-added custom connector keeps its
@@ -111,22 +115,66 @@ export function createConnectorsRouter(
     res.json({ id: req.params.id, connected });
   });
 
-  // Connect — store the secret (iteration 1: auth kind 'secret')
+  // Connect — store the secret. Built-in catalog first (auth kind 'secret'
+  // only); falls back to a customConnectors entry with exactly one secret
+  // name, same admin-first-then-catalog-then-custom order DELETE already
+  // uses below. That fallback is what makes reconnecting a paste-token
+  // custom connector (e.g. Stripe) actually work after DELETE soft-disconnects
+  // it — the entry survives disconnect, so it must be reconnectable here, not
+  // only via re-adding it from scratch through POST /v1/connectors/custom.
   router.post('/v1/connectors/:id/connect', async (req: Request, res: Response) => {
-    const spec = getConnectorSpec(req.params.id);
-    if (!spec) {
-      res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
-      return;
-    }
     if (!requireAdmin(req, res)) return;
+    const id = req.params.id;
 
-    if (spec.auth.kind === 'none') {
-      res.json({ id: spec.id, connected: true });
+    const spec = getConnectorSpec(id);
+    if (spec) {
+      if (spec.auth.kind === 'none') {
+        res.json({ id: spec.id, connected: true });
+        return;
+      }
+
+      if (spec.auth.kind !== 'secret') {
+        res.status(501).json({ error: `Auth kind '${spec.auth.kind}' not yet implemented` });
+        return;
+      }
+
+      const token = (req.body as { token?: unknown })?.token;
+      if (typeof token !== 'string' || !token.trim()) {
+        res.status(400).json({ error: 'token is required and must be a non-empty string' });
+        return;
+      }
+
+      const envName = spec.auth.secretEnv;
+      try {
+        setSecret(envName, token.trim());
+        await mutateGatewayConnectors((c) => {
+          c[spec.id] = { secretEnv: envName };
+        });
+        res.json({ id: spec.id, connected: true });
+      } catch (err) {
+        res.status(500).json({ error: (err as Error).message });
+      }
       return;
     }
 
-    if (spec.auth.kind !== 'secret') {
-      res.status(501).json({ error: `Auth kind '${spec.auth.kind}' not yet implemented` });
+    const entry = (await store.read())[id];
+    if (!entry) {
+      res.status(404).json({ error: `Unknown connector '${id}'` });
+      return;
+    }
+    if (entry.oauth) {
+      res.status(400).json({
+        error: `Connector '${id}' uses OAuth sign-in — start it via POST /v1/connectors/custom/${id}/oauth/start instead`,
+      });
+      return;
+    }
+    if (entry.secretNames.length !== 1) {
+      res.status(400).json({
+        error:
+          entry.secretNames.length === 0
+            ? `Connector '${id}' has no secrets to set — nothing to connect here.`
+            : `Connector '${id}' needs ${entry.secretNames.length} secrets (${entry.secretNames.join(', ')}) — this route only accepts a single value. Remove and re-add it with every value via POST /v1/connectors/custom.`,
+      });
       return;
     }
 
@@ -135,14 +183,9 @@ export function createConnectorsRouter(
       res.status(400).json({ error: 'token is required and must be a non-empty string' });
       return;
     }
-
-    const envName = spec.auth.secretEnv;
     try {
-      setSecret(envName, token.trim());
-      await mutateGatewayConnectors((c) => {
-        c[spec.id] = { secretEnv: envName };
-      });
-      res.json({ id: spec.id, connected: true });
+      setSecret(customSecretKey(id, entry.secretNames[0]), token.trim());
+      res.json({ id, connected: true });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/api/connectors-router.ts
+++ b/src/api/connectors-router.ts
@@ -8,6 +8,7 @@ import { listConnectorStatus } from '../connectors/resolve';
 import { secretEnvOf } from '../connectors/types';
 import { setSecret, deleteSecret, hasSecret } from '../connectors/token-env';
 import { slugify, extractPlaceholders, customSecretKey } from '../connectors/custom';
+import { createCustomConnectorsStore, type CustomConnectorsStore } from '../connectors/custom-connectors-store';
 import type { AgentRunner } from '../agent/runner';
 
 type AuthedRequest = Request & { apiKey: ApiKey };
@@ -43,9 +44,11 @@ export function createConnectorsRouter(
   apiKeys?: ApiKey[],
   configPath?: string,
   agents?: Map<string, AgentRunner>,
+  customConnectorsStore?: CustomConnectorsStore,
 ): Router {
   const router = Router();
   if (apiKeys?.length) router.use(createApiAuthMiddleware(apiKeys));
+  const store = customConnectorsStore ?? createCustomConnectorsStore(configPath);
 
   // Serialise read-modify-write of config.json's gateway.connectors subtree.
   let writeLock: Promise<void> = Promise.resolve();
@@ -70,44 +73,6 @@ export function createConnectorsRouter(
     return run;
   }
 
-  // Same read-modify-write-tmp-rename pattern as mutateGatewayConnectors above,
-  // targeting gateway.customConnectors instead. Shares the same writeLock so a
-  // built-in connect and a custom add can't race each other's read-modify-write.
-  async function mutateCustomConnectors(
-    fn: (connectors: Record<string, CustomConnectorEntry>) => void,
-  ): Promise<void> {
-    if (!configPath) return;
-    const run = writeLock.catch(() => {}).then(async () => {
-      const raw = await fsp.readFile(configPath, 'utf-8');
-      const config = JSON.parse(raw) as {
-        gateway?: { customConnectors?: Record<string, CustomConnectorEntry> };
-        [k: string]: unknown;
-      };
-      config.gateway = config.gateway ?? {};
-      config.gateway.customConnectors = config.gateway.customConnectors ?? {};
-      fn(config.gateway.customConnectors);
-      const tmp = `${configPath}.tmp.${randomUUID()}`;
-      await fsp.writeFile(tmp, JSON.stringify(config, null, 2), 'utf-8');
-      await fsp.rename(tmp, configPath);
-    });
-    writeLock = run.catch(() => {});
-    return run;
-  }
-
-  /** Fresh read of gateway.customConnectors — mirrors token-env.ts's "no caching" stance. */
-  async function readCustomConnectors(): Promise<Record<string, CustomConnectorEntry>> {
-    if (!configPath) return {};
-    try {
-      const raw = await fsp.readFile(configPath, 'utf-8');
-      const config = JSON.parse(raw) as {
-        gateway?: { customConnectors?: Record<string, CustomConnectorEntry> };
-      };
-      return config.gateway?.customConnectors ?? {};
-    } catch {
-      return {};
-    }
-  }
-
   function requireAdmin(req: Request, res: Response): boolean {
     if (!apiKeys?.length) return true; // no auth configured — allow
     if (!isAdmin((req as AuthedRequest).apiKey)) {
@@ -119,7 +84,7 @@ export function createConnectorsRouter(
 
   // List catalog + connected state (built-in + custom)
   router.get('/v1/connectors', async (_req: Request, res: Response) => {
-    res.json({ connectors: listConnectorStatus(await readCustomConnectors()) });
+    res.json({ connectors: listConnectorStatus(await store.read()) });
   });
 
   // Single connector status (used by the web to poll) — built-in first, custom fallback
@@ -132,7 +97,7 @@ export function createConnectorsRouter(
       return;
     }
 
-    const custom = (await readCustomConnectors())[req.params.id];
+    const custom = (await store.read())[req.params.id];
     if (!custom) {
       res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
       return;
@@ -154,13 +119,6 @@ export function createConnectorsRouter(
 
     if (spec.auth.kind === 'none') {
       res.json({ id: spec.id, connected: true });
-      return;
-    }
-
-    if (spec.auth.kind === 'oauth') {
-      res.status(400).json({
-        error: `'${spec.id}' is connected via getpod-ai (OAuth), not a pasted token`,
-      });
       return;
     }
 
@@ -187,34 +145,81 @@ export function createConnectorsRouter(
     }
   });
 
-  // Receive a fresh access_token pushed by getpod-ai's services/api for an
-  // 'oauth'-kind connector — this is how Google connectors get connected (and
-  // kept fresh on refresh) now. Admin-gated exactly like /connect; the caller
-  // is services/api itself, reaching this over the internal network with the
+  // Receive a fresh access_token + full connector shape pushed by getpod-ai's
+  // services/api for a GetPod-managed OAuth connector (github/gmail/
+  // google-drive/google-calendar) — this is how those connect (and stay fresh
+  // on refresh) now. Admin-gated exactly like /connect; the caller is
+  // services/api itself, reaching this over the internal network with the
   // same admin API key any other admin caller would use.
+  //
+  // Unlike /connect, there's no catalog lookup here — CONNECTOR_CATALOG is
+  // empty by default, and these ids are never in it (see catalog.ts's doc
+  // comment). The entry is written into gateway.customConnectors instead,
+  // same storage a user-pasted custom connector uses, with `managed: true` +
+  // `authKind: 'oauth'` marking it as services/api's, not the user's (see
+  // CustomConnectorEntry's doc comment). `secretNames` is never trusted from
+  // the request body — derived from `config` via extractPlaceholders, the
+  // same helper /custom's add route uses, and required to be exactly
+  // ['access_token'] (this route only ever manages one pushed secret).
   router.post('/v1/connectors/:id/oauth/receive', async (req: Request, res: Response) => {
-    const spec = getConnectorSpec(req.params.id);
-    if (!spec) {
-      res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
-      return;
-    }
     if (!requireAdmin(req, res)) return;
-    if (spec.auth.kind !== 'oauth') {
-      res.status(400).json({ error: `'${spec.id}' does not use managed OAuth` });
-      return;
-    }
+    const id = req.params.id;
 
-    const accessToken = (req.body as { access_token?: unknown })?.access_token;
+    const body = req.body as {
+      access_token?: unknown;
+      label?: unknown;
+      description?: unknown;
+      config?: unknown;
+      sourceUrl?: unknown;
+    };
+
+    const accessToken = body?.access_token;
     if (typeof accessToken !== 'string' || !accessToken.trim()) {
       res.status(400).json({ error: 'access_token is required and must be a non-empty string' });
       return;
     }
+    if (typeof body.label !== 'string' || !body.label.trim()) {
+      res.status(400).json({ error: 'label is required and must be a non-empty string' });
+      return;
+    }
+    if (typeof body.config !== 'object' || body.config === null || Array.isArray(body.config)) {
+      res.status(400).json({ error: 'config is required and must be a JSON object' });
+      return;
+    }
+    if (body.description !== undefined && typeof body.description !== 'string') {
+      res.status(400).json({ error: 'description must be a string' });
+      return;
+    }
+    if (body.sourceUrl !== undefined && typeof body.sourceUrl !== 'string') {
+      res.status(400).json({ error: 'sourceUrl must be a string' });
+      return;
+    }
 
-    const envName = spec.auth.secretEnv;
+    const placeholders = extractPlaceholders(body.config);
+    if (placeholders.length !== 1 || placeholders[0] !== 'access_token') {
+      res.status(400).json({
+        error: "config must contain exactly one {access_token} placeholder and no others",
+      });
+      return;
+    }
+
+    const entry: CustomConnectorEntry = {
+      label: body.label.trim(),
+      description: typeof body.description === 'string' ? body.description : undefined,
+      config: body.config as Record<string, unknown>,
+      secretNames: ['access_token'],
+      sourceUrl:
+        typeof body.sourceUrl === 'string' && body.sourceUrl.trim()
+          ? body.sourceUrl.trim()
+          : undefined,
+      authKind: 'oauth',
+      managed: true,
+    };
+
     try {
-      setSecret(envName, accessToken.trim());
-      await mutateGatewayConnectors((c) => {
-        c[spec.id] = { secretEnv: envName };
+      setSecret(customSecretKey(id, 'access_token'), accessToken.trim());
+      await store.mutate((c) => {
+        c[id] = entry;
       });
 
       // A live session already resolved this connector with the stale (or
@@ -224,32 +229,55 @@ export function createConnectorsRouter(
       // can't be hot-patched).
       if (agents) {
         await Promise.all(
-          [...agents.values()].map((runner) => runner.restartSessionsUsingConnector(spec.id)),
+          [...agents.values()].map((runner) => runner.restartSessionsUsingConnector(id)),
         );
       }
 
-      res.json({ id: spec.id, connected: true });
+      res.json({ id, connected: true });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }
   });
 
-  // Disconnect — clear the secret + wiring
+  // Disconnect — clear the secret + wiring. Unified across built-in (catalog)
+  // and custom/managed (customConnectors) storage: checks admin first (this
+  // route used to check "does the id exist" before "is the caller admin" —
+  // unifying with the custom-delete logic below means picking one order, and
+  // admin-first doesn't leak whether an id exists to a non-admin caller),
+  // then tries the catalog, then falls back to customConnectors instead of
+  // 404ing — github/gmail/etc. live there now (see /oauth/receive above), and
+  // this used to be a 404 dead-end for them before this fallback existed.
   router.delete('/v1/connectors/:id', async (req: Request, res: Response) => {
-    const spec = getConnectorSpec(req.params.id);
-    if (!spec) {
-      res.status(404).json({ error: `Unknown connector '${req.params.id}'` });
+    if (!requireAdmin(req, res)) return;
+    const id = req.params.id;
+
+    const spec = getConnectorSpec(id);
+    if (spec) {
+      const envName = secretEnvOf(spec);
+      try {
+        if (envName) deleteSecret(envName);
+        await mutateGatewayConnectors((c) => {
+          delete c[spec.id];
+        });
+        res.json({ id: spec.id, connected: false });
+      } catch (err) {
+        res.status(500).json({ error: (err as Error).message });
+      }
       return;
     }
-    if (!requireAdmin(req, res)) return;
 
-    const envName = secretEnvOf(spec);
+    const existing = await store.read();
+    const entry = existing[id];
+    if (!entry) {
+      res.status(404).json({ error: `Unknown connector '${id}'` });
+      return;
+    }
     try {
-      if (envName) deleteSecret(envName);
-      await mutateGatewayConnectors((c) => {
-        delete c[spec.id];
+      for (const name of entry.secretNames) deleteSecret(customSecretKey(id, name));
+      await store.mutate((c) => {
+        delete c[id];
       });
-      res.json({ id: spec.id, connected: false });
+      res.json({ id, connected: false });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }
@@ -267,6 +295,7 @@ export function createConnectorsRouter(
       config?: unknown;
       secrets?: unknown;
       sourceUrl?: unknown;
+      oauth?: unknown;
     };
 
     if (typeof body.label !== 'string' || !body.label.trim()) {
@@ -279,6 +308,10 @@ export function createConnectorsRouter(
       Array.isArray(body.config)
     ) {
       res.status(400).json({ error: 'config is required and must be a JSON object' });
+      return;
+    }
+    if (body.oauth !== undefined && typeof body.oauth !== 'boolean') {
+      res.status(400).json({ error: 'oauth must be a boolean' });
       return;
     }
     if (body.description !== undefined && typeof body.description !== 'string') {
@@ -304,9 +337,22 @@ export function createConnectorsRouter(
       secrets = body.secrets as Record<string, string>;
     }
 
-    const existing = await readCustomConnectors();
+    const oauth = body.oauth === true;
+    if (oauth && typeof (body.config as { url?: unknown }).url !== 'string') {
+      res.status(400).json({ error: 'config.url is required when oauth is true' });
+      return;
+    }
+
+    const existing = await store.read();
     const id = slugify(body.label, Object.keys(existing));
     const secretNames = extractPlaceholders(body.config);
+    if (oauth && !secretNames.includes('access_token')) {
+      res.status(400).json({
+        error:
+          'oauth connectors need an {access_token} placeholder in config (e.g. headers.Authorization: "Bearer {access_token}")',
+      });
+      return;
+    }
 
     try {
       for (const name of secretNames) {
@@ -322,8 +368,9 @@ export function createConnectorsRouter(
           typeof body.sourceUrl === 'string' && body.sourceUrl.trim()
             ? body.sourceUrl.trim()
             : undefined,
+        oauth: oauth || undefined,
       };
-      await mutateCustomConnectors((c) => {
+      await store.mutate((c) => {
         c[id] = entry;
       });
       const connected = secretNames.every((name: string) => hasSecret(customSecretKey(id, name)));
@@ -333,27 +380,10 @@ export function createConnectorsRouter(
     }
   });
 
-  // Remove a custom connector — clears its namespaced secrets + config entry.
-  router.delete('/v1/connectors/custom/:id', async (req: Request, res: Response) => {
-    if (!requireAdmin(req, res)) return;
-
-    const existing = await readCustomConnectors();
-    const entry = existing[req.params.id];
-    if (!entry) {
-      res.status(404).json({ error: `Unknown custom connector '${req.params.id}'` });
-      return;
-    }
-
-    try {
-      for (const name of entry.secretNames) deleteSecret(customSecretKey(req.params.id, name));
-      await mutateCustomConnectors((c) => {
-        delete c[req.params.id];
-      });
-      res.json({ id: req.params.id, connected: false });
-    } catch (err) {
-      res.status(500).json({ error: (err as Error).message });
-    }
-  });
+  // Custom connector removal is now handled by the unified
+  // `DELETE /v1/connectors/:id` above (falls back to customConnectors when
+  // the id isn't a built-in catalog entry) — this used to be a separate
+  // `/custom/:id` route; retired in favor of one delete path for both.
 
   return router;
 }

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -38,6 +38,10 @@ import { createSkillsRouter } from './skills-router';
 import { createPackagesRouter } from './packages';
 import { createWebhooksRouter } from './webhooks-router';
 import { createConnectorsRouter } from './connectors-router';
+import { createOauthConnectorsRouter, createOauthCallbackRouter } from './oauth-connectors-router';
+import { createCustomConnectorsStore, type CustomConnectorsStore } from '../connectors/custom-connectors-store';
+import { pendingOAuthStore } from '../connectors/pending-oauth-store';
+import { refreshExpiringOAuthConnectors } from '../connectors/oauth-refresh-sweep';
 import { AppsRegistry } from '../apps/registry';
 import { AppInstaller } from '../apps/installer';
 import { RegistryClient } from '../apps/registry-client';
@@ -282,6 +286,11 @@ export class GatewayRouter {
   private readonly appInstaller?: AppInstaller;
   private readonly appRegistryClient?: RegistryClient;
 
+  /** Shared with oauth-connectors-router.ts so a custom-connector add/delete
+   *  and an OAuth-flow completion can't race each other's read-modify-write
+   *  of gateway.customConnectors — see custom-connectors-store.ts. */
+  private readonly customConnectorsStore: CustomConnectorsStore;
+
   constructor(
     agents: Map<string, AgentRunner>,
     configs: Map<string, AgentConfig>,
@@ -301,6 +310,7 @@ export class GatewayRouter {
     this.appsRegistry = appsRegistry;
     this.appInstaller = appInstaller;
     this.appRegistryClient = appRegistryClient;
+    this.customConnectorsStore = createCustomConnectorsStore(configPath);
     this.app = express();
 
     // Initialise counters for all known agents
@@ -733,9 +743,32 @@ export class GatewayRouter {
         this.gatewayConfig.gateway.api.keys,
         this.configPath,
         this.agents,
+        this.customConnectorsStore,
       );
       this.app.use('/api', connectorsRouter);
+
+      // Admin-gated "start an OAuth sign-in" endpoint for oauth:true custom
+      // connectors (Firecrawl etc.) — see oauth-connectors-router.ts's doc
+      // comment for why this is split from the public callback route below.
+      const oauthConnectorsRouter = createOauthConnectorsRouter(
+        this.gatewayConfig.gateway.api.keys,
+        this.gatewayConfig,
+        this.customConnectorsStore,
+      );
+      this.app.use('/api', oauthConnectorsRouter);
     }
+
+    // Public (no auth) — this is what the OAuth provider redirects the end
+    // user's own browser to after they sign in. Mounted at the app root, not
+    // under /api, mirroring the /app/:name/:portName proxy below.
+    this.app.use(
+      createOauthCallbackRouter(
+        undefined,
+        typeof this.gatewayConfig?.gateway?.oauthReturnUrl === 'string'
+          ? this.gatewayConfig.gateway.oauthReturnUrl
+          : undefined,
+      ),
+    );
 
     // Mount cron manager routes with same API key auth as agent router
     if (this.cronManager) {
@@ -1379,6 +1412,10 @@ export class GatewayRouter {
           if (rec.resetAt < now) this.loginAttempts.delete(ip);
         }
         cliPairingStore.prune();
+        pendingOAuthStore.prune();
+        refreshExpiringOAuthConnectors(this.customConnectorsStore).catch((err) => {
+          console.error(`oauth-refresh-sweep: ${(err as Error).message}`);
+        });
       }, 60_000);
       this.ticketPruner.unref();
 

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -37,6 +37,7 @@ import { createWorkspaceRouter } from './workspace-router';
 import { createSkillsRouter } from './skills-router';
 import { createPackagesRouter } from './packages';
 import { createWebhooksRouter } from './webhooks-router';
+import { createConnectorsRouter } from './connectors-router';
 import { AppsRegistry } from '../apps/registry';
 import { AppInstaller } from '../apps/installer';
 import { RegistryClient } from '../apps/registry-client';
@@ -724,6 +725,15 @@ export class GatewayRouter {
     if (this.gatewayConfig?.gateway?.api?.keys?.length) {
       const packagesRouter = createPackagesRouter(this.gatewayConfig.gateway.api.keys);
       this.app.use('/api', packagesRouter);
+    }
+
+    // Mount connector management routes (catalog + secret store + config wiring)
+    if (this.gatewayConfig?.gateway?.api?.keys?.length) {
+      const connectorsRouter = createConnectorsRouter(
+        this.gatewayConfig.gateway.api.keys,
+        this.configPath,
+      );
+      this.app.use('/api', connectorsRouter);
     }
 
     // Mount cron manager routes with same API key auth as agent router

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -732,6 +732,7 @@ export class GatewayRouter {
       const connectorsRouter = createConnectorsRouter(
         this.gatewayConfig.gateway.api.keys,
         this.configPath,
+        this.agents,
       );
       this.app.use('/api', connectorsRouter);
     }

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -1413,7 +1413,7 @@ export class GatewayRouter {
         }
         cliPairingStore.prune();
         pendingOAuthStore.prune();
-        refreshExpiringOAuthConnectors(this.customConnectorsStore).catch((err) => {
+        refreshExpiringOAuthConnectors(this.customConnectorsStore, this.agents).catch((err) => {
           console.error(`oauth-refresh-sweep: ${(err as Error).message}`);
         });
       }, 60_000);

--- a/src/api/oauth-connectors-router.ts
+++ b/src/api/oauth-connectors-router.ts
@@ -3,7 +3,7 @@ import { ApiKey } from '../types';
 import { createApiAuthMiddleware, isAdmin } from './auth';
 import type { CustomConnectorsStore } from '../connectors/custom-connectors-store';
 import { customSecretKey } from '../connectors/custom';
-import { setSecret } from '../connectors/token-env';
+import { getSecret, setSecret } from '../connectors/token-env';
 import { resolveGatewayPublicUrl } from '../config/public-url';
 import {
   discoverOAuthMetadata,
@@ -17,7 +17,17 @@ import {
   refreshTokenSecretKey,
   clientIdSecretKey,
   expiresAtSecretKey,
+  tokenGenerationSecretKey,
 } from '../connectors/oauth-refresh-sweep';
+
+/** Where a connector's registered redirect_uri is cached alongside its
+ *  client_id (below) — only reuse the cached client_id when this still
+ *  matches gateway.publicUrl's current callback URL; otherwise the cached
+ *  client is registered against a redirect_uri the provider would now
+ *  reject, so re-registering is the correct move, not an optimization to skip. */
+function clientRedirectUriSecretKey(id: string): string {
+  return customSecretKey(id, '__client_redirect_uri');
+}
 
 type AuthedRequest = Request & { apiKey: ApiKey };
 
@@ -104,7 +114,21 @@ export function createOauthConnectorsRouter(
 
     try {
       const metadata = await discoverOAuthMetadata(mcpUrl);
-      const clientId = await resolveClientId(metadata, id, redirectUri);
+      // Reuse a client this connector already registered via DCR, rather
+      // than minting (and orphaning, at the provider) a brand-new one on
+      // every Connect click — including retries after an abandoned attempt.
+      // Only valid while the redirect_uri it was registered with still
+      // matches; a changed gateway.publicUrl invalidates the cache.
+      const cachedClientId = getSecret(clientIdSecretKey(id));
+      const cachedRedirectUri = getSecret(clientRedirectUriSecretKey(id));
+      let clientId: string;
+      if (cachedClientId && cachedRedirectUri === redirectUri) {
+        clientId = cachedClientId;
+      } else {
+        clientId = await resolveClientId(metadata, id, redirectUri);
+        setSecret(clientIdSecretKey(id), clientId);
+        setSecret(clientRedirectUriSecretKey(id), redirectUri);
+      }
       const { codeVerifier, codeChallenge } = generatePkce();
       const state = pendingStore.create({ connectorId: id, metadata, clientId, redirectUri, codeVerifier });
       const scope = metadata.scopesSupported.length > 0 ? metadata.scopesSupported.join(' ') : 'offline_access';
@@ -209,6 +233,11 @@ export function createOauthCallbackRouter(
         expiresAtSecretKey(flow.connectorId),
         String(Date.now() + (token.expires_in ?? 3600) * 1000),
       );
+      // Bumped so the background refresh sweep (oauth-refresh-sweep.ts) can
+      // tell, after its own two-network-round-trip refresh, whether a fresher
+      // token landed here in the meantime — and if so, discard its own
+      // now-stale result instead of clobbering this one.
+      setSecret(tokenGenerationSecretKey(flow.connectorId), String(Date.now()));
       if (validReturnUrl) {
         res.redirect(302, validReturnUrl);
         return;

--- a/src/api/oauth-connectors-router.ts
+++ b/src/api/oauth-connectors-router.ts
@@ -1,0 +1,182 @@
+import { Router, Request, Response } from 'express';
+import { ApiKey } from '../types';
+import { createApiAuthMiddleware, isAdmin } from './auth';
+import type { CustomConnectorsStore } from '../connectors/custom-connectors-store';
+import { customSecretKey } from '../connectors/custom';
+import { setSecret } from '../connectors/token-env';
+import { resolveGatewayPublicUrl } from '../config/public-url';
+import {
+  discoverOAuthMetadata,
+  resolveClientId,
+  generatePkce,
+  buildAuthorizeUrl,
+  exchangeCode,
+} from '../connectors/mcp-oauth';
+import { pendingOAuthStore, type PendingOAuthStore } from '../connectors/pending-oauth-store';
+import {
+  refreshTokenSecretKey,
+  clientIdSecretKey,
+  expiresAtSecretKey,
+} from '../connectors/oauth-refresh-sweep';
+
+type AuthedRequest = Request & { apiKey: ApiKey };
+
+/**
+ * Generic OAuth 2.1 + PKCE flow for "custom" connectors marked
+ * `oauth: true` (see CustomConnectorEntry) — e.g. Firecrawl's
+ * `https://mcp.firecrawl.dev/v2/mcp-oauth`. This is the gateway-owned
+ * counterpart to services/api's google_connector.go/github_connector.go: the
+ * whole dance (discovery, DCR, PKCE, token exchange, refresh) happens here,
+ * inside the user's own VM — services/api never sees the resulting token.
+ *
+ * Two routers, deliberately NOT combined into one:
+ *   - createOauthConnectorsRouter(): admin-gated, mounted under /api like every
+ *     other connector-management route (`POST /v1/connectors/custom/:id/oauth/start`).
+ *   - createOauthCallbackRouter(): PUBLIC, no auth — this is the URL the OAuth
+ *     provider redirects the end user's own browser to
+ *     (`GET /oauth/mcp/callback`), which has no API key to present. Its
+ *     security rests on the single-use, TTL'd, unguessable `state` value
+ *     (see pending-oauth-store.ts), the same posture cliPairingStore already
+ *     uses for its own unauthenticated browser-facing routes.
+ */
+export function createOauthConnectorsRouter(
+  apiKeys: ApiKey[] | undefined,
+  gatewayConfig: { gateway?: { publicUrl?: unknown } } | undefined,
+  store: CustomConnectorsStore,
+  pendingStore: PendingOAuthStore = pendingOAuthStore,
+): Router {
+  const router = Router();
+  if (apiKeys?.length) router.use(createApiAuthMiddleware(apiKeys));
+
+  function requireAdmin(req: Request, res: Response): boolean {
+    if (!apiKeys?.length) return true;
+    if (!isAdmin((req as AuthedRequest).apiKey)) {
+      res.status(403).json({ error: 'Connector management requires an admin API key' });
+      return false;
+    }
+    return true;
+  }
+
+  router.post('/v1/connectors/custom/:id/oauth/start', async (req: Request, res: Response) => {
+    if (!requireAdmin(req, res)) return;
+    const id = req.params.id;
+
+    const entry = (await store.read())[id];
+    if (!entry) {
+      res.status(404).json({ error: `Unknown connector '${id}'` });
+      return;
+    }
+    if (!entry.oauth) {
+      res.status(400).json({ error: `Connector '${id}' was not added with oauth: true` });
+      return;
+    }
+    const mcpUrl = entry.config.url;
+    if (typeof mcpUrl !== 'string') {
+      res.status(400).json({ error: `Connector '${id}'.config.url is missing` });
+      return;
+    }
+
+    const publicUrl = resolveGatewayPublicUrl(gatewayConfig?.gateway?.publicUrl);
+    if (!publicUrl) {
+      res.status(500).json({
+        error:
+          'This gateway has no valid gateway.publicUrl configured — OAuth sign-in needs a reachable HTTPS callback URL.',
+      });
+      return;
+    }
+    const redirectUri = `${publicUrl}/oauth/mcp/callback`;
+
+    try {
+      const metadata = await discoverOAuthMetadata(mcpUrl);
+      const clientId = await resolveClientId(metadata, id, redirectUri);
+      const { codeVerifier, codeChallenge } = generatePkce();
+      const state = pendingStore.create({ connectorId: id, metadata, clientId, redirectUri, codeVerifier });
+      const scope = metadata.scopesSupported.length > 0 ? metadata.scopesSupported.join(' ') : 'offline_access';
+      const authorizeUrl = buildAuthorizeUrl({
+        metadata,
+        clientId,
+        redirectUri,
+        scope,
+        codeChallenge,
+        state,
+      });
+      res.json({ authorizeUrl });
+    } catch (err) {
+      res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  return router;
+}
+
+/** See this file's module doc comment — mounted directly on the Express app,
+ *  NOT under any auth middleware, at `/oauth/mcp/callback`. */
+export function createOauthCallbackRouter(
+  pendingStore: PendingOAuthStore = pendingOAuthStore,
+  returnUrl?: string,
+): Router {
+  const router = Router();
+  // This gateway is a generic, product-agnostic fork — it has no business
+  // hardcoding a downstream product's own domain (e.g. app.getpod.ai).
+  // Whoever deploys it can opt into an auto-redirect by setting
+  // gateway.oauthReturnUrl in config.json; absent that, the plain "close this
+  // tab" message below is the safe default. Validated once, at router
+  // construction — a malformed value degrades to "not configured" rather
+  // than injecting a broken redirect into every future callback response.
+  let validReturnUrl: string | undefined;
+  if (returnUrl) {
+    try {
+      validReturnUrl = new URL(returnUrl).toString();
+    } catch {
+      console.error(`oauth-connectors-router: gateway.oauthReturnUrl "${returnUrl}" is not a valid URL — ignoring it`);
+    }
+  }
+
+  function successPage(): string {
+    if (!validReturnUrl) return '<h1>Connected — you can close this tab.</h1>';
+    return `<!doctype html><html><head><meta http-equiv="refresh" content="2;url=${validReturnUrl}"></head>
+<body><h1>Connected!</h1><p>Redirecting you back… <a href="${validReturnUrl}">click here</a> if nothing happens.</p></body></html>`;
+  }
+
+  router.get('/oauth/mcp/callback', async (req: Request, res: Response) => {
+    const state = typeof req.query.state === 'string' ? req.query.state : '';
+    const code = typeof req.query.code === 'string' ? req.query.code : '';
+    const providerError = typeof req.query.error === 'string' ? req.query.error : '';
+
+    const flow = state ? pendingStore.consume(state) : null;
+    if (!flow) {
+      res.status(400).send('<h1>This sign-in link expired or was already used.</h1><p>Go back to GetPod and click Connect again.</p>');
+      return;
+    }
+    if (providerError) {
+      res.status(400).send(`<h1>Sign-in failed: ${providerError}</h1>`);
+      return;
+    }
+    if (!code) {
+      res.status(400).send('<h1>Sign-in failed: no authorization code returned.</h1>');
+      return;
+    }
+
+    try {
+      const token = await exchangeCode({
+        metadata: flow.metadata,
+        clientId: flow.clientId,
+        redirectUri: flow.redirectUri,
+        code,
+        codeVerifier: flow.codeVerifier,
+      });
+      setSecret(customSecretKey(flow.connectorId, 'access_token'), token.access_token);
+      setSecret(clientIdSecretKey(flow.connectorId), flow.clientId);
+      if (token.refresh_token) setSecret(refreshTokenSecretKey(flow.connectorId), token.refresh_token);
+      setSecret(
+        expiresAtSecretKey(flow.connectorId),
+        String(Date.now() + (token.expires_in ?? 3600) * 1000),
+      );
+      res.send(successPage());
+    } catch (err) {
+      res.status(502).send(`<h1>Sign-in failed: ${(err as Error).message}</h1>`);
+    }
+  });
+
+  return router;
+}

--- a/src/api/oauth-connectors-router.ts
+++ b/src/api/oauth-connectors-router.ts
@@ -21,6 +21,22 @@ import {
 
 type AuthedRequest = Request & { apiKey: ApiKey };
 
+// This route is PUBLIC (see module doc comment) and some of what lands in its
+// plain-HTML fallback pages is not ours to trust: `error` is a raw query
+// param off an unauthenticated request, and a token-exchange failure message
+// can embed a token endpoint's own raw JSON response body (see mcp-oauth.ts's
+// tokenRequest()) — reachable via an admin-added custom connector whose
+// token endpoint is attacker-controlled. Escape before ever interpolating
+// into an `<h1>`.
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * Generic OAuth 2.1 + PKCE flow for "custom" connectors marked
  * `oauth: true` (see CustomConnectorEntry) — e.g. Firecrawl's
@@ -151,7 +167,7 @@ export function createOauthCallbackRouter(
       res.redirect(302, url.toString());
       return;
     }
-    res.status(status).send(`<h1>${message}</h1>`);
+    res.status(status).send(`<h1>${escapeHtml(message)}</h1>`);
   }
 
   router.get('/oauth/mcp/callback', async (req: Request, res: Response) => {

--- a/src/api/oauth-connectors-router.ts
+++ b/src/api/oauth-connectors-router.ts
@@ -51,9 +51,10 @@ function escapeHtml(s: string): string {
  * Generic OAuth 2.1 + PKCE flow for "custom" connectors marked
  * `oauth: true` (see CustomConnectorEntry) — e.g. Firecrawl's
  * `https://mcp.firecrawl.dev/v2/mcp-oauth`. This is the gateway-owned
- * counterpart to services/api's google_connector.go/github_connector.go: the
- * whole dance (discovery, DCR, PKCE, token exchange, refresh) happens here,
- * inside the user's own VM — services/api never sees the resulting token.
+ * counterpart to an external control plane's own OAuth handlers (used for
+ * managed connectors like Gmail/GitHub): the whole dance (discovery, DCR,
+ * PKCE, token exchange, refresh) happens here, inside the user's own VM —
+ * no external service ever sees the resulting token.
  *
  * Two routers, deliberately NOT combined into one:
  *   - createOauthConnectorsRouter(): admin-gated, mounted under /api like every
@@ -157,7 +158,7 @@ export function createOauthCallbackRouter(
 ): Router {
   const router = Router();
   // This gateway is a generic, product-agnostic fork — it has no business
-  // hardcoding a downstream product's own domain (e.g. app.getpod.ai).
+  // hardcoding a downstream product's own domain (e.g. app.example.com).
   // Whoever deploys it can opt into an auto-redirect by setting
   // gateway.oauthReturnUrl in config.json; absent that, the plain "close this
   // tab" message below is the safe default. Validated once, at router
@@ -204,7 +205,7 @@ export function createOauthCallbackRouter(
       fail(
         res,
         400,
-        'This sign-in link expired or was already used. Go back to GetPod and click Connect again.',
+        'This sign-in link expired or was already used. Go back and click Connect again.',
         'expired_link',
       );
       return;

--- a/src/api/oauth-connectors-router.ts
+++ b/src/api/oauth-connectors-router.ts
@@ -132,10 +132,26 @@ export function createOauthCallbackRouter(
     }
   }
 
-  function successPage(): string {
-    if (!validReturnUrl) return '<h1>Connected — you can close this tab.</h1>';
-    return `<!doctype html><html><head><meta http-equiv="refresh" content="2;url=${validReturnUrl}"></head>
-<body><h1>Connected!</h1><p>Redirecting you back… <a href="${validReturnUrl}">click here</a> if nothing happens.</p></body></html>`;
+  // No interstitial "Connected!" page + timed meta-refresh here on purpose —
+  // that just makes the user wait and watch a flash of gateway-branded HTML
+  // before landing back in the app. A real HTTP redirect goes straight to
+  // validReturnUrl with nothing to look at in between — on EVERY terminal
+  // outcome, not just success (a denied/expired/failed sign-in used to leave
+  // the user stranded on a bare, unbranded gateway page with no way back).
+  // The plain HTML pages below are only for the unconfigured (self-hosted,
+  // no oauthReturnUrl) case, where there's nowhere else to send the browser.
+  const CLOSE_TAB_PAGE = '<h1>Connected — you can close this tab.</h1>';
+
+  /** Terminal-failure response: redirect back with the reason as a query
+   *  param when the app knows where "back" is, else render it in place. */
+  function fail(res: Response, status: number, message: string, errorCode: string): void {
+    if (validReturnUrl) {
+      const url = new URL(validReturnUrl);
+      url.searchParams.set('connector_oauth_error', errorCode);
+      res.redirect(302, url.toString());
+      return;
+    }
+    res.status(status).send(`<h1>${message}</h1>`);
   }
 
   router.get('/oauth/mcp/callback', async (req: Request, res: Response) => {
@@ -145,15 +161,20 @@ export function createOauthCallbackRouter(
 
     const flow = state ? pendingStore.consume(state) : null;
     if (!flow) {
-      res.status(400).send('<h1>This sign-in link expired or was already used.</h1><p>Go back to GetPod and click Connect again.</p>');
+      fail(
+        res,
+        400,
+        'This sign-in link expired or was already used. Go back to GetPod and click Connect again.',
+        'expired_link',
+      );
       return;
     }
     if (providerError) {
-      res.status(400).send(`<h1>Sign-in failed: ${providerError}</h1>`);
+      fail(res, 400, `Sign-in failed: ${providerError}`, providerError);
       return;
     }
     if (!code) {
-      res.status(400).send('<h1>Sign-in failed: no authorization code returned.</h1>');
+      fail(res, 400, 'Sign-in failed: no authorization code returned.', 'missing_code');
       return;
     }
 
@@ -172,9 +193,13 @@ export function createOauthCallbackRouter(
         expiresAtSecretKey(flow.connectorId),
         String(Date.now() + (token.expires_in ?? 3600) * 1000),
       );
-      res.send(successPage());
+      if (validReturnUrl) {
+        res.redirect(302, validReturnUrl);
+        return;
+      }
+      res.send(CLOSE_TAB_PAGE);
     } catch (err) {
-      res.status(502).send(`<h1>Sign-in failed: ${(err as Error).message}</h1>`);
+      fail(res, 502, `Sign-in failed: ${(err as Error).message}`, 'exchange_failed');
     }
   });
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -705,6 +705,7 @@ export function createApiRouter(
         description: cfg.description,
         model: cfg.claude?.model ?? null,
         allow_tools: cfg.allow_tools ?? false,
+        connectors: cfg.connectors ?? {},
         avatarUrl: cfg.avatar ? `/api/v1/agents/${id}/avatar` : null,
         telegram_connected: !!cfg.telegram?.botToken,
         discord_connected: !!cfg.discord?.botToken,
@@ -1466,8 +1467,8 @@ export function createApiRouter(
       return;
     }
 
-    const body = req.body as { name?: unknown; description?: unknown; model?: unknown; allow_tools?: unknown; telegram_bot_token?: unknown; discord_bot_token?: unknown; line_channel_access_token?: unknown; line_channel_secret?: unknown; line_dm_policy?: unknown; line_dm_allowlist?: unknown; line_group_policy?: unknown; line_group_allowlist?: unknown; line_require_mention?: unknown; line_pairing?: unknown; slack_bot_token?: unknown; slack_signing_secret?: unknown; slack_dm_policy?: unknown; slack_dm_allowlist?: unknown; slack_group_policy?: unknown; slack_group_allowlist?: unknown; slack_require_mention?: unknown; slack_pairing?: unknown };
-    const { name, description, model, allow_tools, telegram_bot_token, discord_bot_token, line_channel_access_token, line_channel_secret, line_dm_policy, line_dm_allowlist, line_group_policy, line_group_allowlist, line_require_mention, line_pairing, slack_bot_token, slack_signing_secret, slack_dm_policy, slack_dm_allowlist, slack_group_policy, slack_group_allowlist, slack_require_mention, slack_pairing } = body;
+    const body = req.body as { name?: unknown; description?: unknown; model?: unknown; allow_tools?: unknown; telegram_bot_token?: unknown; discord_bot_token?: unknown; line_channel_access_token?: unknown; line_channel_secret?: unknown; line_dm_policy?: unknown; line_dm_allowlist?: unknown; line_group_policy?: unknown; line_group_allowlist?: unknown; line_require_mention?: unknown; line_pairing?: unknown; slack_bot_token?: unknown; slack_signing_secret?: unknown; slack_dm_policy?: unknown; slack_dm_allowlist?: unknown; slack_group_policy?: unknown; slack_group_allowlist?: unknown; slack_require_mention?: unknown; slack_pairing?: unknown; connectors?: unknown };
+    const { name, description, model, allow_tools, telegram_bot_token, discord_bot_token, line_channel_access_token, line_channel_secret, line_dm_policy, line_dm_allowlist, line_group_policy, line_group_allowlist, line_require_mention, line_pairing, slack_bot_token, slack_signing_secret, slack_dm_policy, slack_dm_allowlist, slack_group_policy, slack_group_allowlist, slack_require_mention, slack_pairing, connectors } = body;
     if (name !== undefined && name !== null && typeof name !== 'string') {
       res.status(400).json({ error: 'name must be a string or null' });
       return;
@@ -1621,6 +1622,23 @@ export function createApiRouter(
       slack_group_policy !== undefined || slack_group_allowlist !== undefined || slack_require_mention !== undefined ||
       slack_pairing !== undefined;
 
+    // connectors: a partial map of { [connectorId]: { enabled: boolean } } to merge.
+    const connectorPatch: Record<string, { enabled: boolean }> = {};
+    if (connectors !== undefined) {
+      if (typeof connectors !== 'object' || connectors === null || Array.isArray(connectors)) {
+        res.status(400).json({ error: 'connectors must be an object' });
+        return;
+      }
+      for (const [id, val] of Object.entries(connectors as Record<string, unknown>)) {
+        const enabled = (val as { enabled?: unknown })?.enabled;
+        if (typeof enabled !== 'boolean') {
+          res.status(400).json({ error: `connectors.${id}.enabled must be a boolean` });
+          return;
+        }
+        connectorPatch[id] = { enabled };
+      }
+    }
+
     try {
       await writeAgentsToConfig(configPath, (agents) => {
         const agent = (agents as Record<string, unknown>[]).find((a) => a.id === agentId);
@@ -1735,6 +1753,10 @@ export function createApiRouter(
               else existing.pairing = slack_pairing;
             }
           }
+        }
+        if (connectors !== undefined) {
+          const existing = (agent.connectors as Record<string, { enabled: boolean }>) ?? {};
+          agent.connectors = { ...existing, ...connectorPatch };
         }
       });
     } catch (err) {
@@ -1892,6 +1914,15 @@ export function createApiRouter(
         for (const id of slack_group_allowlist) clearPendingSender('slack', agentId, id);
       }
     }
+    if (connectors !== undefined) {
+      cfg.connectors = { ...(cfg.connectors ?? {}), ...connectorPatch };
+      // Enablement is read at spawn — respawn live sessions so they pick it up.
+      const runner = agentRunners.get(agentId);
+      if (runner) {
+        runner.updateAgentConfig(cfg);
+        await runner.restartOrDefer();
+      }
+    }
 
     res.json({
       agent: {
@@ -1900,6 +1931,7 @@ export function createApiRouter(
         description: cfg.description,
         model: cfg.claude?.model,
         allow_tools: cfg.allow_tools ?? false,
+        connectors: cfg.connectors ?? {},
         telegram_connected: !!cfg.telegram?.botToken,
         discord_connected: !!cfg.discord?.botToken,
         telegram_token_preview: cfg.telegram?.botToken ? maskToken(cfg.telegram.botToken) : null,

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -12,6 +12,12 @@ const HOT_RELOADABLE_AGENT_FIELDS: string[] = [
   'session.idleTimeoutMinutes',
   'session.maxConcurrent',
   'heartbeat.rateLimitMinutes',
+  // Per-agent connector enablement ({connectorId: {enabled}}) — only affects
+  // NEW session spawns (SessionProcess reads it fresh via AgentRunner's own
+  // live object reference, see index.ts's 'changes' handler); an
+  // already-running session's subprocess still needs an explicit restart
+  // (restartSessionsUsingConnector) to pick it up mid-conversation.
+  'connectors',
 ];
 
 // Gateway-level (non-agent) fields that can be hot-reloaded; agentId will be '' in ConfigChange
@@ -21,6 +27,10 @@ const HOT_RELOADABLE_GATEWAY_FIELDS: string[] = [
   // call — and turning the level up to chase a live problem is precisely when a
   // restart is unaffordable, since it kills the sessions being investigated.
   'gateway.logs',
+  // Same "new spawns only" caveat as 'connectors' above — customConnectors is
+  // where built-in oauth-managed AND user-pasted connector definitions both
+  // live (see connectors/types.ts's CustomConnectorEntry).
+  'gateway.customConnectors',
 ];
 
 export interface ConfigChange {
@@ -209,6 +219,7 @@ export class ConfigWatcher extends EventEmitter {
         { field: 'telegram.botToken', oldVal: oldAgent.telegram?.botToken, newVal: newAgent.telegram?.botToken },
         { field: 'discord.botToken', oldVal: oldAgent.discord?.botToken, newVal: newAgent.discord?.botToken },
         { field: 'description', oldVal: oldAgent.description, newVal: newAgent.description },
+        { field: 'connectors', oldVal: oldAgent.connectors, newVal: newAgent.connectors },
       ];
 
       for (const { field, oldVal, newVal } of fieldPairs) {
@@ -229,6 +240,7 @@ export class ConfigWatcher extends EventEmitter {
       { field: 'gateway.headless', oldVal: oldCfg.gateway.headless, newVal: newCfg.gateway.headless },
       { field: 'gateway.publicUrl', oldVal: oldCfg.gateway.publicUrl, newVal: newCfg.gateway.publicUrl },
       { field: 'gateway.logs', oldVal: oldCfg.gateway.logs, newVal: newCfg.gateway.logs },
+      { field: 'gateway.customConnectors', oldVal: oldCfg.gateway.customConnectors, newVal: newCfg.gateway.customConnectors },
     ];
     for (const { field, oldVal, newVal } of gatewayFieldPairs) {
       if (!deepEqual(oldVal, newVal)) {

--- a/src/connectors/catalog.ts
+++ b/src/connectors/catalog.ts
@@ -1,0 +1,49 @@
+/**
+ * Hardcoded connector catalog.
+ *
+ * The catalog is well-known server metadata (not user data), so it lives in code:
+ * it doubles as the security boundary (only vetted servers can be injected) and
+ * avoids a config-migration. Per-connector secrets live in mcp-token.env; per-agent
+ * enablement lives in AgentConfig.connectors.
+ *
+ * To add a connector whose auth kind is already supported (none / secret), just add
+ * an entry here — token-env, resolve, the router and the web panel are all generic.
+ */
+
+import type { ConnectorSpec } from './types';
+
+export const CONNECTOR_CATALOG: ConnectorSpec[] = [
+  {
+    id: 'github',
+    label: 'GitHub',
+    description: 'Repos, issues, and pull requests via the official GitHub MCP server.',
+    transport: 'http',
+    auth: { kind: 'secret', secretEnv: 'GITHUB_TOKEN' },
+    setup: {
+      // GitHub's classic-PAT page accepts scopes + description query params
+      // (fine-grained tokens do not); the GitHub MCP server works with a classic PAT.
+      tokenUrl:
+        'https://github.com/settings/tokens/new?scopes=repo,read:org&description=GetPod%20connector',
+      label: 'Create a GitHub token',
+      hint: 'Opens GitHub with repo + read:org scopes pre-filled. Generate it, then paste it here.',
+    },
+    build: (secret) => ({
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: { Authorization: `Bearer ${secret ?? ''}` },
+    }),
+    // Local docker stdio alternative (kept for reference; needs the cached image and
+    // does not work inside app-agent containers without docker-in-docker):
+    //   transport: 'stdio',
+    //   build: (secret) => ({
+    //     command: 'docker',
+    //     args: ['run', '-i', '--rm', '-e', 'GITHUB_PERSONAL_ACCESS_TOKEN',
+    //            'ghcr.io/github/github-mcp-server'],
+    //     env: { GITHUB_PERSONAL_ACCESS_TOKEN: secret ?? '' },
+    //   }),
+  },
+];
+
+export function getConnectorSpec(id: string): ConnectorSpec | undefined {
+  return CONNECTOR_CATALOG.find((c) => c.id === id);
+}

--- a/src/connectors/catalog.ts
+++ b/src/connectors/catalog.ts
@@ -19,6 +19,7 @@ export const CONNECTOR_CATALOG: ConnectorSpec[] = [
     description: 'Repos, issues, and pull requests via the official GitHub MCP server.',
     transport: 'http',
     auth: { kind: 'secret', secretEnv: 'GITHUB_TOKEN' },
+    repoUrl: 'https://github.com/github/github-mcp-server',
     setup: {
       // GitHub's classic-PAT page accepts scopes + description query params
       // (fine-grained tokens do not); the GitHub MCP server works with a classic PAT.
@@ -41,6 +42,82 @@ export const CONNECTOR_CATALOG: ConnectorSpec[] = [
     //            'ghcr.io/github/github-mcp-server'],
     //     env: { GITHUB_PERSONAL_ACCESS_TOKEN: secret ?? '' },
     //   }),
+  },
+  // ── Google connectors — real OAuth (authorization_code + refresh), but the
+  // whole client_secret-touching flow lives in getpod-ai's services/api, NOT
+  // here — this gateway only ever receives a short-lived access_token via
+  // POST /v1/connectors/:id/oauth/receive (connectors-router.ts). Reason: this
+  // gateway runs inside the user's own VM, reachable by that user's own
+  // shell/SSH — a client_secret shared across every user can't live here
+  // safely. See types.ts's 'oauth' auth kind doc comment.
+  //
+  // Both community servers below (io.github.domdomegg/{gmail,google-drive,
+  // google-cal}-mcp on the MCP registry) read the SAME env var name
+  // (GOOGLE_ACCESS_TOKEN) in their process, but each catalog entry stores its
+  // OWN secret under a distinct key (GMAIL_ACCESS_TOKEN / GDRIVE_ACCESS_TOKEN /
+  // GCAL_ACCESS_TOKEN) so connecting one doesn't silently mark the others
+  // "connected" too.
+  {
+    id: 'gmail',
+    label: 'Gmail',
+    description: 'Read, search, and send email via Gmail.',
+    transport: 'stdio',
+    auth: { kind: 'oauth', secretEnv: 'GMAIL_ACCESS_TOKEN' },
+    repoUrl: 'https://github.com/domdomegg/gmail-mcp',
+    build: (secret) => ({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'gmail-mcp'],
+      env: { GOOGLE_ACCESS_TOKEN: secret ?? '' },
+    }),
+  },
+  {
+    id: 'google-drive',
+    label: 'Google Drive',
+    description: 'List, search, and manage files in Google Drive.',
+    transport: 'stdio',
+    auth: { kind: 'oauth', secretEnv: 'GDRIVE_ACCESS_TOKEN' },
+    repoUrl: 'https://github.com/domdomegg/google-drive-mcp',
+    build: (secret) => ({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'google-drive-mcp'],
+      env: { GOOGLE_ACCESS_TOKEN: secret ?? '' },
+    }),
+  },
+  {
+    id: 'google-calendar',
+    label: 'Google Calendar',
+    description: 'List, create, and manage calendar events.',
+    transport: 'stdio',
+    auth: { kind: 'oauth', secretEnv: 'GCAL_ACCESS_TOKEN' },
+    repoUrl: 'https://github.com/domdomegg/google-cal-mcp',
+    build: (secret) => ({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'google-cal-mcp'],
+      env: { GOOGLE_ACCESS_TOKEN: secret ?? '' },
+    }),
+  },
+  // Microsoft 365 (Outlook/OneDrive/Teams) — the one registry entry
+  // (com.proscendia/microsoft-365) is a remote streamable-http server with NO
+  // static header/token: it does its own Microsoft OAuth at connect-time
+  // (server-side, once the MCP client opens the connection), so there is
+  // nothing for us to store — auth.kind 'none'. UNVERIFIED whether Claude
+  // Code's MCP client actually completes that handshake; enabling this for an
+  // agent is the live test.
+  {
+    id: 'microsoft-365',
+    label: 'Microsoft 365',
+    description: 'Outlook, OneDrive, and Teams via the user\'s own Microsoft account.',
+    transport: 'http',
+    auth: { kind: 'none' },
+    // No GitHub repo published by the vendor — link to their site instead.
+    repoUrl: 'https://proscendia.com',
+    build: () => ({
+      type: 'http',
+      url: 'https://microsoft-mcp.proscendia.com/mcp',
+    }),
   },
 ];
 

--- a/src/connectors/catalog.ts
+++ b/src/connectors/catalog.ts
@@ -18,16 +18,14 @@ export const CONNECTOR_CATALOG: ConnectorSpec[] = [
     label: 'GitHub',
     description: 'Repos, issues, and pull requests via the official GitHub MCP server.',
     transport: 'http',
-    auth: { kind: 'secret', secretEnv: 'GITHUB_TOKEN' },
+    // Real OAuth (authorization_code, no refresh — GitHub OAuth App user
+    // tokens don't expire unless the org opts into expiring tokens, which
+    // getpod's App doesn't) — same push-only shape as the Google connectors
+    // below: the client_secret lives in getpod-ai's services/api only, this
+    // gateway only ever receives the short-lived-in-name-only access_token
+    // via POST /v1/connectors/:id/oauth/receive. See types.ts's 'oauth' doc.
+    auth: { kind: 'oauth', secretEnv: 'GITHUB_TOKEN' },
     repoUrl: 'https://github.com/github/github-mcp-server',
-    setup: {
-      // GitHub's classic-PAT page accepts scopes + description query params
-      // (fine-grained tokens do not); the GitHub MCP server works with a classic PAT.
-      tokenUrl:
-        'https://github.com/settings/tokens/new?scopes=repo,read:org&description=GetPod%20connector',
-      label: 'Create a GitHub token',
-      hint: 'Opens GitHub with repo + read:org scopes pre-filled. Generate it, then paste it here.',
-    },
     build: (secret) => ({
       type: 'http',
       url: 'https://api.githubcopilot.com/mcp/',

--- a/src/connectors/catalog.ts
+++ b/src/connectors/catalog.ts
@@ -6,14 +6,13 @@
  * entry here and token-env, resolve, the router and the web panel are all
  * generic enough to pick it up with no other changes.
  *
- * GetPod's own offerings (github/gmail/google-drive/google-calendar) are
- * deliberately NOT here — they're pushed in as managed custom connectors by
- * services/api instead (see connectors-router.ts's POST /oauth/receive and
- * services/api's internal/vm/connector_push.go). Keeping GetPod's own product
- * decisions (which endpoint, which scopes) out of this file matters because
- * this repo is a fork meant to be PR'd back upstream — baking product opinion
- * into shared fork code would make every future endpoint/scope change touch a
- * file we also want to keep diff-minimal for that PR.
+ * Managed OAuth connectors (Google Workspace, GitHub, or anything else an
+ * external control plane owns the client_secret for) are deliberately NOT
+ * here — they're pushed in as managed custom connectors instead (see
+ * connectors-router.ts's POST /oauth/receive). Keeping that kind of
+ * product-specific decision (which endpoint, which scopes) out of this file
+ * keeps the built-in catalog generic, free of any one deployer's own product
+ * opinions.
  */
 
 import type { ConnectorSpec } from './types';

--- a/src/connectors/catalog.ts
+++ b/src/connectors/catalog.ts
@@ -1,123 +1,24 @@
 /**
  * Hardcoded connector catalog.
  *
- * The catalog is well-known server metadata (not user data), so it lives in code:
- * it doubles as the security boundary (only vetted servers can be injected) and
- * avoids a config-migration. Per-connector secrets live in mcp-token.env; per-agent
- * enablement lives in AgentConfig.connectors.
+ * Empty by default. This tier is for a deployer's OWN hand-reviewed, hardcoded
+ * connectors whose auth kind is already supported (none / secret) — add an
+ * entry here and token-env, resolve, the router and the web panel are all
+ * generic enough to pick it up with no other changes.
  *
- * To add a connector whose auth kind is already supported (none / secret), just add
- * an entry here — token-env, resolve, the router and the web panel are all generic.
+ * GetPod's own offerings (github/gmail/google-drive/google-calendar) are
+ * deliberately NOT here — they're pushed in as managed custom connectors by
+ * services/api instead (see connectors-router.ts's POST /oauth/receive and
+ * services/api's internal/vm/connector_push.go). Keeping GetPod's own product
+ * decisions (which endpoint, which scopes) out of this file matters because
+ * this repo is a fork meant to be PR'd back upstream — baking product opinion
+ * into shared fork code would make every future endpoint/scope change touch a
+ * file we also want to keep diff-minimal for that PR.
  */
 
 import type { ConnectorSpec } from './types';
 
-export const CONNECTOR_CATALOG: ConnectorSpec[] = [
-  {
-    id: 'github',
-    label: 'GitHub',
-    description: 'Repos, issues, and pull requests via the official GitHub MCP server.',
-    transport: 'http',
-    // Real OAuth (authorization_code, no refresh — GitHub OAuth App user
-    // tokens don't expire unless the org opts into expiring tokens, which
-    // getpod's App doesn't) — same push-only shape as the Google connectors
-    // below: the client_secret lives in getpod-ai's services/api only, this
-    // gateway only ever receives the short-lived-in-name-only access_token
-    // via POST /v1/connectors/:id/oauth/receive. See types.ts's 'oauth' doc.
-    auth: { kind: 'oauth', secretEnv: 'GITHUB_TOKEN' },
-    repoUrl: 'https://github.com/github/github-mcp-server',
-    build: (secret) => ({
-      type: 'http',
-      url: 'https://api.githubcopilot.com/mcp/',
-      headers: { Authorization: `Bearer ${secret ?? ''}` },
-    }),
-    // Local docker stdio alternative (kept for reference; needs the cached image and
-    // does not work inside app-agent containers without docker-in-docker):
-    //   transport: 'stdio',
-    //   build: (secret) => ({
-    //     command: 'docker',
-    //     args: ['run', '-i', '--rm', '-e', 'GITHUB_PERSONAL_ACCESS_TOKEN',
-    //            'ghcr.io/github/github-mcp-server'],
-    //     env: { GITHUB_PERSONAL_ACCESS_TOKEN: secret ?? '' },
-    //   }),
-  },
-  // ── Google connectors — real OAuth (authorization_code + refresh), but the
-  // whole client_secret-touching flow lives in getpod-ai's services/api, NOT
-  // here — this gateway only ever receives a short-lived access_token via
-  // POST /v1/connectors/:id/oauth/receive (connectors-router.ts). Reason: this
-  // gateway runs inside the user's own VM, reachable by that user's own
-  // shell/SSH — a client_secret shared across every user can't live here
-  // safely. See types.ts's 'oauth' auth kind doc comment.
-  //
-  // Both community servers below (io.github.domdomegg/{gmail,google-drive,
-  // google-cal}-mcp on the MCP registry) read the SAME env var name
-  // (GOOGLE_ACCESS_TOKEN) in their process, but each catalog entry stores its
-  // OWN secret under a distinct key (GMAIL_ACCESS_TOKEN / GDRIVE_ACCESS_TOKEN /
-  // GCAL_ACCESS_TOKEN) so connecting one doesn't silently mark the others
-  // "connected" too.
-  {
-    id: 'gmail',
-    label: 'Gmail',
-    description: 'Read, search, and send email via Gmail.',
-    transport: 'stdio',
-    auth: { kind: 'oauth', secretEnv: 'GMAIL_ACCESS_TOKEN' },
-    repoUrl: 'https://github.com/domdomegg/gmail-mcp',
-    build: (secret) => ({
-      type: 'stdio',
-      command: 'npx',
-      args: ['-y', 'gmail-mcp'],
-      env: { GOOGLE_ACCESS_TOKEN: secret ?? '' },
-    }),
-  },
-  {
-    id: 'google-drive',
-    label: 'Google Drive',
-    description: 'List, search, and manage files in Google Drive.',
-    transport: 'stdio',
-    auth: { kind: 'oauth', secretEnv: 'GDRIVE_ACCESS_TOKEN' },
-    repoUrl: 'https://github.com/domdomegg/google-drive-mcp',
-    build: (secret) => ({
-      type: 'stdio',
-      command: 'npx',
-      args: ['-y', 'google-drive-mcp'],
-      env: { GOOGLE_ACCESS_TOKEN: secret ?? '' },
-    }),
-  },
-  {
-    id: 'google-calendar',
-    label: 'Google Calendar',
-    description: 'List, create, and manage calendar events.',
-    transport: 'stdio',
-    auth: { kind: 'oauth', secretEnv: 'GCAL_ACCESS_TOKEN' },
-    repoUrl: 'https://github.com/domdomegg/google-cal-mcp',
-    build: (secret) => ({
-      type: 'stdio',
-      command: 'npx',
-      args: ['-y', 'google-cal-mcp'],
-      env: { GOOGLE_ACCESS_TOKEN: secret ?? '' },
-    }),
-  },
-  // Microsoft 365 (Outlook/OneDrive/Teams) — the one registry entry
-  // (com.proscendia/microsoft-365) is a remote streamable-http server with NO
-  // static header/token: it does its own Microsoft OAuth at connect-time
-  // (server-side, once the MCP client opens the connection), so there is
-  // nothing for us to store — auth.kind 'none'. UNVERIFIED whether Claude
-  // Code's MCP client actually completes that handshake; enabling this for an
-  // agent is the live test.
-  {
-    id: 'microsoft-365',
-    label: 'Microsoft 365',
-    description: 'Outlook, OneDrive, and Teams via the user\'s own Microsoft account.',
-    transport: 'http',
-    auth: { kind: 'none' },
-    // No GitHub repo published by the vendor — link to their site instead.
-    repoUrl: 'https://proscendia.com',
-    build: () => ({
-      type: 'http',
-      url: 'https://microsoft-mcp.proscendia.com/mcp',
-    }),
-  },
-];
+export const CONNECTOR_CATALOG: ConnectorSpec[] = [];
 
 export function getConnectorSpec(id: string): ConnectorSpec | undefined {
   return CONNECTOR_CATALOG.find((c) => c.id === id);

--- a/src/connectors/custom-connectors-store.ts
+++ b/src/connectors/custom-connectors-store.ts
@@ -1,0 +1,60 @@
+import * as fsp from 'fs/promises';
+import { randomUUID } from 'crypto';
+import type { CustomConnectorEntry } from '../types';
+
+/**
+ * Read-modify-write access to config.json's `gateway.customConnectors` subtree,
+ * extracted out of connectors-router.ts so a second router (oauth-connectors-router.ts)
+ * can share the exact same write lock instead of racing an independent one —
+ * two routers each holding their own `Promise`-chain lock over the same file
+ * would defeat the point of serializing writes at all.
+ *
+ * One instance is created per gateway process (see gateway-router.ts's
+ * constructor) and threaded into every router that touches customConnectors.
+ */
+export interface CustomConnectorsStore {
+  /** Serialised read-modify-write of the whole customConnectors map. */
+  mutate(fn: (connectors: Record<string, CustomConnectorEntry>) => void): Promise<void>;
+  /** Fresh read — mirrors token-env.ts's "no caching" stance. */
+  read(): Promise<Record<string, CustomConnectorEntry>>;
+}
+
+export function createCustomConnectorsStore(configPath?: string): CustomConnectorsStore {
+  let writeLock: Promise<void> = Promise.resolve();
+
+  async function mutate(
+    fn: (connectors: Record<string, CustomConnectorEntry>) => void,
+  ): Promise<void> {
+    if (!configPath) return; // no persistence target (e.g. tests) — secret store is authoritative
+    const run = writeLock.catch(() => {}).then(async () => {
+      const raw = await fsp.readFile(configPath, 'utf-8');
+      const config = JSON.parse(raw) as {
+        gateway?: { customConnectors?: Record<string, CustomConnectorEntry> };
+        [k: string]: unknown;
+      };
+      config.gateway = config.gateway ?? {};
+      config.gateway.customConnectors = config.gateway.customConnectors ?? {};
+      fn(config.gateway.customConnectors);
+      const tmp = `${configPath}.tmp.${randomUUID()}`;
+      await fsp.writeFile(tmp, JSON.stringify(config, null, 2), 'utf-8');
+      await fsp.rename(tmp, configPath);
+    });
+    writeLock = run.catch(() => {});
+    return run;
+  }
+
+  async function read(): Promise<Record<string, CustomConnectorEntry>> {
+    if (!configPath) return {};
+    try {
+      const raw = await fsp.readFile(configPath, 'utf-8');
+      const config = JSON.parse(raw) as {
+        gateway?: { customConnectors?: Record<string, CustomConnectorEntry> };
+      };
+      return config.gateway?.customConnectors ?? {};
+    } catch {
+      return {};
+    }
+  }
+
+  return { mutate, read };
+}

--- a/src/connectors/custom.ts
+++ b/src/connectors/custom.ts
@@ -1,0 +1,78 @@
+/**
+ * Custom (user-pasted) connector helpers — id generation, placeholder
+ * extraction, and secret substitution. Kept separate from catalog.ts (the
+ * code-reviewed, built-in tier) because these entries are admin-trusted data,
+ * not code — see CustomConnectorEntry's doc comment in connectors/types.ts.
+ */
+
+import { CONNECTOR_CATALOG } from './catalog';
+
+const PLACEHOLDER_RE = /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
+
+/** Lowercase, dash-separated id from a human label, e.g. "Google Calendar!" → "google-calendar". */
+function slugBase(label: string): string {
+  const slug = label
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'connector';
+}
+
+/**
+ * A slug not already used by a built-in catalog id or an existing custom id.
+ * Appends -2, -3, ... on collision (custom ids are user-facing, not secret,
+ * so a readable suffix beats a random one).
+ */
+export function slugify(label: string, existingCustomIds: Iterable<string>): string {
+  const taken = new Set<string>(CONNECTOR_CATALOG.map((c) => c.id));
+  for (const id of existingCustomIds) taken.add(id);
+
+  const base = slugBase(label);
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/** Recursively collect every unique {name} placeholder found in string values. */
+export function extractPlaceholders(config: unknown): string[] {
+  const found = new Set<string>();
+  const walk = (value: unknown): void => {
+    if (typeof value === 'string') {
+      for (const m of value.matchAll(PLACEHOLDER_RE)) found.add(m[1]);
+    } else if (Array.isArray(value)) {
+      value.forEach(walk);
+    } else if (value && typeof value === 'object') {
+      Object.values(value as Record<string, unknown>).forEach(walk);
+    }
+  };
+  walk(config);
+  return [...found];
+}
+
+/** Recursively replace every {name} in string values with secrets[name] (or '' if absent). */
+export function substitutePlaceholders(
+  config: Record<string, unknown>,
+  secrets: Record<string, string>,
+): Record<string, unknown> {
+  const walk = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+      return value.replace(PLACEHOLDER_RE, (_match, name: string) => secrets[name] ?? '');
+    }
+    if (Array.isArray(value)) return value.map(walk);
+    if (value && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, walk(v)]),
+      );
+    }
+    return value;
+  };
+  return walk(config) as Record<string, unknown>;
+}
+
+/** Namespaced mcp-token.env key so two custom connectors reusing {api_key} don't collide. */
+export function customSecretKey(id: string, name: string): string {
+  return `CUSTOM__${id}__${name}`;
+}

--- a/src/connectors/custom.ts
+++ b/src/connectors/custom.ts
@@ -23,6 +23,14 @@ function slugBase(label: string): string {
  * A slug not already used by a built-in catalog id or an existing custom id.
  * Appends -2, -3, ... on collision (custom ids are user-facing, not secret,
  * so a readable suffix beats a random one).
+ *
+ * Note: CONNECTOR_CATALOG is empty by default, so this no longer reserves
+ * ids like 'github'/'gmail' the way it did when they were built-in entries —
+ * those are now managed custom connectors pushed by services/api (see
+ * connectors-router.ts's /oauth/receive). A user-added custom connector could
+ * theoretically slug-collide with one of those ids. Accepted as a low-severity,
+ * self-recoverable edge case (both paths are admin-trusted anyway) rather than
+ * reserving a hardcoded list here — not fixed.
  */
 export function slugify(label: string, existingCustomIds: Iterable<string>): string {
   const taken = new Set<string>(CONNECTOR_CATALOG.map((c) => c.id));

--- a/src/connectors/custom.ts
+++ b/src/connectors/custom.ts
@@ -26,7 +26,7 @@ function slugBase(label: string): string {
  *
  * Note: CONNECTOR_CATALOG is empty by default, so this no longer reserves
  * ids like 'github'/'gmail' the way it did when they were built-in entries —
- * those are now managed custom connectors pushed by services/api (see
+ * those are now managed custom connectors pushed by an external control plane (see
  * connectors-router.ts's /oauth/receive). A user-added custom connector could
  * theoretically slug-collide with one of those ids. Accepted as a low-severity,
  * self-recoverable edge case (both paths are admin-trusted anyway) rather than

--- a/src/connectors/mcp-oauth.ts
+++ b/src/connectors/mcp-oauth.ts
@@ -146,7 +146,7 @@ export async function resolveClientId(
   redirectUri: string,
 ): Promise<string> {
   if (metadata.registrationEndpoint) {
-    return registerClient(metadata.registrationEndpoint, redirectUri, `GetPod (${connectorId})`);
+    return registerClient(metadata.registrationEndpoint, redirectUri, `claude-gateway (${connectorId})`);
   }
   const envKey = `MCP_OAUTH_CLIENT_ID__${connectorId.replace(/[^a-zA-Z0-9]+/g, '_').toUpperCase()}`;
   const staticClientId = process.env[envKey];

--- a/src/connectors/mcp-oauth.ts
+++ b/src/connectors/mcp-oauth.ts
@@ -1,0 +1,254 @@
+/**
+ * Generic OAuth 2.1 + PKCE (+ optional Dynamic Client Registration) support for
+ * "custom" MCP connectors whose only auth option is a real OAuth sign-in (no
+ * static API key) — e.g. Firecrawl's `https://mcp.firecrawl.dev/v2/mcp-oauth`.
+ *
+ * This module never touches Express or the pending-flow store — pure discovery
+ * + token functions, unit-testable with plain HTTP mocks. See
+ * `pending-oauth-store.ts` for the in-flight-flow state and
+ * `api/oauth-connectors-router.ts` for the HTTP endpoints that glue this
+ * together with `connectors/custom.ts`'s existing secret storage.
+ *
+ * Empirically verified against production Firecrawl (2026-09, this repo's own
+ * throwaway PoC — see git history / PR description, not reproduced here):
+ * DCR genuinely works with an arbitrary redirect_uri (no pre-registration
+ * needed), and the RFC 8707 `resource` parameter is REQUIRED on both the
+ * authorize request and the token exchange — omitting it yields a token that
+ * exchanges fine but is rejected by the MCP endpoint itself
+ * ("OAUTH_CONNECTION_INVALID"). Always pass `resource` through this module's
+ * functions; never make it optional.
+ */
+
+import crypto from 'crypto';
+
+export interface OAuthMetadata {
+  /** The MCP server URL this metadata was discovered for — also the RFC 8707 `resource`. */
+  resource: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  /** Absent when the AS doesn't advertise RFC 7591 Dynamic Client Registration. */
+  registrationEndpoint?: string;
+  scopesSupported: string[];
+}
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+  refresh_token?: string;
+  scope?: string;
+}
+
+/** Parse `resource_metadata="<url>"` out of a WWW-Authenticate header value. */
+function parseResourceMetadataUrl(header: string | null): string | null {
+  if (!header) return null;
+  const m = header.match(/resource_metadata="([^"]+)"/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Discover OAuth metadata for an MCP server by probing it unauthenticated
+ * (expects a 401 advertising `resource_metadata`, per RFC 9728), then walking
+ * protected-resource metadata → authorization-server metadata (RFC 8414).
+ * Throws a descriptive error at whichever step fails — callers surface it
+ * to the admin as "can't set up OAuth for this URL", not a generic 500.
+ */
+export async function discoverOAuthMetadata(mcpUrl: string): Promise<OAuthMetadata> {
+  const probe = await fetch(mcpUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+  });
+  if (probe.status !== 401) {
+    throw new Error(
+      `Expected a 401 challenge from ${mcpUrl} (got ${probe.status}) — this server may not require OAuth, or isn't an MCP server at all.`,
+    );
+  }
+  const resourceMetadataUrl = parseResourceMetadataUrl(probe.headers.get('www-authenticate'));
+  if (!resourceMetadataUrl) {
+    throw new Error(
+      `${mcpUrl} returned 401 but no "resource_metadata" in its WWW-Authenticate header — can't discover its OAuth server.`,
+    );
+  }
+
+  const prm = await fetch(resourceMetadataUrl).then((r) => {
+    if (!r.ok) throw new Error(`Protected-resource metadata fetch failed: ${r.status}`);
+    return r.json() as Promise<Record<string, unknown>>;
+  });
+  const authServers: unknown = prm.authorization_servers;
+  if (!Array.isArray(authServers) || typeof authServers[0] !== 'string') {
+    throw new Error(`${resourceMetadataUrl} has no authorization_servers listed.`);
+  }
+  const issuer = new URL(authServers[0]);
+
+  // RFC 8414 §3.1: well-known path is inserted before the issuer's own path
+  // component (usually empty, as it is for Firecrawl).
+  const asMetaUrl = new URL(
+    `/.well-known/oauth-authorization-server${issuer.pathname === '/' ? '' : issuer.pathname}`,
+    issuer.origin,
+  );
+  const asMeta = await fetch(asMetaUrl.toString()).then((r) => {
+    if (!r.ok) throw new Error(`Authorization-server metadata fetch failed: ${r.status}`);
+    return r.json() as Promise<Record<string, unknown>>;
+  });
+
+  if (typeof asMeta.authorization_endpoint !== 'string' || typeof asMeta.token_endpoint !== 'string') {
+    throw new Error(`${asMetaUrl} is missing authorization_endpoint/token_endpoint.`);
+  }
+
+  return {
+    resource: mcpUrl,
+    authorizationEndpoint: asMeta.authorization_endpoint,
+    tokenEndpoint: asMeta.token_endpoint,
+    registrationEndpoint:
+      typeof asMeta.registration_endpoint === 'string' ? asMeta.registration_endpoint : undefined,
+    scopesSupported: Array.isArray(asMeta.scopes_supported) ? asMeta.scopes_supported : [],
+  };
+}
+
+/**
+ * Register a public (no client_secret) client via RFC 7591 DCR. Throws if the
+ * server rejects it — callers fall back to a per-connector static client_id
+ * (an env var an admin configured by hand) when this isn't available at all,
+ * see `resolveClientId` below.
+ */
+export async function registerClient(
+  registrationEndpoint: string,
+  redirectUri: string,
+  clientName: string,
+): Promise<string> {
+  const resp = await fetch(registrationEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      redirect_uris: [redirectUri],
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      client_name: clientName,
+    }),
+  });
+  const body = (await resp.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!resp.ok || typeof body.client_id !== 'string') {
+    throw new Error(`Dynamic client registration failed (${resp.status}): ${JSON.stringify(body)}`);
+  }
+  return body.client_id;
+}
+
+/**
+ * Resolve a client_id for `metadata`: try DCR first, fall back to a static
+ * `MCP_OAUTH_CLIENT_ID__<connectorId>` env var (an admin-configured client_id
+ * for a provider that advertises no registration_endpoint at all).
+ */
+export async function resolveClientId(
+  metadata: OAuthMetadata,
+  connectorId: string,
+  redirectUri: string,
+): Promise<string> {
+  if (metadata.registrationEndpoint) {
+    return registerClient(metadata.registrationEndpoint, redirectUri, `GetPod (${connectorId})`);
+  }
+  const envKey = `MCP_OAUTH_CLIENT_ID__${connectorId.replace(/[^a-zA-Z0-9]+/g, '_').toUpperCase()}`;
+  const staticClientId = process.env[envKey];
+  if (!staticClientId) {
+    throw new Error(
+      `${metadata.authorizationEndpoint}'s server advertises no Dynamic Client Registration, and no ${envKey} env var is set as a fallback.`,
+    );
+  }
+  return staticClientId;
+}
+
+export interface PkcePair {
+  codeVerifier: string;
+  codeChallenge: string;
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function generatePkce(): PkcePair {
+  const codeVerifier = base64url(crypto.randomBytes(32));
+  const codeChallenge = base64url(crypto.createHash('sha256').update(codeVerifier).digest());
+  return { codeVerifier, codeChallenge };
+}
+
+export function generateState(): string {
+  return base64url(crypto.randomBytes(16));
+}
+
+export function buildAuthorizeUrl(opts: {
+  metadata: OAuthMetadata;
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  codeChallenge: string;
+  state: string;
+}): string {
+  const url = new URL(opts.metadata.authorizationEndpoint);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', opts.clientId);
+  url.searchParams.set('redirect_uri', opts.redirectUri);
+  url.searchParams.set('scope', opts.scope);
+  url.searchParams.set('code_challenge', opts.codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', opts.state);
+  // Required — see this file's module doc comment. Never omit.
+  url.searchParams.set('resource', opts.metadata.resource);
+  return url.toString();
+}
+
+async function tokenRequest(tokenEndpoint: string, body: URLSearchParams): Promise<TokenResponse> {
+  const resp = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  const parsed = (await resp.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!resp.ok || typeof parsed.access_token !== 'string') {
+    throw new Error(`Token request failed (${resp.status}): ${JSON.stringify(parsed)}`);
+  }
+  return {
+    access_token: parsed.access_token,
+    token_type: typeof parsed.token_type === 'string' ? parsed.token_type : 'bearer',
+    expires_in: typeof parsed.expires_in === 'number' ? parsed.expires_in : undefined,
+    refresh_token: typeof parsed.refresh_token === 'string' ? parsed.refresh_token : undefined,
+    scope: typeof parsed.scope === 'string' ? parsed.scope : undefined,
+  };
+}
+
+export function exchangeCode(opts: {
+  metadata: OAuthMetadata;
+  clientId: string;
+  redirectUri: string;
+  code: string;
+  codeVerifier: string;
+}): Promise<TokenResponse> {
+  return tokenRequest(
+    opts.metadata.tokenEndpoint,
+    new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: opts.code,
+      redirect_uri: opts.redirectUri,
+      client_id: opts.clientId,
+      code_verifier: opts.codeVerifier,
+      resource: opts.metadata.resource, // required — see module doc comment
+    }),
+  );
+}
+
+export function refreshAccessToken(opts: {
+  metadata: OAuthMetadata;
+  clientId: string;
+  refreshToken: string;
+}): Promise<TokenResponse> {
+  return tokenRequest(
+    opts.metadata.tokenEndpoint,
+    new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: opts.refreshToken,
+      client_id: opts.clientId,
+      resource: opts.metadata.resource, // required — see module doc comment
+    }),
+  );
+}

--- a/src/connectors/oauth-refresh-sweep.ts
+++ b/src/connectors/oauth-refresh-sweep.ts
@@ -5,22 +5,34 @@
  * refreshExpiringGoogleConnectors). Runs on the same 60s interval as
  * cliPairingStore.prune() (see gateway-router.ts) via refreshExpiringOAuthConnectors().
  *
- * Storage note: refresh_token, the client_id used to obtain it, and the
- * access_token's expiry timestamp are stored via the existing
- * customSecretKey()-namespaced mcp-token.env mechanism under synthetic,
+ * Storage note: refresh_token, the client_id used to obtain it, the access_token's
+ * expiry timestamp, and this sweep's own failure bookkeeping are stored via the
+ * existing customSecretKey()-namespaced mcp-token.env mechanism under synthetic,
  * double-underscore-prefixed names (`__refresh_token`, `__client_id`,
- * `__token_expires_at`) — never a real {placeholder} from the pasted config,
- * so extractPlaceholders() at add-time never picks them up as user-facing
- * secrets. Reusing this storage (rather than a new file) keeps exactly one
- * place that holds connector secrets.
+ * `__token_expires_at`, `__refresh_fail_count`, `__refresh_backoff_until`,
+ * `__token_generation`) — never a real {placeholder} from the pasted config, so
+ * extractPlaceholders() at add-time never picks them up as user-facing secrets.
+ * Reusing this storage (rather than a new file) keeps exactly one place that holds
+ * connector secrets.
  */
 
+import type { AgentRunner } from '../agent/runner';
 import type { CustomConnectorsStore } from './custom-connectors-store';
 import { customSecretKey } from './custom';
-import { getSecret, setSecret } from './token-env';
+import { getSecret, setSecret, deleteSecret } from './token-env';
 import { discoverOAuthMetadata, refreshAccessToken } from './mcp-oauth';
 
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
+// After a failed refresh, wait this long before trying that connector again —
+// without this a permanently-broken refresh_token (network blip is fine and
+// self-heals next tick, but a revoked/expired one never will) gets hammered
+// every single 60s tick forever.
+const REFRESH_BACKOFF_MS = 5 * 60 * 1000;
+// Consecutive failures before giving up on a connector entirely: clear its
+// tokens so `hasSecret`-based status flips to "not connected" (a real signal
+// the user can act on) instead of an indefinitely-retrying green checkmark
+// backed by a token that will never refresh again.
+const MAX_CONSECUTIVE_FAILURES = 3;
 
 export function refreshTokenSecretKey(id: string): string {
   return customSecretKey(id, '__refresh_token');
@@ -31,18 +43,42 @@ export function clientIdSecretKey(id: string): string {
 export function expiresAtSecretKey(id: string): string {
   return customSecretKey(id, '__token_expires_at');
 }
+export function refreshFailCountSecretKey(id: string): string {
+  return customSecretKey(id, '__refresh_fail_count');
+}
+export function refreshBackoffUntilSecretKey(id: string): string {
+  return customSecretKey(id, '__refresh_backoff_until');
+}
+/** Bumped on every write of a connector's access_token — by the OAuth callback
+ *  on a fresh sign-in AND by this sweep on a successful refresh. Read back
+ *  before this sweep commits its own refreshed token so a fresh manual
+ *  reconnect that lands mid-refresh always wins instead of being silently
+ *  clobbered by a slower, now-stale refresh attempt (see tokenGenerationKey's
+ *  use below). */
+export function tokenGenerationSecretKey(id: string): string {
+  return customSecretKey(id, '__token_generation');
+}
 
 /**
  * Scan every oauth:true custom connector; refresh any whose access_token is
  * within REFRESH_SKEW_MS of its recorded expiry. Best-effort per connector —
  * one failure (network blip, revoked refresh_token) is logged and skipped,
  * never throws out of the sweep so one broken connector can't stop the rest
- * from refreshing.
+ * from refreshing. `agents` (optional, all live AgentRunners) lets a
+ * successful refresh restart sessions already using the connector, the same
+ * way POST /oauth/receive does for managed connectors — a live session's MCP
+ * subprocess has the OLD token baked into its env and can't be hot-patched.
  */
-export async function refreshExpiringOAuthConnectors(store: CustomConnectorsStore): Promise<void> {
+export async function refreshExpiringOAuthConnectors(
+  store: CustomConnectorsStore,
+  agents?: Map<string, AgentRunner>,
+): Promise<void> {
   const connectors = await store.read();
   for (const [id, entry] of Object.entries(connectors)) {
     if (!entry.oauth) continue;
+
+    const backoffUntilRaw = getSecret(refreshBackoffUntilSecretKey(id));
+    if (backoffUntilRaw && Number(backoffUntilRaw) > Date.now()) continue; // recent failure — still backing off
 
     const expiresAtRaw = getSecret(expiresAtSecretKey(id));
     const expiresAt = expiresAtRaw ? Number(expiresAtRaw) : null;
@@ -51,19 +87,57 @@ export async function refreshExpiringOAuthConnectors(store: CustomConnectorsStor
     const refreshToken = getSecret(refreshTokenSecretKey(id));
     const clientId = getSecret(clientIdSecretKey(id));
     const mcpUrl = typeof entry.config.url === 'string' ? entry.config.url : null;
-    if (!refreshToken || !clientId || !mcpUrl) continue; // nothing to refresh with
+    if (!refreshToken || !clientId || !mcpUrl) continue; // nothing to refresh with (e.g. disconnected)
+
+    // Captured before the two network round-trips below so a concurrent
+    // manual reconnect (a fresh /oauth/mcp/callback exchange for this same
+    // connector, racing this refresh) can be detected before this sweep
+    // commits a write derived from what may now be a stale refresh_token.
+    const generationBefore = getSecret(tokenGenerationSecretKey(id));
 
     try {
       const metadata = await discoverOAuthMetadata(mcpUrl);
       const token = await refreshAccessToken({ metadata, clientId, refreshToken });
+
+      if (getSecret(tokenGenerationSecretKey(id)) !== generationBefore) {
+        // Someone else (a manual reconnect) wrote a newer token while this
+        // refresh was in flight — that write is strictly fresher than
+        // whatever this call would produce, so abandon ours rather than
+        // clobber it. Not a failure: don't touch the backoff/fail-count.
+        continue;
+      }
+
       setSecret(customSecretKey(id, 'access_token'), token.access_token);
       if (token.refresh_token) setSecret(refreshTokenSecretKey(id), token.refresh_token);
-      setSecret(
-        expiresAtSecretKey(id),
-        String(Date.now() + (token.expires_in ?? 3600) * 1000),
-      );
+      setSecret(expiresAtSecretKey(id), String(Date.now() + (token.expires_in ?? 3600) * 1000));
+      setSecret(tokenGenerationSecretKey(id), String(Date.now()));
+      deleteSecret(refreshFailCountSecretKey(id));
+      deleteSecret(refreshBackoffUntilSecretKey(id));
+
+      if (agents) {
+        await Promise.all(
+          [...agents.values()].map((runner) => runner.restartSessionsUsingConnector(id)),
+        );
+      }
     } catch (err) {
       console.error(`oauth-refresh-sweep: connector=${id} refresh failed: ${(err as Error).message}`);
+      const failCount = Number(getSecret(refreshFailCountSecretKey(id)) ?? '0') + 1;
+      if (failCount >= MAX_CONSECUTIVE_FAILURES) {
+        // Give up — a refresh_token that fails this many times in a row is
+        // not coming back on its own (revoked, or the provider rotated it
+        // out from under us). Clear everything so status correctly reports
+        // "not connected" instead of a stale green checkmark, and so this
+        // loop stops calling a dead token endpoint on every future tick.
+        deleteSecret(customSecretKey(id, 'access_token'));
+        deleteSecret(refreshTokenSecretKey(id));
+        deleteSecret(clientIdSecretKey(id));
+        deleteSecret(expiresAtSecretKey(id));
+        deleteSecret(refreshFailCountSecretKey(id));
+        deleteSecret(refreshBackoffUntilSecretKey(id));
+      } else {
+        setSecret(refreshFailCountSecretKey(id), String(failCount));
+        setSecret(refreshBackoffUntilSecretKey(id), String(Date.now() + REFRESH_BACKOFF_MS));
+      }
     }
   }
 }

--- a/src/connectors/oauth-refresh-sweep.ts
+++ b/src/connectors/oauth-refresh-sweep.ts
@@ -1,9 +1,9 @@
 /**
  * Periodic refresh for OAuth-flavored custom connectors (CustomConnectorEntry.oauth
- * === true) — the gateway-side analog of services/api's
- * google_connector_subscription.go (StartGoogleConnectorRefreshSweep /
- * refreshExpiringGoogleConnectors). Runs on the same 60s interval as
- * cliPairingStore.prune() (see gateway-router.ts) via refreshExpiringOAuthConnectors().
+ * === true) — the gateway-side counterpart to whatever refresh loop an external
+ * control plane runs for its own managed connectors. Runs on the same 60s
+ * interval as cliPairingStore.prune() (see gateway-router.ts) via
+ * refreshExpiringOAuthConnectors().
  *
  * Storage note: refresh_token, the client_id used to obtain it, the access_token's
  * expiry timestamp, and this sweep's own failure bookkeeping are stored via the

--- a/src/connectors/oauth-refresh-sweep.ts
+++ b/src/connectors/oauth-refresh-sweep.ts
@@ -1,0 +1,69 @@
+/**
+ * Periodic refresh for OAuth-flavored custom connectors (CustomConnectorEntry.oauth
+ * === true) — the gateway-side analog of services/api's
+ * google_connector_subscription.go (StartGoogleConnectorRefreshSweep /
+ * refreshExpiringGoogleConnectors). Runs on the same 60s interval as
+ * cliPairingStore.prune() (see gateway-router.ts) via refreshExpiringOAuthConnectors().
+ *
+ * Storage note: refresh_token, the client_id used to obtain it, and the
+ * access_token's expiry timestamp are stored via the existing
+ * customSecretKey()-namespaced mcp-token.env mechanism under synthetic,
+ * double-underscore-prefixed names (`__refresh_token`, `__client_id`,
+ * `__token_expires_at`) — never a real {placeholder} from the pasted config,
+ * so extractPlaceholders() at add-time never picks them up as user-facing
+ * secrets. Reusing this storage (rather than a new file) keeps exactly one
+ * place that holds connector secrets.
+ */
+
+import type { CustomConnectorsStore } from './custom-connectors-store';
+import { customSecretKey } from './custom';
+import { getSecret, setSecret } from './token-env';
+import { discoverOAuthMetadata, refreshAccessToken } from './mcp-oauth';
+
+const REFRESH_SKEW_MS = 5 * 60 * 1000;
+
+export function refreshTokenSecretKey(id: string): string {
+  return customSecretKey(id, '__refresh_token');
+}
+export function clientIdSecretKey(id: string): string {
+  return customSecretKey(id, '__client_id');
+}
+export function expiresAtSecretKey(id: string): string {
+  return customSecretKey(id, '__token_expires_at');
+}
+
+/**
+ * Scan every oauth:true custom connector; refresh any whose access_token is
+ * within REFRESH_SKEW_MS of its recorded expiry. Best-effort per connector —
+ * one failure (network blip, revoked refresh_token) is logged and skipped,
+ * never throws out of the sweep so one broken connector can't stop the rest
+ * from refreshing.
+ */
+export async function refreshExpiringOAuthConnectors(store: CustomConnectorsStore): Promise<void> {
+  const connectors = await store.read();
+  for (const [id, entry] of Object.entries(connectors)) {
+    if (!entry.oauth) continue;
+
+    const expiresAtRaw = getSecret(expiresAtSecretKey(id));
+    const expiresAt = expiresAtRaw ? Number(expiresAtRaw) : null;
+    if (expiresAt && expiresAt - Date.now() >= REFRESH_SKEW_MS) continue; // not due yet
+
+    const refreshToken = getSecret(refreshTokenSecretKey(id));
+    const clientId = getSecret(clientIdSecretKey(id));
+    const mcpUrl = typeof entry.config.url === 'string' ? entry.config.url : null;
+    if (!refreshToken || !clientId || !mcpUrl) continue; // nothing to refresh with
+
+    try {
+      const metadata = await discoverOAuthMetadata(mcpUrl);
+      const token = await refreshAccessToken({ metadata, clientId, refreshToken });
+      setSecret(customSecretKey(id, 'access_token'), token.access_token);
+      if (token.refresh_token) setSecret(refreshTokenSecretKey(id), token.refresh_token);
+      setSecret(
+        expiresAtSecretKey(id),
+        String(Date.now() + (token.expires_in ?? 3600) * 1000),
+      );
+    } catch (err) {
+      console.error(`oauth-refresh-sweep: connector=${id} refresh failed: ${(err as Error).message}`);
+    }
+  }
+}

--- a/src/connectors/pending-oauth-store.ts
+++ b/src/connectors/pending-oauth-store.ts
@@ -1,0 +1,66 @@
+import crypto from 'crypto';
+import type { OAuthMetadata } from './mcp-oauth';
+
+/**
+ * In-memory bridge between a `POST .../oauth/start` call and the later
+ * `GET /oauth/mcp/callback` the provider redirects the user's browser to.
+ * Modeled directly on `cli-viewer/pairing-store.ts`'s `CliPairingStore`: a
+ * `Map` keyed by a random, single-use, TTL'd id (the OAuth `state` value
+ * here), pruned on the same interval as that store.
+ *
+ * Deliberately NOT persisted to disk — a flow is only ever a few minutes
+ * from start to callback; a gateway restart mid-flow just means the user
+ * clicks "Connect" again.
+ */
+export interface PendingOAuth {
+  connectorId: string;
+  metadata: OAuthMetadata;
+  clientId: string;
+  redirectUri: string;
+  codeVerifier: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+const FLOW_TTL_MS = 5 * 60 * 1000;
+
+export class PendingOAuthStore {
+  private readonly flows = new Map<string, PendingOAuth>();
+
+  /** Start a flow, returning the `state` value to embed in the authorize URL. */
+  create(entry: Omit<PendingOAuth, 'createdAt' | 'expiresAt'>): string {
+    const state = crypto.randomBytes(16).toString('base64url');
+    const now = Date.now();
+    this.flows.set(state, { ...entry, createdAt: now, expiresAt: now + FLOW_TTL_MS });
+    return state;
+  }
+
+  /**
+   * Consume (single-use) the flow for `state`. Returns null if unknown,
+   * expired, or already consumed — the callback handler treats all three the
+   * same way (a generic "this sign-in link expired, try again" response).
+   */
+  consume(state: string): PendingOAuth | null {
+    const flow = this.flows.get(state);
+    if (!flow) return null;
+    this.flows.delete(state);
+    if (flow.expiresAt <= Date.now()) return null;
+    return flow;
+  }
+
+  /** Drop expired flows. Call on the same interval as `cliPairingStore.prune()`. */
+  prune(): void {
+    const now = Date.now();
+    for (const [state, flow] of this.flows) {
+      if (flow.expiresAt <= now) this.flows.delete(state);
+    }
+  }
+
+  /** Test/introspection helper. */
+  size(): number {
+    return this.flows.size;
+  }
+}
+
+/** Process-wide singleton — mirrors `cliPairingStore`'s shape. */
+export const pendingOAuthStore = new PendingOAuthStore();

--- a/src/connectors/resolve.ts
+++ b/src/connectors/resolve.ts
@@ -1,0 +1,59 @@
+/**
+ * Connector resolution — the single source of truth shared by the session spawner
+ * and the HTTP API.
+ *
+ * resolveEnabledConnectors(): for the injection point in SessionProcess.writeMcpConfig.
+ * listConnectorStatus(): for GET /v1/connectors.
+ */
+
+import type { AgentConfig } from '../types';
+import { CONNECTOR_CATALOG } from './catalog';
+import { secretEnvOf, type ConnectorStatus } from './types';
+import { readTokenEnv } from './token-env';
+
+/**
+ * Build the mcpServers entries for every connector that is (a) in the catalog,
+ * (b) enabled for this agent, and (c) connected (secret present, or auth kind 'none').
+ * Returns a map keyed by connector id, ready to merge into mcp-config.json.
+ */
+export function resolveEnabledConnectors(
+  agentConfig: Pick<AgentConfig, 'connectors'>,
+): Record<string, unknown> {
+  const enabled = agentConfig.connectors ?? {};
+  const tokenEnv = readTokenEnv();
+  const out: Record<string, unknown> = {};
+
+  for (const spec of CONNECTOR_CATALOG) {
+    if (!enabled[spec.id]?.enabled) continue;
+
+    const envName = secretEnvOf(spec);
+    if (envName === null) {
+      // No-auth connector — always injectable when enabled.
+      out[spec.id] = spec.build(null);
+      continue;
+    }
+
+    const secret = tokenEnv[envName];
+    if (!secret) continue; // enabled but not connected — skip
+    out[spec.id] = spec.build(secret);
+  }
+
+  return out;
+}
+
+/** Catalog + connected state for the API. `connected` reflects secret presence. */
+export function listConnectorStatus(): ConnectorStatus[] {
+  const tokenEnv = readTokenEnv();
+  return CONNECTOR_CATALOG.map((spec) => {
+    const envName = secretEnvOf(spec);
+    const connected = envName === null ? true : !!tokenEnv[envName];
+    return {
+      id: spec.id,
+      label: spec.label,
+      description: spec.description,
+      authKind: spec.auth.kind,
+      connected,
+      setup: spec.setup,
+    };
+  });
+}

--- a/src/connectors/resolve.ts
+++ b/src/connectors/resolve.ts
@@ -97,7 +97,7 @@ export function listConnectorStatus(
       id,
       label: entry.label,
       description: entry.description,
-      authKind: entry.authKind ?? (entry.secretNames.length > 0 ? 'secret' : 'none'),
+      authKind: entry.authKind ?? (entry.oauth ? 'oauth' : entry.secretNames.length > 0 ? 'secret' : 'none'),
       connected,
       // A services/api-managed entry (github/gmail/google-drive/google-calendar)
       // reports as 'built-in' so the web panel doesn't show the "Custom" badge

--- a/src/connectors/resolve.ts
+++ b/src/connectors/resolve.ts
@@ -97,10 +97,14 @@ export function listConnectorStatus(
       id,
       label: entry.label,
       description: entry.description,
-      authKind: entry.secretNames.length > 0 ? 'secret' : 'none',
+      authKind: entry.authKind ?? (entry.secretNames.length > 0 ? 'secret' : 'none'),
       connected,
-      source: 'custom',
+      // A services/api-managed entry (github/gmail/google-drive/google-calendar)
+      // reports as 'built-in' so the web panel doesn't show the "Custom" badge
+      // on something GetPod implemented, not something the user pasted.
+      source: entry.managed ? 'built-in' : 'custom',
       repoUrl: entry.sourceUrl,
+      oauth: entry.oauth,
     };
   });
 

--- a/src/connectors/resolve.ts
+++ b/src/connectors/resolve.ts
@@ -113,9 +113,10 @@ export function listConnectorStatus(
       description: entry.description,
       authKind: entry.authKind ?? (entry.oauth ? 'oauth' : entry.secretNames.length > 0 ? 'secret' : 'none'),
       connected,
-      // A services/api-managed entry (github/gmail/google-drive/google-calendar)
-      // reports as 'built-in' so the web panel doesn't show the "Custom" badge
-      // on something GetPod implemented, not something the user pasted.
+      // An externally-managed entry (github/gmail/google-drive/google-calendar,
+      // say) reports as 'built-in' so the web panel doesn't show the "Custom"
+      // badge on something the deployer's own control plane pushed in, not
+      // something the user pasted.
       source: entry.managed ? 'built-in' : 'custom',
       repoUrl: entry.sourceUrl,
       oauth: entry.oauth,

--- a/src/connectors/resolve.ts
+++ b/src/connectors/resolve.ts
@@ -6,25 +6,35 @@
  * listConnectorStatus(): for GET /v1/connectors.
  */
 
-import type { AgentConfig } from '../types';
+import type { AgentConfig, CustomConnectorEntry } from '../types';
 import { CONNECTOR_CATALOG } from './catalog';
 import { secretEnvOf, type ConnectorStatus } from './types';
 import { readTokenEnv } from './token-env';
+import { customSecretKey, substitutePlaceholders } from './custom';
 
 /**
- * Build the mcpServers entries for every connector that is (a) in the catalog,
- * (b) enabled for this agent, and (c) connected (secret present, or auth kind 'none').
+ * Build the mcpServers entries for every connector that is (a) in the catalog
+ * (built-in) or customConnectors (user-pasted), (b) enabled for this agent, and
+ * (c) connected (all required secrets present, or auth kind 'none'/no placeholders).
  * Returns a map keyed by connector id, ready to merge into mcp-config.json.
+ *
+ * Enablement is opt-OUT, not opt-in: a globally-connected connector is
+ * available to every agent by default the moment it's connected — an agent
+ * only misses it if explicitly disabled (`{enabled: false}`). This matches
+ * how the built-in catalog already works as a security boundary (only
+ * *connecting* a connector at all is the gate); per-agent is a refinement,
+ * not a second required step.
  */
 export function resolveEnabledConnectors(
   agentConfig: Pick<AgentConfig, 'connectors'>,
+  customConnectors: Record<string, CustomConnectorEntry> = {},
 ): Record<string, unknown> {
   const enabled = agentConfig.connectors ?? {};
   const tokenEnv = readTokenEnv();
   const out: Record<string, unknown> = {};
 
   for (const spec of CONNECTOR_CATALOG) {
-    if (!enabled[spec.id]?.enabled) continue;
+    if (enabled[spec.id]?.enabled === false) continue; // explicitly opted out
 
     const envName = secretEnvOf(spec);
     if (envName === null) {
@@ -34,17 +44,37 @@ export function resolveEnabledConnectors(
     }
 
     const secret = tokenEnv[envName];
-    if (!secret) continue; // enabled but not connected — skip
+    if (!secret) continue; // not connected — skip regardless of enablement
     out[spec.id] = spec.build(secret);
+  }
+
+  for (const [id, entry] of Object.entries(customConnectors)) {
+    if (enabled[id]?.enabled === false) continue; // explicitly opted out
+
+    const secrets: Record<string, string> = {};
+    let allPresent = true;
+    for (const name of entry.secretNames) {
+      const value = tokenEnv[customSecretKey(id, name)];
+      if (!value) {
+        allPresent = false;
+        break;
+      }
+      secrets[name] = value;
+    }
+    if (!allPresent) continue; // enabled but not fully connected — skip
+
+    out[id] = substitutePlaceholders(entry.config, secrets);
   }
 
   return out;
 }
 
 /** Catalog + connected state for the API. `connected` reflects secret presence. */
-export function listConnectorStatus(): ConnectorStatus[] {
+export function listConnectorStatus(
+  customConnectors: Record<string, CustomConnectorEntry> = {},
+): ConnectorStatus[] {
   const tokenEnv = readTokenEnv();
-  return CONNECTOR_CATALOG.map((spec) => {
+  const builtins: ConnectorStatus[] = CONNECTOR_CATALOG.map((spec) => {
     const envName = secretEnvOf(spec);
     const connected = envName === null ? true : !!tokenEnv[envName];
     return {
@@ -54,6 +84,25 @@ export function listConnectorStatus(): ConnectorStatus[] {
       authKind: spec.auth.kind,
       connected,
       setup: spec.setup,
+      source: 'built-in',
+      repoUrl: spec.repoUrl,
     };
   });
+
+  const customs: ConnectorStatus[] = Object.entries(customConnectors).map(([id, entry]) => {
+    const connected = entry.secretNames.every(
+      (name: string) => !!tokenEnv[customSecretKey(id, name)],
+    );
+    return {
+      id,
+      label: entry.label,
+      description: entry.description,
+      authKind: entry.secretNames.length > 0 ? 'secret' : 'none',
+      connected,
+      source: 'custom',
+      repoUrl: entry.sourceUrl,
+    };
+  });
+
+  return [...builtins, ...customs];
 }

--- a/src/connectors/resolve.ts
+++ b/src/connectors/resolve.ts
@@ -37,33 +37,47 @@ export function resolveEnabledConnectors(
     if (enabled[spec.id]?.enabled === false) continue; // explicitly opted out
 
     const envName = secretEnvOf(spec);
-    if (envName === null) {
-      // No-auth connector — always injectable when enabled.
-      out[spec.id] = spec.build(null);
-      continue;
-    }
+    try {
+      if (envName === null) {
+        // No-auth connector — always injectable when enabled.
+        out[spec.id] = spec.build(null);
+        continue;
+      }
 
-    const secret = tokenEnv[envName];
-    if (!secret) continue; // not connected — skip regardless of enablement
-    out[spec.id] = spec.build(secret);
+      const secret = tokenEnv[envName];
+      if (!secret) continue; // not connected — skip regardless of enablement
+      out[spec.id] = spec.build(secret);
+    } catch (err) {
+      // A deployer-defined CONNECTOR_CATALOG entry's build() throwing must
+      // not abort resolution for every OTHER connector — or worse, the whole
+      // session spawn — for every user of this agent. Skip just this one.
+      console.error(`resolveEnabledConnectors: connector=${spec.id} build() failed: ${(err as Error).message}`);
+    }
   }
 
   for (const [id, entry] of Object.entries(customConnectors)) {
     if (enabled[id]?.enabled === false) continue; // explicitly opted out
 
-    const secrets: Record<string, string> = {};
-    let allPresent = true;
-    for (const name of entry.secretNames) {
-      const value = tokenEnv[customSecretKey(id, name)];
-      if (!value) {
-        allPresent = false;
-        break;
+    try {
+      const secrets: Record<string, string> = {};
+      let allPresent = true;
+      for (const name of entry.secretNames) {
+        const value = tokenEnv[customSecretKey(id, name)];
+        if (!value) {
+          allPresent = false;
+          break;
+        }
+        secrets[name] = value;
       }
-      secrets[name] = value;
-    }
-    if (!allPresent) continue; // enabled but not fully connected — skip
+      if (!allPresent) continue; // enabled but not fully connected — skip
 
-    out[id] = substitutePlaceholders(entry.config, secrets);
+      out[id] = substitutePlaceholders(entry.config, secrets);
+    } catch (err) {
+      // Same isolation as the built-in loop above — a malformed pasted
+      // config (see CustomConnectorEntry's doc comment: admin-trusted, not
+      // code-reviewed) must not take down every other connector's resolution.
+      console.error(`resolveEnabledConnectors: connector=${id} resolve failed: ${(err as Error).message}`);
+    }
   }
 
   return out;

--- a/src/connectors/token-env.ts
+++ b/src/connectors/token-env.ts
@@ -1,0 +1,86 @@
+/**
+ * Connector secret storage — ~/.claude-gateway/mcp-token.env
+ *
+ * A plain dotenv file (mode 0600) of `KEY=value` lines, one per connector secret
+ * (e.g. GITHUB_TOKEN=ghp_...). This mirrors the gateway's existing secret posture
+ * (~/.claude-gateway/.env holds bot tokens in plaintext); config.json only ever holds
+ * the env-var NAME, never the value.
+ *
+ * The file is parsed fresh on every read so a web "connect" takes effect on the next
+ * session spawn with no daemon restart. All ops fail soft.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** Resolve the mcp-token.env path (override via GATEWAY_MCP_TOKEN_ENV, used by tests). */
+function tokenEnvPath(): string {
+  return (
+    process.env.GATEWAY_MCP_TOKEN_ENV ??
+    path.join(os.homedir(), '.claude-gateway', 'mcp-token.env')
+  );
+}
+
+/** Parse a dotenv file body into a flat map. Ignores blank lines and `#` comments. */
+function parse(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+/** Read all connector secrets. Returns {} if the file is missing or unreadable. */
+export function readTokenEnv(): Record<string, string> {
+  try {
+    return parse(fs.readFileSync(tokenEnvPath(), 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+/** Get a single secret value, or null if absent. */
+export function getSecret(envName: string): string | null {
+  const v = readTokenEnv()[envName];
+  return v === undefined || v === '' ? null : v;
+}
+
+/** True when the secret is present and non-empty. */
+export function hasSecret(envName: string): boolean {
+  return getSecret(envName) !== null;
+}
+
+/** Atomically rewrite the file (mode 0600) from a map. */
+function writeAll(map: Record<string, string>): void {
+  const file = tokenEnvPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const body =
+    Object.entries(map)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('\n') + '\n';
+  const tmp = `${file}.tmp.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmp, body, { mode: 0o600 });
+  fs.renameSync(tmp, file);
+}
+
+/** Upsert a secret line (creates the file if needed). */
+export function setSecret(envName: string, value: string): void {
+  const map = readTokenEnv();
+  map[envName] = value;
+  writeAll(map);
+}
+
+/** Remove a secret line. No-op if absent. */
+export function deleteSecret(envName: string): void {
+  const map = readTokenEnv();
+  if (!(envName in map)) return;
+  delete map[envName];
+  writeAll(map);
+}

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Connector catalog types.
+ *
+ * A "connector" is a managed MCP server the gateway can inject into a Claude Code
+ * session's mcp-config.json. The gateway only stores the catalog (here, in code),
+ * the per-connector secret (in mcp-token.env), and the per-agent enablement
+ * (AgentConfig.connectors). At spawn, an enabled+connected connector is resolved to
+ * an mcpServers entry via spec.build(secret) — Claude Code then talks to the real
+ * MCP server directly.
+ */
+
+export type ConnectorAuthKind = 'none' | 'secret' | 'oauth_device' | 'oauth';
+export type ConnectorTransport = 'http' | 'stdio';
+
+export type ConnectorAuth =
+  | { kind: 'none' }
+  | { kind: 'secret'; secretEnv: string } // iteration 1 — paste a token (e.g. GitHub PAT)
+  | {
+      kind: 'oauth_device';
+      secretEnv: string;
+      clientId: string;
+      scopes: string[];
+      deviceCodeUrl: string;
+      tokenUrl: string;
+    }
+  | {
+      kind: 'oauth';
+      secretEnv: string; // env name holding the (refreshed) access token
+      clientId: string;
+      clientSecret: string;
+      scopes: string[];
+      authUrl: string;
+      tokenUrl: string;
+      redirectPath: string;
+    };
+
+/**
+ * UI-only help for obtaining a connector's secret (e.g. a deep link to GitHub's
+ * PAT-creation page with scopes pre-filled). Pure presentation metadata — never
+ * reaches spec.build() or the written mcp-config.json.
+ */
+export interface ConnectorSetup {
+  /** Deep link that generates/obtains the token (opened in a new tab). */
+  tokenUrl: string;
+  /** Button label, e.g. 'Create a GitHub token'. */
+  label?: string;
+  /** One-line instruction shown under the paste box. */
+  hint?: string;
+}
+
+export interface ConnectorSpec {
+  /** Stable id, also the mcpServers entry name (e.g. 'github'). */
+  id: string;
+  /** Human label for the UI. */
+  label: string;
+  description?: string;
+  transport: ConnectorTransport;
+  auth: ConnectorAuth;
+  /** Optional guided token-generation help for the web panel. */
+  setup?: ConnectorSetup;
+  /**
+   * Build the mcpServers entry for this connector. `secret` is the resolved token
+   * (null for auth.kind === 'none' or when not yet connected).
+   */
+  build(secret: string | null): Record<string, unknown>;
+}
+
+export interface ConnectorStatus {
+  id: string;
+  label: string;
+  description?: string;
+  authKind: ConnectorAuthKind;
+  /** True when the connector's secret is present (or auth.kind === 'none'). */
+  connected: boolean;
+  /** Optional guided token-generation help for the web panel. */
+  setup?: ConnectorSetup;
+}
+
+/** Returns the env-var name a spec's secret is stored under, or null for kind 'none'. */
+export function secretEnvOf(spec: ConnectorSpec): string | null {
+  return spec.auth.kind === 'none' ? null : spec.auth.secretEnv;
+}

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -12,6 +12,12 @@
 export type ConnectorAuthKind = 'none' | 'secret' | 'oauth_device' | 'oauth';
 export type ConnectorTransport = 'http' | 'stdio';
 
+// Note: there is deliberately no 'oauth' variant here. A *built-in*
+// ConnectorSpec can never be oauth-kind — that concept now lives only on
+// CustomConnectorEntry.authKind below, since every oauth-managed connector
+// (github/gmail/google-drive/google-calendar) is pushed in as a managed
+// custom connector by services/api, not declared in catalog.ts. See
+// CustomConnectorEntry's doc comment for why.
 export type ConnectorAuth =
   | { kind: 'none' }
   | { kind: 'secret'; secretEnv: string } // paste a token (e.g. GitHub PAT)
@@ -22,19 +28,6 @@ export type ConnectorAuth =
       scopes: string[];
       deviceCodeUrl: string;
       tokenUrl: string;
-    }
-  | {
-      // Managed externally by services/api (getpod-ai), NOT by this gateway —
-      // the gateway never sees a client_secret or a refresh_token, only ever
-      // receives a short-lived access_token via POST
-      // /v1/connectors/:id/oauth/receive (connectors-router.ts). Reason: this
-      // gateway runs inside the user's own VM (SSH + agent shell access), so
-      // a client_secret shared across every user could never live here
-      // safely. The web panel shows a "Connect" link to services/api's own
-      // OAuth start endpoint instead of the paste-a-token modal `secretEnv`
-      // kinds use.
-      kind: 'oauth';
-      secretEnv: string;
     };
 
 /**
@@ -92,6 +85,10 @@ export interface ConnectorStatus {
   source: 'built-in' | 'custom';
   /** repoUrl (built-in) or sourceUrl (custom) — see their doc comments. */
   repoUrl?: string;
+  /** Mirrors CustomConnectorEntry.oauth — tells the web panel to render a
+   *  "Connect" link pointed at THIS gateway's oauth/start endpoint instead of
+   *  a paste-token modal. Always absent for built-in entries. */
+  oauth?: boolean;
 }
 
 /** Returns the env-var name a spec's secret is stored under, or null for kind 'none'. */
@@ -117,4 +114,33 @@ export interface CustomConnectorEntry {
   secretNames: string[];
   /** Where the user says this config came from — their own reference, unverified. */
   sourceUrl?: string;
+  /**
+   * Set ONLY by services/api's push (POST /oauth/receive) for a GetPod-managed
+   * OAuth connector (github/gmail/google-drive/google-calendar) — never by a
+   * genuine user-pasted add (POST /v1/connectors/custom leaves this unset).
+   * listConnectorStatus reports this verbatim instead of inferring from
+   * secretNames, since a managed entry IS oauth-kind even though it lives in
+   * the same customConnectors storage as a user-pasted one.
+   */
+  authKind?: 'oauth';
+  /**
+   * Set ONLY by services/api's push, same as authKind above — tells
+   * listConnectorStatus to report `source: 'built-in'` instead of 'custom' so
+   * the web panel doesn't show the "Custom" badge on something GetPod
+   * implemented and pushed in, not something the user pasted themselves.
+   */
+  managed?: boolean;
+  /**
+   * Set when the admin who added this connector marked it as "this MCP
+   * server uses OAuth sign-in" (see api/oauth-connectors-router.ts). Purely a
+   * discovery/UX hint — it does NOT change how the secret is resolved
+   * (`config` must still carry an `{access_token}` placeholder, and
+   * `secretNames` must still include `'access_token'`, exactly like a
+   * user-pasted static-token connector; connectors/resolve.ts needs no
+   * awareness of this field at all). It only tells the web panel to show a
+   * "Connect" button that hits `oauth/start` on THIS gateway (not
+   * services/api), and tells `oauth/start` which `config.url` to run
+   * discovery against.
+   */
+  oauth?: boolean;
 }

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -14,7 +14,7 @@ export type ConnectorTransport = 'http' | 'stdio';
 
 export type ConnectorAuth =
   | { kind: 'none' }
-  | { kind: 'secret'; secretEnv: string } // iteration 1 — paste a token (e.g. GitHub PAT)
+  | { kind: 'secret'; secretEnv: string } // paste a token (e.g. GitHub PAT)
   | {
       kind: 'oauth_device';
       secretEnv: string;
@@ -24,14 +24,17 @@ export type ConnectorAuth =
       tokenUrl: string;
     }
   | {
+      // Managed externally by services/api (getpod-ai), NOT by this gateway —
+      // the gateway never sees a client_secret or a refresh_token, only ever
+      // receives a short-lived access_token via POST
+      // /v1/connectors/:id/oauth/receive (connectors-router.ts). Reason: this
+      // gateway runs inside the user's own VM (SSH + agent shell access), so
+      // a client_secret shared across every user could never live here
+      // safely. The web panel shows a "Connect" link to services/api's own
+      // OAuth start endpoint instead of the paste-a-token modal `secretEnv`
+      // kinds use.
       kind: 'oauth';
-      secretEnv: string; // env name holding the (refreshed) access token
-      clientId: string;
-      clientSecret: string;
-      scopes: string[];
-      authUrl: string;
-      tokenUrl: string;
-      redirectPath: string;
+      secretEnv: string;
     };
 
 /**
@@ -59,6 +62,13 @@ export interface ConnectorSpec {
   /** Optional guided token-generation help for the web panel. */
   setup?: ConnectorSetup;
   /**
+   * Link to the underlying MCP server's repo/docs/vendor page — shown as a
+   * small external link in the web panel so a user can see what they're
+   * actually running before connecting (most of today's catalog is a
+   * community package, not an Anthropic/vendor-official one).
+   */
+  repoUrl?: string;
+  /**
    * Build the mcpServers entry for this connector. `secret` is the resolved token
    * (null for auth.kind === 'none' or when not yet connected).
    */
@@ -74,9 +84,37 @@ export interface ConnectorStatus {
   connected: boolean;
   /** Optional guided token-generation help for the web panel. */
   setup?: ConnectorSetup;
+  /**
+   * 'built-in' = code-reviewed CONNECTOR_CATALOG entry (the security boundary —
+   * only vetted servers). 'custom' = user-pasted raw mcpServers JSON, admin-trusted
+   * but NOT code-reviewed — see connectors/custom.ts.
+   */
+  source: 'built-in' | 'custom';
+  /** repoUrl (built-in) or sourceUrl (custom) — see their doc comments. */
+  repoUrl?: string;
 }
 
 /** Returns the env-var name a spec's secret is stored under, or null for kind 'none'. */
 export function secretEnvOf(spec: ConnectorSpec): string | null {
   return spec.auth.kind === 'none' ? null : spec.auth.secretEnv;
+}
+
+/**
+ * A user-pasted connector: raw mcpServers-entry JSON (from the MCP registry, a
+ * docs page, wherever) with `{placeholderName}` tokens standing in for secrets.
+ * Stored in config.json's gateway.customConnectors, keyed by a slugified id.
+ * Unlike ConnectorSpec, there's no build() — resolve.ts does a generic
+ * find-and-replace of `{name}` against the connector's own namespaced secrets
+ * (see connectors/custom.ts: customSecretKey, substitutePlaceholders).
+ */
+export interface CustomConnectorEntry {
+  label: string;
+  description?: string;
+  /** Raw config as pasted, e.g. {"command":"npx","args":["gmail-mcp"]} or
+   *  {"type":"streamable-http","url":"...","headers":{"Authorization":"Bearer {api_key}"}}. */
+  config: Record<string, unknown>;
+  /** Placeholder names found in `config` at add-time, e.g. ['api_key']. */
+  secretNames: string[];
+  /** Where the user says this config came from — their own reference, unverified. */
+  sourceUrl?: string;
 }

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -16,7 +16,7 @@ export type ConnectorTransport = 'http' | 'stdio';
 // ConnectorSpec can never be oauth-kind — that concept now lives only on
 // CustomConnectorEntry.authKind below, since every oauth-managed connector
 // (github/gmail/google-drive/google-calendar) is pushed in as a managed
-// custom connector by services/api, not declared in catalog.ts. See
+// custom connector by an external control plane, not declared in catalog.ts. See
 // CustomConnectorEntry's doc comment for why.
 export type ConnectorAuth =
   | { kind: 'none' }
@@ -115,19 +115,20 @@ export interface CustomConnectorEntry {
   /** Where the user says this config came from — their own reference, unverified. */
   sourceUrl?: string;
   /**
-   * Set ONLY by services/api's push (POST /oauth/receive) for a GetPod-managed
-   * OAuth connector (github/gmail/google-drive/google-calendar) — never by a
-   * genuine user-pasted add (POST /v1/connectors/custom leaves this unset).
-   * listConnectorStatus reports this verbatim instead of inferring from
-   * secretNames, since a managed entry IS oauth-kind even though it lives in
-   * the same customConnectors storage as a user-pasted one.
+   * Set ONLY by an external control plane's push (POST /oauth/receive) for a
+   * managed OAuth connector (github/gmail/google-drive/google-calendar, say)
+   * — never by a genuine user-pasted add (POST /v1/connectors/custom leaves
+   * this unset). listConnectorStatus reports this verbatim instead of
+   * inferring from secretNames, since a managed entry IS oauth-kind even
+   * though it lives in the same customConnectors storage as a user-pasted one.
    */
   authKind?: 'oauth';
   /**
-   * Set ONLY by services/api's push, same as authKind above — tells
+   * Set ONLY by that same push, same as authKind above — tells
    * listConnectorStatus to report `source: 'built-in'` instead of 'custom' so
-   * the web panel doesn't show the "Custom" badge on something GetPod
-   * implemented and pushed in, not something the user pasted themselves.
+   * the web panel doesn't show the "Custom" badge on something the deployer's
+   * own control plane implemented and pushed in, not something the user
+   * pasted themselves.
    */
   managed?: boolean;
   /**
@@ -138,9 +139,9 @@ export interface CustomConnectorEntry {
    * `secretNames` must still include `'access_token'`, exactly like a
    * user-pasted static-token connector; connectors/resolve.ts needs no
    * awareness of this field at all). It only tells the web panel to show a
-   * "Connect" button that hits `oauth/start` on THIS gateway (not
-   * services/api), and tells `oauth/start` which `config.url` to run
-   * discovery against.
+   * "Connect" button that hits `oauth/start` on THIS gateway (not an
+   * external control plane), and tells `oauth/start` which `config.url` to
+   * run discovery against.
    */
   oauth?: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -921,6 +921,13 @@ async function main(): Promise<void> {
         if (change.field === 'gateway.headless') {
           // Applies to sessions spawned after the change; running sessions keep their backend.
           config.gateway.headless = change.newValue as boolean | undefined;
+        } else if (change.field === 'gateway.customConnectors') {
+          // Same "new spawns only" scope as the agent-level 'connectors' case
+          // below — an already-running session's subprocess isn't hot-patched
+          // (see restartSessionsUsingConnector for that case), but every
+          // subsequent chat/spawn now sees connect/disconnect/add-custom
+          // changes without a gateway restart.
+          config.gateway.customConnectors = change.newValue as GatewayConfig['gateway']['customConnectors'];
         }
         if (change.field === 'gateway.logs') {
           // Re-installing the policy is enough: every logger reads it per call,
@@ -956,6 +963,11 @@ async function main(): Promise<void> {
         case 'heartbeat.rateLimitMinutes':
           if (!agentConfig.heartbeat) agentConfig.heartbeat = {};
           agentConfig.heartbeat.rateLimitMinutes = change.newValue as number;
+          break;
+        case 'connectors':
+          // Per-agent connector enablement toggles — same scope note as
+          // gateway.customConnectors above.
+          agentConfig.connectors = change.newValue as AgentConfig['connectors'];
           break;
       }
     }

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -20,6 +20,7 @@ import {
   extractToolDetail,
   truncateDetail,
 } from '../utils/tool-labels';
+import { resolveEnabledConnectors } from '../connectors/resolve';
 
 export const MAX_HISTORY_MESSAGES = 50;
 
@@ -621,6 +622,14 @@ export class SessionProcess extends EventEmitter {
     const projectServers = this.readProjectScopedMcp();
     const extraServers: Record<string, unknown> = {};
     for (const [name, server] of Object.entries({ ...userServers, ...projectServers })) {
+      if (name !== 'telegram' && name !== 'gateway') extraServers[name] = server;
+    }
+
+    // Connectors: catalog entries enabled for THIS agent AND connected (secret present
+    // in mcp-token.env). Resolved fresh each spawn so a web "connect" is picked up
+    // without a daemon restart. Secrets land only in this 0600 mcp-config.json.
+    const connectorServers = resolveEnabledConnectors(this.agentConfig);
+    for (const [name, server] of Object.entries(connectorServers)) {
       if (name !== 'telegram' && name !== 'gateway') extraServers[name] = server;
     }
 

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -628,7 +628,10 @@ export class SessionProcess extends EventEmitter {
     // Connectors: catalog entries enabled for THIS agent AND connected (secret present
     // in mcp-token.env). Resolved fresh each spawn so a web "connect" is picked up
     // without a daemon restart. Secrets land only in this 0600 mcp-config.json.
-    const connectorServers = resolveEnabledConnectors(this.agentConfig);
+    const connectorServers = resolveEnabledConnectors(
+      this.agentConfig,
+      this.gatewayConfig.gateway.customConnectors,
+    );
     for (const [name, server] of Object.entries(connectorServers)) {
       if (name !== 'telegram' && name !== 'gateway') extraServers[name] = server;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,14 @@ export interface GatewayConfig {
      * disabled. A trailing slash is trimmed when building links.
      */
     publicUrl?: string;
+    /**
+     * Optional "come back here after signing in" URL for the generic MCP
+     * OAuth callback (oauth-connectors-router.ts) — e.g. a downstream
+     * product's own connectors page. This gateway is product-agnostic, so
+     * it never hardcodes one; unset = the callback just shows a plain
+     * "Connected, close this tab" page instead of auto-redirecting anywhere.
+     */
+    oauthReturnUrl?: string;
     models?: ModelConfig[];
     api?: {
       keys: ApiKey[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,8 @@ export interface AgentConfig {
   knowledge?: GatewayConfig['gateway']['knowledge'];
   /** Avatar filename relative to agent dir, e.g. "avatar.png". null = no avatar. */
   avatar?: string;
+  /** Per-agent connector enablement, keyed by connector id (e.g. "github"). */
+  connectors?: Record<string, { enabled: boolean }>;
 }
 
 export interface AgentStats {
@@ -260,7 +262,6 @@ export interface GatewayConfig {
       cleanupHour?: number;      // 0-23, default 0
       cleanupTimezone?: string;  // IANA timezone, default "UTC"
     };
-    /**
     /**
      * App-store Docker housekeeping (issue #302). Best-effort reclaim of the
      * build cache and dangling `<none>` images left behind by every app
@@ -452,6 +453,12 @@ export interface GatewayConfig {
         reviewModel?: string;      // default matches the dreaming reviewer's default
       };
     };
+    /**
+     * Connector wiring/state (non-secret). Keyed by connector id; records which
+     * env-var name (in mcp-token.env) holds each connector's secret. Written by the
+     * connectors connect/disconnect routes. The secret VALUE never lives here.
+     */
+    connectors?: Record<string, { secretEnv: string }>;
   };
   agents: AgentConfig[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+export type { CustomConnectorEntry } from './connectors/types';
+import type { CustomConnectorEntry } from './connectors/types';
+
 export interface SessionConfig {
   idleTimeoutMinutes?: number; // default 30
   maxConcurrent?: number; // default 20
@@ -459,6 +462,12 @@ export interface GatewayConfig {
      * connectors connect/disconnect routes. The secret VALUE never lives here.
      */
     connectors?: Record<string, { secretEnv: string }>;
+    /**
+     * User-pasted (not code-reviewed) connectors — second tier alongside the
+     * built-in CONNECTOR_CATALOG. Keyed by slugified id. See
+     * connectors/types.ts's CustomConnectorEntry doc for the security tradeoff.
+     */
+    customConnectors?: Record<string, CustomConnectorEntry>;
   };
   agents: AgentConfig[];
 }

--- a/tests/unit/config-watcher.test.ts
+++ b/tests/unit/config-watcher.test.ts
@@ -112,6 +112,8 @@ describe('config-watcher', () => {
     alfredDangerouslySkip?: boolean;
     publicUrl?: string;
     logs?: Record<string, unknown>;
+    alfredConnectors?: Record<string, { enabled: boolean }>;
+    customConnectors?: Record<string, unknown>;
   }): Record<string, unknown> {
     return {
       gateway: {
@@ -119,6 +121,7 @@ describe('config-watcher', () => {
         timezone: 'Asia/Bangkok',
         ...(overrides?.publicUrl ? { publicUrl: overrides.publicUrl } : {}),
         ...(overrides?.logs ? { logs: overrides.logs } : {}),
+        ...(overrides?.customConnectors ? { customConnectors: overrides.customConnectors } : {}),
       },
       agents: [
         {
@@ -134,6 +137,7 @@ describe('config-watcher', () => {
             dangerouslySkipPermissions: overrides?.alfredDangerouslySkip ?? true,
             extraFlags: overrides?.alfredExtraFlags ?? [],
           },
+          ...(overrides?.alfredConnectors ? { connectors: overrides.alfredConnectors } : {}),
         },
         {
           id: 'baerbel',
@@ -211,6 +215,75 @@ describe('config-watcher', () => {
       newValue: { level: 'debug', maxFiles: 5 },
       // Turning the level up to chase a live problem is exactly when a restart
       // is unaffordable — it kills the sessions being investigated.
+      hotReloadable: true,
+    });
+
+    watcher.stop();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Connector config (per-agent `connectors` + gateway-level `customConnectors`)
+  // must hot-reload too — previously missing from the field-diff list, which
+  // meant connecting/adding a connector required a full gateway restart before
+  // any session (new or existing) would see it, even though the file on disk
+  // was already correct. See connector_push.go / connectors-router.ts for the
+  // write side; this only covers the watcher detecting + flagging the change.
+  // ---------------------------------------------------------------------------
+  it('emits changes with hotReloadable=true when a per-agent connectors toggle changes', () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    writeConfigFile(configPath, rawConfig({ alfredConnectors: { gmail: { enabled: false } } }));
+
+    const initialConfig = loadConfig(configPath);
+    const watcher = new ConfigWatcher(configPath, initialConfig, logger);
+
+    const changeSpy = jest.fn();
+    watcher.on('changes', changeSpy);
+
+    writeConfigFile(configPath, rawConfig({ alfredConnectors: { gmail: { enabled: true } } }));
+    watcher.reload();
+
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    const changes: ConfigChange[] = changeSpy.mock.calls[0][0];
+    const connectorsChange = changes.find(c => c.field === 'connectors');
+    expect(connectorsChange).toMatchObject({
+      agentId: 'alfred',
+      field: 'connectors',
+      oldValue: { gmail: { enabled: false } },
+      newValue: { gmail: { enabled: true } },
+      hotReloadable: true,
+    });
+
+    watcher.stop();
+  });
+
+  it('emits changes with hotReloadable=true when gateway.customConnectors changes', () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    writeConfigFile(configPath, rawConfig());
+
+    const initialConfig = loadConfig(configPath);
+    const watcher = new ConfigWatcher(configPath, initialConfig, logger);
+
+    const changeSpy = jest.fn();
+    watcher.on('changes', changeSpy);
+
+    const gmailEntry = {
+      label: 'Gmail',
+      config: { type: 'stdio', command: 'npx', args: ['-y', 'gmail-mcp'], env: { GOOGLE_ACCESS_TOKEN: '{access_token}' } },
+      secretNames: ['access_token'],
+      authKind: 'oauth',
+      managed: true,
+    };
+    writeConfigFile(configPath, rawConfig({ customConnectors: { gmail: gmailEntry } }));
+    watcher.reload();
+
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    const changes: ConfigChange[] = changeSpy.mock.calls[0][0];
+    const customConnectorsChange = changes.find(c => c.field === 'gateway.customConnectors');
+    expect(customConnectorsChange).toMatchObject({
+      agentId: '',
+      field: 'gateway.customConnectors',
+      oldValue: undefined,
+      newValue: { gmail: gmailEntry },
       hotReloadable: true,
     });
 

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the connectors feature (native MCP injection).
+ *
+ *  token-env        — secret storage in mcp-token.env (0600, fresh parse)
+ *  resolve          — enabled+connected → injected mcpServers entry
+ *  boot-safety      — config.json with gateway.connectors but no token loads (no throw)
+ *  connectors-router — GET / connect / status / delete + admin gating
+ *  mcp-config gen    — writeMcpConfig emits the github entry only when connected
+ */
+
+import express from 'express';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ApiKey } from '../../src/types';
+
+const TOKEN_ENV = '/tmp/connectors-test-mcp-token.env';
+
+beforeEach(() => {
+  process.env.GATEWAY_MCP_TOKEN_ENV = TOKEN_ENV;
+  try { fs.rmSync(TOKEN_ENV); } catch { /* ignore */ }
+  jest.resetModules();
+});
+
+afterAll(() => {
+  delete process.env.GATEWAY_MCP_TOKEN_ENV;
+  try { fs.rmSync(TOKEN_ENV); } catch { /* ignore */ }
+});
+
+describe('token-env', () => {
+  it('set/get/has/delete round-trip and 0600 perms', () => {
+    const { setSecret, getSecret, hasSecret, deleteSecret, readTokenEnv } =
+      require('../../src/connectors/token-env');
+
+    expect(getSecret('GITHUB_TOKEN')).toBeNull();
+    expect(hasSecret('GITHUB_TOKEN')).toBe(false);
+
+    setSecret('GITHUB_TOKEN', 'ghp_abc123');
+    expect(getSecret('GITHUB_TOKEN')).toBe('ghp_abc123');
+    expect(hasSecret('GITHUB_TOKEN')).toBe(true);
+    expect(readTokenEnv()).toEqual({ GITHUB_TOKEN: 'ghp_abc123' });
+
+    // File is 0600
+    expect(fs.statSync(TOKEN_ENV).mode & 0o777).toBe(0o600);
+
+    // Upsert keeps other keys
+    setSecret('OTHER', 'x');
+    setSecret('GITHUB_TOKEN', 'ghp_new');
+    expect(readTokenEnv()).toEqual({ GITHUB_TOKEN: 'ghp_new', OTHER: 'x' });
+
+    deleteSecret('GITHUB_TOKEN');
+    expect(getSecret('GITHUB_TOKEN')).toBeNull();
+    expect(readTokenEnv()).toEqual({ OTHER: 'x' });
+  });
+
+  it('missing file → empty, no throw', () => {
+    const { readTokenEnv, getSecret } = require('../../src/connectors/token-env');
+    expect(readTokenEnv()).toEqual({});
+    expect(getSecret('NOPE')).toBeNull();
+  });
+
+  it('reads fresh each call (no caching)', () => {
+    const { setSecret, getSecret } = require('../../src/connectors/token-env');
+    expect(getSecret('K')).toBeNull();
+    fs.writeFileSync(TOKEN_ENV, 'K=external\n', { mode: 0o600 });
+    expect(getSecret('K')).toBe('external');
+    setSecret('K', 'updated');
+    expect(getSecret('K')).toBe('updated');
+  });
+});
+
+describe('resolve', () => {
+  it('enabled + connected → github http entry with bearer; disabled/disconnected → omitted', () => {
+    const { setSecret } = require('../../src/connectors/token-env');
+    const { resolveEnabledConnectors, listConnectorStatus } =
+      require('../../src/connectors/resolve');
+
+    // disabled → omitted
+    expect(resolveEnabledConnectors({ connectors: {} })).toEqual({});
+
+    // enabled but not connected → omitted
+    expect(resolveEnabledConnectors({ connectors: { github: { enabled: true } } })).toEqual({});
+
+    // enabled + connected → entry present
+    setSecret('GITHUB_TOKEN', 'ghp_xyz');
+    const resolved = resolveEnabledConnectors({ connectors: { github: { enabled: true } } });
+    expect(resolved.github).toEqual({
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: { Authorization: 'Bearer ghp_xyz' },
+    });
+
+    // connected reflected in status
+    const status = listConnectorStatus().find((c: { id: string }) => c.id === 'github');
+    expect(status).toMatchObject({ id: 'github', authKind: 'secret', connected: true });
+
+    // guided token-generation help is surfaced for the web panel
+    expect(status.setup.tokenUrl).toMatch(/^https:\/\/github\.com\/settings\/tokens\/new/);
+    expect(typeof status.setup.label).toBe('string');
+    expect(status.setup.label.length).toBeGreaterThan(0);
+  });
+});
+
+describe('boot-safety', () => {
+  it('loadConfig does not throw when gateway.connectors references an unset env var', () => {
+    const { loadConfig } = require('../../src/config/loader');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-boot-'));
+    const cfgPath = path.join(dir, 'config.json');
+    fs.writeFileSync(cfgPath, JSON.stringify({
+      gateway: {
+        logDir: '/tmp', timezone: 'UTC',
+        api: { keys: [{ key: 'k', agents: '*', admin: true }] },
+        connectors: { github: { secretEnv: 'GITHUB_TOKEN' } },
+      },
+      agents: [{
+        id: 'a1', description: 'd', workspace: dir, env: '',
+        claude: { model: 'claude-opus-4-8', extraFlags: [] },
+      }],
+    }, null, 2));
+
+    delete process.env.GITHUB_TOKEN;
+    expect(() => loadConfig(cfgPath)).not.toThrow();
+    const cfg = loadConfig(cfgPath);
+    expect(cfg.gateway.connectors).toEqual({ github: { secretEnv: 'GITHUB_TOKEN' } });
+  });
+});
+
+describe('connectors-router', () => {
+  const adminKey = 'admin-key';
+  const scopedKey = 'scoped-key';
+  const apiKeys: ApiKey[] = [
+    { key: adminKey, agents: '*', admin: true },
+    { key: scopedKey, agents: ['a1'] },
+  ];
+
+  function makeApp(configPath?: string) {
+    const { createConnectorsRouter } = require('../../src/api/connectors-router');
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createConnectorsRouter(apiKeys, configPath));
+    return app;
+  }
+
+  it('GET /v1/connectors returns catalog with connected=false initially', async () => {
+    const res = await request(makeApp()).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    expect(res.status).toBe(200);
+    const github = res.body.connectors.find((c: { id: string }) => c.id === 'github');
+    expect(github).toMatchObject({ id: 'github', label: 'GitHub', connected: false });
+    expect(github.setup.tokenUrl).toMatch(/^https:\/\/github\.com\/settings\/tokens\/new/);
+    expect(github.setup.label).toBeTruthy();
+  });
+
+  it('rejects missing / invalid key', async () => {
+    expect((await request(makeApp()).get('/api/v1/connectors')).status).toBe(401);
+    expect((await request(makeApp()).get('/api/v1/connectors').set('X-Api-Key', 'nope')).status).toBe(403);
+  });
+
+  it('non-admin cannot connect', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/connectors/github/connect')
+      .set('X-Api-Key', scopedKey)
+      .send({ token: 'ghp_x' });
+    expect(res.status).toBe(403);
+  });
+
+  it('connect stores secret + writes config.json; delete clears both', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-router-'));
+    const cfgPath = path.join(dir, 'config.json');
+    fs.writeFileSync(cfgPath, JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2));
+    const app = makeApp(cfgPath);
+    const { getSecret } = require('../../src/connectors/token-env');
+
+    // empty token rejected
+    const bad = await request(app).post('/api/v1/connectors/github/connect').set('X-Api-Key', adminKey).send({ token: '  ' });
+    expect(bad.status).toBe(400);
+
+    // connect
+    const ok = await request(app).post('/api/v1/connectors/github/connect').set('X-Api-Key', adminKey).send({ token: 'ghp_secret' });
+    expect(ok.status).toBe(200);
+    expect(ok.body).toEqual({ id: 'github', connected: true });
+    expect(getSecret('GITHUB_TOKEN')).toBe('ghp_secret');
+    const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    expect(written.gateway.connectors).toEqual({ github: { secretEnv: 'GITHUB_TOKEN' } });
+
+    // status reflects connected
+    const status = await request(app).get('/api/v1/connectors/github/status').set('X-Api-Key', adminKey);
+    expect(status.body).toEqual({ id: 'github', connected: true });
+
+    // delete
+    const del = await request(app).delete('/api/v1/connectors/github').set('X-Api-Key', adminKey);
+    expect(del.status).toBe(200);
+    expect(getSecret('GITHUB_TOKEN')).toBeNull();
+    expect(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')).gateway.connectors).toEqual({});
+  });
+
+  it('unknown connector → 404', async () => {
+    const res = await request(makeApp()).post('/api/v1/connectors/nope/connect').set('X-Api-Key', adminKey).send({ token: 'x' });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -77,15 +77,26 @@ describe('resolve', () => {
     const { resolveEnabledConnectors, listConnectorStatus } =
       require('../../src/connectors/resolve');
 
-    // disabled → omitted
-    expect(resolveEnabledConnectors({ connectors: {} })).toEqual({});
+    // Enablement is opt-out (default enabled) — microsoft-365 needs no secret
+    // so it resolves by default regardless of config; explicitly opt it out
+    // in these assertions to keep this test focused on github.
+    const noMs365 = { connectors: { 'microsoft-365': { enabled: false as const } } };
+
+    // no config, not connected → omitted
+    expect(resolveEnabledConnectors(noMs365)).toEqual({});
 
     // enabled but not connected → omitted
-    expect(resolveEnabledConnectors({ connectors: { github: { enabled: true } } })).toEqual({});
+    expect(
+      resolveEnabledConnectors({
+        connectors: { github: { enabled: true }, 'microsoft-365': { enabled: false } },
+      }),
+    ).toEqual({});
 
     // enabled + connected → entry present
     setSecret('GITHUB_TOKEN', 'ghp_xyz');
-    const resolved = resolveEnabledConnectors({ connectors: { github: { enabled: true } } });
+    const resolved = resolveEnabledConnectors({
+      connectors: { github: { enabled: true }, 'microsoft-365': { enabled: false } },
+    });
     expect(resolved.github).toEqual({
       type: 'http',
       url: 'https://api.githubcopilot.com/mcp/',
@@ -100,6 +111,112 @@ describe('resolve', () => {
     expect(status.setup.tokenUrl).toMatch(/^https:\/\/github\.com\/settings\/tokens\/new/);
     expect(typeof status.setup.label).toBe('string');
     expect(status.setup.label.length).toBeGreaterThan(0);
+  });
+
+  // POC (manual-token) Google connectors: each keeps its own secret slot even
+  // though the community servers they wrap both read GOOGLE_ACCESS_TOKEN — so
+  // connecting Gmail must not flip Drive's `connected` too.
+  it('gmail + google-drive: independent secret slots, each resolves its own stdio entry', () => {
+    const { setSecret } = require('../../src/connectors/token-env');
+    const { resolveEnabledConnectors, listConnectorStatus } =
+      require('../../src/connectors/resolve');
+
+    const enabled = {
+      connectors: {
+        gmail: { enabled: true },
+        'google-drive': { enabled: true },
+        // Opt-out: microsoft-365 needs no secret, so opt-in default resolves
+        // it regardless — excluded here to keep this test focused on Google.
+        'microsoft-365': { enabled: false as const },
+      },
+    };
+    expect(resolveEnabledConnectors(enabled)).toEqual({});
+
+    setSecret('GMAIL_ACCESS_TOKEN', 'ya29.gmail');
+    const gmailOnly = resolveEnabledConnectors(enabled);
+    expect(gmailOnly.gmail).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'gmail-mcp'],
+      env: { GOOGLE_ACCESS_TOKEN: 'ya29.gmail' },
+    });
+    expect(gmailOnly['google-drive']).toBeUndefined();
+
+    const statusAfterGmail = listConnectorStatus();
+    expect(statusAfterGmail.find((c: { id: string }) => c.id === 'gmail')).toMatchObject({
+      connected: true,
+    });
+    expect(statusAfterGmail.find((c: { id: string }) => c.id === 'google-drive')).toMatchObject({
+      connected: false,
+    });
+
+    setSecret('GDRIVE_ACCESS_TOKEN', 'ya29.drive');
+    const both = resolveEnabledConnectors(enabled);
+    expect(both['google-drive']).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'google-drive-mcp'],
+      env: { GOOGLE_ACCESS_TOKEN: 'ya29.drive' },
+    });
+  });
+
+  it('custom connector: opt-out default enablement; partially-connected → omitted; fully-connected → substituted', () => {
+    const { setSecret } = require('../../src/connectors/token-env');
+    const { resolveEnabledConnectors } = require('../../src/connectors/resolve');
+
+    const customConnectors = {
+      calendar: {
+        label: 'Calendar',
+        config: {
+          type: 'streamable-http',
+          url: 'https://server.smithery.ai/calendar/mcp',
+          headers: { Authorization: 'Bearer {smithery_api_key}', 'X-Extra': '{unset_var}' },
+        },
+        secretNames: ['smithery_api_key', 'unset_var'],
+      },
+    };
+    // microsoft-365 opted out throughout — see the "opt-out" comment above.
+    const noMs365 = { 'microsoft-365': { enabled: false as const } };
+    const agentConfig = { connectors: { calendar: { enabled: true }, ...noMs365 } };
+
+    // No config at all (not even mentioning `calendar`) → still resolves once
+    // secrets exist, because enablement defaults to on (opt-out model).
+    setSecret('CUSTOM__calendar__smithery_api_key', 'sk-abc');
+    setSecret('CUSTOM__calendar__unset_var', 'val');
+    expect(resolveEnabledConnectors({ connectors: noMs365 }, customConnectors)).toEqual({
+      calendar: {
+        type: 'streamable-http',
+        url: 'https://server.smithery.ai/calendar/mcp',
+        headers: { Authorization: 'Bearer sk-abc', 'X-Extra': 'val' },
+      },
+    });
+
+    // Explicitly disabled for this agent → omitted even though fully connected.
+    expect(
+      resolveEnabledConnectors(
+        { connectors: { calendar: { enabled: false }, ...noMs365 } },
+        customConnectors,
+      ),
+    ).toEqual({});
+
+    // Reset secrets to re-test the partial-connection path from a clean slate.
+    const { deleteSecret } = require('../../src/connectors/token-env');
+    deleteSecret('CUSTOM__calendar__smithery_api_key');
+    deleteSecret('CUSTOM__calendar__unset_var');
+
+    // Enabled but only one of two required secrets present → still omitted.
+    setSecret('CUSTOM__calendar__smithery_api_key', 'sk-abc');
+    expect(resolveEnabledConnectors(agentConfig, customConnectors)).toEqual({});
+
+    // Both secrets present → substituted into the raw config.
+    setSecret('CUSTOM__calendar__unset_var', 'val');
+    expect(resolveEnabledConnectors(agentConfig, customConnectors)).toEqual({
+      calendar: {
+        type: 'streamable-http',
+        url: 'https://server.smithery.ai/calendar/mcp',
+        headers: { Authorization: 'Bearer sk-abc', 'X-Extra': 'val' },
+      },
+    });
   });
 });
 
@@ -150,6 +267,7 @@ describe('connectors-router', () => {
     expect(github).toMatchObject({ id: 'github', label: 'GitHub', connected: false });
     expect(github.setup.tokenUrl).toMatch(/^https:\/\/github\.com\/settings\/tokens\/new/);
     expect(github.setup.label).toBeTruthy();
+    expect(github.repoUrl).toBe('https://github.com/github/github-mcp-server');
   });
 
   it('rejects missing / invalid key', async () => {

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -247,6 +247,37 @@ describe('resolve', () => {
       },
     });
   });
+
+  // A user-added generic-OAuth custom connector (oauth: true, added via
+  // POST /v1/connectors/custom, no explicit authKind — that field is only
+  // ever set by services/api's managed push, see CustomConnectorEntry's doc
+  // comment) must still report authKind: 'oauth', not fall through to
+  // 'secret' just because secretNames is non-empty — the web panel's Auth
+  // column and icon both key off this.
+  it("listConnectorStatus: a user-added oauth:true custom connector reports authKind 'oauth', not 'secret'", () => {
+    const { listConnectorStatus } = require('../../src/connectors/resolve');
+    const customConnectors = {
+      firecrawl: {
+        label: 'Firecrawl',
+        config: {
+          type: 'http',
+          url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+          headers: { Authorization: 'Bearer {access_token}' },
+        },
+        secretNames: ['access_token'],
+        oauth: true,
+      },
+    };
+    const status = listConnectorStatus(customConnectors).find(
+      (c: { id: string }) => c.id === 'firecrawl',
+    );
+    expect(status).toMatchObject({
+      id: 'firecrawl',
+      authKind: 'oauth',
+      source: 'custom',
+      oauth: true,
+    });
+  });
 });
 
 describe('boot-safety', () => {
@@ -405,6 +436,60 @@ describe('connectors-router', () => {
     expect(del.status).toBe(200);
     expect(getSecret('CUSTOM__github__access_token')).toBeNull();
     expect(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')).gateway.customConnectors).toEqual({});
+  });
+
+  // A genuinely user-added custom connector (no entry.managed — nothing pushed
+  // it, the user pasted it themselves) has no catalog to fall back on for its
+  // config/label/description, unlike github/gmail/etc. above. Disconnecting it
+  // must not discard that config — only the secret — so the row survives and
+  // can be reconnected without retyping everything.
+  it("DELETE on a genuinely user-added custom connector clears the secret but keeps the entry (soft disconnect)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-router-'));
+    const cfgPath = path.join(dir, 'config.json');
+    fs.writeFileSync(cfgPath, JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2));
+    const app = makeApp(cfgPath);
+    const { getSecret } = require('../../src/connectors/token-env');
+
+    const add = await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({
+        label: 'Smithery Calendar',
+        description: 'Calendar via Smithery',
+        config: {
+          type: 'streamable-http',
+          url: 'https://server.smithery.ai/calendar/mcp',
+          headers: { Authorization: 'Bearer {api_key}' },
+        },
+        secrets: { api_key: 'sk-abc' },
+      });
+    expect(add.status).toBe(200);
+    const id = add.body.id;
+    expect(getSecret(`CUSTOM__${id}__api_key`)).toBe('sk-abc');
+
+    const del = await request(app).delete(`/api/v1/connectors/${id}`).set('X-Api-Key', adminKey);
+    expect(del.status).toBe(200);
+    expect(del.body).toEqual({ id, connected: false });
+
+    // Secret is gone...
+    expect(getSecret(`CUSTOM__${id}__api_key`)).toBeNull();
+    // ...but the entry — and therefore the row — is still there.
+    const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    expect(written.gateway.customConnectors[id]).toMatchObject({
+      label: 'Smithery Calendar',
+      description: 'Calendar via Smithery',
+      config: {
+        type: 'streamable-http',
+        url: 'https://server.smithery.ai/calendar/mcp',
+        headers: { Authorization: 'Bearer {api_key}' },
+      },
+      secretNames: ['api_key'],
+    });
+
+    const list = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    expect(list.body.connectors).toEqual([
+      expect.objectContaining({ id, label: 'Smithery Calendar', source: 'custom', connected: false }),
+    ]);
   });
 
   it('unknown connector → 404', async () => {

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -72,74 +72,112 @@ describe('token-env', () => {
 });
 
 describe('resolve', () => {
-  it('enabled + connected → github http entry with bearer; disabled/disconnected → omitted', () => {
+  it('CONNECTOR_CATALOG is empty by default — nothing resolves from it, regardless of config', () => {
+    const { resolveEnabledConnectors } = require('../../src/connectors/resolve');
+    expect(resolveEnabledConnectors({})).toEqual({});
+    expect(resolveEnabledConnectors({ connectors: { anything: { enabled: true } } })).toEqual({});
+  });
+
+  // github/gmail/etc. are no longer built-in catalog entries — they're managed
+  // custom connectors pushed by services/api (see connectors-router.ts's
+  // /oauth/receive). This exercises the exact shape that route writes:
+  // authKind:'oauth' + managed:true, resolved through the generic
+  // customConnectors path like any other custom connector.
+  it('managed connector (github): enabled + connected → http entry with bearer; disabled/disconnected → omitted', () => {
     const { setSecret } = require('../../src/connectors/token-env');
     const { resolveEnabledConnectors, listConnectorStatus } =
       require('../../src/connectors/resolve');
 
-    // Enablement is opt-out (default enabled) — microsoft-365 needs no secret
-    // so it resolves by default regardless of config; explicitly opt it out
-    // in these assertions to keep this test focused on github.
-    const noMs365 = { connectors: { 'microsoft-365': { enabled: false as const } } };
+    const customConnectors = {
+      github: {
+        label: 'GitHub',
+        description: 'Repos, issues, and pull requests via the official GitHub MCP server.',
+        config: {
+          type: 'http',
+          url: 'https://api.githubcopilot.com/mcp/',
+          headers: { Authorization: 'Bearer {access_token}' },
+        },
+        secretNames: ['access_token'],
+        sourceUrl: 'https://github.com/github/github-mcp-server',
+        authKind: 'oauth' as const,
+        managed: true,
+      },
+    };
 
-    // no config, not connected → omitted
-    expect(resolveEnabledConnectors(noMs365)).toEqual({});
+    // not connected → omitted
+    expect(resolveEnabledConnectors({}, customConnectors)).toEqual({});
 
     // enabled but not connected → omitted
     expect(
-      resolveEnabledConnectors({
-        connectors: { github: { enabled: true }, 'microsoft-365': { enabled: false } },
-      }),
+      resolveEnabledConnectors({ connectors: { github: { enabled: true } } }, customConnectors),
     ).toEqual({});
 
-    // enabled + connected → entry present
-    setSecret('GITHUB_TOKEN', 'ghp_xyz');
-    const resolved = resolveEnabledConnectors({
-      connectors: { github: { enabled: true }, 'microsoft-365': { enabled: false } },
-    });
+    // enabled + connected → entry present, placeholder substituted
+    setSecret('CUSTOM__github__access_token', 'ghp_xyz');
+    const resolved = resolveEnabledConnectors(
+      { connectors: { github: { enabled: true } } },
+      customConnectors,
+    );
     expect(resolved.github).toEqual({
       type: 'http',
       url: 'https://api.githubcopilot.com/mcp/',
       headers: { Authorization: 'Bearer ghp_xyz' },
     });
 
-    // connected reflected in status — github is now a real OAuth connector
-    // (services/api-driven, no paste-token setup help to surface).
-    const status = listConnectorStatus().find((c: { id: string }) => c.id === 'github');
-    expect(status).toMatchObject({ id: 'github', authKind: 'oauth', connected: true });
+    // disabled for this agent → omitted even though connected
+    expect(
+      resolveEnabledConnectors({ connectors: { github: { enabled: false } } }, customConnectors),
+    ).toEqual({});
+
+    // status reports it as built-in (not "Custom") and oauth-kind, no setup help
+    const status = listConnectorStatus(customConnectors).find(
+      (c: { id: string }) => c.id === 'github',
+    );
+    expect(status).toMatchObject({
+      id: 'github',
+      authKind: 'oauth',
+      connected: true,
+      source: 'built-in',
+    });
     expect(status.setup).toBeUndefined();
   });
 
-  // POC (manual-token) Google connectors: each keeps its own secret slot even
-  // though the community servers they wrap both read GOOGLE_ACCESS_TOKEN — so
-  // connecting Gmail must not flip Drive's `connected` too.
-  it('gmail + google-drive: independent secret slots, each resolves its own stdio entry', () => {
+  // Two independent managed connectors pushed by services/api must not share
+  // connected state, even though both are custom-connector entries.
+  it('two managed connectors: independent secret slots, each resolves its own entry', () => {
     const { setSecret } = require('../../src/connectors/token-env');
     const { resolveEnabledConnectors, listConnectorStatus } =
       require('../../src/connectors/resolve');
 
-    const enabled = {
-      connectors: {
-        gmail: { enabled: true },
-        'google-drive': { enabled: true },
-        // Opt-out: microsoft-365 needs no secret, so opt-in default resolves
-        // it regardless — excluded here to keep this test focused on Google.
-        'microsoft-365': { enabled: false as const },
+    const customConnectors = {
+      gmail: {
+        label: 'Gmail',
+        config: { type: 'http', url: 'https://gmailmcp.googleapis.com/mcp/v1', headers: { Authorization: 'Bearer {access_token}' } },
+        secretNames: ['access_token'],
+        authKind: 'oauth' as const,
+        managed: true,
+      },
+      'google-drive': {
+        label: 'Google Drive',
+        config: { type: 'http', url: 'https://drivemcp.googleapis.com/mcp/v1', headers: { Authorization: 'Bearer {access_token}' } },
+        secretNames: ['access_token'],
+        authKind: 'oauth' as const,
+        managed: true,
       },
     };
-    expect(resolveEnabledConnectors(enabled)).toEqual({});
+    const enabled = { connectors: { gmail: { enabled: true }, 'google-drive': { enabled: true } } };
+    expect(resolveEnabledConnectors(enabled, customConnectors)).toEqual({});
 
-    setSecret('GMAIL_ACCESS_TOKEN', 'ya29.gmail');
-    const gmailOnly = resolveEnabledConnectors(enabled);
+    setSecret('CUSTOM__gmail__access_token', 'ya29.gmail');
+    const gmailOnly = resolveEnabledConnectors(enabled, customConnectors);
     expect(gmailOnly.gmail).toEqual({
-      type: 'stdio',
-      command: 'npx',
-      args: ['-y', 'gmail-mcp'],
-      env: { GOOGLE_ACCESS_TOKEN: 'ya29.gmail' },
+      type: 'http',
+      url: 'https://gmailmcp.googleapis.com/mcp/v1',
+      headers: { Authorization: 'Bearer ya29.gmail' },
     });
     expect(gmailOnly['google-drive']).toBeUndefined();
 
-    const statusAfterGmail = listConnectorStatus();
+    const statusAfterGmail = listConnectorStatus(customConnectors);
     expect(statusAfterGmail.find((c: { id: string }) => c.id === 'gmail')).toMatchObject({
       connected: true,
     });
@@ -147,17 +185,16 @@ describe('resolve', () => {
       connected: false,
     });
 
-    setSecret('GDRIVE_ACCESS_TOKEN', 'ya29.drive');
-    const both = resolveEnabledConnectors(enabled);
+    setSecret('CUSTOM__google-drive__access_token', 'ya29.drive');
+    const both = resolveEnabledConnectors(enabled, customConnectors);
     expect(both['google-drive']).toEqual({
-      type: 'stdio',
-      command: 'npx',
-      args: ['-y', 'google-drive-mcp'],
-      env: { GOOGLE_ACCESS_TOKEN: 'ya29.drive' },
+      type: 'http',
+      url: 'https://drivemcp.googleapis.com/mcp/v1',
+      headers: { Authorization: 'Bearer ya29.drive' },
     });
   });
 
-  it('custom connector: opt-out default enablement; partially-connected → omitted; fully-connected → substituted', () => {
+  it('genuine user-pasted custom connector: opt-out default enablement; partially-connected → omitted; fully-connected → substituted', () => {
     const { setSecret } = require('../../src/connectors/token-env');
     const { resolveEnabledConnectors } = require('../../src/connectors/resolve');
 
@@ -172,15 +209,13 @@ describe('resolve', () => {
         secretNames: ['smithery_api_key', 'unset_var'],
       },
     };
-    // microsoft-365 opted out throughout — see the "opt-out" comment above.
-    const noMs365 = { 'microsoft-365': { enabled: false as const } };
-    const agentConfig = { connectors: { calendar: { enabled: true }, ...noMs365 } };
+    const agentConfig = { connectors: { calendar: { enabled: true } } };
 
     // No config at all (not even mentioning `calendar`) → still resolves once
     // secrets exist, because enablement defaults to on (opt-out model).
     setSecret('CUSTOM__calendar__smithery_api_key', 'sk-abc');
     setSecret('CUSTOM__calendar__unset_var', 'val');
-    expect(resolveEnabledConnectors({ connectors: noMs365 }, customConnectors)).toEqual({
+    expect(resolveEnabledConnectors({}, customConnectors)).toEqual({
       calendar: {
         type: 'streamable-http',
         url: 'https://server.smithery.ai/calendar/mcp',
@@ -190,10 +225,7 @@ describe('resolve', () => {
 
     // Explicitly disabled for this agent → omitted even though fully connected.
     expect(
-      resolveEnabledConnectors(
-        { connectors: { calendar: { enabled: false }, ...noMs365 } },
-        customConnectors,
-      ),
+      resolveEnabledConnectors({ connectors: { calendar: { enabled: false } } }, customConnectors),
     ).toEqual({});
 
     // Reset secrets to re-test the partial-connection path from a clean slate.
@@ -257,18 +289,10 @@ describe('connectors-router', () => {
     return app;
   }
 
-  it('GET /v1/connectors returns catalog with connected=false initially', async () => {
+  it('GET /v1/connectors returns an empty catalog by default (CONNECTOR_CATALOG is empty)', async () => {
     const res = await request(makeApp()).get('/api/v1/connectors').set('X-Api-Key', adminKey);
     expect(res.status).toBe(200);
-    const github = res.body.connectors.find((c: { id: string }) => c.id === 'github');
-    expect(github).toMatchObject({
-      id: 'github',
-      label: 'GitHub',
-      authKind: 'oauth',
-      connected: false,
-    });
-    expect(github.setup).toBeUndefined();
-    expect(github.repoUrl).toBe('https://github.com/github/github-mcp-server');
+    expect(res.body.connectors).toEqual([]);
   });
 
   it('rejects missing / invalid key', async () => {
@@ -276,46 +300,111 @@ describe('connectors-router', () => {
     expect((await request(makeApp()).get('/api/v1/connectors').set('X-Api-Key', 'nope')).status).toBe(403);
   });
 
+  // CONNECTOR_CATALOG is empty by default now, so /connect 404s for every id
+  // before ever reaching requireAdmin — mock one synthetic 'secret'-kind
+  // built-in entry (the shape a deployer's own fork might hardcode) so this
+  // still exercises the route's actual admin gate, not just its 404 path.
+  // jest.isolateModules scopes the mock to this test only — it does NOT leak
+  // into later tests the way a bare jest.doMock would (doMock registrations
+  // survive jest.resetModules(), which only clears cached instances).
   it('non-admin cannot connect', async () => {
-    const res = await request(makeApp())
-      .post('/api/v1/connectors/github/connect')
-      .set('X-Api-Key', scopedKey)
-      .send({ token: 'ghp_x' });
+    const stubSpec = {
+      id: 'stub-secret',
+      label: 'Stub',
+      transport: 'http',
+      auth: { kind: 'secret', secretEnv: 'STUB_TOKEN' },
+      build: () => ({}),
+    };
+    let res!: request.Response;
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('../../src/connectors/catalog', () => ({
+        CONNECTOR_CATALOG: [stubSpec],
+        getConnectorSpec: (id: string) => (id === 'stub-secret' ? stubSpec : undefined),
+      }));
+      const { createConnectorsRouter } = require('../../src/api/connectors-router');
+      const app = express();
+      app.use(express.json());
+      app.use('/api', createConnectorsRouter(apiKeys));
+      res = await request(app)
+        .post('/api/v1/connectors/stub-secret/connect')
+        .set('X-Api-Key', scopedKey)
+        .send({ token: 'ghp_x' });
+    });
+    // jest.doMock registrations outlive isolateModulesAsync's registry scope
+    // (it only isolates the module cache, not the mock registry) — undo it
+    // explicitly so later tests' fresh `require`s get the real catalog again.
+    jest.dontMock('../../src/connectors/catalog');
     expect(res.status).toBe(403);
   });
 
-  // github is oauth-kind now (services/api pushes the token via /oauth/receive,
-  // same as gmail/drive/calendar — see tests/unit/oauth-connectors.test.ts for
-  // that route's dedicated coverage). This test keeps the router-level
-  // connect→status→delete round trip exercised end-to-end from this suite.
-  it('oauth/receive stores the access token + writes config.json; delete clears both', async () => {
+  // github is a services/api-managed custom connector now (pushed via
+  // /oauth/receive with a full config shape, not just a token — same as
+  // gmail/drive/calendar; see tests/unit/oauth-connectors.test.ts for that
+  // route's dedicated payload-shape coverage). This test keeps the
+  // router-level push→status→delete round trip exercised end-to-end.
+  it('oauth/receive stores the full managed shape + secret; delete clears both', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-router-'));
     const cfgPath = path.join(dir, 'config.json');
     fs.writeFileSync(cfgPath, JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2));
     const app = makeApp(cfgPath);
     const { getSecret } = require('../../src/connectors/token-env');
+    const pushPayload = {
+      access_token: 'ghu_pushed',
+      label: 'GitHub',
+      description: 'Repos, issues, and pull requests via the official GitHub MCP server.',
+      config: {
+        type: 'http',
+        url: 'https://api.githubcopilot.com/mcp/',
+        headers: { Authorization: 'Bearer {access_token}' },
+      },
+      sourceUrl: 'https://github.com/github/github-mcp-server',
+    };
 
     // empty access_token rejected
-    const bad = await request(app).post('/api/v1/connectors/github/oauth/receive').set('X-Api-Key', adminKey).send({ access_token: '  ' });
+    const bad = await request(app)
+      .post('/api/v1/connectors/github/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send({ ...pushPayload, access_token: '  ' });
     expect(bad.status).toBe(400);
 
     // receive
-    const ok = await request(app).post('/api/v1/connectors/github/oauth/receive').set('X-Api-Key', adminKey).send({ access_token: 'ghu_pushed' });
+    const ok = await request(app)
+      .post('/api/v1/connectors/github/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send(pushPayload);
     expect(ok.status).toBe(200);
     expect(ok.body).toEqual({ id: 'github', connected: true });
-    expect(getSecret('GITHUB_TOKEN')).toBe('ghu_pushed');
+    expect(getSecret('CUSTOM__github__access_token')).toBe('ghu_pushed');
     const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
-    expect(written.gateway.connectors).toEqual({ github: { secretEnv: 'GITHUB_TOKEN' } });
+    expect(written.gateway.customConnectors.github).toMatchObject({
+      label: 'GitHub',
+      secretNames: ['access_token'],
+      authKind: 'oauth',
+      managed: true,
+    });
+
+    // GET /v1/connectors reports it as built-in (not "Custom") and oauth-kind
+    const list = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    expect(list.body.connectors).toEqual([
+      expect.objectContaining({
+        id: 'github',
+        label: 'GitHub',
+        authKind: 'oauth',
+        connected: true,
+        source: 'built-in',
+        repoUrl: pushPayload.sourceUrl,
+      }),
+    ]);
 
     // status reflects connected
     const status = await request(app).get('/api/v1/connectors/github/status').set('X-Api-Key', adminKey);
     expect(status.body).toEqual({ id: 'github', connected: true });
 
-    // delete
+    // delete — via the unified route (github has no catalog entry, falls back to customConnectors)
     const del = await request(app).delete('/api/v1/connectors/github').set('X-Api-Key', adminKey);
     expect(del.status).toBe(200);
-    expect(getSecret('GITHUB_TOKEN')).toBeNull();
-    expect(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')).gateway.connectors).toEqual({});
+    expect(getSecret('CUSTOM__github__access_token')).toBeNull();
+    expect(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')).gateway.customConnectors).toEqual({});
   });
 
   it('unknown connector → 404', async () => {

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -507,6 +507,46 @@ describe('connectors-router', () => {
     ]);
   });
 
+  // A "No auth" custom connector (no {placeholder} in its pasted config, so
+  // secretNames: []) has no secret for the soft-disconnect above to clear.
+  // listConnectorStatus's `secretNames.every(...)` is vacuously true on an
+  // empty array, so soft-disconnecting it would report connected: true again
+  // on the very next GET — Disconnect would look broken (click it, the row
+  // never leaves "Connected"). DELETE must remove the entry outright instead.
+  it('DELETE on a "No auth" (zero-secret) custom connector removes the entry, not a no-op soft disconnect', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-router-'));
+    const cfgPath = path.join(dir, 'config.json');
+    fs.writeFileSync(cfgPath, JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2));
+    const app = makeApp(cfgPath);
+
+    const add = await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({
+        label: 'sdfasdfasf',
+        config: { type: 'http', url: 'https://example.com/mcp' },
+      });
+    expect(add.status).toBe(200);
+    const id = add.body.id;
+
+    // Reported connected — and always would be, per the vacuous every([]).
+    const before = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    expect(before.body.connectors).toEqual([
+      expect.objectContaining({ id, label: 'sdfasdfasf', authKind: 'none', connected: true }),
+    ]);
+
+    const del = await request(app).delete(`/api/v1/connectors/${id}`).set('X-Api-Key', adminKey);
+    expect(del.status).toBe(200);
+    expect(del.body).toEqual({ id, connected: false });
+
+    // The entry itself is gone — not left behind still reporting connected.
+    const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    expect(written.gateway.customConnectors ?? {}).toEqual({});
+
+    const after = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    expect(after.body.connectors).toEqual([]);
+  });
+
   // The exact bug the soft-disconnect fix above exposed: once DELETE keeps a
   // custom connector's entry alive, POST .../connect must actually be able to
   // reconnect it — before this fallback existed, this route only ever looked

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -103,14 +103,11 @@ describe('resolve', () => {
       headers: { Authorization: 'Bearer ghp_xyz' },
     });
 
-    // connected reflected in status
+    // connected reflected in status — github is now a real OAuth connector
+    // (services/api-driven, no paste-token setup help to surface).
     const status = listConnectorStatus().find((c: { id: string }) => c.id === 'github');
-    expect(status).toMatchObject({ id: 'github', authKind: 'secret', connected: true });
-
-    // guided token-generation help is surfaced for the web panel
-    expect(status.setup.tokenUrl).toMatch(/^https:\/\/github\.com\/settings\/tokens\/new/);
-    expect(typeof status.setup.label).toBe('string');
-    expect(status.setup.label.length).toBeGreaterThan(0);
+    expect(status).toMatchObject({ id: 'github', authKind: 'oauth', connected: true });
+    expect(status.setup).toBeUndefined();
   });
 
   // POC (manual-token) Google connectors: each keeps its own secret slot even
@@ -264,9 +261,13 @@ describe('connectors-router', () => {
     const res = await request(makeApp()).get('/api/v1/connectors').set('X-Api-Key', adminKey);
     expect(res.status).toBe(200);
     const github = res.body.connectors.find((c: { id: string }) => c.id === 'github');
-    expect(github).toMatchObject({ id: 'github', label: 'GitHub', connected: false });
-    expect(github.setup.tokenUrl).toMatch(/^https:\/\/github\.com\/settings\/tokens\/new/);
-    expect(github.setup.label).toBeTruthy();
+    expect(github).toMatchObject({
+      id: 'github',
+      label: 'GitHub',
+      authKind: 'oauth',
+      connected: false,
+    });
+    expect(github.setup).toBeUndefined();
     expect(github.repoUrl).toBe('https://github.com/github/github-mcp-server');
   });
 
@@ -283,22 +284,26 @@ describe('connectors-router', () => {
     expect(res.status).toBe(403);
   });
 
-  it('connect stores secret + writes config.json; delete clears both', async () => {
+  // github is oauth-kind now (services/api pushes the token via /oauth/receive,
+  // same as gmail/drive/calendar — see tests/unit/oauth-connectors.test.ts for
+  // that route's dedicated coverage). This test keeps the router-level
+  // connect→status→delete round trip exercised end-to-end from this suite.
+  it('oauth/receive stores the access token + writes config.json; delete clears both', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-router-'));
     const cfgPath = path.join(dir, 'config.json');
     fs.writeFileSync(cfgPath, JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2));
     const app = makeApp(cfgPath);
     const { getSecret } = require('../../src/connectors/token-env');
 
-    // empty token rejected
-    const bad = await request(app).post('/api/v1/connectors/github/connect').set('X-Api-Key', adminKey).send({ token: '  ' });
+    // empty access_token rejected
+    const bad = await request(app).post('/api/v1/connectors/github/oauth/receive').set('X-Api-Key', adminKey).send({ access_token: '  ' });
     expect(bad.status).toBe(400);
 
-    // connect
-    const ok = await request(app).post('/api/v1/connectors/github/connect').set('X-Api-Key', adminKey).send({ token: 'ghp_secret' });
+    // receive
+    const ok = await request(app).post('/api/v1/connectors/github/oauth/receive').set('X-Api-Key', adminKey).send({ access_token: 'ghu_pushed' });
     expect(ok.status).toBe(200);
     expect(ok.body).toEqual({ id: 'github', connected: true });
-    expect(getSecret('GITHUB_TOKEN')).toBe('ghp_secret');
+    expect(getSecret('GITHUB_TOKEN')).toBe('ghu_pushed');
     const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
     expect(written.gateway.connectors).toEqual({ github: { secretEnv: 'GITHUB_TOKEN' } });
 

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -79,7 +79,7 @@ describe('resolve', () => {
   });
 
   // github/gmail/etc. are no longer built-in catalog entries — they're managed
-  // custom connectors pushed by services/api (see connectors-router.ts's
+  // custom connectors pushed by an external control plane (see connectors-router.ts's
   // /oauth/receive). This exercises the exact shape that route writes:
   // authKind:'oauth' + managed:true, resolved through the generic
   // customConnectors path like any other custom connector.
@@ -142,7 +142,7 @@ describe('resolve', () => {
     expect(status.setup).toBeUndefined();
   });
 
-  // Two independent managed connectors pushed by services/api must not share
+  // Two independent managed connectors pushed by an external control plane must not share
   // connected state, even though both are custom-connector entries.
   it('two managed connectors: independent secret slots, each resolves its own entry', () => {
     const { setSecret } = require('../../src/connectors/token-env');
@@ -250,7 +250,7 @@ describe('resolve', () => {
 
   // A user-added generic-OAuth custom connector (oauth: true, added via
   // POST /v1/connectors/custom, no explicit authKind — that field is only
-  // ever set by services/api's managed push, see CustomConnectorEntry's doc
+  // ever set by an external control plane's managed push, see CustomConnectorEntry's doc
   // comment) must still report authKind: 'oauth', not fall through to
   // 'secret' just because secretNames is non-empty — the web panel's Auth
   // column and icon both key off this.
@@ -530,7 +530,7 @@ describe('connectors-router', () => {
     expect(getSecret(customSecretKey('github', 'access_token'))).toBe('ghu_real_oauth_token'); // untouched
   });
 
-  // github is a services/api-managed custom connector now (pushed via
+  // github is an externally-managed custom connector now (pushed via
   // /oauth/receive with a full config shape, not just a token — same as
   // gmail/drive/calendar; see tests/unit/oauth-connectors.test.ts for that
   // route's dedicated payload-shape coverage). This test keeps the

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -278,6 +278,69 @@ describe('resolve', () => {
       oauth: true,
     });
   });
+
+  // Regression: a deployer-defined CONNECTOR_CATALOG entry's build() throwing
+  // used to propagate straight out of resolveEnabledConnectors — called
+  // unguarded inside session spawn (session/process.ts's writeMcpConfig), so
+  // one bad catalog entry aborted the ENTIRE session for every user of the
+  // agent, not just the resolution of that one connector.
+  it('a built-in catalog entry whose build() throws is skipped, not fatal to the whole resolution', () => {
+    const throwingSpec = {
+      id: 'flaky',
+      label: 'Flaky',
+      transport: 'http',
+      auth: { kind: 'none' },
+      build: () => {
+        throw new Error('boom');
+      },
+    };
+    let result!: Record<string, unknown>;
+    jest.isolateModules(() => {
+      jest.doMock('../../src/connectors/catalog', () => ({
+        CONNECTOR_CATALOG: [throwingSpec],
+        getConnectorSpec: () => undefined,
+      }));
+      const { resolveEnabledConnectors } = require('../../src/connectors/resolve');
+      result = resolveEnabledConnectors({});
+    });
+    jest.dontMock('../../src/connectors/catalog');
+    expect(result).toEqual({});
+  });
+
+  // Same isolation for the customConnectors path — a malformed pasted config
+  // (admin-trusted, not code-reviewed) must not take down every OTHER
+  // connector's resolution for this session.
+  it('a custom connector whose substitution throws is skipped, not fatal to the whole resolution', () => {
+    const { setSecret } = require('../../src/connectors/token-env');
+    setSecret('CUSTOM__broken__api_key', 'sk-abc');
+    setSecret('CUSTOM__fine__api_key', 'sk-xyz');
+
+    let result!: Record<string, unknown>;
+    jest.isolateModules(() => {
+      jest.doMock('../../src/connectors/custom', () => {
+        const real = jest.requireActual('../../src/connectors/custom');
+        return {
+          ...real,
+          substitutePlaceholders: (config: unknown, secrets: Record<string, string>) => {
+            if (JSON.stringify(config).includes('broken')) throw new Error('malformed config');
+            return real.substitutePlaceholders(config, secrets);
+          },
+        };
+      });
+      const { resolveEnabledConnectors } = require('../../src/connectors/resolve');
+      result = resolveEnabledConnectors(
+        {},
+        {
+          broken: { label: 'Broken', config: { url: 'https://broken.example/{api_key}' }, secretNames: ['api_key'] },
+          fine: { label: 'Fine', config: { url: 'https://fine.example', headers: { Authorization: 'Bearer {api_key}' } }, secretNames: ['api_key'] },
+        },
+      );
+    });
+    jest.dontMock('../../src/connectors/custom');
+
+    expect(result.broken).toBeUndefined();
+    expect(result.fine).toEqual({ url: 'https://fine.example', headers: { Authorization: 'Bearer sk-xyz' } });
+  });
 });
 
 describe('boot-safety', () => {
@@ -381,6 +444,90 @@ describe('connectors-router', () => {
     // explicitly so later tests' fresh `require`s get the real catalog again.
     jest.dontMock('../../src/connectors/catalog');
     expect(res.status).toBe(403);
+  });
+
+  // Regression: connect/delete for a built-in catalog entry used to also
+  // read-modify-write config.json's gateway.connectors subtree via a
+  // dedicated function+lock (mutateGatewayConnectors) that nothing ever read
+  // back — dead state with its own uncoordinated lock racing
+  // custom-connectors-store.ts's lock on the same file. That write path was
+  // removed; this proves the actually-meaningful behavior (the secret itself,
+  // and connected status derived from it) still works end-to-end with no
+  // config.json at all.
+  it('catalog secret-kind connect/delete round-trip works with no config.json (no dead file write to break)', async () => {
+    const stubSpec = {
+      id: 'stub-secret',
+      label: 'Stub',
+      transport: 'http',
+      auth: { kind: 'secret', secretEnv: 'STUB_TOKEN' },
+      build: () => ({}),
+    };
+    let connectRes!: request.Response;
+    let statusAfterConnect!: request.Response;
+    let deleteRes!: request.Response;
+    let statusAfterDelete!: request.Response;
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('../../src/connectors/catalog', () => ({
+        CONNECTOR_CATALOG: [stubSpec],
+        getConnectorSpec: (id: string) => (id === 'stub-secret' ? stubSpec : undefined),
+      }));
+      const { createConnectorsRouter } = require('../../src/api/connectors-router');
+      const app = express();
+      app.use(express.json());
+      app.use('/api', createConnectorsRouter(apiKeys)); // no configPath at all
+      connectRes = await request(app)
+        .post('/api/v1/connectors/stub-secret/connect')
+        .set('X-Api-Key', adminKey)
+        .send({ token: 'stub-token-value' });
+      statusAfterConnect = await request(app)
+        .get('/api/v1/connectors/stub-secret/status')
+        .set('X-Api-Key', adminKey);
+      deleteRes = await request(app)
+        .delete('/api/v1/connectors/stub-secret')
+        .set('X-Api-Key', adminKey);
+      statusAfterDelete = await request(app)
+        .get('/api/v1/connectors/stub-secret/status')
+        .set('X-Api-Key', adminKey);
+    });
+    jest.dontMock('../../src/connectors/catalog');
+
+    expect(connectRes.status).toBe(200);
+    expect(connectRes.body).toEqual({ id: 'stub-secret', connected: true });
+    expect(statusAfterConnect.body).toEqual({ id: 'stub-secret', connected: true });
+    expect(deleteRes.status).toBe(200);
+    expect(deleteRes.body).toEqual({ id: 'stub-secret', connected: false });
+    expect(statusAfterDelete.body).toEqual({ id: 'stub-secret', connected: false });
+  });
+
+  // Regression: a managed connector (github/gmail/etc., pushed via
+  // /oauth/receive) has authKind:'oauth' + managed:true but — unlike a
+  // user's own oauth:true custom connector — never sets `oauth: true` itself.
+  // /connect's guard used to check only `entry.oauth`, so a managed entry
+  // slipped through it and could be overwritten with an arbitrary string via
+  // this route, bypassing the real OAuth flow and skipping the session
+  // restart /oauth/receive does.
+  it('/connect rejects a managed connector — cannot overwrite its real OAuth token with an arbitrary string', async () => {
+    const cfgPath = tmpConfig({
+      github: {
+        label: 'GitHub',
+        config: { type: 'http', url: 'https://api.githubcopilot.com/mcp/', headers: { Authorization: 'Bearer {access_token}' } },
+        secretNames: ['access_token'],
+        authKind: 'oauth',
+        managed: true,
+      },
+    });
+    const { setSecret, getSecret } = require('../../src/connectors/token-env');
+    const { customSecretKey } = require('../../src/connectors/custom');
+    setSecret(customSecretKey('github', 'access_token'), 'ghu_real_oauth_token');
+
+    const res = await request(makeApp(cfgPath))
+      .post('/api/v1/connectors/github/connect')
+      .set('X-Api-Key', adminKey)
+      .send({ token: 'anything-an-attacker-or-mistake-typed' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/managed externally/i);
+    expect(getSecret(customSecretKey('github', 'access_token'))).toBe('ghu_real_oauth_token'); // untouched
   });
 
   // github is a services/api-managed custom connector now (pushed via
@@ -545,6 +692,49 @@ describe('connectors-router', () => {
 
     const after = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
     expect(after.body.connectors).toEqual([]);
+  });
+
+  // Regression: disconnecting an oauth:true custom connector used to only
+  // clear its secretNames (just 'access_token') — the refresh sweep's own
+  // bookkeeping (__refresh_token/__client_id/__token_expires_at) lived
+  // outside secretNames and survived, so oauth-refresh-sweep.ts would
+  // silently mint a fresh access_token and resurrect a connector the user
+  // just disconnected the next time its (unaffected) expiry came due.
+  it('DELETE on an oauth:true custom connector also clears the refresh sweep\'s own secrets', async () => {
+    const cfgPath = tmpConfig({
+      firecrawl: {
+        label: 'Firecrawl',
+        config: { type: 'http', url: 'https://mcp.firecrawl.dev/v2/mcp-oauth', headers: { Authorization: 'Bearer {access_token}' } },
+        secretNames: ['access_token'],
+        oauth: true,
+      },
+    });
+    const { setSecret, getSecret } = require('../../src/connectors/token-env');
+    const { customSecretKey } = require('../../src/connectors/custom');
+    const {
+      refreshTokenSecretKey,
+      clientIdSecretKey,
+      expiresAtSecretKey,
+      refreshFailCountSecretKey,
+      refreshBackoffUntilSecretKey,
+    } = require('../../src/connectors/oauth-refresh-sweep');
+
+    setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_live');
+    setSecret(refreshTokenSecretKey('firecrawl'), 'fcr_live');
+    setSecret(clientIdSecretKey('firecrawl'), 'dyn_live');
+    setSecret(expiresAtSecretKey('firecrawl'), String(Date.now() + 3600_000));
+    setSecret(refreshFailCountSecretKey('firecrawl'), '1');
+    setSecret(refreshBackoffUntilSecretKey('firecrawl'), String(Date.now() + 60_000));
+
+    const del = await request(makeApp(cfgPath)).delete('/api/v1/connectors/firecrawl').set('X-Api-Key', adminKey);
+    expect(del.status).toBe(200);
+
+    expect(getSecret(customSecretKey('firecrawl', 'access_token'))).toBeNull();
+    expect(getSecret(refreshTokenSecretKey('firecrawl'))).toBeNull();
+    expect(getSecret(clientIdSecretKey('firecrawl'))).toBeNull();
+    expect(getSecret(expiresAtSecretKey('firecrawl'))).toBeNull();
+    expect(getSecret(refreshFailCountSecretKey('firecrawl'))).toBeNull();
+    expect(getSecret(refreshBackoffUntilSecretKey('firecrawl'))).toBeNull();
   });
 
   // The exact bug the soft-disconnect fix above exposed: once DELETE keeps a

--- a/tests/unit/connectors.test.ts
+++ b/tests/unit/connectors.test.ts
@@ -320,6 +320,21 @@ describe('connectors-router', () => {
     return app;
   }
 
+  /** Write a temp config.json pre-seeded with the given customConnectors, return its path. */
+  function tmpConfig(customConnectors: Record<string, unknown>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-router-'));
+    const cfgPath = path.join(dir, 'config.json');
+    fs.writeFileSync(
+      cfgPath,
+      JSON.stringify(
+        { gateway: { logDir: '/tmp', timezone: 'UTC', customConnectors }, agents: [] },
+        null,
+        2,
+      ),
+    );
+    return cfgPath;
+  }
+
   it('GET /v1/connectors returns an empty catalog by default (CONNECTOR_CATALOG is empty)', async () => {
     const res = await request(makeApp()).get('/api/v1/connectors').set('X-Api-Key', adminKey);
     expect(res.status).toBe(200);
@@ -490,6 +505,94 @@ describe('connectors-router', () => {
     expect(list.body.connectors).toEqual([
       expect.objectContaining({ id, label: 'Smithery Calendar', source: 'custom', connected: false }),
     ]);
+  });
+
+  // The exact bug the soft-disconnect fix above exposed: once DELETE keeps a
+  // custom connector's entry alive, POST .../connect must actually be able to
+  // reconnect it — before this fallback existed, this route only ever looked
+  // in the built-in CONNECTOR_CATALOG and 404'd for any customConnectors id.
+  it('POST .../connect reconnects a single-secret custom connector after DELETE soft-disconnected it', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-router-'));
+    const cfgPath = path.join(dir, 'config.json');
+    fs.writeFileSync(cfgPath, JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2));
+    const app = makeApp(cfgPath);
+    const { getSecret } = require('../../src/connectors/token-env');
+
+    const add = await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({
+        label: 'Stripe',
+        config: { type: 'http', url: 'https://mcp.stripe.com', headers: { Authorization: 'Bearer {api_key}' } },
+        secrets: { api_key: 'sk_test_old' },
+      });
+    const id = add.body.id;
+
+    await request(app).delete(`/api/v1/connectors/${id}`).set('X-Api-Key', adminKey);
+    expect(getSecret(`CUSTOM__${id}__api_key`)).toBeNull();
+
+    const reconnect = await request(app)
+      .post(`/api/v1/connectors/${id}/connect`)
+      .set('X-Api-Key', adminKey)
+      .send({ token: 'sk_test_new' });
+    expect(reconnect.status).toBe(200);
+    expect(reconnect.body).toEqual({ id, connected: true });
+    expect(getSecret(`CUSTOM__${id}__api_key`)).toBe('sk_test_new');
+
+    const status = await request(app).get(`/api/v1/connectors/${id}/status`).set('X-Api-Key', adminKey);
+    expect(status.body).toEqual({ id, connected: true });
+  });
+
+  it('POST .../connect on an oauth:true custom connector rejects with a clear message instead of trying to store a plain token', async () => {
+    const app = makeApp(tmpConfig({
+      firecrawl: {
+        label: 'Firecrawl',
+        config: { type: 'http', url: 'https://mcp.firecrawl.dev/v2/mcp-oauth', headers: { Authorization: 'Bearer {access_token}' } },
+        secretNames: ['access_token'],
+        oauth: true,
+      },
+    }));
+    const res = await request(app)
+      .post('/api/v1/connectors/firecrawl/connect')
+      .set('X-Api-Key', adminKey)
+      .send({ token: 'whatever' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/oauth\/start/);
+  });
+
+  it('POST .../connect on a multi-secret custom connector rejects instead of silently storing the token under one name', async () => {
+    const app = makeApp(tmpConfig({
+      calendar: {
+        label: 'Calendar',
+        config: {
+          type: 'streamable-http',
+          url: 'https://server.smithery.ai/calendar/mcp',
+          headers: { Authorization: 'Bearer {smithery_api_key}', 'X-Extra': '{unset_var}' },
+        },
+        secretNames: ['smithery_api_key', 'unset_var'],
+      },
+    }));
+    const res = await request(app)
+      .post('/api/v1/connectors/calendar/connect')
+      .set('X-Api-Key', adminKey)
+      .send({ token: 'whatever' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/needs 2 secrets/);
+  });
+
+  it('non-admin cannot reconnect a customConnectors entry either', async () => {
+    const app = makeApp(tmpConfig({
+      stripe: {
+        label: 'Stripe',
+        config: { type: 'http', url: 'https://mcp.stripe.com', headers: { Authorization: 'Bearer {api_key}' } },
+        secretNames: ['api_key'],
+      },
+    }));
+    const res = await request(app)
+      .post('/api/v1/connectors/stripe/connect')
+      .set('X-Api-Key', scopedKey)
+      .send({ token: 'whatever' });
+    expect(res.status).toBe(403);
   });
 
   it('unknown connector → 404', async () => {

--- a/tests/unit/custom-connectors.test.ts
+++ b/tests/unit/custom-connectors.test.ts
@@ -235,25 +235,41 @@ describe('connectors-router — custom connectors', () => {
     expect(del.status).toBe(404);
   });
 
-  it('delete clears the namespaced secret + config entry (unified DELETE route)', async () => {
+  it('delete clears the namespaced secret but keeps the config entry (soft disconnect, unified DELETE route)', async () => {
+    // A genuinely user-added custom connector has no fallback catalog the way
+    // github/gmail/etc. do (see resolve.ts's managed-vs-custom split) — its
+    // config IS the customConnectors entry, so DELETE must not discard it or
+    // the row (and everything the user pasted) is gone for good. Only the
+    // secret is cleared; reconnecting just needs a fresh token/OAuth grant.
     const cfgPath = tmpConfig();
     const app = makeApp(cfgPath);
     const { getSecret } = require('../../src/connectors/token-env');
 
+    const rollforgeConfig = {
+      command: 'npx',
+      args: ['@agentutility/mcp-rollforge'],
+      env: { TOKEN: '{token}' },
+    };
     await request(app)
       .post('/api/v1/connectors/custom')
       .set('X-Api-Key', adminKey)
-      .send({
-        label: 'Rollforge',
-        config: { command: 'npx', args: ['@agentutility/mcp-rollforge'], env: { TOKEN: '{token}' } },
-        secrets: { token: 'shhh' },
-      });
+      .send({ label: 'Rollforge', config: rollforgeConfig, secrets: { token: 'shhh' } });
     expect(getSecret('CUSTOM__rollforge__token')).toBe('shhh');
 
     const del = await request(app).delete('/api/v1/connectors/rollforge').set('X-Api-Key', adminKey);
     expect(del.status).toBe(200);
+    expect(del.body).toEqual({ id: 'rollforge', connected: false });
     expect(getSecret('CUSTOM__rollforge__token')).toBeNull();
-    expect(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')).gateway.customConnectors).toEqual({});
+
+    const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')).gateway.customConnectors;
+    expect(written.rollforge).toMatchObject({ label: 'Rollforge', config: rollforgeConfig });
+
+    // The row survives, reported as not connected — not silently dropped
+    // from GET /v1/connectors the way a hard delete would.
+    const list = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    expect(list.body.connectors).toEqual([
+      expect.objectContaining({ id: 'rollforge', label: 'Rollforge', connected: false, source: 'custom' }),
+    ]);
   });
 
   it('unified DELETE requires admin even for a custom-connector id (checked before the catalog/custom lookup)', async () => {

--- a/tests/unit/custom-connectors.test.ts
+++ b/tests/unit/custom-connectors.test.ts
@@ -31,8 +31,13 @@ describe('custom helpers', () => {
   it('slugify: lowercases, dashes, and de-dupes against catalog + existing ids', () => {
     const { slugify } = require('../../src/connectors/custom');
     expect(slugify('Weather API!', [])).toBe('weather-api');
-    // Collides with the built-in 'github' id
-    expect(slugify('GitHub', [])).toBe('github-2');
+    // CONNECTOR_CATALOG is empty by default now, so there's no built-in id
+    // left to collide with — 'github' (and gmail/drive/calendar) are managed
+    // custom connector ids pushed by services/api, not reserved here. A user
+    // adding their own custom connector labeled "GitHub" could theoretically
+    // slug-collide with a services/api-managed id (accepted edge case, see
+    // custom.ts's note — admin-trusted either way, self-recoverable).
+    expect(slugify('GitHub', [])).toBe('github');
     // Collides with an existing custom id
     expect(slugify('Foo', ['foo'])).toBe('foo-2');
     expect(slugify('Foo', ['foo', 'foo-2'])).toBe('foo-3');
@@ -154,9 +159,22 @@ describe('connectors-router — custom connectors', () => {
     });
   });
 
-  it('creates with secrets provided inline → connected:true, and GET /v1/connectors merges it in with source "custom"', async () => {
+  it('creates with secrets provided inline → connected:true, and GET /v1/connectors merges both a managed and a genuine custom entry with the right source', async () => {
     const cfgPath = tmpConfig();
     const app = makeApp(cfgPath);
+
+    // A services/api-managed push (github) reports source: 'built-in' — see
+    // oauth-connectors.test.ts for that route's dedicated coverage; this test
+    // is about the GET /v1/connectors merge, not the push itself.
+    await request(app)
+      .post('/api/v1/connectors/github/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send({
+        access_token: 'ghu_x',
+        label: 'GitHub',
+        config: { type: 'http', url: 'https://api.githubcopilot.com/mcp/', headers: { Authorization: 'Bearer {access_token}' } },
+      });
+
     const create = await request(app)
       .post('/api/v1/connectors/custom')
       .set('X-Api-Key', adminKey)
@@ -209,11 +227,15 @@ describe('connectors-router — custom connectors', () => {
     const app = makeApp(tmpConfig());
     const status = await request(app).get('/api/v1/connectors/nope/status').set('X-Api-Key', adminKey);
     expect(status.status).toBe(404);
-    const del = await request(app).delete('/api/v1/connectors/custom/nope').set('X-Api-Key', adminKey);
+    // DELETE /custom/:id was retired — deleting a custom connector now goes
+    // through the same unified DELETE /v1/connectors/:id every other
+    // connector uses (falls back to customConnectors when the catalog lookup
+    // misses; see connectors-router.ts).
+    const del = await request(app).delete('/api/v1/connectors/nope').set('X-Api-Key', adminKey);
     expect(del.status).toBe(404);
   });
 
-  it('delete clears the namespaced secret + config entry', async () => {
+  it('delete clears the namespaced secret + config entry (unified DELETE route)', async () => {
     const cfgPath = tmpConfig();
     const app = makeApp(cfgPath);
     const { getSecret } = require('../../src/connectors/token-env');
@@ -228,9 +250,20 @@ describe('connectors-router — custom connectors', () => {
       });
     expect(getSecret('CUSTOM__rollforge__token')).toBe('shhh');
 
-    const del = await request(app).delete('/api/v1/connectors/custom/rollforge').set('X-Api-Key', adminKey);
+    const del = await request(app).delete('/api/v1/connectors/rollforge').set('X-Api-Key', adminKey);
     expect(del.status).toBe(200);
     expect(getSecret('CUSTOM__rollforge__token')).toBeNull();
     expect(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')).gateway.customConnectors).toEqual({});
+  });
+
+  it('unified DELETE requires admin even for a custom-connector id (checked before the catalog/custom lookup)', async () => {
+    const app = makeApp(tmpConfig());
+    await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({ label: 'Rollforge', config: { command: 'npx' } });
+
+    const res = await request(app).delete('/api/v1/connectors/rollforge').set('X-Api-Key', scopedKey);
+    expect(res.status).toBe(403);
   });
 });

--- a/tests/unit/custom-connectors.test.ts
+++ b/tests/unit/custom-connectors.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Unit tests for custom (user-pasted) connectors — the 2nd, admin-trusted-not-
+ * code-reviewed tier alongside CONNECTOR_CATALOG.
+ *
+ *  custom helpers    — slugify / extractPlaceholders / substitutePlaceholders
+ *  connectors-router — POST /custom (create), DELETE /custom/:id, GET merges tiers
+ */
+
+import express from 'express';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ApiKey } from '../../src/types';
+
+const TOKEN_ENV = '/tmp/custom-connectors-test-mcp-token.env';
+
+beforeEach(() => {
+  process.env.GATEWAY_MCP_TOKEN_ENV = TOKEN_ENV;
+  try { fs.rmSync(TOKEN_ENV); } catch { /* ignore */ }
+  jest.resetModules();
+});
+
+afterAll(() => {
+  delete process.env.GATEWAY_MCP_TOKEN_ENV;
+  try { fs.rmSync(TOKEN_ENV); } catch { /* ignore */ }
+});
+
+describe('custom helpers', () => {
+  it('slugify: lowercases, dashes, and de-dupes against catalog + existing ids', () => {
+    const { slugify } = require('../../src/connectors/custom');
+    expect(slugify('Weather API!', [])).toBe('weather-api');
+    // Collides with the built-in 'github' id
+    expect(slugify('GitHub', [])).toBe('github-2');
+    // Collides with an existing custom id
+    expect(slugify('Foo', ['foo'])).toBe('foo-2');
+    expect(slugify('Foo', ['foo', 'foo-2'])).toBe('foo-3');
+  });
+
+  it('extractPlaceholders: finds every unique {name} in nested string values', () => {
+    const { extractPlaceholders } = require('../../src/connectors/custom');
+    const config = {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer {api_key}', 'X-Team': '{team_id}' },
+      nested: ['{team_id}', 'no-placeholder-here'],
+    };
+    expect(extractPlaceholders(config).sort()).toEqual(['api_key', 'team_id']);
+  });
+
+  it('extractPlaceholders: empty when there are none', () => {
+    const { extractPlaceholders } = require('../../src/connectors/custom');
+    expect(extractPlaceholders({ command: 'npx', args: ['some-mcp'] })).toEqual([]);
+  });
+
+  it('substitutePlaceholders: replaces recursively, missing secrets become empty string', () => {
+    const { substitutePlaceholders } = require('../../src/connectors/custom');
+    const config = { headers: { Authorization: 'Bearer {api_key}' }, list: ['{a}', 'x'] };
+    expect(substitutePlaceholders(config, { api_key: 'sk-123', a: 'A' })).toEqual({
+      headers: { Authorization: 'Bearer sk-123' },
+      list: ['A', 'x'],
+    });
+    expect(substitutePlaceholders(config, {})).toEqual({
+      headers: { Authorization: 'Bearer ' },
+      list: ['', 'x'],
+    });
+  });
+});
+
+describe('connectors-router — custom connectors', () => {
+  const adminKey = 'admin-key';
+  const scopedKey = 'scoped-key';
+  const apiKeys: ApiKey[] = [
+    { key: adminKey, agents: '*', admin: true },
+    { key: scopedKey, agents: ['a1'] },
+  ];
+
+  function makeApp(configPath?: string) {
+    const { createConnectorsRouter } = require('../../src/api/connectors-router');
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createConnectorsRouter(apiKeys, configPath));
+    return app;
+  }
+
+  function tmpConfig() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-custom-'));
+    const cfgPath = path.join(dir, 'config.json');
+    fs.writeFileSync(
+      cfgPath,
+      JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2),
+    );
+    return cfgPath;
+  }
+
+  it('non-admin cannot add a custom connector', async () => {
+    const res = await request(makeApp(tmpConfig()))
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', scopedKey)
+      .send({ label: 'X', config: { command: 'npx', args: ['x-mcp'] } });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a missing/invalid config body', async () => {
+    const app = makeApp(tmpConfig());
+    const noConfig = await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({ label: 'X' });
+    expect(noConfig.status).toBe(400);
+
+    const arrayConfig = await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({ label: 'X', config: ['not', 'an', 'object'] });
+    expect(arrayConfig.status).toBe(400);
+
+    const noLabel = await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({ config: { command: 'npx' } });
+    expect(noLabel.status).toBe(400);
+  });
+
+  it('creates with no secrets provided → connected:false when placeholders exist', async () => {
+    const cfgPath = tmpConfig();
+    const app = makeApp(cfgPath);
+    const res = await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({
+        label: 'Smithery Google Calendar',
+        description: 'Calendar via Smithery',
+        config: {
+          type: 'streamable-http',
+          url: 'https://server.smithery.ai/@mayla-debug/mcp-google-calendar2/mcp',
+          headers: { Authorization: 'Bearer {smithery_api_key}' },
+        },
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: 'smithery-google-calendar', label: 'Smithery Google Calendar', connected: false });
+
+    const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    expect(written.gateway.customConnectors['smithery-google-calendar']).toEqual({
+      label: 'Smithery Google Calendar',
+      description: 'Calendar via Smithery',
+      config: {
+        type: 'streamable-http',
+        url: 'https://server.smithery.ai/@mayla-debug/mcp-google-calendar2/mcp',
+        headers: { Authorization: 'Bearer {smithery_api_key}' },
+      },
+      secretNames: ['smithery_api_key'],
+    });
+  });
+
+  it('creates with secrets provided inline → connected:true, and GET /v1/connectors merges it in with source "custom"', async () => {
+    const cfgPath = tmpConfig();
+    const app = makeApp(cfgPath);
+    const create = await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({
+        label: 'No Auth Server',
+        config: { type: 'streamable-http', url: 'https://mcp.airshelf.ai/mcp' },
+      });
+    expect(create.status).toBe(200);
+    expect(create.body).toEqual({ id: 'no-auth-server', label: 'No Auth Server', connected: true });
+
+    const list = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    const github = list.body.connectors.find((c: { id: string }) => c.id === 'github');
+    expect(github.source).toBe('built-in');
+    const custom = list.body.connectors.find((c: { id: string }) => c.id === 'no-auth-server');
+    expect(custom).toMatchObject({ id: 'no-auth-server', label: 'No Auth Server', connected: true, source: 'custom' });
+    expect(custom.repoUrl).toBeUndefined(); // no sourceUrl was given
+  });
+
+  it('sourceUrl round-trips as repoUrl in GET /v1/connectors; omitted when not given', async () => {
+    const cfgPath = tmpConfig();
+    const app = makeApp(cfgPath);
+    await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({
+        label: 'Rollforge',
+        config: { command: 'npx', args: ['@agentutility/mcp-rollforge'] },
+        sourceUrl: 'https://github.com/agentutility/mcp-rollforge',
+      });
+
+    const list = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    const custom = list.body.connectors.find((c: { id: string }) => c.id === 'rollforge');
+    expect(custom.repoUrl).toBe('https://github.com/agentutility/mcp-rollforge');
+
+    const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    expect(written.gateway.customConnectors.rollforge.sourceUrl).toBe(
+      'https://github.com/agentutility/mcp-rollforge',
+    );
+  });
+
+  it('rejects a non-string sourceUrl', async () => {
+    const res = await request(makeApp(tmpConfig()))
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({ label: 'X', config: { command: 'npx' }, sourceUrl: 123 });
+    expect(res.status).toBe(400);
+  });
+
+  it('unknown connector id → 404 on status/delete', async () => {
+    const app = makeApp(tmpConfig());
+    const status = await request(app).get('/api/v1/connectors/nope/status').set('X-Api-Key', adminKey);
+    expect(status.status).toBe(404);
+    const del = await request(app).delete('/api/v1/connectors/custom/nope').set('X-Api-Key', adminKey);
+    expect(del.status).toBe(404);
+  });
+
+  it('delete clears the namespaced secret + config entry', async () => {
+    const cfgPath = tmpConfig();
+    const app = makeApp(cfgPath);
+    const { getSecret } = require('../../src/connectors/token-env');
+
+    await request(app)
+      .post('/api/v1/connectors/custom')
+      .set('X-Api-Key', adminKey)
+      .send({
+        label: 'Rollforge',
+        config: { command: 'npx', args: ['@agentutility/mcp-rollforge'], env: { TOKEN: '{token}' } },
+        secrets: { token: 'shhh' },
+      });
+    expect(getSecret('CUSTOM__rollforge__token')).toBe('shhh');
+
+    const del = await request(app).delete('/api/v1/connectors/custom/rollforge').set('X-Api-Key', adminKey);
+    expect(del.status).toBe(200);
+    expect(getSecret('CUSTOM__rollforge__token')).toBeNull();
+    expect(JSON.parse(fs.readFileSync(cfgPath, 'utf-8')).gateway.customConnectors).toEqual({});
+  });
+});

--- a/tests/unit/custom-connectors.test.ts
+++ b/tests/unit/custom-connectors.test.ts
@@ -33,9 +33,9 @@ describe('custom helpers', () => {
     expect(slugify('Weather API!', [])).toBe('weather-api');
     // CONNECTOR_CATALOG is empty by default now, so there's no built-in id
     // left to collide with — 'github' (and gmail/drive/calendar) are managed
-    // custom connector ids pushed by services/api, not reserved here. A user
+    // custom connector ids pushed by an external control plane, not reserved here. A user
     // adding their own custom connector labeled "GitHub" could theoretically
-    // slug-collide with a services/api-managed id (accepted edge case, see
+    // slug-collide with an externally-managed id (accepted edge case, see
     // custom.ts's note — admin-trusted either way, self-recoverable).
     expect(slugify('GitHub', [])).toBe('github');
     // Collides with an existing custom id
@@ -163,7 +163,7 @@ describe('connectors-router — custom connectors', () => {
     const cfgPath = tmpConfig();
     const app = makeApp(cfgPath);
 
-    // A services/api-managed push (github) reports source: 'built-in' — see
+    // An externally-managed push (github) reports source: 'built-in' — see
     // oauth-connectors.test.ts for that route's dedicated coverage; this test
     // is about the GET /v1/connectors merge, not the push itself.
     await request(app)

--- a/tests/unit/mcp-oauth.test.ts
+++ b/tests/unit/mcp-oauth.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for connectors/mcp-oauth.ts — the generic OAuth 2.1 + PKCE (+ DCR)
+ * helpers behind "custom" connectors marked `oauth: true` (Firecrawl etc.).
+ *
+ * The `resource` (RFC 8707) assertions in the authorize/token tests are a
+ * deliberate regression guard: a live PoC against production Firecrawl this
+ * session found that OMITTING `resource` yields a token that exchanges fine
+ * but is rejected by the MCP endpoint itself ("OAUTH_CONNECTION_INVALID") —
+ * never let it silently disappear from these calls again.
+ */
+
+import {
+  discoverOAuthMetadata,
+  registerClient,
+  resolveClientId,
+  generatePkce,
+  generateState,
+  buildAuthorizeUrl,
+  exchangeCode,
+  refreshAccessToken,
+  type OAuthMetadata,
+} from '../../src/connectors/mcp-oauth';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  delete process.env.MCP_OAUTH_CLIENT_ID__FIRECRAWL;
+});
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+  };
+}
+
+describe('generatePkce / generateState', () => {
+  it('produces a base64url code_verifier and a matching S256 code_challenge', () => {
+    const { codeVerifier, codeChallenge } = generatePkce();
+    expect(codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(codeChallenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(codeChallenge).not.toBe(codeVerifier);
+    // Same verifier always yields the same challenge (pure function of the verifier).
+    const crypto = require('crypto');
+    const expected = crypto
+      .createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    expect(codeChallenge).toBe(expected);
+  });
+
+  it('generateState produces distinct values each call', () => {
+    expect(generateState()).not.toBe(generateState());
+  });
+});
+
+describe('discoverOAuthMetadata', () => {
+  const MCP_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+  const PRM_URL = 'https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth';
+
+  it('walks probe 401 -> protected-resource metadata -> authorization-server metadata', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse(401, { error: 'invalid_token' }, { 'www-authenticate': `Bearer resource_metadata="${PRM_URL}"` }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { authorization_servers: ['https://www.firecrawl.dev'] }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_endpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+          token_endpoint: 'https://www.firecrawl.dev/api/oauth/token',
+          registration_endpoint: 'https://www.firecrawl.dev/api/oauth/register',
+          scopes_supported: ['firecrawl:global', 'offline_access'],
+        }),
+      );
+
+    const meta = await discoverOAuthMetadata(MCP_URL);
+    expect(meta).toEqual({
+      resource: MCP_URL,
+      authorizationEndpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+      tokenEndpoint: 'https://www.firecrawl.dev/api/oauth/token',
+      registrationEndpoint: 'https://www.firecrawl.dev/api/oauth/register',
+      scopesSupported: ['firecrawl:global', 'offline_access'],
+    });
+    expect(mockFetch).toHaveBeenNthCalledWith(2, PRM_URL);
+    expect(mockFetch).toHaveBeenNthCalledWith(3, 'https://www.firecrawl.dev/.well-known/oauth-authorization-server');
+  });
+
+  it('throws a clear error when the probe does not return 401', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    await expect(discoverOAuthMetadata(MCP_URL)).rejects.toThrow(/Expected a 401/);
+  });
+
+  it('throws when the 401 has no resource_metadata in WWW-Authenticate', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(401, {}, { 'www-authenticate': 'Bearer error="invalid_token"' }));
+    await expect(discoverOAuthMetadata(MCP_URL)).rejects.toThrow(/no "resource_metadata"/);
+  });
+
+  it('registration_endpoint is undefined (not thrown) when the AS advertises none', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse(401, {}, { 'www-authenticate': `Bearer resource_metadata="${PRM_URL}"` }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { authorization_servers: ['https://auth.example.com'] }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: 'https://auth.example.com/token',
+        }),
+      );
+    const meta = await discoverOAuthMetadata(MCP_URL);
+    expect(meta.registrationEndpoint).toBeUndefined();
+    expect(meta.scopesSupported).toEqual([]);
+  });
+});
+
+describe('registerClient / resolveClientId', () => {
+  it('registerClient posts DCR params and returns the issued client_id', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { client_id: 'dyn_abc123' }));
+    const clientId = await registerClient(
+      'https://www.firecrawl.dev/api/oauth/register',
+      'https://pod.example.com/gateway/oauth/mcp/callback',
+      'GetPod (firecrawl)',
+    );
+    expect(clientId).toBe('dyn_abc123');
+    const [, init] = mockFetch.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.redirect_uris).toEqual(['https://pod.example.com/gateway/oauth/mcp/callback']);
+    expect(body.token_endpoint_auth_method).toBe('none');
+  });
+
+  it('registerClient throws with the response body when DCR is rejected', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(400, { error: 'invalid_redirect_uri' }));
+    await expect(
+      registerClient('https://as.example.com/register', 'https://x/callback', 'x'),
+    ).rejects.toThrow(/invalid_redirect_uri/);
+  });
+
+  const metaWithDcr: OAuthMetadata = {
+    resource: 'https://mcp.example.com/oauth',
+    authorizationEndpoint: 'https://as.example.com/authorize',
+    tokenEndpoint: 'https://as.example.com/token',
+    registrationEndpoint: 'https://as.example.com/register',
+    scopesSupported: [],
+  };
+  const metaWithoutDcr: OAuthMetadata = { ...metaWithDcr, registrationEndpoint: undefined };
+
+  it('resolveClientId uses DCR when registration_endpoint is present', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { client_id: 'dyn_xyz' }));
+    const id = await resolveClientId(metaWithDcr, 'firecrawl', 'https://x/callback');
+    expect(id).toBe('dyn_xyz');
+  });
+
+  it('resolveClientId falls back to MCP_OAUTH_CLIENT_ID__<CONNECTOR_ID> when no registration_endpoint', async () => {
+    process.env.MCP_OAUTH_CLIENT_ID__FIRECRAWL = 'static-client-id';
+    const id = await resolveClientId(metaWithoutDcr, 'firecrawl', 'https://x/callback');
+    expect(id).toBe('static-client-id');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('resolveClientId throws a clear error when no DCR and no static fallback configured', async () => {
+    await expect(resolveClientId(metaWithoutDcr, 'firecrawl', 'https://x/callback')).rejects.toThrow(
+      /MCP_OAUTH_CLIENT_ID__FIRECRAWL/,
+    );
+  });
+});
+
+describe('buildAuthorizeUrl', () => {
+  it('includes response_type, client_id, redirect_uri, scope, PKCE params, state, AND resource', () => {
+    const metadata: OAuthMetadata = {
+      resource: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+      authorizationEndpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+      tokenEndpoint: 'https://www.firecrawl.dev/api/oauth/token',
+      scopesSupported: [],
+    };
+    const url = new URL(
+      buildAuthorizeUrl({
+        metadata,
+        clientId: 'dyn_abc',
+        redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+        scope: 'firecrawl:global offline_access',
+        codeChallenge: 'challenge123',
+        state: 'state456',
+      }),
+    );
+    expect(url.origin + url.pathname).toBe('https://www.firecrawl.dev/api/oauth/authorize');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('client_id')).toBe('dyn_abc');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://pod.example.com/gateway/oauth/mcp/callback');
+    expect(url.searchParams.get('scope')).toBe('firecrawl:global offline_access');
+    expect(url.searchParams.get('code_challenge')).toBe('challenge123');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('state')).toBe('state456');
+    // Regression guard — see file doc comment.
+    expect(url.searchParams.get('resource')).toBe('https://mcp.firecrawl.dev/v2/mcp-oauth');
+  });
+});
+
+describe('exchangeCode / refreshAccessToken', () => {
+  const metadata: OAuthMetadata = {
+    resource: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+    authorizationEndpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+    tokenEndpoint: 'https://www.firecrawl.dev/api/oauth/token',
+    scopesSupported: [],
+  };
+
+  it('exchangeCode posts grant_type=authorization_code with the PKCE verifier AND resource', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, {
+        access_token: 'fco_1',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'fcr_1',
+        scope: 'firecrawl:global offline_access',
+      }),
+    );
+    const token = await exchangeCode({
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      code: 'the-code',
+      codeVerifier: 'the-verifier',
+    });
+    expect(token.access_token).toBe('fco_1');
+    expect(token.refresh_token).toBe('fcr_1');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(metadata.tokenEndpoint);
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('the-code');
+    expect(body.get('code_verifier')).toBe('the-verifier');
+    // Regression guard — see file doc comment.
+    expect(body.get('resource')).toBe(metadata.resource);
+  });
+
+  it('exchangeCode throws with the error body when the token endpoint rejects', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(400, { error: 'invalid_grant' }));
+    await expect(
+      exchangeCode({
+        metadata,
+        clientId: 'dyn_abc',
+        redirectUri: 'https://x/callback',
+        code: 'bad-code',
+        codeVerifier: 'v',
+      }),
+    ).rejects.toThrow(/invalid_grant/);
+  });
+
+  it('refreshAccessToken posts grant_type=refresh_token with the refresh token AND resource', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { access_token: 'fco_2', token_type: 'bearer', expires_in: 3600, refresh_token: 'fcr_2' }),
+    );
+    const token = await refreshAccessToken({
+      metadata,
+      clientId: 'dyn_abc',
+      refreshToken: 'fcr_1',
+    });
+    expect(token.access_token).toBe('fco_2');
+
+    const [, init] = mockFetch.mock.calls[0];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('fcr_1');
+    expect(body.get('resource')).toBe(metadata.resource);
+  });
+});

--- a/tests/unit/mcp-oauth.test.ts
+++ b/tests/unit/mcp-oauth.test.ts
@@ -128,7 +128,7 @@ describe('registerClient / resolveClientId', () => {
     const clientId = await registerClient(
       'https://www.firecrawl.dev/api/oauth/register',
       'https://pod.example.com/gateway/oauth/mcp/callback',
-      'GetPod (firecrawl)',
+      'claude-gateway (firecrawl)',
     );
     expect(clientId).toBe('dyn_abc123');
     const [, init] = mockFetch.mock.calls[0];

--- a/tests/unit/oauth-connectors-router.test.ts
+++ b/tests/unit/oauth-connectors-router.test.ts
@@ -232,6 +232,29 @@ describe('createOauthCallbackRouter — GET /oauth/mcp/callback', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  // This route is public (no auth) — `error` is a raw, attacker-controllable
+  // query param. Without escaping, a state a real admin's browser is holding
+  // (leaked via referrer/history/logs) plus a crafted `error` value would be
+  // reflected straight into the HTML response.
+  it('HTML-escapes the provider error before putting it in the fallback page (no oauthReturnUrl configured)', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const state = pendingStore.create({
+      connectorId: 'firecrawl',
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      codeVerifier: 'verifier',
+    });
+    const app = makeApp(pendingStore); // no returnUrl — takes the plain-HTML fallback path
+    const payload = '<script>alert(1)</script>';
+    const res = await request(app).get(
+      `/oauth/mcp/callback?state=${state}&error=${encodeURIComponent(payload)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.text).not.toContain('<script>');
+    expect(res.text).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
   it('exchanges the code and writes access_token, refresh_token, client_id, and expiry into mcp-token.env', async () => {
     const pendingStore = new PendingOAuthStore();
     const state = pendingStore.create({

--- a/tests/unit/oauth-connectors-router.test.ts
+++ b/tests/unit/oauth-connectors-router.test.ts
@@ -62,7 +62,7 @@ function tmpConfig(customConnectors: Record<string, unknown> = {}) {
         gateway: {
           logDir: '/tmp',
           timezone: 'UTC',
-          publicUrl: 'https://pod-abc.vm.getpod.ai/gateway',
+          publicUrl: 'https://pod-abc.vm.example.com/gateway',
           customConnectors,
         },
         agents: [],
@@ -84,7 +84,7 @@ describe('createOauthConnectorsRouter — POST /v1/connectors/custom/:id/oauth/s
       '/api',
       createOauthConnectorsRouter(
         apiKeys,
-        { gateway: { publicUrl: 'https://pod-abc.vm.getpod.ai/gateway' } },
+        { gateway: { publicUrl: 'https://pod-abc.vm.example.com/gateway' } },
         store,
         pendingStore,
       ),
@@ -125,7 +125,7 @@ describe('createOauthConnectorsRouter — POST /v1/connectors/custom/:id/oauth/s
       '/api',
       createOauthConnectorsRouter(
         [{ key: 'scoped', agents: ['a1'] }, ...apiKeys],
-        { gateway: { publicUrl: 'https://pod-abc.vm.getpod.ai/gateway' } },
+        { gateway: { publicUrl: 'https://pod-abc.vm.example.com/gateway' } },
         store,
       ),
     );
@@ -163,7 +163,7 @@ describe('createOauthConnectorsRouter — POST /v1/connectors/custom/:id/oauth/s
     const url = new URL(res.body.authorizeUrl);
     expect(url.origin + url.pathname).toBe('https://www.firecrawl.dev/api/oauth/authorize');
     expect(url.searchParams.get('client_id')).toBe('dyn_abc123');
-    expect(url.searchParams.get('redirect_uri')).toBe('https://pod-abc.vm.getpod.ai/gateway/oauth/mcp/callback');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://pod-abc.vm.example.com/gateway/oauth/mcp/callback');
     expect(url.searchParams.get('code_challenge_method')).toBe('S256');
     expect(url.searchParams.get('resource')).toBe('https://mcp.firecrawl.dev/v2/mcp-oauth');
     expect(url.searchParams.get('scope')).toBe('firecrawl:global offline_access');
@@ -229,7 +229,7 @@ describe('createOauthConnectorsRouter — POST /v1/connectors/custom/:id/oauth/s
     const store = createCustomConnectorsStore(cfgPath);
     const appV1 = express();
     appV1.use(express.json());
-    appV1.use('/api', createOauthConnectorsRouter(apiKeys, { gateway: { publicUrl: 'https://pod-abc.vm.getpod.ai/gateway' } }, store, pendingStore));
+    appV1.use('/api', createOauthConnectorsRouter(apiKeys, { gateway: { publicUrl: 'https://pod-abc.vm.example.com/gateway' } }, store, pendingStore));
 
     const discoveryMocks = () => [
       jsonResponse(401, {}, { 'www-authenticate': `Bearer resource_metadata="https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth"` }),
@@ -247,7 +247,7 @@ describe('createOauthConnectorsRouter — POST /v1/connectors/custom/:id/oauth/s
     // Same connector, new gateway.publicUrl (e.g. a fresh tunnel) → different redirect_uri.
     const appV2 = express();
     appV2.use(express.json());
-    appV2.use('/api', createOauthConnectorsRouter(apiKeys, { gateway: { publicUrl: 'https://pod-abc-new-tunnel.vm.getpod.ai/gateway' } }, store, pendingStore));
+    appV2.use('/api', createOauthConnectorsRouter(apiKeys, { gateway: { publicUrl: 'https://pod-abc-new-tunnel.vm.example.com/gateway' } }, store, pendingStore));
     for (const m of discoveryMocks()) mockFetch.mockResolvedValueOnce(m);
     mockFetch.mockResolvedValueOnce(jsonResponse(201, { client_id: 'dyn_new_redirect' }));
     const res = await request(appV2).post('/api/v1/connectors/custom/firecrawl/oauth/start').set('X-Api-Key', adminKey);
@@ -385,10 +385,10 @@ describe('createOauthCallbackRouter — GET /oauth/mcp/callback', () => {
       jsonResponse(200, { access_token: 'fco_1', token_type: 'bearer', expires_in: 3600 }),
     );
 
-    const app = makeApp(pendingStore, 'https://app.getpod.ai/connectors');
+    const app = makeApp(pendingStore, 'https://app.example.com/connectors');
     const res = await request(app).get(`/oauth/mcp/callback?state=${state}&code=c1`);
     expect(res.status).toBe(302);
-    expect(res.headers.location).toBe('https://app.getpod.ai/connectors');
+    expect(res.headers.location).toBe('https://app.example.com/connectors');
   });
 
   it('an invalid oauthReturnUrl falls back to the plain "close this tab" message instead of crashing', async () => {
@@ -425,21 +425,21 @@ describe('createOauthCallbackRouter — GET /oauth/mcp/callback', () => {
       codeVerifier: 'verifier',
     });
 
-    const app = makeApp(pendingStore, 'https://app.getpod.ai/connectors');
+    const app = makeApp(pendingStore, 'https://app.example.com/connectors');
     const res = await request(app).get(`/oauth/mcp/callback?state=${state}&error=access_denied`);
     expect(res.status).toBe(302);
     const location = new URL(res.headers.location);
-    expect(location.origin + location.pathname).toBe('https://app.getpod.ai/connectors');
+    expect(location.origin + location.pathname).toBe('https://app.example.com/connectors');
     expect(location.searchParams.get('connector_oauth_error')).toBe('access_denied');
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('with a configured oauthReturnUrl, an expired/unknown state also redirects back instead of a bare 400 page', async () => {
-    const app = makeApp(new PendingOAuthStore(), 'https://app.getpod.ai/connectors');
+    const app = makeApp(new PendingOAuthStore(), 'https://app.example.com/connectors');
     const res = await request(app).get('/oauth/mcp/callback?state=nope&code=abc');
     expect(res.status).toBe(302);
     const location = new URL(res.headers.location);
-    expect(location.origin + location.pathname).toBe('https://app.getpod.ai/connectors');
+    expect(location.origin + location.pathname).toBe('https://app.example.com/connectors');
     expect(location.searchParams.get('connector_oauth_error')).toBe('expired_link');
   });
 

--- a/tests/unit/oauth-connectors-router.test.ts
+++ b/tests/unit/oauth-connectors-router.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests for api/oauth-connectors-router.ts — the two routers backing
+ * generic OAuth sign-in for `oauth: true` custom connectors:
+ *   createOauthConnectorsRouter() — admin-gated POST .../oauth/start
+ *   createOauthCallbackRouter()  — public GET /oauth/mcp/callback
+ */
+
+import express from 'express';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ApiKey } from '../../src/types';
+import { createCustomConnectorsStore } from '../../src/connectors/custom-connectors-store';
+import { PendingOAuthStore } from '../../src/connectors/pending-oauth-store';
+import type { OAuthMetadata } from '../../src/connectors/mcp-oauth';
+
+const TOKEN_ENV = '/tmp/oauth-connectors-router-test-mcp-token.env';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+beforeEach(() => {
+  process.env.GATEWAY_MCP_TOKEN_ENV = TOKEN_ENV;
+  try {
+    fs.rmSync(TOKEN_ENV);
+  } catch {
+    /* ignore */
+  }
+  mockFetch.mockReset();
+});
+
+afterAll(() => {
+  delete process.env.GATEWAY_MCP_TOKEN_ENV;
+  try {
+    fs.rmSync(TOKEN_ENV);
+  } catch {
+    /* ignore */
+  }
+});
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+  };
+}
+
+const adminKey = 'admin-key';
+const apiKeys: ApiKey[] = [{ key: adminKey, agents: '*', admin: true }];
+
+function tmpConfig(customConnectors: Record<string, unknown> = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-oauth-'));
+  const cfgPath = path.join(dir, 'config.json');
+  fs.writeFileSync(
+    cfgPath,
+    JSON.stringify(
+      {
+        gateway: {
+          logDir: '/tmp',
+          timezone: 'UTC',
+          publicUrl: 'https://pod-abc.vm.getpod.ai/gateway',
+          customConnectors,
+        },
+        agents: [],
+      },
+      null,
+      2,
+    ),
+  );
+  return cfgPath;
+}
+
+describe('createOauthConnectorsRouter — POST /v1/connectors/custom/:id/oauth/start', () => {
+  function makeApp(configPath: string, pendingStore: PendingOAuthStore) {
+    const { createOauthConnectorsRouter } = require('../../src/api/oauth-connectors-router');
+    const store = createCustomConnectorsStore(configPath);
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api',
+      createOauthConnectorsRouter(
+        apiKeys,
+        { gateway: { publicUrl: 'https://pod-abc.vm.getpod.ai/gateway' } },
+        store,
+        pendingStore,
+      ),
+    );
+    return app;
+  }
+
+  const firecrawlEntry = {
+    label: 'Firecrawl',
+    config: { type: 'http', url: 'https://mcp.firecrawl.dev/v2/mcp-oauth', headers: { Authorization: 'Bearer {access_token}' } },
+    secretNames: ['access_token'],
+    oauth: true,
+  };
+
+  it('404s for an unknown connector id', async () => {
+    const app = makeApp(tmpConfig(), new PendingOAuthStore());
+    const res = await request(app)
+      .post('/api/v1/connectors/custom/nope/oauth/start')
+      .set('X-Api-Key', adminKey);
+    expect(res.status).toBe(404);
+  });
+
+  it("400s when the connector wasn't added with oauth: true", async () => {
+    const app = makeApp(tmpConfig({ plain: { ...firecrawlEntry, oauth: undefined } }), new PendingOAuthStore());
+    const res = await request(app)
+      .post('/api/v1/connectors/custom/plain/oauth/start')
+      .set('X-Api-Key', adminKey);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/oauth: true/);
+  });
+
+  it('non-admin cannot start an OAuth flow', async () => {
+    const scopedApp = express();
+    scopedApp.use(express.json());
+    const { createOauthConnectorsRouter } = require('../../src/api/oauth-connectors-router');
+    const store = createCustomConnectorsStore(tmpConfig({ firecrawl: firecrawlEntry }));
+    scopedApp.use(
+      '/api',
+      createOauthConnectorsRouter(
+        [{ key: 'scoped', agents: ['a1'] }, ...apiKeys],
+        { gateway: { publicUrl: 'https://pod-abc.vm.getpod.ai/gateway' } },
+        store,
+      ),
+    );
+    const res = await request(scopedApp)
+      .post('/api/v1/connectors/custom/firecrawl/oauth/start')
+      .set('X-Api-Key', 'scoped');
+    expect(res.status).toBe(403);
+  });
+
+  it('discovers metadata, registers a client via DCR, and returns an authorize URL that includes PKCE + resource', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const app = makeApp(tmpConfig({ firecrawl: firecrawlEntry }), pendingStore);
+
+    const prmUrl = 'https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth';
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse(401, {}, { 'www-authenticate': `Bearer resource_metadata="${prmUrl}"` }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { authorization_servers: ['https://www.firecrawl.dev'] }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_endpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+          token_endpoint: 'https://www.firecrawl.dev/api/oauth/token',
+          registration_endpoint: 'https://www.firecrawl.dev/api/oauth/register',
+          scopes_supported: ['firecrawl:global', 'offline_access'],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(201, { client_id: 'dyn_abc123' }));
+
+    const res = await request(app)
+      .post('/api/v1/connectors/custom/firecrawl/oauth/start')
+      .set('X-Api-Key', adminKey);
+
+    expect(res.status).toBe(200);
+    const url = new URL(res.body.authorizeUrl);
+    expect(url.origin + url.pathname).toBe('https://www.firecrawl.dev/api/oauth/authorize');
+    expect(url.searchParams.get('client_id')).toBe('dyn_abc123');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://pod-abc.vm.getpod.ai/gateway/oauth/mcp/callback');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('resource')).toBe('https://mcp.firecrawl.dev/v2/mcp-oauth');
+    expect(url.searchParams.get('scope')).toBe('firecrawl:global offline_access');
+    expect(pendingStore.size()).toBe(1);
+  });
+
+  it('502s with the discovery error when the MCP url does not look like an OAuth server', async () => {
+    const app = makeApp(tmpConfig({ firecrawl: firecrawlEntry }), new PendingOAuthStore());
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, {}));
+    const res = await request(app)
+      .post('/api/v1/connectors/custom/firecrawl/oauth/start')
+      .set('X-Api-Key', adminKey);
+    expect(res.status).toBe(502);
+    expect(res.body.error).toMatch(/Expected a 401/);
+  });
+
+  it("500s when gateway.publicUrl isn't a valid /gateway URL", async () => {
+    const { createOauthConnectorsRouter } = require('../../src/api/oauth-connectors-router');
+    const store = createCustomConnectorsStore(tmpConfig({ firecrawl: firecrawlEntry }));
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createOauthConnectorsRouter(apiKeys, { gateway: { publicUrl: undefined } }, store));
+    const res = await request(app)
+      .post('/api/v1/connectors/custom/firecrawl/oauth/start')
+      .set('X-Api-Key', adminKey);
+    expect(res.status).toBe(500);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('createOauthCallbackRouter — GET /oauth/mcp/callback', () => {
+  function makeApp(pendingStore: PendingOAuthStore, returnUrl?: string) {
+    const { createOauthCallbackRouter } = require('../../src/api/oauth-connectors-router');
+    const app = express();
+    app.use(createOauthCallbackRouter(pendingStore, returnUrl));
+    return app;
+  }
+
+  const metadata: OAuthMetadata = {
+    resource: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+    authorizationEndpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+    tokenEndpoint: 'https://www.firecrawl.dev/api/oauth/token',
+    scopesSupported: [],
+  };
+
+  it('returns 400 for an unknown/expired state, and never calls the token endpoint', async () => {
+    const app = makeApp(new PendingOAuthStore());
+    const res = await request(app).get('/oauth/mcp/callback?state=nope&code=abc');
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the provider reports an error, without touching the token endpoint', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const state = pendingStore.create({
+      connectorId: 'firecrawl',
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      codeVerifier: 'verifier',
+    });
+    const app = makeApp(pendingStore);
+    const res = await request(app).get(`/oauth/mcp/callback?state=${state}&error=access_denied`);
+    expect(res.status).toBe(400);
+    expect(res.text).toMatch(/access_denied/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('exchanges the code and writes access_token, refresh_token, client_id, and expiry into mcp-token.env', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const state = pendingStore.create({
+      connectorId: 'firecrawl',
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      codeVerifier: 'verifier-123',
+    });
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, {
+        access_token: 'fco_new',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'fcr_new',
+      }),
+    );
+
+    const app = makeApp(pendingStore);
+    const res = await request(app).get(`/oauth/mcp/callback?state=${state}&code=the-code`);
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/Connected/);
+
+    const { readTokenEnv } = require('../../src/connectors/token-env');
+    const env = readTokenEnv();
+    expect(env['CUSTOM__firecrawl__access_token']).toBe('fco_new');
+    expect(env['CUSTOM__firecrawl____refresh_token']).toBe('fcr_new');
+    expect(env['CUSTOM__firecrawl____client_id']).toBe('dyn_abc');
+    expect(Number(env['CUSTOM__firecrawl____token_expires_at'])).toBeGreaterThan(Date.now());
+
+    // The token endpoint call itself used the stored PKCE verifier + resource.
+    const [, init] = mockFetch.mock.calls[0];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('code_verifier')).toBe('verifier-123');
+    expect(body.get('resource')).toBe(metadata.resource);
+  });
+
+  it('with a configured oauthReturnUrl, the success page auto-redirects there', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const state = pendingStore.create({
+      connectorId: 'firecrawl',
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      codeVerifier: 'verifier',
+    });
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { access_token: 'fco_1', token_type: 'bearer', expires_in: 3600 }),
+    );
+
+    const app = makeApp(pendingStore, 'https://app.getpod.ai/connectors');
+    const res = await request(app).get(`/oauth/mcp/callback?state=${state}&code=c1`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('http-equiv="refresh"');
+    expect(res.text).toContain('https://app.getpod.ai/connectors');
+  });
+
+  it('an invalid oauthReturnUrl falls back to the plain "close this tab" message instead of crashing', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const state = pendingStore.create({
+      connectorId: 'firecrawl',
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      codeVerifier: 'verifier',
+    });
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { access_token: 'fco_1', token_type: 'bearer', expires_in: 3600 }),
+    );
+
+    const app = makeApp(pendingStore, 'not-a-valid-url');
+    const res = await request(app).get(`/oauth/mcp/callback?state=${state}&code=c1`);
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('http-equiv="refresh"');
+    expect(res.text).toMatch(/close this tab/);
+  });
+
+  it('the same state cannot be replayed — a second callback with the same state 400s', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const state = pendingStore.create({
+      connectorId: 'firecrawl',
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      codeVerifier: 'verifier',
+    });
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { access_token: 'fco_1', token_type: 'bearer', expires_in: 3600 }),
+    );
+    const app = makeApp(pendingStore);
+    const first = await request(app).get(`/oauth/mcp/callback?state=${state}&code=c1`);
+    expect(first.status).toBe(200);
+    const second = await request(app).get(`/oauth/mcp/callback?state=${state}&code=c2`);
+    expect(second.status).toBe(400);
+  });
+
+  it('502s and does not write any secret when the token exchange itself fails', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const state = pendingStore.create({
+      connectorId: 'firecrawl',
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      codeVerifier: 'verifier',
+    });
+    mockFetch.mockResolvedValueOnce(jsonResponse(400, { error: 'invalid_grant' }));
+    const app = makeApp(pendingStore);
+    const res = await request(app).get(`/oauth/mcp/callback?state=${state}&code=bad`);
+    expect(res.status).toBe(502);
+
+    const { hasSecret } = require('../../src/connectors/token-env');
+    expect(hasSecret('CUSTOM__firecrawl__access_token')).toBe(false);
+  });
+});

--- a/tests/unit/oauth-connectors-router.test.ts
+++ b/tests/unit/oauth-connectors-router.test.ts
@@ -180,6 +180,82 @@ describe('createOauthConnectorsRouter — POST /v1/connectors/custom/:id/oauth/s
     expect(res.body.error).toMatch(/Expected a 401/);
   });
 
+  // Regression: every /oauth/start call re-ran DCR unconditionally, so every
+  // abandoned or retried "Connect" click registered (and orphaned, at the
+  // provider) a brand-new OAuth client. The second call for the same
+  // connector must reuse the client_id from the first instead of
+  // registering again.
+  it('reuses the DCR-registered client_id on a second /oauth/start call for the same connector — no second registration', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const app = makeApp(tmpConfig({ firecrawl: firecrawlEntry }), pendingStore);
+
+    const discoveryMocks = () => [
+      jsonResponse(401, {}, { 'www-authenticate': `Bearer resource_metadata="https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth"` }),
+      jsonResponse(200, { authorization_servers: ['https://www.firecrawl.dev'] }),
+      jsonResponse(200, {
+        authorization_endpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+        token_endpoint: 'https://www.firecrawl.dev/api/oauth/token',
+        registration_endpoint: 'https://www.firecrawl.dev/api/oauth/register',
+      }),
+    ];
+
+    // First call: discovery (3) + DCR registration (1) = 4 fetches.
+    for (const m of discoveryMocks()) mockFetch.mockResolvedValueOnce(m);
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { client_id: 'dyn_first_registration' }));
+    const first = await request(app)
+      .post('/api/v1/connectors/custom/firecrawl/oauth/start')
+      .set('X-Api-Key', adminKey);
+    expect(first.status).toBe(200);
+    expect(new URL(first.body.authorizeUrl).searchParams.get('client_id')).toBe('dyn_first_registration');
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+
+    // Second call: discovery only (3) — no registration call this time.
+    for (const m of discoveryMocks()) mockFetch.mockResolvedValueOnce(m);
+    const second = await request(app)
+      .post('/api/v1/connectors/custom/firecrawl/oauth/start')
+      .set('X-Api-Key', adminKey);
+    expect(second.status).toBe(200);
+    expect(new URL(second.body.authorizeUrl).searchParams.get('client_id')).toBe('dyn_first_registration');
+    expect(mockFetch).toHaveBeenCalledTimes(4 + 3); // not 4 + 4 — no re-registration
+  });
+
+  // A cached client_id was registered against a specific redirect_uri — if
+  // gateway.publicUrl changes, that redirect_uri is no longer valid at the
+  // provider, so the cache must be invalidated and a fresh client registered.
+  it('re-registers instead of reusing the cache when the redirect_uri (gateway.publicUrl) has changed', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const cfgPath = tmpConfig({ firecrawl: firecrawlEntry });
+    const { createOauthConnectorsRouter } = require('../../src/api/oauth-connectors-router');
+    const store = createCustomConnectorsStore(cfgPath);
+    const appV1 = express();
+    appV1.use(express.json());
+    appV1.use('/api', createOauthConnectorsRouter(apiKeys, { gateway: { publicUrl: 'https://pod-abc.vm.getpod.ai/gateway' } }, store, pendingStore));
+
+    const discoveryMocks = () => [
+      jsonResponse(401, {}, { 'www-authenticate': `Bearer resource_metadata="https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth"` }),
+      jsonResponse(200, { authorization_servers: ['https://www.firecrawl.dev'] }),
+      jsonResponse(200, {
+        authorization_endpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+        token_endpoint: 'https://www.firecrawl.dev/api/oauth/token',
+        registration_endpoint: 'https://www.firecrawl.dev/api/oauth/register',
+      }),
+    ];
+    for (const m of discoveryMocks()) mockFetch.mockResolvedValueOnce(m);
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { client_id: 'dyn_old_redirect' }));
+    await request(appV1).post('/api/v1/connectors/custom/firecrawl/oauth/start').set('X-Api-Key', adminKey);
+
+    // Same connector, new gateway.publicUrl (e.g. a fresh tunnel) → different redirect_uri.
+    const appV2 = express();
+    appV2.use(express.json());
+    appV2.use('/api', createOauthConnectorsRouter(apiKeys, { gateway: { publicUrl: 'https://pod-abc-new-tunnel.vm.getpod.ai/gateway' } }, store, pendingStore));
+    for (const m of discoveryMocks()) mockFetch.mockResolvedValueOnce(m);
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { client_id: 'dyn_new_redirect' }));
+    const res = await request(appV2).post('/api/v1/connectors/custom/firecrawl/oauth/start').set('X-Api-Key', adminKey);
+
+    expect(res.status).toBe(200);
+    expect(new URL(res.body.authorizeUrl).searchParams.get('client_id')).toBe('dyn_new_redirect');
+  });
+
   it("500s when gateway.publicUrl isn't a valid /gateway URL", async () => {
     const { createOauthConnectorsRouter } = require('../../src/api/oauth-connectors-router');
     const store = createCustomConnectorsStore(tmpConfig({ firecrawl: firecrawlEntry }));
@@ -284,6 +360,10 @@ describe('createOauthCallbackRouter — GET /oauth/mcp/callback', () => {
     expect(env['CUSTOM__firecrawl____refresh_token']).toBe('fcr_new');
     expect(env['CUSTOM__firecrawl____client_id']).toBe('dyn_abc');
     expect(Number(env['CUSTOM__firecrawl____token_expires_at'])).toBeGreaterThan(Date.now());
+    // Bumped so oauth-refresh-sweep.ts can detect a fresher token written
+    // here while one of its own refreshes was still in flight, and discard
+    // its own now-stale result instead of clobbering this one.
+    expect(env['CUSTOM__firecrawl____token_generation']).toBeTruthy();
 
     // The token endpoint call itself used the stored PKCE verifier + resource.
     const [, init] = mockFetch.mock.calls[0];

--- a/tests/unit/oauth-connectors-router.test.ts
+++ b/tests/unit/oauth-connectors-router.test.ts
@@ -269,7 +269,7 @@ describe('createOauthCallbackRouter — GET /oauth/mcp/callback', () => {
     expect(body.get('resource')).toBe(metadata.resource);
   });
 
-  it('with a configured oauthReturnUrl, the success page auto-redirects there', async () => {
+  it('with a configured oauthReturnUrl, a real HTTP redirect goes straight there — no interstitial page', async () => {
     const pendingStore = new PendingOAuthStore();
     const state = pendingStore.create({
       connectorId: 'firecrawl',
@@ -284,9 +284,8 @@ describe('createOauthCallbackRouter — GET /oauth/mcp/callback', () => {
 
     const app = makeApp(pendingStore, 'https://app.getpod.ai/connectors');
     const res = await request(app).get(`/oauth/mcp/callback?state=${state}&code=c1`);
-    expect(res.status).toBe(200);
-    expect(res.text).toContain('http-equiv="refresh"');
-    expect(res.text).toContain('https://app.getpod.ai/connectors');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://app.getpod.ai/connectors');
   });
 
   it('an invalid oauthReturnUrl falls back to the plain "close this tab" message instead of crashing', async () => {
@@ -305,8 +304,40 @@ describe('createOauthCallbackRouter — GET /oauth/mcp/callback', () => {
     const app = makeApp(pendingStore, 'not-a-valid-url');
     const res = await request(app).get(`/oauth/mcp/callback?state=${state}&code=c1`);
     expect(res.status).toBe(200);
-    expect(res.text).not.toContain('http-equiv="refresh"');
+    expect(res.headers.location).toBeUndefined();
     expect(res.text).toMatch(/close this tab/);
+  });
+
+  // The exact bug a real user hit: with oauthReturnUrl configured, denying
+  // consent used to leave the browser stranded on a bare gateway page with
+  // no way back — only the success path redirected. Every terminal outcome
+  // must redirect back when the app knows where "back" is.
+  it('with a configured oauthReturnUrl, denying consent also redirects back — with the reason in a query param, not stranded on a bare gateway page', async () => {
+    const pendingStore = new PendingOAuthStore();
+    const state = pendingStore.create({
+      connectorId: 'firecrawl',
+      metadata,
+      clientId: 'dyn_abc',
+      redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+      codeVerifier: 'verifier',
+    });
+
+    const app = makeApp(pendingStore, 'https://app.getpod.ai/connectors');
+    const res = await request(app).get(`/oauth/mcp/callback?state=${state}&error=access_denied`);
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.location);
+    expect(location.origin + location.pathname).toBe('https://app.getpod.ai/connectors');
+    expect(location.searchParams.get('connector_oauth_error')).toBe('access_denied');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('with a configured oauthReturnUrl, an expired/unknown state also redirects back instead of a bare 400 page', async () => {
+    const app = makeApp(new PendingOAuthStore(), 'https://app.getpod.ai/connectors');
+    const res = await request(app).get('/oauth/mcp/callback?state=nope&code=abc');
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.location);
+    expect(location.origin + location.pathname).toBe('https://app.getpod.ai/connectors');
+    expect(location.searchParams.get('connector_oauth_error')).toBe('expired_link');
   });
 
   it('the same state cannot be replayed — a second callback with the same state 400s', async () => {

--- a/tests/unit/oauth-connectors.test.ts
+++ b/tests/unit/oauth-connectors.test.ts
@@ -52,9 +52,10 @@ describe('connectors-router — oauth-kind connectors', () => {
     return cfgPath;
   }
 
-  it('GET /v1/connectors reports gmail/google-drive/google-calendar as authKind "oauth"', async () => {
+  it('GET /v1/connectors reports github/gmail/google-drive/google-calendar as authKind "oauth"', async () => {
     const res = await request(makeApp(tmpConfig())).get('/api/v1/connectors').set('X-Api-Key', adminKey);
     const byId = Object.fromEntries(res.body.connectors.map((c: { id: string; authKind: string }) => [c.id, c.authKind]));
+    expect(byId.github).toBe('oauth');
     expect(byId.gmail).toBe('oauth');
     expect(byId['google-drive']).toBe('oauth');
     expect(byId['google-calendar']).toBe('oauth');
@@ -77,8 +78,10 @@ describe('connectors-router — oauth-kind connectors', () => {
   });
 
   it('oauth/receive rejects a non-oauth connector', async () => {
+    // microsoft-365 is auth kind 'none' — github is 'oauth' now too, so it's
+    // no longer a valid non-oauth example here.
     const res = await request(makeApp(tmpConfig()))
-      .post('/api/v1/connectors/github/oauth/receive')
+      .post('/api/v1/connectors/microsoft-365/oauth/receive')
       .set('X-Api-Key', adminKey)
       .send({ access_token: 'at-1' });
     expect(res.status).toBe(400);

--- a/tests/unit/oauth-connectors.test.ts
+++ b/tests/unit/oauth-connectors.test.ts
@@ -1,12 +1,12 @@
 /**
  * Managed OAuth connectors (github/Gmail/Drive/Calendar) — the gateway never
- * does the OAuth dance itself (client_secret lives in getpod-ai's services/api,
- * which runs infra the user never gets shell access to) and has no catalog
- * entry for any of them (CONNECTOR_CATALOG is empty by default — see
+ * does the OAuth dance itself (client_secret lives in an external control
+ * plane, which runs infra the user never gets shell access to) and has no
+ * catalog entry for any of them (CONNECTOR_CATALOG is empty by default — see
  * catalog.ts). This covers the receiving end: POST /oauth/receive stores a
  * pushed access_token + full connector shape as a managed custom connector
  * (authKind:'oauth', managed:true), reported as source:'built-in' so the web
- * panel doesn't show a "Custom" badge on something GetPod pushed in.
+ * panel doesn't show a "Custom" badge on something that control plane pushed in.
  */
 
 import express from 'express';
@@ -55,7 +55,7 @@ describe('connectors-router — oauth-kind connectors', () => {
     return cfgPath;
   }
 
-  /** The shape services/api's real push sends — see internal/vm/connector_push.go. */
+  /** The shape a real control-plane push sends. */
   function pushPayload(overrides: Record<string, unknown> = {}) {
     return {
       access_token: 'at-pushed-1',

--- a/tests/unit/oauth-connectors.test.ts
+++ b/tests/unit/oauth-connectors.test.ts
@@ -1,0 +1,152 @@
+/**
+ * 'oauth'-kind connectors (Gmail/Drive/Calendar) — the gateway never does the
+ * OAuth dance itself (client_secret lives in getpod-ai's services/api, which
+ * runs infra the user never gets shell access to). This just covers the
+ * receiving end: POST /oauth/receive stores a pushed access_token, and the
+ * ordinary paste-token /connect route correctly refuses 'oauth'-kind ids.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ApiKey } from '../../src/types';
+
+const TOKEN_ENV = '/tmp/oauth-connectors-test-mcp-token.env';
+
+beforeEach(() => {
+  process.env.GATEWAY_MCP_TOKEN_ENV = TOKEN_ENV;
+  try { fs.rmSync(TOKEN_ENV); } catch { /* ignore */ }
+  jest.resetModules();
+});
+
+afterAll(() => {
+  delete process.env.GATEWAY_MCP_TOKEN_ENV;
+  try { fs.rmSync(TOKEN_ENV); } catch { /* ignore */ }
+});
+
+describe('connectors-router — oauth-kind connectors', () => {
+  const adminKey = 'admin-key';
+  const scopedKey = 'scoped-key';
+  const apiKeys: ApiKey[] = [
+    { key: adminKey, agents: '*', admin: true },
+    { key: scopedKey, agents: ['a1'] },
+  ];
+
+  function makeApp(configPath?: string, agents?: Map<string, unknown>) {
+    const { createConnectorsRouter } = require('../../src/api/connectors-router');
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createConnectorsRouter(apiKeys, configPath, agents));
+    return app;
+  }
+
+  function tmpConfig() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-oauth-'));
+    const cfgPath = path.join(dir, 'config.json');
+    fs.writeFileSync(
+      cfgPath,
+      JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC' }, agents: [] }, null, 2),
+    );
+    return cfgPath;
+  }
+
+  it('GET /v1/connectors reports gmail/google-drive/google-calendar as authKind "oauth"', async () => {
+    const res = await request(makeApp(tmpConfig())).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    const byId = Object.fromEntries(res.body.connectors.map((c: { id: string; authKind: string }) => [c.id, c.authKind]));
+    expect(byId.gmail).toBe('oauth');
+    expect(byId['google-drive']).toBe('oauth');
+    expect(byId['google-calendar']).toBe('oauth');
+  });
+
+  it('POST /connect rejects an oauth-kind connector (not a paste-token flow)', async () => {
+    const res = await request(makeApp(tmpConfig()))
+      .post('/api/v1/connectors/gmail/connect')
+      .set('X-Api-Key', adminKey)
+      .send({ token: 'whatever' });
+    expect(res.status).toBe(400);
+  });
+
+  it('oauth/receive requires admin', async () => {
+    const res = await request(makeApp(tmpConfig()))
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', scopedKey)
+      .send({ access_token: 'at-1' });
+    expect(res.status).toBe(403);
+  });
+
+  it('oauth/receive rejects a non-oauth connector', async () => {
+    const res = await request(makeApp(tmpConfig()))
+      .post('/api/v1/connectors/github/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send({ access_token: 'at-1' });
+    expect(res.status).toBe(400);
+  });
+
+  it('oauth/receive rejects a missing/blank access_token', async () => {
+    const app = makeApp(tmpConfig());
+    const missing = await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send({});
+    expect(missing.status).toBe(400);
+
+    const blank = await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send({ access_token: '   ' });
+    expect(blank.status).toBe(400);
+  });
+
+  it('oauth/receive stores the token and marks the connector connected', async () => {
+    const cfgPath = tmpConfig();
+    const app = makeApp(cfgPath);
+
+    const res = await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send({ access_token: 'at-pushed-1' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: 'gmail', connected: true });
+
+    const { getSecret } = require('../../src/connectors/token-env');
+    expect(getSecret('GMAIL_ACCESS_TOKEN')).toBe('at-pushed-1');
+
+    const list = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    const gmail = list.body.connectors.find((c: { id: string }) => c.id === 'gmail');
+    expect(gmail.connected).toBe(true);
+
+    const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    expect(written.gateway.connectors.gmail).toEqual({ secretEnv: 'GMAIL_ACCESS_TOKEN' });
+  });
+
+  it('oauth/receive restarts sessions using the connector across every tracked AgentRunner', async () => {
+    const restartSessionsUsingConnector = jest.fn().mockResolvedValue({ restarted: true });
+    const fakeRunner = { restartSessionsUsingConnector } as unknown;
+    const agents = new Map([['agent-1', fakeRunner]]);
+
+    const app = makeApp(tmpConfig(), agents);
+    const res = await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send({ access_token: 'at-2' });
+
+    expect(res.status).toBe(200);
+    expect(restartSessionsUsingConnector).toHaveBeenCalledWith('gmail');
+  });
+
+  it('disconnect clears the secret for an oauth-kind connector', async () => {
+    const app = makeApp(tmpConfig());
+    await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send({ access_token: 'at-3' });
+
+    const del = await request(app).delete('/api/v1/connectors/gmail').set('X-Api-Key', adminKey);
+    expect(del.status).toBe(200);
+
+    const { getSecret } = require('../../src/connectors/token-env');
+    expect(getSecret('GMAIL_ACCESS_TOKEN')).toBeNull();
+  });
+});

--- a/tests/unit/oauth-connectors.test.ts
+++ b/tests/unit/oauth-connectors.test.ts
@@ -1,9 +1,12 @@
 /**
- * 'oauth'-kind connectors (Gmail/Drive/Calendar) — the gateway never does the
- * OAuth dance itself (client_secret lives in getpod-ai's services/api, which
- * runs infra the user never gets shell access to). This just covers the
- * receiving end: POST /oauth/receive stores a pushed access_token, and the
- * ordinary paste-token /connect route correctly refuses 'oauth'-kind ids.
+ * Managed OAuth connectors (github/Gmail/Drive/Calendar) — the gateway never
+ * does the OAuth dance itself (client_secret lives in getpod-ai's services/api,
+ * which runs infra the user never gets shell access to) and has no catalog
+ * entry for any of them (CONNECTOR_CATALOG is empty by default — see
+ * catalog.ts). This covers the receiving end: POST /oauth/receive stores a
+ * pushed access_token + full connector shape as a managed custom connector
+ * (authKind:'oauth', managed:true), reported as source:'built-in' so the web
+ * panel doesn't show a "Custom" badge on something GetPod pushed in.
  */
 
 import express from 'express';
@@ -52,42 +55,72 @@ describe('connectors-router — oauth-kind connectors', () => {
     return cfgPath;
   }
 
-  it('GET /v1/connectors reports github/gmail/google-drive/google-calendar as authKind "oauth"', async () => {
-    const res = await request(makeApp(tmpConfig())).get('/api/v1/connectors').set('X-Api-Key', adminKey);
-    const byId = Object.fromEntries(res.body.connectors.map((c: { id: string; authKind: string }) => [c.id, c.authKind]));
-    expect(byId.github).toBe('oauth');
-    expect(byId.gmail).toBe('oauth');
-    expect(byId['google-drive']).toBe('oauth');
-    expect(byId['google-calendar']).toBe('oauth');
+  /** The shape services/api's real push sends — see internal/vm/connector_push.go. */
+  function pushPayload(overrides: Record<string, unknown> = {}) {
+    return {
+      access_token: 'at-pushed-1',
+      label: 'Gmail',
+      description: 'Search threads, read messages, manage labels, and draft email.',
+      config: {
+        type: 'http',
+        url: 'https://gmailmcp.googleapis.com/mcp/v1',
+        headers: { Authorization: 'Bearer {access_token}' },
+      },
+      sourceUrl: 'https://developers.google.com/workspace/gmail/api/guides/configure-mcp-server',
+      ...overrides,
+    };
+  }
+
+  it('GET /v1/connectors reports a pushed connector as authKind "oauth", source "built-in"', async () => {
+    const app = makeApp(tmpConfig());
+    await request(app).post('/api/v1/connectors/gmail/oauth/receive').set('X-Api-Key', adminKey).send(pushPayload());
+
+    const res = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
+    const gmail = res.body.connectors.find((c: { id: string }) => c.id === 'gmail');
+    expect(gmail).toMatchObject({ id: 'gmail', authKind: 'oauth', source: 'built-in', connected: true });
   });
 
-  it('POST /connect rejects an oauth-kind connector (not a paste-token flow)', async () => {
+  it('POST /connect 404s for an id with no built-in catalog entry (CONNECTOR_CATALOG is empty by default)', async () => {
     const res = await request(makeApp(tmpConfig()))
       .post('/api/v1/connectors/gmail/connect')
       .set('X-Api-Key', adminKey)
       .send({ token: 'whatever' });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(404);
   });
 
-  it('oauth/receive requires admin', async () => {
+  it('oauth/receive requires admin (checked before any payload validation)', async () => {
     const res = await request(makeApp(tmpConfig()))
       .post('/api/v1/connectors/gmail/oauth/receive')
       .set('X-Api-Key', scopedKey)
-      .send({ access_token: 'at-1' });
+      .send(pushPayload());
     expect(res.status).toBe(403);
   });
 
-  it('oauth/receive rejects a non-oauth connector', async () => {
-    // microsoft-365 is auth kind 'none' — github is 'oauth' now too, so it's
-    // no longer a valid non-oauth example here.
-    const res = await request(makeApp(tmpConfig()))
-      .post('/api/v1/connectors/microsoft-365/oauth/receive')
+  it('oauth/receive rejects a config whose placeholders are not exactly {access_token}', async () => {
+    const app = makeApp(tmpConfig());
+
+    const noPlaceholder = await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
       .set('X-Api-Key', adminKey)
-      .send({ access_token: 'at-1' });
-    expect(res.status).toBe(400);
+      .send(pushPayload({ config: { type: 'http', url: 'https://example.com' } }));
+    expect(noPlaceholder.status).toBe(400);
+
+    const extraPlaceholder = await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send(
+        pushPayload({
+          config: {
+            type: 'http',
+            url: 'https://example.com',
+            headers: { Authorization: 'Bearer {access_token}', 'X-Extra': '{something_else}' },
+          },
+        }),
+      );
+    expect(extraPlaceholder.status).toBe(400);
   });
 
-  it('oauth/receive rejects a missing/blank access_token', async () => {
+  it('oauth/receive rejects a missing/blank access_token, or a missing label/config', async () => {
     const app = makeApp(tmpConfig());
     const missing = await request(app)
       .post('/api/v1/connectors/gmail/oauth/receive')
@@ -98,30 +131,47 @@ describe('connectors-router — oauth-kind connectors', () => {
     const blank = await request(app)
       .post('/api/v1/connectors/gmail/oauth/receive')
       .set('X-Api-Key', adminKey)
-      .send({ access_token: '   ' });
+      .send(pushPayload({ access_token: '   ' }));
     expect(blank.status).toBe(400);
+
+    const noLabel = await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send(pushPayload({ label: undefined }));
+    expect(noLabel.status).toBe(400);
+
+    const noConfig = await request(app)
+      .post('/api/v1/connectors/gmail/oauth/receive')
+      .set('X-Api-Key', adminKey)
+      .send(pushPayload({ config: undefined }));
+    expect(noConfig.status).toBe(400);
   });
 
-  it('oauth/receive stores the token and marks the connector connected', async () => {
+  it('oauth/receive stores the full shape + secret, marks the connector connected', async () => {
     const cfgPath = tmpConfig();
     const app = makeApp(cfgPath);
 
     const res = await request(app)
       .post('/api/v1/connectors/gmail/oauth/receive')
       .set('X-Api-Key', adminKey)
-      .send({ access_token: 'at-pushed-1' });
+      .send(pushPayload());
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ id: 'gmail', connected: true });
 
     const { getSecret } = require('../../src/connectors/token-env');
-    expect(getSecret('GMAIL_ACCESS_TOKEN')).toBe('at-pushed-1');
+    expect(getSecret('CUSTOM__gmail__access_token')).toBe('at-pushed-1');
 
     const list = await request(app).get('/api/v1/connectors').set('X-Api-Key', adminKey);
     const gmail = list.body.connectors.find((c: { id: string }) => c.id === 'gmail');
     expect(gmail.connected).toBe(true);
 
     const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
-    expect(written.gateway.connectors.gmail).toEqual({ secretEnv: 'GMAIL_ACCESS_TOKEN' });
+    expect(written.gateway.customConnectors.gmail).toMatchObject({
+      label: 'Gmail',
+      secretNames: ['access_token'],
+      authKind: 'oauth',
+      managed: true,
+    });
   });
 
   it('oauth/receive restarts sessions using the connector across every tracked AgentRunner', async () => {
@@ -133,23 +183,23 @@ describe('connectors-router — oauth-kind connectors', () => {
     const res = await request(app)
       .post('/api/v1/connectors/gmail/oauth/receive')
       .set('X-Api-Key', adminKey)
-      .send({ access_token: 'at-2' });
+      .send(pushPayload());
 
     expect(res.status).toBe(200);
     expect(restartSessionsUsingConnector).toHaveBeenCalledWith('gmail');
   });
 
-  it('disconnect clears the secret for an oauth-kind connector', async () => {
+  it('disconnect clears the secret for a managed oauth connector via the unified DELETE route', async () => {
     const app = makeApp(tmpConfig());
     await request(app)
       .post('/api/v1/connectors/gmail/oauth/receive')
       .set('X-Api-Key', adminKey)
-      .send({ access_token: 'at-3' });
+      .send(pushPayload());
 
     const del = await request(app).delete('/api/v1/connectors/gmail').set('X-Api-Key', adminKey);
     expect(del.status).toBe(200);
 
     const { getSecret } = require('../../src/connectors/token-env');
-    expect(getSecret('GMAIL_ACCESS_TOKEN')).toBeNull();
+    expect(getSecret('CUSTOM__gmail__access_token')).toBeNull();
   });
 });

--- a/tests/unit/oauth-refresh-sweep.test.ts
+++ b/tests/unit/oauth-refresh-sweep.test.ts
@@ -8,9 +8,13 @@ import {
   refreshTokenSecretKey,
   clientIdSecretKey,
   expiresAtSecretKey,
+  refreshFailCountSecretKey,
+  refreshBackoffUntilSecretKey,
+  tokenGenerationSecretKey,
 } from '../../src/connectors/oauth-refresh-sweep';
-import { setSecret, readTokenEnv } from '../../src/connectors/token-env';
+import { setSecret, getSecret, readTokenEnv } from '../../src/connectors/token-env';
 import { customSecretKey } from '../../src/connectors/custom';
+import type { AgentRunner } from '../../src/agent/runner';
 
 const TOKEN_ENV = '/tmp/oauth-refresh-sweep-test-mcp-token.env';
 
@@ -170,5 +174,147 @@ describe('refreshExpiringOAuthConnectors', () => {
     );
     await refreshExpiringOAuthConnectors(store);
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // Regression: a network blip self-heals next tick (fail count resets on
+  // any success), but a refresh_token that keeps failing must eventually
+  // stop being retried AND stop reporting "connected" — before this fix the
+  // sweep retried an already-dead refresh_token forever, every 60s, while
+  // status kept showing a green checkmark for a connector that could never
+  // actually refresh again.
+  describe('failure backoff and give-up', () => {
+    function setUpDueFirecrawl() {
+      setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_old');
+      setSecret(refreshTokenSecretKey('firecrawl'), 'fcr_old');
+      setSecret(clientIdSecretKey('firecrawl'), 'dyn_abc');
+      setSecret(expiresAtSecretKey('firecrawl'), String(Date.now() + 1000));
+    }
+
+    it('backs off after a failure — a second sweep tick immediately after does not retry the network call', async () => {
+      setUpDueFirecrawl();
+      mockFetch.mockRejectedValueOnce(new Error('network unreachable'));
+
+      const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+      await refreshExpiringOAuthConnectors(store);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(getSecret(refreshBackoffUntilSecretKey('firecrawl'))).not.toBeNull();
+
+      // Next tick, still within the backoff window — must not call out again.
+      await refreshExpiringOAuthConnectors(store);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after 3 consecutive failures: clears all tokens so status correctly reports disconnected', async () => {
+      setUpDueFirecrawl();
+      const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+
+      for (let i = 0; i < 3; i++) {
+        mockFetch.mockRejectedValueOnce(new Error('invalid_grant'));
+        // Clear any backoff from the previous iteration so this tick is due again.
+        setSecret(refreshBackoffUntilSecretKey('firecrawl'), '0');
+        await refreshExpiringOAuthConnectors(store);
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const env = readTokenEnv();
+      expect(env['CUSTOM__firecrawl__access_token']).toBeUndefined();
+      expect(env[refreshTokenSecretKey('firecrawl')]).toBeUndefined();
+      expect(env[clientIdSecretKey('firecrawl')]).toBeUndefined();
+      expect(env[refreshFailCountSecretKey('firecrawl')]).toBeUndefined();
+    });
+
+    it('a success resets the failure count — one earlier blip does not count toward giving up later', async () => {
+      setUpDueFirecrawl();
+      const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+
+      mockFetch.mockRejectedValueOnce(new Error('network unreachable'));
+      await refreshExpiringOAuthConnectors(store);
+      expect(getSecret(refreshFailCountSecretKey('firecrawl'))).toBe('1');
+
+      // Force past the backoff window and let this attempt succeed.
+      setSecret(refreshBackoffUntilSecretKey('firecrawl'), '0');
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(401, {}, { 'www-authenticate': 'Bearer resource_metadata="https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth"' }))
+        .mockResolvedValueOnce(jsonResponse(200, { authorization_servers: ['https://www.firecrawl.dev'] }))
+        .mockResolvedValueOnce(jsonResponse(200, { authorization_endpoint: 'https://www.firecrawl.dev/api/oauth/authorize', token_endpoint: 'https://www.firecrawl.dev/api/oauth/token' }))
+        .mockResolvedValueOnce(jsonResponse(200, { access_token: 'fco_new', token_type: 'bearer', expires_in: 3600 }));
+      await refreshExpiringOAuthConnectors(store);
+
+      expect(getSecret(refreshFailCountSecretKey('firecrawl'))).toBeNull();
+      expect(getSecret(refreshBackoffUntilSecretKey('firecrawl'))).toBeNull();
+    });
+  });
+
+  // Regression: disconnect only ever cleared secretNames (just access_token for
+  // an oauth entry) — refresh_token/client_id/expiry survived, so the sweep
+  // would silently resurrect a connector the user just disconnected. The fix
+  // lives in connectors-router.ts's DELETE handler; this proves the sweep's
+  // own precondition (no refresh_token/client_id) correctly makes it a no-op
+  // once that cleanup has happened.
+  it('does nothing for a connector whose refresh_token/client_id were cleared by a disconnect', async () => {
+    setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_old');
+    setSecret(expiresAtSecretKey('firecrawl'), String(Date.now() + 1000));
+    // No refresh_token/client_id — this is the post-disconnect state.
+
+    const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+    await refreshExpiringOAuthConnectors(store);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(readTokenEnv()['CUSTOM__firecrawl__access_token']).toBe('fco_old'); // untouched, not resurrected
+  });
+
+  it('restarts sessions using the connector after a successful refresh', async () => {
+    setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_old');
+    setSecret(refreshTokenSecretKey('firecrawl'), 'fcr_old');
+    setSecret(clientIdSecretKey('firecrawl'), 'dyn_abc');
+    setSecret(expiresAtSecretKey('firecrawl'), String(Date.now() + 1000));
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(401, {}, { 'www-authenticate': 'Bearer resource_metadata="https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth"' }))
+      .mockResolvedValueOnce(jsonResponse(200, { authorization_servers: ['https://www.firecrawl.dev'] }))
+      .mockResolvedValueOnce(jsonResponse(200, { authorization_endpoint: 'https://www.firecrawl.dev/api/oauth/authorize', token_endpoint: 'https://www.firecrawl.dev/api/oauth/token' }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: 'fco_new', token_type: 'bearer', expires_in: 3600 }));
+
+    const restartSessionsUsingConnector = jest.fn().mockResolvedValue({ restarted: true });
+    const agents = new Map<string, AgentRunner>([
+      ['getpod', { restartSessionsUsingConnector } as unknown as AgentRunner],
+    ]);
+
+    const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+    await refreshExpiringOAuthConnectors(store, agents);
+
+    expect(restartSessionsUsingConnector).toHaveBeenCalledWith('firecrawl');
+  });
+
+  // Regression: a manual reconnect (fresh /oauth/mcp/callback exchange) racing
+  // this sweep's own in-flight refresh must win — the sweep's write is derived
+  // from a refresh_token that may already be stale the instant a fresher sign-in
+  // lands, so it must detect that and discard its own result instead of
+  // clobbering the newer one.
+  it('abandons its own refresh result if a fresher token was written while it was in flight', async () => {
+    setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_old');
+    setSecret(refreshTokenSecretKey('firecrawl'), 'fcr_old');
+    setSecret(clientIdSecretKey('firecrawl'), 'dyn_abc');
+    setSecret(expiresAtSecretKey('firecrawl'), String(Date.now() + 1000));
+    setSecret(tokenGenerationSecretKey('firecrawl'), 'gen-1');
+
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(401, {}, { 'www-authenticate': 'Bearer resource_metadata="https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth"' }))
+      .mockResolvedValueOnce(jsonResponse(200, { authorization_servers: ['https://www.firecrawl.dev'] }))
+      .mockResolvedValueOnce(jsonResponse(200, { authorization_endpoint: 'https://www.firecrawl.dev/api/oauth/authorize', token_endpoint: 'https://www.firecrawl.dev/api/oauth/token' }))
+      // Simulate a concurrent manual reconnect landing its own fresher token
+      // (and bumping the generation stamp) while this sweep's token request
+      // is still in flight, just before the sweep's response resolves.
+      .mockImplementationOnce(async () => {
+        setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_from_manual_reconnect');
+        setSecret(tokenGenerationSecretKey('firecrawl'), 'gen-2-from-manual-reconnect');
+        return jsonResponse(200, { access_token: 'fco_from_sweep_stale', token_type: 'bearer', expires_in: 3600 });
+      });
+
+    const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+    await refreshExpiringOAuthConnectors(store);
+
+    // The sweep's own (now-stale) result must NOT have overwritten the fresher one.
+    expect(readTokenEnv()['CUSTOM__firecrawl__access_token']).toBe('fco_from_manual_reconnect');
+    expect(getSecret(tokenGenerationSecretKey('firecrawl'))).toBe('gen-2-from-manual-reconnect');
   });
 });

--- a/tests/unit/oauth-refresh-sweep.test.ts
+++ b/tests/unit/oauth-refresh-sweep.test.ts
@@ -276,7 +276,7 @@ describe('refreshExpiringOAuthConnectors', () => {
 
     const restartSessionsUsingConnector = jest.fn().mockResolvedValue({ restarted: true });
     const agents = new Map<string, AgentRunner>([
-      ['getpod', { restartSessionsUsingConnector } as unknown as AgentRunner],
+      ['main', { restartSessionsUsingConnector } as unknown as AgentRunner],
     ]);
 
     const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));

--- a/tests/unit/oauth-refresh-sweep.test.ts
+++ b/tests/unit/oauth-refresh-sweep.test.ts
@@ -1,0 +1,174 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createCustomConnectorsStore } from '../../src/connectors/custom-connectors-store';
+import {
+  refreshExpiringOAuthConnectors,
+  refreshTokenSecretKey,
+  clientIdSecretKey,
+  expiresAtSecretKey,
+} from '../../src/connectors/oauth-refresh-sweep';
+import { setSecret, readTokenEnv } from '../../src/connectors/token-env';
+import { customSecretKey } from '../../src/connectors/custom';
+
+const TOKEN_ENV = '/tmp/oauth-refresh-sweep-test-mcp-token.env';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+beforeEach(() => {
+  process.env.GATEWAY_MCP_TOKEN_ENV = TOKEN_ENV;
+  try {
+    fs.rmSync(TOKEN_ENV);
+  } catch {
+    /* ignore */
+  }
+  mockFetch.mockReset();
+});
+
+afterAll(() => {
+  delete process.env.GATEWAY_MCP_TOKEN_ENV;
+  try {
+    fs.rmSync(TOKEN_ENV);
+  } catch {
+    /* ignore */
+  }
+});
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+  };
+}
+
+function tmpConfigWith(customConnectors: Record<string, unknown>) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgw-refresh-'));
+  const cfgPath = path.join(dir, 'config.json');
+  fs.writeFileSync(
+    cfgPath,
+    JSON.stringify({ gateway: { logDir: '/tmp', timezone: 'UTC', customConnectors }, agents: [] }, null, 2),
+  );
+  return cfgPath;
+}
+
+const firecrawlEntry = {
+  label: 'Firecrawl',
+  config: { type: 'http', url: 'https://mcp.firecrawl.dev/v2/mcp-oauth', headers: { Authorization: 'Bearer {access_token}' } },
+  secretNames: ['access_token'],
+  oauth: true,
+};
+
+describe('refreshExpiringOAuthConnectors', () => {
+  it('skips a connector whose token is not near expiry yet — no network calls at all', async () => {
+    setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_old');
+    setSecret(refreshTokenSecretKey('firecrawl'), 'fcr_old');
+    setSecret(clientIdSecretKey('firecrawl'), 'dyn_abc');
+    setSecret(expiresAtSecretKey('firecrawl'), String(Date.now() + 30 * 60 * 1000)); // 30 min out
+
+    const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+    await refreshExpiringOAuthConnectors(store);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(readTokenEnv()['CUSTOM__firecrawl__access_token']).toBe('fco_old');
+  });
+
+  it('refreshes a connector within the skew window and rewrites access_token/refresh_token/expiry', async () => {
+    setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_old');
+    setSecret(refreshTokenSecretKey('firecrawl'), 'fcr_old');
+    setSecret(clientIdSecretKey('firecrawl'), 'dyn_abc');
+    setSecret(expiresAtSecretKey('firecrawl'), String(Date.now() + 60 * 1000)); // 1 min out — due
+
+    const prmUrl = 'https://mcp.firecrawl.dev/.well-known/oauth-protected-resource/v2/mcp-oauth';
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse(401, {}, { 'www-authenticate': `Bearer resource_metadata="${prmUrl}"` }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { authorization_servers: ['https://www.firecrawl.dev'] }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_endpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+          token_endpoint: 'https://www.firecrawl.dev/api/oauth/token',
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { access_token: 'fco_new', token_type: 'bearer', expires_in: 3600, refresh_token: 'fcr_new' }),
+      );
+
+    const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+    await refreshExpiringOAuthConnectors(store);
+
+    const env = readTokenEnv();
+    expect(env['CUSTOM__firecrawl__access_token']).toBe('fco_new');
+    expect(env[refreshTokenSecretKey('firecrawl')]).toBe('fcr_new');
+    expect(Number(env[expiresAtSecretKey('firecrawl')])).toBeGreaterThan(Date.now() + 3500 * 1000);
+
+    // The refresh grant itself used the stored refresh_token + client_id + resource.
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+    const body = new URLSearchParams(lastCall[1].body as string);
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('fcr_old');
+    expect(body.get('client_id')).toBe('dyn_abc');
+    expect(body.get('resource')).toBe('https://mcp.firecrawl.dev/v2/mcp-oauth');
+  });
+
+  it('one connector failing to refresh does not stop a second, due, connector from refreshing', async () => {
+    setSecret(customSecretKey('broken', 'access_token'), 'fco_broken');
+    setSecret(refreshTokenSecretKey('broken'), 'fcr_broken');
+    setSecret(clientIdSecretKey('broken'), 'dyn_broken');
+    setSecret(expiresAtSecretKey('broken'), String(Date.now() + 1000));
+
+    setSecret(customSecretKey('ok', 'access_token'), 'fco_ok_old');
+    setSecret(refreshTokenSecretKey('ok'), 'fcr_ok');
+    setSecret(clientIdSecretKey('ok'), 'dyn_ok');
+    setSecret(expiresAtSecretKey('ok'), String(Date.now() + 1000));
+
+    const brokenEntry = { ...firecrawlEntry, config: { ...firecrawlEntry.config, url: 'https://mcp.broken.example/oauth' } };
+    const okEntry = { ...firecrawlEntry, config: { ...firecrawlEntry.config, url: 'https://mcp.ok.example/oauth' } };
+
+    // "broken" connector: discovery probe itself fails outright.
+    mockFetch.mockRejectedValueOnce(new Error('network unreachable'));
+    // "ok" connector: full successful discovery + refresh chain.
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse(401, {}, { 'www-authenticate': 'Bearer resource_metadata="https://mcp.ok.example/.well-known/oauth-protected-resource/oauth"' }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { authorization_servers: ['https://auth.ok.example'] }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_endpoint: 'https://auth.ok.example/authorize',
+          token_endpoint: 'https://auth.ok.example/token',
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: 'fco_ok_new', token_type: 'bearer', expires_in: 3600 }));
+
+    const store = createCustomConnectorsStore(tmpConfigWith({ broken: brokenEntry, ok: okEntry }));
+    await expect(refreshExpiringOAuthConnectors(store)).resolves.not.toThrow();
+
+    const env = readTokenEnv();
+    expect(env['CUSTOM__broken__access_token']).toBe('fco_broken'); // untouched
+    expect(env['CUSTOM__ok__access_token']).toBe('fco_ok_new'); // refreshed despite the other's failure
+  });
+
+  it('skips a connector with no stored refresh_token/client_id (nothing to refresh with)', async () => {
+    setSecret(customSecretKey('firecrawl', 'access_token'), 'fco_old');
+    setSecret(expiresAtSecretKey('firecrawl'), String(Date.now() + 1000));
+    // Deliberately no refresh_token / client_id secrets set.
+
+    const store = createCustomConnectorsStore(tmpConfigWith({ firecrawl: firecrawlEntry }));
+    await refreshExpiringOAuthConnectors(store);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-oauth custom connectors entirely', async () => {
+    const store = createCustomConnectorsStore(
+      tmpConfigWith({ plain: { ...firecrawlEntry, oauth: undefined } }),
+    );
+    await refreshExpiringOAuthConnectors(store);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/pending-oauth-store.test.ts
+++ b/tests/unit/pending-oauth-store.test.ts
@@ -1,0 +1,68 @@
+import { PendingOAuthStore } from '../../src/connectors/pending-oauth-store';
+import type { OAuthMetadata } from '../../src/connectors/mcp-oauth';
+
+const metadata: OAuthMetadata = {
+  resource: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+  authorizationEndpoint: 'https://www.firecrawl.dev/api/oauth/authorize',
+  tokenEndpoint: 'https://www.firecrawl.dev/api/oauth/token',
+  scopesSupported: [],
+};
+
+function baseEntry() {
+  return {
+    connectorId: 'firecrawl',
+    metadata,
+    clientId: 'dyn_abc',
+    redirectUri: 'https://pod.example.com/gateway/oauth/mcp/callback',
+    codeVerifier: 'verifier-123',
+  };
+}
+
+describe('PendingOAuthStore', () => {
+  it('create() returns a state string, and consume() returns the exact flow that was stored', () => {
+    const store = new PendingOAuthStore();
+    const state = store.create(baseEntry());
+    expect(typeof state).toBe('string');
+    expect(state.length).toBeGreaterThan(10);
+
+    const flow = store.consume(state);
+    expect(flow).toMatchObject(baseEntry());
+  });
+
+  it('consume() is single-use — a second call for the same state returns null', () => {
+    const store = new PendingOAuthStore();
+    const state = store.create(baseEntry());
+    expect(store.consume(state)).not.toBeNull();
+    expect(store.consume(state)).toBeNull();
+  });
+
+  it('consume() returns null for an unknown state', () => {
+    const store = new PendingOAuthStore();
+    expect(store.consume('never-created')).toBeNull();
+  });
+
+  it('consume() returns null once the flow has expired, even though it was never consumed', () => {
+    const store = new PendingOAuthStore();
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000_000);
+    const state = store.create(baseEntry());
+    nowSpy.mockReturnValue(1_000_000 + 6 * 60 * 1000); // 6 minutes later, TTL is 5
+    expect(store.consume(state)).toBeNull();
+    nowSpy.mockRestore();
+  });
+
+  it('prune() removes expired flows but leaves live ones', () => {
+    const store = new PendingOAuthStore();
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000_000);
+    const expiredState = store.create(baseEntry());
+    nowSpy.mockReturnValue(1_000_000 + 6 * 60 * 1000);
+    const liveState = store.create(baseEntry());
+    expect(store.size()).toBe(2);
+    store.prune();
+    expect(store.size()).toBe(1);
+    expect(store.consume(liveState)).not.toBeNull();
+    nowSpy.mockRestore();
+    void expiredState;
+  });
+});

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -320,7 +320,7 @@ describe('SessionProcess', () => {
       return JSON.parse(fs.readFileSync(p, 'utf-8')).mcpServers;
     }
 
-    // github is a services/api-managed custom connector now (CONNECTOR_CATALOG
+    // github is an externally-managed custom connector now (CONNECTOR_CATALOG
     // is empty by default — see catalog.ts), so these inject via
     // gatewayConfig.gateway.customConnectors + the CUSTOM__<id>__<name> secret
     // key, not a built-in catalog entry + a bare GITHUB_TOKEN.

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -343,12 +343,26 @@ describe('SessionProcess', () => {
       expect(readMcpConfig().github).toBeUndefined();
     });
 
-    it('not enabled → github entry omitted even with token', async () => {
+    it('explicitly disabled → github entry omitted even with token', async () => {
+      // Enablement is opt-out (default on) — an empty `connectors: {}` no
+      // longer means "nothing enabled"; it must be explicitly {enabled: false}.
       fs.writeFileSync(TOKEN_ENV, 'GITHUB_TOKEN=ghp_inject\n', { mode: 0o600 });
-      agentConfig.connectors = {};
+      agentConfig.connectors = { github: { enabled: false } };
       const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
       await sp.start();
       expect(readMcpConfig().github).toBeUndefined();
+    });
+
+    it('opt-out default: empty connectors config still injects a connected connector', async () => {
+      fs.writeFileSync(TOKEN_ENV, 'GITHUB_TOKEN=ghp_default\n', { mode: 0o600 });
+      agentConfig.connectors = {};
+      const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+      expect(readMcpConfig().github).toEqual({
+        type: 'http',
+        url: 'https://api.githubcopilot.com/mcp/',
+        headers: { Authorization: 'Bearer ghp_default' },
+      });
     });
   });
 
@@ -1006,6 +1020,10 @@ describe('SessionProcess', () => {
     try {
       // No settings.json, no .claude.json
       mockHomeDir = fakeHome;
+      // Enablement is opt-out (default on) — microsoft-365 needs no secret, so
+      // it would otherwise appear here regardless of this test's intent (a
+      // baseline session with no connectors configured).
+      agentConfig.connectors = { 'microsoft-365': { enabled: false } };
 
       const sp = makeSp('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
       await expect(sp.start()).resolves.not.toThrow();

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -320,9 +320,26 @@ describe('SessionProcess', () => {
       return JSON.parse(fs.readFileSync(p, 'utf-8')).mcpServers;
     }
 
+    // github is a services/api-managed custom connector now (CONNECTOR_CATALOG
+    // is empty by default — see catalog.ts), so these inject via
+    // gatewayConfig.gateway.customConnectors + the CUSTOM__<id>__<name> secret
+    // key, not a built-in catalog entry + a bare GITHUB_TOKEN.
+    const githubCustomConnector = {
+      label: 'GitHub',
+      config: {
+        type: 'http',
+        url: 'https://api.githubcopilot.com/mcp/',
+        headers: { Authorization: 'Bearer {access_token}' },
+      },
+      secretNames: ['access_token'],
+      authKind: 'oauth' as const,
+      managed: true,
+    };
+
     it('enabled + connected → github http entry injected with bearer header', async () => {
-      fs.writeFileSync(TOKEN_ENV, 'GITHUB_TOKEN=ghp_inject\n', { mode: 0o600 });
+      fs.writeFileSync(TOKEN_ENV, 'CUSTOM__github__access_token=ghp_inject\n', { mode: 0o600 });
       agentConfig.connectors = { github: { enabled: true } };
+      gatewayConfig.gateway.customConnectors = { github: githubCustomConnector };
       const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
       await sp.start();
 
@@ -338,6 +355,7 @@ describe('SessionProcess', () => {
 
     it('enabled but no token → github entry omitted', async () => {
       agentConfig.connectors = { github: { enabled: true } };
+      gatewayConfig.gateway.customConnectors = { github: githubCustomConnector };
       const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
       await sp.start();
       expect(readMcpConfig().github).toBeUndefined();
@@ -346,16 +364,18 @@ describe('SessionProcess', () => {
     it('explicitly disabled → github entry omitted even with token', async () => {
       // Enablement is opt-out (default on) — an empty `connectors: {}` no
       // longer means "nothing enabled"; it must be explicitly {enabled: false}.
-      fs.writeFileSync(TOKEN_ENV, 'GITHUB_TOKEN=ghp_inject\n', { mode: 0o600 });
+      fs.writeFileSync(TOKEN_ENV, 'CUSTOM__github__access_token=ghp_inject\n', { mode: 0o600 });
       agentConfig.connectors = { github: { enabled: false } };
+      gatewayConfig.gateway.customConnectors = { github: githubCustomConnector };
       const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
       await sp.start();
       expect(readMcpConfig().github).toBeUndefined();
     });
 
     it('opt-out default: empty connectors config still injects a connected connector', async () => {
-      fs.writeFileSync(TOKEN_ENV, 'GITHUB_TOKEN=ghp_default\n', { mode: 0o600 });
+      fs.writeFileSync(TOKEN_ENV, 'CUSTOM__github__access_token=ghp_default\n', { mode: 0o600 });
       agentConfig.connectors = {};
+      gatewayConfig.gateway.customConnectors = { github: githubCustomConnector };
       const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
       await sp.start();
       expect(readMcpConfig().github).toEqual({

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -302,6 +302,57 @@ describe('SessionProcess', () => {
   });
 
   // --------------------------------------------------------------------------
+  // U-SP-CONN: connector injection into mcp-config.json
+  // --------------------------------------------------------------------------
+  describe('connector injection', () => {
+    const TOKEN_ENV = '/tmp/sp-connectors-mcp-token.env';
+    beforeEach(() => {
+      process.env.GATEWAY_MCP_TOKEN_ENV = TOKEN_ENV;
+      try { fs.rmSync(TOKEN_ENV); } catch { /* ignore */ }
+    });
+    afterEach(() => {
+      delete process.env.GATEWAY_MCP_TOKEN_ENV;
+      try { fs.rmSync(TOKEN_ENV); } catch { /* ignore */ }
+    });
+
+    function readMcpConfig(): Record<string, unknown> {
+      const p = path.join(agentConfig.workspace, '.sessions', 'chat:111', 'mcp-config.json');
+      return JSON.parse(fs.readFileSync(p, 'utf-8')).mcpServers;
+    }
+
+    it('enabled + connected → github http entry injected with bearer header', async () => {
+      fs.writeFileSync(TOKEN_ENV, 'GITHUB_TOKEN=ghp_inject\n', { mode: 0o600 });
+      agentConfig.connectors = { github: { enabled: true } };
+      const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+
+      const servers = readMcpConfig();
+      expect(servers.github).toEqual({
+        type: 'http',
+        url: 'https://api.githubcopilot.com/mcp/',
+        headers: { Authorization: 'Bearer ghp_inject' },
+      });
+      // gateway server always still present
+      expect(servers.gateway).toBeDefined();
+    });
+
+    it('enabled but no token → github entry omitted', async () => {
+      agentConfig.connectors = { github: { enabled: true } };
+      const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+      expect(readMcpConfig().github).toBeUndefined();
+    });
+
+    it('not enabled → github entry omitted even with token', async () => {
+      fs.writeFileSync(TOKEN_ENV, 'GITHUB_TOKEN=ghp_inject\n', { mode: 0o600 });
+      agentConfig.connectors = {};
+      const sp = new SessionProcess('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+      await sp.start();
+      expect(readMcpConfig().github).toBeUndefined();
+    });
+  });
+
+  // --------------------------------------------------------------------------
   // U-SP-06: No MCP config for api source
   // --------------------------------------------------------------------------
   it('U-SP-06: No MCP config written for api source', async () => {


### PR DESCRIPTION
## Summary

Adds a first-class "connectors" feature to the gateway: a catalog + secret store +
config injector that lets each agent enable a set of MCP servers, with three ways
a connector gets its credentials:

1. **Managed OAuth** — a control-plane the deployer runs owns the OAuth
   client_secret and token refresh loop *off* the gateway (the gateway runs
   inside the end user's own VM/box, reachable by that user's own shell/SSH —
   a shared client_secret can't live there safely), and
   pushes a fresh `access_token` to the gateway via `POST /v1/connectors/:id/oauth/receive`.
2. **Generic custom OAuth** — for any MCP server that only offers OAuth 2.1 sign-in
   (PKCE + Dynamic Client Registration, no static API key), the gateway runs the
   *entire* flow itself, on the VM — discovery, DCR, PKCE, token exchange, and a
   background refresh sweep. No third party ever sees the token.
3. **Plain paste-token** — the simplest case: the user pastes a static API key
   directly into a custom connector's config.

Connectors resolve into each session's `mcp-config.json` fresh at spawn
(`resolveEnabledConnectors`), respecting per-agent opt-out enablement — a
connector globally connected is available to every agent by default unless that
agent explicitly disables it.

## Why

Today, wiring an MCP server into the gateway means hand-editing `config.json` and
restarting. This gives every agent a live "Connectors" surface (add, connect,
disconnect, per-agent toggle) without ever putting a vendor's client_secret on a
box the end user can shell into.

## Design notes / tradeoffs

- Secrets live in a dedicated `mcp-token.env` (0600, separate from `config.json`),
  namespaced `CUSTOM__<id>__<name>`. `config.json`'s `gateway.customConnectors`
  only ever holds the non-secret wiring (label, url, header template with a
  `{placeholder}`, which secrets it needs).
- A custom connector's pasted config is **admin-trusted, not code-reviewed** — the
  admin API key is the whole trust boundary here, same as any other admin-gated
  mutation this gateway already exposes.
- Disconnecting a connector is a *soft* disconnect when there's a secret to clear
  and something worth preserving (keeps the pasted config so reconnecting doesn't
  mean retyping it) — but a hard delete when there's nothing to preserve (a
  "No auth" connector with zero secrets, or a managed entry whose definition lives
  entirely in the external control plane anyway).
- The OAuth refresh sweep runs every 60s (same interval as the existing
  `cliPairingStore.prune()`), with backoff after a failed refresh and a hard
  give-up (clearing the connector back to "disconnected") after 3 consecutive
  failures — so a revoked refresh_token doesn't retry forever.

## Backward compatibility

Verified against a clean rebase onto current `main`: every new field on shared
types (`CustomConnectorEntry`, `AgentConfig.connectors`,
`gateway.customConnectors`, `gateway.oauthReturnUrl`) is optional and defaults
safely on a pre-existing `config.json` that has none of them. No new npm
dependency was added — everything is built on Node's own `crypto`/`fetch`/`fs`.
Nothing in this PR runs at boot beyond the (already-existing) 60s interval, which
is a no-op when `customConnectors` is empty.

## How to test

```
npx jest tests/unit/connectors.test.ts tests/unit/custom-connectors.test.ts \
  tests/unit/oauth-connectors.test.ts tests/unit/oauth-connectors-router.test.ts \
  tests/unit/mcp-oauth.test.ts tests/unit/pending-oauth-store.test.ts \
  tests/unit/oauth-refresh-sweep.test.ts tests/unit/session-process.test.ts \
  tests/unit/config-watcher.test.ts
```

Live-verified end to end against a running gateway container, including: adding a
custom connector (both plain-token and `oauth: true` shapes), the full PKCE+DCR
sign-in round trip against a real third-party MCP server, disconnect/reconnect,
per-agent enablement, and the managed push-receive path.

## Checklist

- [x] Reviewed my own code — this branch went through a dedicated internal audit
      pass after the initial implementation (three independent review passes
      covering CRUD/storage, the OAuth/PKCE/DCR flow, and gateway wiring/session
      integration), which surfaced and fixed 8 real issues before this PR: a dead
      config-write path with its own uncoordinated file lock, a way to overwrite a
      managed connector's real OAuth token through the wrong route, disconnect not
      actually disabling an OAuth connector (the refresh sweep would silently
      resurrect it), the refresh sweep never restarting sessions despite its own
      doc comment claiming it did, no backoff on repeated refresh failure, a race
      between the sweep and a manual reconnect, no per-connector error isolation
      in resolution, and unbounded DCR client registration on every Connect retry.
- [x] Tests pass
- [x] No console errors
