### PR TITLE
Add system-scope install mode to `claude-gateway service install`

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -93,13 +93,23 @@ never mistaken for one.
 
 | Command | Description |
 |---------|-------------|
-| `claude-gateway service install [--manager systemd\|pm2] [--config <path>] [--yes] [--print] [--force]` | Generate and start a service |
-| `claude-gateway service status [--manager systemd\|pm2]` | Report installed/enabled/active state as JSON |
-| `claude-gateway service uninstall [--manager systemd\|pm2] [--yes]` | Stop and remove the service |
+| `claude-gateway service install [--manager systemd\|pm2] [--scope user\|system] [--run-as <user>] [--after <target,...>] [--env-file <path>] [--env KEY=VALUE,...] [--config <path>] [--yes] [--print] [--force]` | Generate and start a service |
+| `claude-gateway service status [--manager systemd\|pm2] [--scope user\|system]` | Report installed/enabled/active state as JSON |
+| `claude-gateway service uninstall [--manager systemd\|pm2] [--scope user\|system] [--yes]` | Stop and remove the service |
 
 - `systemd` (the default) installs a **user** unit at `~/.config/systemd/user/claude-gateway.service` —
   no `sudo`, and it runs as the user that owns `~/.claude-gateway`. Run
   `loginctl enable-linger <user>` once if it must survive logout.
+- `--scope system` (systemd only) installs a root-owned unit at
+  `/etc/systemd/system/claude-gateway.service` instead, for automated/infra provisioning that needs
+  a fixed system account. Requires already running as root (never escalates via `sudo`) and
+  `--run-as <user>`, which becomes the unit's `User=`; `WantedBy=` is `multi-user.target` instead of
+  `default.target`, and the `loginctl` hint is skipped. It never triggers the system-scope conflict
+  check below against itself.
+- `--after <target,...>`, `--env-file <path>`, and `--env KEY=VALUE,...` customize the generated unit
+  (either scope): extra `After=` ordering targets, an `EnvironmentFile=-<path>` for secrets that never
+  appear in the unit text, and additional non-secret `Environment=` lines. `--env` refuses to override
+  `HOME`, `PATH`, or `GATEWAY_CONFIG`.
 - Every path in the generated unit (node, entry point, config, working directory) is absolute, and
   `ExecStart` always uses the explicit `gateway start` command. No secrets are written into the
   unit — the gateway reads `~/.claude-gateway/.env` itself.
@@ -108,9 +118,12 @@ never mistaken for one.
   and refuse to run non-interactively without it.
 - `install` verifies `/health` on the **local bind address**, and `uninstall` reports the state the
   manager actually reports afterwards — never the state that was intended.
-- (systemd) `install` refuses by default if a `claude-gateway.service` unit already exists and is
-  enabled or active at *system* scope (e.g. from provisioning outside this CLI) — it prints the exact
-  `sudo systemctl disable --now claude-gateway.service` to resolve it; pass `--force` to install anyway.
+- (systemd, user-scope installs) `install` refuses by default if a `claude-gateway.service` unit
+  already exists and is enabled or active at *system* scope (e.g. from provisioning outside this
+  CLI) — it prints the exact `sudo systemctl disable --now claude-gateway.service` to resolve it;
+  pass `--force` to install anyway.
+- Re-running `install` against an already-active unit whose rendered content changed restarts it
+  automatically; unchanged content leaves the running unit alone.
 - After installing, `gateway restart`/`stop` detect and drive that same service.
 
 ## Versions & updates

--- a/CLI.md
+++ b/CLI.md
@@ -118,6 +118,11 @@ never mistaken for one.
   and refuse to run non-interactively without it.
 - `install` verifies `/health` on the **local bind address**, and `uninstall` reports the state the
   manager actually reports afterwards — never the state that was intended.
+- `install` exit codes: `0` fully healthy, `1` install/enable itself failed (or a validation/
+  confirmation gate refused — nothing was written), `2` install/enable succeeded but `/health`
+  never answered within the poll window. Distinguishing `1` from `2` by exit code alone means a
+  caller doesn't have to parse the JSON result on stdout just to tell "didn't happen" apart from
+  "happened, health unconfirmed".
 - (systemd, user-scope installs) `install` refuses by default if a `claude-gateway.service` unit
   already exists and is enabled or active at *system* scope (e.g. from provisioning outside this
   CLI) — it prints the exact `sudo systemctl disable --now claude-gateway.service` to resolve it;

--- a/README.md
+++ b/README.md
@@ -136,13 +136,38 @@ The systemd path writes `~/.config/systemd/user/claude-gateway.service`. Run
 `loginctl enable-linger $USER` once if it must keep running while you're logged out.
 The unit sets `OOMPolicy=continue` so that an OOM-killed child process (e.g. a dev server an
 agent spawned on its own) doesn't take the whole gateway down with it — only `Restart=always`
-restarting the *gateway's own* process is intended. Installs from before this was added need to
-re-run `claude-gateway service install` to regenerate the unit file *and then*
-`systemctl --user restart claude-gateway.service` — reinstalling alone reloads systemd's unit
-definition but does not restart an already-running unit, so the live process keeps the old
-`OOMPolicy` until it's explicitly restarted (or the host reboots).
+restarting the *gateway's own* process is intended. Re-running `claude-gateway service install`
+against an already-active unit whose rendered content changed (a newer CLI version, or different
+flags) automatically restarts it via `systemctl ... restart`, so the update takes effect
+immediately; re-running with unchanged content leaves the running unit alone.
 Prefer [PM2](https://pm2.keymetrics.io)? `claude-gateway service install --manager pm2` registers
 and saves the process instead (run `pm2 startup` separately for boot-time start).
+
+**System-scope installs (for automated/infra provisioning)**
+
+Pass `--scope system` to install a root-owned unit at `/etc/systemd/system/claude-gateway.service`
+instead — for provisioning that needs the gateway to run under a fixed system account rather than
+whoever happens to run the install interactively. It requires:
+
+```bash
+sudo claude-gateway service install --scope system --run-as gwuser --yes
+```
+
+- The caller must already be root — `--scope system` never escalates via `sudo` on its own, and
+  refuses immediately if it isn't.
+- `--run-as <user>` is required and becomes the unit's `User=`; `WantedBy=` is
+  `multi-user.target` instead of `default.target`, so it starts at boot regardless of any login
+  session (the `loginctl enable-linger` hint is skipped — it's meaningless here).
+- A system-scope install never refuses itself over the system-scope conflict check described
+  above — that check exists to protect a *user*-scope install from colliding with an externally
+  provisioned system-scope unit, and a system-scope install *is* that unit.
+- `--after <target1,target2>`, `--env-file <path>`, and `--env KEY=VALUE[,KEY=VALUE...]` further
+  customize the generated unit (both scopes): extra `After=` ordering targets, an
+  `EnvironmentFile=-<path>` for feeding secrets in without ever writing them into the unit text,
+  and additional non-secret `Environment=` lines. `--env` refuses to override `HOME`, `PATH`, or
+  `GATEWAY_CONFIG` (the installer's own reserved names) — use `--env-file` for anything sensitive.
+- `service status --scope system` and `service uninstall --scope system` work the same way against
+  the system-scope unit (uninstall also requires root).
 
 Once installed, drive it through the CLI — it detects whichever manager owns the process:
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ sudo claude-gateway service install --scope system --run-as gwuser --yes
 - `--run-as <user>` is required and becomes the unit's `User=`; `WantedBy=` is
   `multi-user.target` instead of `default.target`, so it starts at boot regardless of any login
   session (the `loginctl enable-linger` hint is skipped — it's meaningless here).
+- `WorkingDirectory=`/`HOME=`/the config path all resolve to `--run-as`'s own home directory
+  (looked up via `getent passwd`, not the installing root process's home) — the unit runs as that
+  user, so its paths must be theirs. If the user's `~/.claude-gateway` doesn't exist yet, the
+  install creates it and `chown`s it to them (an already-existing directory is left alone,
+  trusting whatever ownership it already has). Refuses if `--run-as` doesn't resolve to a real
+  user on this host.
 - A system-scope install never refuses itself over the system-scope conflict check described
   above — that check exists to protect a *user*-scope install from colliding with an externally
   provisioned system-scope unit, and a system-scope install *is* that unit.

--- a/README.md
+++ b/README.md
@@ -160,10 +160,14 @@ sudo claude-gateway service install --scope system --run-as gwuser --yes
   session (the `loginctl enable-linger` hint is skipped — it's meaningless here).
 - `WorkingDirectory=`/`HOME=`/the config path all resolve to `--run-as`'s own home directory
   (looked up via `getent passwd`, not the installing root process's home) — the unit runs as that
-  user, so its paths must be theirs. If the user's `~/.claude-gateway` doesn't exist yet, the
-  install creates it and `chown`s it to them (an already-existing directory is left alone,
-  trusting whatever ownership it already has). Refuses if `--run-as` doesn't resolve to a real
-  user on this host.
+  user, so its paths must be theirs. A `~/...` in `--config`/`--env-file` expands against that same
+  home. `$GATEWAY_CONFIG` from the installing (root) process's own environment is **not** consulted
+  for a system-scope install — only an explicit `--config` is — since it belongs to root's
+  environment, not `--run-as`'s. If the user's `~/.claude-gateway` doesn't exist yet, the install
+  creates it and `chown`s it to them; if it already exists but is owned by someone else (e.g. a
+  prior install used a different `--run-as`), ownership is reassigned to match. An
+  already-correctly-owned directory is left untouched. Refuses if `--run-as` doesn't resolve to a
+  real user on this host.
 - A system-scope install never refuses itself over the system-scope conflict check described
   above — that check exists to protect a *user*-scope install from colliding with an externally
   provisioned system-scope unit, and a system-scope install *is* that unit.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ non-interactive run is refused rather than left hanging). Always stop the gatewa
 `service uninstall` or `systemctl --user stop claude-gateway.service` — a bare `kill <pid>` bypasses
 systemd's own stop tracking, so `Restart=always` brings it right back regardless of exit code.
 
+`install`'s exit code distinguishes three outcomes: `0` fully healthy, `1` install/enable itself
+failed or a validation/confirmation gate refused (nothing was written), `2` install/enable
+succeeded but `/health` never answered within the poll window. A script that only checks the exit
+code — not the JSON result on stdout — can still tell "didn't happen" apart from "happened, health
+unconfirmed" this way.
+
 `install` also refuses (rather than just warning) if a `claude-gateway.service` unit already
 exists and is enabled or active at *system* scope (e.g. one written by provisioning outside this
 CLI) — installing a second, independent unit alongside it would race for the port on the next

--- a/scripts/gen-cli.ts
+++ b/scripts/gen-cli.ts
@@ -164,13 +164,23 @@ never mistaken for one.
 
 | Command | Description |
 |---------|-------------|
-| \`claude-gateway service install [--manager systemd\\|pm2] [--config <path>] [--yes] [--print] [--force]\` | Generate and start a service |
-| \`claude-gateway service status [--manager systemd\\|pm2]\` | Report installed/enabled/active state as JSON |
-| \`claude-gateway service uninstall [--manager systemd\\|pm2] [--yes]\` | Stop and remove the service |
+| \`claude-gateway service install [--manager systemd\\|pm2] [--scope user\\|system] [--run-as <user>] [--after <target,...>] [--env-file <path>] [--env KEY=VALUE,...] [--config <path>] [--yes] [--print] [--force]\` | Generate and start a service |
+| \`claude-gateway service status [--manager systemd\\|pm2] [--scope user\\|system]\` | Report installed/enabled/active state as JSON |
+| \`claude-gateway service uninstall [--manager systemd\\|pm2] [--scope user\\|system] [--yes]\` | Stop and remove the service |
 
 - \`systemd\` (the default) installs a **user** unit at \`~/.config/systemd/user/claude-gateway.service\` —
   no \`sudo\`, and it runs as the user that owns \`~/.claude-gateway\`. Run
   \`loginctl enable-linger <user>\` once if it must survive logout.
+- \`--scope system\` (systemd only) installs a root-owned unit at
+  \`/etc/systemd/system/claude-gateway.service\` instead, for automated/infra provisioning that needs
+  a fixed system account. Requires already running as root (never escalates via \`sudo\`) and
+  \`--run-as <user>\`, which becomes the unit's \`User=\`; \`WantedBy=\` is \`multi-user.target\` instead of
+  \`default.target\`, and the \`loginctl\` hint is skipped. It never triggers the system-scope conflict
+  check below against itself.
+- \`--after <target,...>\`, \`--env-file <path>\`, and \`--env KEY=VALUE,...\` customize the generated unit
+  (either scope): extra \`After=\` ordering targets, an \`EnvironmentFile=-<path>\` for secrets that never
+  appear in the unit text, and additional non-secret \`Environment=\` lines. \`--env\` refuses to override
+  \`HOME\`, \`PATH\`, or \`GATEWAY_CONFIG\`.
 - Every path in the generated unit (node, entry point, config, working directory) is absolute, and
   \`ExecStart\` always uses the explicit \`gateway start\` command. No secrets are written into the
   unit — the gateway reads \`~/.claude-gateway/.env\` itself.
@@ -179,9 +189,12 @@ never mistaken for one.
   and refuse to run non-interactively without it.
 - \`install\` verifies \`/health\` on the **local bind address**, and \`uninstall\` reports the state the
   manager actually reports afterwards — never the state that was intended.
-- (systemd) \`install\` refuses by default if a \`claude-gateway.service\` unit already exists and is
-  enabled or active at *system* scope (e.g. from provisioning outside this CLI) — it prints the exact
-  \`sudo systemctl disable --now claude-gateway.service\` to resolve it; pass \`--force\` to install anyway.
+- (systemd, user-scope installs) \`install\` refuses by default if a \`claude-gateway.service\` unit
+  already exists and is enabled or active at *system* scope (e.g. from provisioning outside this
+  CLI) — it prints the exact \`sudo systemctl disable --now claude-gateway.service\` to resolve it;
+  pass \`--force\` to install anyway.
+- Re-running \`install\` against an already-active unit whose rendered content changed restarts it
+  automatically; unchanged content leaves the running unit alone.
 - After installing, \`gateway restart\`/\`stop\` detect and drive that same service.
 
 ## Versions & updates

--- a/scripts/gen-cli.ts
+++ b/scripts/gen-cli.ts
@@ -189,6 +189,11 @@ never mistaken for one.
   and refuse to run non-interactively without it.
 - \`install\` verifies \`/health\` on the **local bind address**, and \`uninstall\` reports the state the
   manager actually reports afterwards — never the state that was intended.
+- \`install\` exit codes: \`0\` fully healthy, \`1\` install/enable itself failed (or a validation/
+  confirmation gate refused — nothing was written), \`2\` install/enable succeeded but \`/health\`
+  never answered within the poll window. Distinguishing \`1\` from \`2\` by exit code alone means a
+  caller doesn't have to parse the JSON result on stdout just to tell "didn't happen" apart from
+  "happened, health unconfirmed".
 - (systemd, user-scope installs) \`install\` refuses by default if a \`claude-gateway.service\` unit
   already exists and is enabled or active at *system* scope (e.g. from provisioning outside this
   CLI) — it prints the exact \`sudo systemctl disable --now claude-gateway.service\` to resolve it;

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -12,24 +12,35 @@ import { writeCommandHelp } from '../output';
 /**
  * `service install|status|uninstall` — run the gateway under a process manager.
  *
- * systemd installs a *user* unit (`~/.config/systemd/user/`) so no privilege
- * escalation is needed and the service runs as the same user that owns
- * ~/.claude-gateway. PM2 is offered for hosts that already standardise on it.
+ * systemd defaults to installing a *user* unit (`~/.config/systemd/user/`) so no
+ * privilege escalation is needed and the service runs as the same user that owns
+ * ~/.claude-gateway. `--scope system` opts into a root-owned unit at
+ * `/etc/systemd/system/` for automated/infra provisioning that needs the gateway
+ * to run under a fixed system account — it never auto-escalates via sudo; the
+ * caller must already be root. PM2 is offered for hosts that already standardise
+ * on it (user scope only — `--scope system` is systemd-only).
  *
  * Everything the generated unit references is an absolute path resolved here
  * (node binary, entry point, config, working directory) — a unit that inherits
  * PATH or cwd from an interactive shell breaks the moment systemd starts it at
  * boot. Secrets are never written into the unit: the gateway reads
- * ~/.claude-gateway/.env itself.
+ * ~/.claude-gateway/.env itself. `--env` is for non-secret overrides only — use
+ * `--env-file` (EnvironmentFile=) to point at a file holding actual secrets.
  */
 
 const UNIT_NAME = 'claude-gateway.service';
 const PM2_NAME = 'gateway';
 const HEALTH_ATTEMPTS = 20;
 const HEALTH_INTERVAL_MS = 500;
+/** Env var names the installer itself sets — `--env` may not override these. */
+const RESERVED_ENV_KEYS = new Set(['HOME', 'PATH', 'GATEWAY_CONFIG']);
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export type ServiceManager = 'systemd' | 'pm2';
 type ServiceAction = 'install' | 'status' | 'uninstall';
+/** systemd install scope. `user` (default) needs no privileges; `system`
+ *  targets /etc/systemd/system and is for root-driven provisioning. */
+export type ServiceScope = 'user' | 'system';
 
 export interface LaunchSpec {
   node: string;
@@ -126,26 +137,55 @@ function systemdQuote(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
+/** Extra, opt-in shape of the rendered unit — on top of the LaunchSpec triple
+ *  every manager shares. Systemd-only (PM2 has no equivalent concept), which is
+ *  why this is a separate parameter rather than folded into LaunchSpec. */
+export interface SystemdUnitOptions {
+  scope: ServiceScope;
+  /** Required by the caller when scope === 'system'; ignored for 'user'. */
+  runAs?: string;
+  /** Extra `After=` targets appended after the default `network-online.target`. */
+  after: string[];
+  /** Adds `EnvironmentFile=-<path>` — the sanctioned way to feed secrets in,
+   *  since they never appear in the unit text itself. */
+  envFile?: string;
+  /** Additional `Environment="KEY=VALUE"` lines. Never for secrets — this text
+   *  is written straight into the unit file. */
+  extraEnv: Record<string, string>;
+}
+
+/** Default when a caller (or an existing test) passes no options — matches the
+ *  behavior this command had before --scope existed exactly, so `--scope user`
+ *  (or omitting it) is a strict no-op change. */
+const DEFAULT_SYSTEMD_UNIT_OPTIONS: SystemdUnitOptions = { scope: 'user', after: [], extraEnv: {} };
+
 /** Pure renderer — exported so `--print` and the tests see the exact bytes that
  *  would be written to disk. */
-export function renderSystemdUnit(spec: LaunchSpec): string {
+export function renderSystemdUnit(spec: LaunchSpec, opts: SystemdUnitOptions = DEFAULT_SYSTEMD_UNIT_OPTIONS): string {
   const q = systemdQuote;
+  const after = ['network-online.target', ...opts.after].join(' ');
+  const extraEnvLines = Object.entries(opts.extraEnv)
+    .map(([key, value]) => `Environment="${key}=${q(value)}"`)
+    .join('\n');
+  const userLine = opts.scope === 'system' && opts.runAs ? `User=${opts.runAs}\n` : '';
+  const envFileLine = opts.envFile ? `EnvironmentFile=-"${q(opts.envFile)}"\n` : '';
+  const wantedBy = opts.scope === 'system' ? 'multi-user.target' : 'default.target';
   return `[Unit]
 Description=Claude Gateway
 Documentation=https://github.com/0xMaxMa/claude-gateway
 Wants=network-online.target
-After=network-online.target
+After=${after}
 
 [Service]
 Type=simple
-# WorkingDirectory is deliberately unquoted, unlike every other value here:
+${userLine}# WorkingDirectory is deliberately unquoted, unlike every other value here:
 # systemd takes the rest of the line as the path, and rejects a quoted one
 # ("path is not absolute"). Escaping is unnecessary for the same reason.
 WorkingDirectory=${spec.cwd}
 Environment="HOME=${q(spec.home)}"
 Environment="PATH=${q(spec.pathEnv)}"
 Environment="GATEWAY_CONFIG=${q(spec.config)}"
-ExecStart="${q(spec.node)}" "${q(spec.entry)}" gateway start --config "${q(spec.config)}"
+${extraEnvLines ? extraEnvLines + '\n' : ''}${envFileLine}ExecStart="${q(spec.node)}" "${q(spec.entry)}" gateway start --config "${q(spec.config)}"
 Restart=always
 RestartSec=5
 # Without this, systemd's default OOMPolicy=stop treats an OOM-killed
@@ -156,7 +196,7 @@ RestartSec=5
 OOMPolicy=continue
 
 [Install]
-WantedBy=default.target
+WantedBy=${wantedBy}
 `;
 }
 
@@ -179,8 +219,18 @@ export function pm2StartArgs(spec: LaunchSpec): string[] {
   ];
 }
 
-function unitPath(): string {
-  return path.join(os.homedir(), '.config', 'systemd', 'user', UNIT_NAME);
+function unitPath(scope: ServiceScope): string {
+  return scope === 'system'
+    ? path.join('/etc', 'systemd', 'system', UNIT_NAME)
+    : path.join(os.homedir(), '.config', 'systemd', 'user', UNIT_NAME);
+}
+
+/** True when this process is already root. Systemd `--scope system` never
+ *  auto-escalates via sudo (unlike `gateway restart`/`stop`, which is driving
+ *  an *existing* unit rather than deciding what account a new one runs as) —
+ *  it fails fast instead, so the caller stays in control of the escalation. */
+function isRoot(): boolean {
+  return typeof process.getuid === 'function' && process.getuid() === 0;
 }
 
 function run(file: string, args: string[]): void {
@@ -236,14 +286,15 @@ async function waitForHealth(config: CliConfigView, flags: Record<string, string
   return false;
 }
 
-// ─── systemd (user scope) ─────────────────────────────────────────────────────
+// ─── systemd ───────────────────────────────────────────────────────────────
 
 /** `is-enabled`/`is-active` for `UNIT_NAME` at the given scope — the query
- *  both `systemdState()` (user scope, for `service status`) and
- *  `systemScopeConflict()` (system scope, for the install-time check below)
- *  need, differing only in scope. A named boolean rather than a raw argv
- *  fragment (`['--user']`/`[]`) so a future call site passing the wrong array
- *  fails to compile instead of silently querying the wrong scope. */
+ *  both `systemdState()` (the install's own scope, for `service status`) and
+ *  `systemScopeConflict()` (always system scope, for the user-scope
+ *  install-time check below) need, differing only in scope. A named boolean
+ *  rather than a raw argv fragment (`['--user']`/`[]`) so a future call site
+ *  passing the wrong array fails to compile instead of silently querying the
+ *  wrong scope. */
 function unitFlagState(userScope: boolean): { enabled: boolean; active: boolean } {
   const scopeArgs = userScope ? ['--user'] : [];
   let enabled = false;
@@ -261,13 +312,17 @@ function unitFlagState(userScope: boolean): { enabled: boolean; active: boolean 
   return { enabled, active };
 }
 
-function systemdState(): { installed: boolean; enabled: boolean; active: boolean } {
-  return { installed: fs.existsSync(unitPath()), ...unitFlagState(true) };
+function systemdState(scope: ServiceScope): { installed: boolean; enabled: boolean; active: boolean } {
+  return { installed: fs.existsSync(unitPath(scope)), ...unitFlagState(scope === 'user') };
 }
 
-function systemdStatus(flags: Record<string, string | boolean>): number {
-  const state = systemdState();
-  printJson({ manager: 'systemd-user', unit: unitPath(), ...state }, flags);
+function systemdManagerLabel(scope: ServiceScope): 'systemd-user' | 'systemd-system' {
+  return scope === 'user' ? 'systemd-user' : 'systemd-system';
+}
+
+function systemdStatus(flags: Record<string, string | boolean>, scope: ServiceScope): number {
+  const state = systemdState(scope);
+  printJson({ manager: systemdManagerLabel(scope), unit: unitPath(scope), ...state }, flags);
   return state.active ? 0 : 1;
 }
 
@@ -298,31 +353,129 @@ function writeSystemScopeConflictRefusal(): void {
   );
 }
 
+/** `--after <target1,target2,...>` — extra `After=` ordering targets, appended
+ *  to the unit's default `network-online.target`. Comma-separated rather than
+ *  a repeatable flag: the shared CLI parser (src/cli/args.ts) has no concept
+ *  of repeated flags accumulating into an array, and adding one there would
+ *  change every command's flag type, not just this one. */
+function parseAfterTargets(flags: Record<string, string | boolean>): string[] | null {
+  const raw = flags.after;
+  if (raw === undefined) return [];
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    process.stderr.write('--after requires a comma-separated list of systemd unit/target names.\n');
+    return null;
+  }
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** `--env KEY=VALUE[,KEY=VALUE...]` — extra `Environment=` lines. Rejects
+ *  malformed pairs and the three variable names the installer itself sets, so
+ *  a typo silently overriding HOME/PATH/GATEWAY_CONFIG fails loudly instead of
+ *  producing a unit that starts the wrong binary. Never for secrets — this
+ *  text is written straight into the unit file; point at --env-file instead. */
+function parseExtraEnv(flags: Record<string, string | boolean>): Record<string, string> | null {
+  const raw = flags.env;
+  if (raw === undefined) return {};
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    process.stderr.write('--env requires a comma-separated list of KEY=VALUE pairs.\n');
+    return null;
+  }
+  const out: Record<string, string> = {};
+  for (const pair of raw.split(',')) {
+    const trimmed = pair.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) {
+      process.stderr.write(`Invalid --env entry "${trimmed}" — expected KEY=VALUE.\n`);
+      return null;
+    }
+    const key = trimmed.slice(0, eq);
+    const value = trimmed.slice(eq + 1);
+    if (!ENV_KEY_RE.test(key)) {
+      process.stderr.write(`Invalid --env key "${key}" — must match [A-Za-z_][A-Za-z0-9_]*.\n`);
+      return null;
+    }
+    if (RESERVED_ENV_KEYS.has(key)) {
+      process.stderr.write(`--env cannot override "${key}" — it is set by the installer itself.\n`);
+      return null;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/** `--env-file <path>` — adds `EnvironmentFile=-<path>` so a caller can feed
+ *  secrets to the unit without ever putting them in its text. `-` means
+ *  systemd tolerates the file being absent. */
+function parseEnvFile(flags: Record<string, string | boolean>): string | undefined {
+  return typeof flags['env-file'] === 'string' ? path.resolve(expandHome(flags['env-file'])) : undefined;
+}
+
+/** Resolve and validate everything `renderSystemdUnit()` needs beyond the
+ *  shared LaunchSpec triple. Returns null (with a message already on stderr)
+ *  on any invalid input — install must never write a unit from a half-parsed
+ *  flag set. */
+function resolveSystemdUnitOptions(flags: Record<string, string | boolean>, scope: ServiceScope): SystemdUnitOptions | null {
+  const after = parseAfterTargets(flags);
+  if (after === null) return null;
+  const extraEnv = parseExtraEnv(flags);
+  if (extraEnv === null) return null;
+  const envFile = parseEnvFile(flags);
+
+  let runAs: string | undefined;
+  if (scope === 'system') {
+    if (typeof flags['run-as'] !== 'string' || flags['run-as'].trim() === '') {
+      process.stderr.write('--scope system requires --run-as <user>.\n');
+      return null;
+    }
+    runAs = flags['run-as'];
+  }
+
+  return { scope, runAs, after, envFile, extraEnv };
+}
+
 async function systemdInstall(
   flags: Record<string, string | boolean>,
   config: CliConfigView,
+  scope: ServiceScope,
 ): Promise<number> {
+  if (scope === 'system' && !isRoot()) {
+    process.stderr.write(
+      `--scope system must be run as root — it writes ${unitPath('system')} and can restart a system-wide unit.\n` +
+        'Re-run as root; this command never escalates via sudo on its own.\n',
+    );
+    return 1;
+  }
+  const unitOpts = resolveSystemdUnitOptions(flags, scope);
+  if (!unitOpts) return 1;
+
   const spec = resolveLaunchSpec(flags);
   if (!spec) return 1;
-  const unit = renderSystemdUnit(spec);
-  const file = unitPath();
+  const unit = renderSystemdUnit(spec, unitOpts);
+  const file = unitPath(scope);
+  const scopeArgs = scope === 'user' ? ['--user'] : [];
 
   // stderr, not stdout: stdout carries the JSON result (see printJson).
   printFilePreview(file, unit, (line) => process.stderr.write(line + '\n'));
   if (flags.print === true) return 0;
 
-  // Refuse by default rather than only warning: a warning a user proceeds
-  // past (or never reads) still ends up with two enabled units. Disabling the
-  // conflicting unit automatically would need sudo — deliberately outside
-  // this command's scope (see the file-level comment) — and it may belong to
-  // a provisioning system this installer has no context on, so this stops
-  // and hands back the exact command to resolve it instead.
-  if (flags.force !== true && systemScopeConflict()) {
+  // The system-scope conflict guard exists to protect a *user-scope* install
+  // from racing an externally-provisioned system-scope unit (issue #450). A
+  // system-scope install IS that externally-provisioned unit — checking it
+  // against itself would always refuse.
+  if (scope === 'user' && flags.force !== true && systemScopeConflict()) {
     writeSystemScopeConflictRefusal();
     return 1;
   }
 
-  if (!(await confirm(flags, 'install', `Install and start ${UNIT_NAME} for user ${os.userInfo().username}?`))) {
+  const confirmQuestion =
+    scope === 'system'
+      ? `Install and start ${UNIT_NAME} at system scope, running as ${unitOpts.runAs}?`
+      : `Install and start ${UNIT_NAME} for user ${os.userInfo().username}?`;
+  if (!(await confirm(flags, 'install', confirmQuestion))) {
     process.stderr.write('Aborted — nothing was written.\n');
     return 1;
   }
@@ -330,45 +483,70 @@ async function systemdInstall(
   // `confirm()` can block indefinitely on the y/N prompt — re-check right
   // before writing anything, in case a conflicting unit appeared while it
   // was waiting on the operator.
-  if (flags.force !== true && systemScopeConflict()) {
+  if (scope === 'user' && flags.force !== true && systemScopeConflict()) {
     writeSystemScopeConflictRefusal();
     return 1;
   }
 
+  // Read the state a repeated install needs to decide enable vs. restart,
+  // before anything is overwritten: whether the unit is already running, and
+  // whether its content is about to change. A `daemon-reload` alone reloads
+  // systemd's cached definition but does not restart an active unit, so a
+  // repeated install used to apply an updated unit silently kept the stale
+  // one running (issue #457) — restart explicitly when content changes under
+  // an active unit, and leave an unchanged active unit alone otherwise.
+  let previousContent: string | null;
+  try {
+    previousContent = fs.readFileSync(file, 'utf8') as unknown as string;
+  } catch {
+    previousContent = null;
+  }
+  const wasActive = unitFlagState(scope === 'user').active;
+
   try {
     fs.mkdirSync(spec.cwd, { recursive: true });
-    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
-    fs.writeFileSync(file, unit, { encoding: 'utf8', mode: 0o600 });
-    run('systemctl', ['--user', 'daemon-reload']);
-    run('systemctl', ['--user', 'enable', '--now', UNIT_NAME]);
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: scope === 'user' ? 0o700 : 0o755 });
+    fs.writeFileSync(file, unit, { encoding: 'utf8', mode: scope === 'user' ? 0o600 : 0o644 });
+    run('systemctl', [...scopeArgs, 'daemon-reload']);
+    if (wasActive && previousContent !== null && previousContent !== unit) {
+      run('systemctl', [...scopeArgs, 'restart', UNIT_NAME]);
+    } else {
+      run('systemctl', [...scopeArgs, 'enable', '--now', UNIT_NAME]);
+    }
   } catch (err) {
     process.stderr.write(
-      `Could not install or start the user service: ${(err as Error).message}\n` +
-        `Inspect it with: systemctl --user status ${UNIT_NAME} --no-pager\n`,
+      `Could not install or start the ${scope} service: ${(err as Error).message}\n` +
+        `Inspect it with: systemctl ${scopeArgs.join(' ')} status ${UNIT_NAME} --no-pager\n`,
     );
     return 1;
   }
 
   const healthy = await waitForHealth(config, flags);
-  printJson({ manager: 'systemd-user', unit: file, ...systemdState(), health: healthy ? 'up' : 'down' }, flags);
+  printJson({ manager: systemdManagerLabel(scope), unit: file, ...systemdState(scope), health: healthy ? 'up' : 'down' }, flags);
   process.stderr.write(
-    `Installed ${UNIT_NAME}.\n` +
-      `To keep it running after you log out: loginctl enable-linger ${os.userInfo().username}\n`,
+    scope === 'system'
+      ? `Installed ${UNIT_NAME} at system scope, running as ${unitOpts.runAs}.\n`
+      : `Installed ${UNIT_NAME}.\n` + `To keep it running after you log out: loginctl enable-linger ${os.userInfo().username}\n`,
   );
   if (!healthy) {
-    process.stderr.write(`Service did not answer /health yet — check: journalctl --user -u ${UNIT_NAME} -n 50 --no-pager\n`);
+    process.stderr.write(`Service did not answer /health yet — check: journalctl ${scopeArgs.join(' ')} -u ${UNIT_NAME} -n 50 --no-pager\n`);
     return 1;
   }
   return 0;
 }
 
-async function systemdUninstall(flags: Record<string, string | boolean>): Promise<number> {
-  const file = unitPath();
-  const before = systemdState();
+async function systemdUninstall(flags: Record<string, string | boolean>, scope: ServiceScope): Promise<number> {
+  if (scope === 'system' && !isRoot()) {
+    process.stderr.write(`--scope system must be run as root — it removes ${unitPath('system')}.\n`);
+    return 1;
+  }
+  const file = unitPath(scope);
+  const scopeArgs = scope === 'user' ? ['--user'] : [];
+  const before = systemdState(scope);
   if (!before.installed && !before.enabled && !before.active) {
     // Nothing to stop — prompting to stop a service that isn't there only
     // teaches people to answer these prompts without reading them.
-    printJson({ manager: 'systemd-user', unit: file, ...before }, flags);
+    printJson({ manager: systemdManagerLabel(scope), unit: file, ...before }, flags);
     process.stderr.write(`${UNIT_NAME} is not installed — nothing to remove.\n`);
     return 0;
   }
@@ -378,7 +556,7 @@ async function systemdUninstall(flags: Record<string, string | boolean>): Promis
     return 1;
   }
   try {
-    run('systemctl', ['--user', 'disable', '--now', UNIT_NAME]);
+    run('systemctl', [...scopeArgs, 'disable', '--now', UNIT_NAME]);
   } catch {
     /* already stopped, or never installed */
   }
@@ -391,17 +569,17 @@ async function systemdUninstall(flags: Record<string, string | boolean>): Promis
     }
   }
   try {
-    run('systemctl', ['--user', 'daemon-reload']);
+    run('systemctl', [...scopeArgs, 'daemon-reload']);
   } catch {
     /* nothing to reload without systemd */
   }
   // Report what systemd actually says, not what was intended: the disable above
   // is best-effort, and claiming a stopped service that is still running would
   // be exactly the silent failure this codebase forbids.
-  const state = systemdState();
-  printJson({ manager: 'systemd-user', unit: file, ...state }, flags);
+  const state = systemdState(scope);
+  printJson({ manager: systemdManagerLabel(scope), unit: file, ...state }, flags);
   if (state.active || state.installed) {
-    process.stderr.write(`${UNIT_NAME} is still present — check: systemctl --user status ${UNIT_NAME} --no-pager\n`);
+    process.stderr.write(`${UNIT_NAME} is still present — check: systemctl ${scopeArgs.join(' ')} status ${UNIT_NAME} --no-pager\n`);
     return 1;
   }
   return 0;
@@ -531,14 +709,15 @@ async function pm2Uninstall(flags: Record<string, string | boolean>): Promise<nu
 // ─── entry point ──────────────────────────────────────────────────────────────
 
 const USAGE_LINE =
-  'claude-gateway service <install|status|uninstall> [--manager systemd|pm2] [--config <path>] [--yes] [--print] [--force]';
+  'claude-gateway service <install|status|uninstall> [--manager systemd|pm2] [--scope user|system] [--run-as <user>] ' +
+  '[--after <target,...>] [--env-file <path>] [--env KEY=VALUE,...] [--config <path>] [--yes] [--print] [--force]';
 
 /** Pick the manager to act on when `--manager` is omitted. `status`/`uninstall`
  *  act on whatever is actually installed; `install` always defaults to systemd
  *  so it can't silently pick a different manager than the one documented. */
-function detectServiceManager(action: ServiceAction): ServiceManager {
+function detectServiceManager(action: ServiceAction, scope: ServiceScope): ServiceManager {
   if (action === 'install') return 'systemd';
-  if (fs.existsSync(unitPath())) return 'systemd';
+  if (fs.existsSync(unitPath(scope))) return 'systemd';
   try {
     if (pm2Entry()) return 'pm2';
   } catch {
@@ -547,11 +726,19 @@ function detectServiceManager(action: ServiceAction): ServiceManager {
   return 'systemd';
 }
 
-function parseManager(flags: Record<string, string | boolean>, action: ServiceAction): ServiceManager | null {
+function parseManager(flags: Record<string, string | boolean>, action: ServiceAction, scope: ServiceScope): ServiceManager | null {
   const raw = flags.manager;
-  if (raw === undefined) return detectServiceManager(action);
+  if (raw === undefined) return detectServiceManager(action, scope);
   if (raw === 'systemd' || raw === 'pm2') return raw;
   process.stderr.write('Unknown --manager. Expected systemd or pm2.\n');
+  return null;
+}
+
+function parseScope(flags: Record<string, string | boolean>): ServiceScope | null {
+  const raw = flags.scope;
+  if (raw === undefined) return 'user';
+  if (raw === 'user' || raw === 'system') return raw;
+  process.stderr.write('Unknown --scope. Expected user or system.\n');
   return null;
 }
 
@@ -569,9 +756,12 @@ export async function runService(
       'run the gateway as a systemd-user or PM2 service',
       USAGE_LINE,
       [
-        '  systemd installs a user unit in ~/.config/systemd/user (no sudo).',
+        '  systemd installs a user unit in ~/.config/systemd/user (no sudo) by default.',
         '  install refuses if a claude-gateway unit already exists at system scope;',
         '  --force overrides that check.',
+        '  --scope system installs a root-owned unit in /etc/systemd/system instead —',
+        '  requires running as root already (never escalates via sudo) and --run-as <user>.',
+        '  --after, --env-file, and --env customize the generated unit further (systemd only).',
       ],
     );
     return flags.help === true ? 0 : 1;
@@ -587,12 +777,20 @@ export async function runService(
     return 1;
   }
 
-  const manager = parseManager(flags, action);
+  const scope = parseScope(flags);
+  if (!scope) return 1;
+
+  const manager = parseManager(flags, action, scope);
   if (!manager) return 1;
 
+  if (manager === 'pm2' && scope === 'system') {
+    process.stderr.write('--scope system only applies to the systemd manager, not pm2.\n');
+    return 1;
+  }
+
   if (manager === 'systemd') {
-    if (action === 'install') return systemdInstall(flags, config);
-    return action === 'status' ? systemdStatus(flags) : await systemdUninstall(flags);
+    if (action === 'install') return systemdInstall(flags, config, scope);
+    return action === 'status' ? systemdStatus(flags, scope) : await systemdUninstall(flags, scope);
   }
   if (action === 'install') return pm2Install(flags, config);
   return action === 'status' ? pm2Status(flags) : await pm2Uninstall(flags);

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -408,6 +408,16 @@ function parseAfterTargets(flags: Record<string, string | boolean>): string[] | 
       process.stderr.write(`Invalid --after target "${target}" — must not contain a NUL byte or line break.\n`);
       return null;
     }
+    // No valid systemd unit/target name contains whitespace — a space
+    // inside one comma-separated entry almost always means the caller meant
+    // two separate targets and used a space instead of a comma by mistake.
+    // Silently accepting it would splice an unintended second `After=`
+    // target in via renderSystemdUnit()'s space-join, rather than erroring
+    // on the typo.
+    if (/\s/.test(target)) {
+      process.stderr.write(`Invalid --after target "${target}" — systemd unit/target names cannot contain whitespace (use a comma to separate multiple targets).\n`);
+      return null;
+    }
   }
   return targets;
 }
@@ -606,6 +616,14 @@ async function systemdInstall(
     fs.chmodSync(file, scope === 'user' ? 0o600 : 0o644);
     run('systemctl', [...scopeArgs, 'daemon-reload']);
     if (wasActive && previousContent !== null && previousContent !== unit) {
+      // `restart` alone doesn't guarantee the unit is enabled — if it had
+      // drifted to active-but-disabled (started manually, or an
+      // externally-provisioned unit that was only ever started, not
+      // enabled), only restarting would leave it silently unable to survive
+      // the next reboot. The pre-#457 code always ran `enable --now`
+      // unconditionally on every install, which held that invariant
+      // regardless of prior state; this branch has to keep holding it too.
+      run('systemctl', [...scopeArgs, 'enable', UNIT_NAME]);
       run('systemctl', [...scopeArgs, 'restart', UNIT_NAME]);
     } else {
       run('systemctl', [...scopeArgs, 'enable', '--now', UNIT_NAME]);

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -168,7 +168,11 @@ export function renderSystemdUnit(spec: LaunchSpec, opts: SystemdUnitOptions = D
     .map(([key, value]) => `Environment="${key}=${q(value)}"`)
     .join('\n');
   const userLine = opts.scope === 'system' && opts.runAs ? `User=${opts.runAs}\n` : '';
-  const envFileLine = opts.envFile ? `EnvironmentFile=-"${q(opts.envFile)}"\n` : '';
+  // Unquoted, like WorkingDirectory= above: EnvironmentFile= takes a single
+  // bare path (with an optional leading `-`), not a quoted value — wrapping it
+  // in quotes makes systemd read the quote character as part of the path and
+  // reject it as "not absolute" (verified with `systemd-analyze verify`).
+  const envFileLine = opts.envFile ? `EnvironmentFile=-${opts.envFile}\n` : '';
   const wantedBy = opts.scope === 'system' ? 'multi-user.target' : 'default.target';
   return `[Unit]
 Description=Claude Gateway
@@ -231,6 +235,18 @@ function unitPath(scope: ServiceScope): string {
  *  it fails fast instead, so the caller stays in control of the escalation. */
 function isRoot(): boolean {
   return typeof process.getuid === 'function' && process.getuid() === 0;
+}
+
+/** `systemctl`/`journalctl` args for the given scope. */
+function scopeCliArgs(scope: ServiceScope): string[] {
+  return scope === 'user' ? ['--user'] : [];
+}
+
+/** Same, rendered for a hint message — with a trailing space so `system`
+ *  scope (an empty args array) doesn't leave a double space before the next
+ *  word, e.g. "journalctl  -u ...". */
+function scopeHintPrefix(scope: ServiceScope): string {
+  return scope === 'user' ? '--user ' : '';
 }
 
 function run(file: string, args: string[]): void {
@@ -353,6 +369,18 @@ function writeSystemScopeConflictRefusal(): void {
   );
 }
 
+/** Every flag parsed below is spliced into a single line of the rendered unit
+ *  verbatim (target names, env values, the run-as user, the env-file path) —
+ *  a NUL or newline in any of them would let the caller inject an extra
+ *  directive, or a whole new `[Section]`, into unit text meant to hold one
+ *  value (NUL also throws downstream at spawn — same convention as the
+ *  settings.json value guard in src/session/process.ts). Reject outright
+ *  rather than encoding: this codebase never trusts external input without
+ *  validating it at the boundary. */
+function hasUnsafeUnitChars(value: string): boolean {
+  return /[\0\r\n]/.test(value);
+}
+
 /** `--after <target1,target2,...>` — extra `After=` ordering targets, appended
  *  to the unit's default `network-online.target`. Comma-separated rather than
  *  a repeatable flag: the shared CLI parser (src/cli/args.ts) has no concept
@@ -365,10 +393,17 @@ function parseAfterTargets(flags: Record<string, string | boolean>): string[] | 
     process.stderr.write('--after requires a comma-separated list of systemd unit/target names.\n');
     return null;
   }
-  return raw
+  const targets = raw
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
+  for (const target of targets) {
+    if (hasUnsafeUnitChars(target)) {
+      process.stderr.write(`Invalid --after target "${target}" — must not contain a NUL byte or line break.\n`);
+      return null;
+    }
+  }
+  return targets;
 }
 
 /** `--env KEY=VALUE[,KEY=VALUE...]` — extra `Environment=` lines. Rejects
@@ -402,6 +437,10 @@ function parseExtraEnv(flags: Record<string, string | boolean>): Record<string, 
       process.stderr.write(`--env cannot override "${key}" — it is set by the installer itself.\n`);
       return null;
     }
+    if (hasUnsafeUnitChars(value)) {
+      process.stderr.write(`Invalid --env value for "${key}" — must not contain a NUL byte or line break.\n`);
+      return null;
+    }
     out[key] = value;
   }
   return out;
@@ -409,9 +448,17 @@ function parseExtraEnv(flags: Record<string, string | boolean>): Record<string, 
 
 /** `--env-file <path>` — adds `EnvironmentFile=-<path>` so a caller can feed
  *  secrets to the unit without ever putting them in its text. `-` means
- *  systemd tolerates the file being absent. */
-function parseEnvFile(flags: Record<string, string | boolean>): string | undefined {
-  return typeof flags['env-file'] === 'string' ? path.resolve(expandHome(flags['env-file'])) : undefined;
+ *  systemd tolerates the file being absent. Returns null (with a message
+ *  already on stderr) for a path containing a line break — everything else
+ *  reuses the null-on-invalid contract `resolveSystemdUnitOptions()` expects. */
+function parseEnvFile(flags: Record<string, string | boolean>): string | undefined | null {
+  if (typeof flags['env-file'] !== 'string') return undefined;
+  const resolved = path.resolve(expandHome(flags['env-file']));
+  if (hasUnsafeUnitChars(resolved)) {
+    process.stderr.write('Invalid --env-file path — must not contain a NUL byte or line break.\n');
+    return null;
+  }
+  return resolved;
 }
 
 /** Resolve and validate everything `renderSystemdUnit()` needs beyond the
@@ -424,6 +471,7 @@ function resolveSystemdUnitOptions(flags: Record<string, string | boolean>, scop
   const extraEnv = parseExtraEnv(flags);
   if (extraEnv === null) return null;
   const envFile = parseEnvFile(flags);
+  if (envFile === null) return null;
 
   let runAs: string | undefined;
   if (scope === 'system') {
@@ -431,8 +479,13 @@ function resolveSystemdUnitOptions(flags: Record<string, string | boolean>, scop
       process.stderr.write('--scope system requires --run-as <user>.\n');
       return null;
     }
+    if (hasUnsafeUnitChars(flags['run-as'])) {
+      process.stderr.write('Invalid --run-as value — must not contain a NUL byte or line break.\n');
+      return null;
+    }
     runAs = flags['run-as'];
   }
+
 
   return { scope, runAs, after, envFile, extraEnv };
 }
@@ -442,13 +495,6 @@ async function systemdInstall(
   config: CliConfigView,
   scope: ServiceScope,
 ): Promise<number> {
-  if (scope === 'system' && !isRoot()) {
-    process.stderr.write(
-      `--scope system must be run as root — it writes ${unitPath('system')} and can restart a system-wide unit.\n` +
-        'Re-run as root; this command never escalates via sudo on its own.\n',
-    );
-    return 1;
-  }
   const unitOpts = resolveSystemdUnitOptions(flags, scope);
   if (!unitOpts) return 1;
 
@@ -456,11 +502,23 @@ async function systemdInstall(
   if (!spec) return 1;
   const unit = renderSystemdUnit(spec, unitOpts);
   const file = unitPath(scope);
-  const scopeArgs = scope === 'user' ? ['--user'] : [];
+  const scopeArgs = scopeCliArgs(scope);
 
   // stderr, not stdout: stdout carries the JSON result (see printJson).
   printFilePreview(file, unit, (line) => process.stderr.write(line + '\n'));
   if (flags.print === true) return 0;
+
+  // The root check goes here, after the print short-circuit above, matching
+  // the systemScopeConflict() check below: `--print` is a pure read — it
+  // must always show the preview regardless of any other reason install
+  // itself would be refused.
+  if (scope === 'system' && !isRoot()) {
+    process.stderr.write(
+      `--scope system must be run as root — it writes ${unitPath('system')} and can restart a system-wide unit.\n` +
+        'Re-run as root; this command never escalates via sudo on its own.\n',
+    );
+    return 1;
+  }
 
   // The system-scope conflict guard exists to protect a *user-scope* install
   // from racing an externally-provisioned system-scope unit (issue #450). A
@@ -516,7 +574,7 @@ async function systemdInstall(
   } catch (err) {
     process.stderr.write(
       `Could not install or start the ${scope} service: ${(err as Error).message}\n` +
-        `Inspect it with: systemctl ${scopeArgs.join(' ')} status ${UNIT_NAME} --no-pager\n`,
+        `Inspect it with: systemctl ${scopeHintPrefix(scope)}status ${UNIT_NAME} --no-pager\n`,
     );
     return 1;
   }
@@ -529,7 +587,7 @@ async function systemdInstall(
       : `Installed ${UNIT_NAME}.\n` + `To keep it running after you log out: loginctl enable-linger ${os.userInfo().username}\n`,
   );
   if (!healthy) {
-    process.stderr.write(`Service did not answer /health yet — check: journalctl ${scopeArgs.join(' ')} -u ${UNIT_NAME} -n 50 --no-pager\n`);
+    process.stderr.write(`Service did not answer /health yet — check: journalctl ${scopeHintPrefix(scope)}-u ${UNIT_NAME} -n 50 --no-pager\n`);
     return 1;
   }
   return 0;
@@ -541,7 +599,7 @@ async function systemdUninstall(flags: Record<string, string | boolean>, scope: 
     return 1;
   }
   const file = unitPath(scope);
-  const scopeArgs = scope === 'user' ? ['--user'] : [];
+  const scopeArgs = scopeCliArgs(scope);
   const before = systemdState(scope);
   if (!before.installed && !before.enabled && !before.active) {
     // Nothing to stop — prompting to stop a service that isn't there only
@@ -579,7 +637,7 @@ async function systemdUninstall(flags: Record<string, string | boolean>, scope: 
   const state = systemdState(scope);
   printJson({ manager: systemdManagerLabel(scope), unit: file, ...state }, flags);
   if (state.active || state.installed) {
-    process.stderr.write(`${UNIT_NAME} is still present — check: systemctl ${scopeArgs.join(' ')} status ${UNIT_NAME} --no-pager\n`);
+    process.stderr.write(`${UNIT_NAME} is still present — check: systemctl ${scopeHintPrefix(scope)}status ${UNIT_NAME} --no-pager\n`);
     return 1;
   }
   return 0;

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -6,7 +6,6 @@ import { CliConfigView, resolveLocalUrl } from '../http-client';
 import { createRl, ask, printFilePreview } from '../prompt';
 import { probeHealth } from '../health';
 import { printJson } from '../output';
-import { expandHome } from '../../utils/paths';
 import { writeCommandHelp } from '../output';
 
 /**
@@ -55,9 +54,25 @@ function gatewayHome(home: string = os.homedir()): string {
   return path.join(home, '.claude-gateway');
 }
 
-function configPath(flags: Record<string, string | boolean>, home: string = os.homedir()): string {
-  const explicit = typeof flags.config === 'string' ? flags.config : process.env.GATEWAY_CONFIG;
-  return path.resolve(expandHome(explicit ?? path.join(gatewayHome(home), 'config.json')));
+/** Same `~`/`~/...` expansion as the shared `expandHome()` (src/utils/paths.ts),
+ *  but against an explicit `home` rather than always `os.homedir()`. That
+ *  shared helper is used by the server too and means "this process's own
+ *  home" everywhere else — for a `--scope system --run-as <user>` install,
+ *  this process's own home is root's, not the target user's, so a `~` in
+ *  `--config`/`--env-file` needs its own expansion here instead. */
+function expandHomeAs(p: string, home: string): string {
+  if (p === '~') return home;
+  if (p.startsWith('~/')) return path.join(home, p.slice(2));
+  return p;
+}
+
+/** `allowEnvFallback` is false for a `--scope system` install: `$GATEWAY_CONFIG`
+ *  belongs to the *installing* (root) process's environment, which has no
+ *  reliable relationship to `--run-as`'s intended config — inheriting it
+ *  would silently point the unit at a path the run-as user can't read. */
+function configPath(flags: Record<string, string | boolean>, home: string = os.homedir(), allowEnvFallback: boolean = true): string {
+  const explicit = typeof flags.config === 'string' ? flags.config : allowEnvFallback ? process.env.GATEWAY_CONFIG : undefined;
+  return path.resolve(expandHomeAs(explicit ?? path.join(gatewayHome(home), 'config.json'), home));
 }
 
 /**
@@ -136,8 +151,13 @@ function resolveRunAsUser(username: string): { uid: number; gid: number; home: s
  *  `home` defaults to the installing process's own home. A `--scope system
  *  --run-as <user>` install passes that user's real home instead — the unit
  *  runs as them (`User=<user>`), so its WorkingDirectory/HOME/config path
- *  must be theirs, not the root process that wrote the unit. */
-export function resolveLaunchSpec(flags: Record<string, string | boolean>, home: string = os.homedir()): LaunchSpec | null {
+ *  must be theirs, not the root process that wrote the unit. `allowEnvConfig`
+ *  is false for that same case — see `configPath()`. */
+export function resolveLaunchSpec(
+  flags: Record<string, string | boolean>,
+  home: string = os.homedir(),
+  allowEnvConfig: boolean = true,
+): LaunchSpec | null {
   // dist/cli/commands/service.js → dist/entry.js, the thin dispatcher that
   // loads only the side it needs. index.js is still a working boot entry and is
   // used when a partially-updated install predates the split, so a unit is
@@ -157,7 +177,7 @@ export function resolveLaunchSpec(flags: Record<string, string | boolean>, home:
     node,
     entry,
     cwd: gatewayHome(home),
-    config: configPath(flags, home),
+    config: configPath(flags, home, allowEnvConfig),
     home,
     pathEnv: servicePath(home),
   };
@@ -503,8 +523,10 @@ function parseExtraEnv(flags: Record<string, string | boolean>): Record<string, 
  *  secrets to the unit without ever putting them in its text. `-` means
  *  systemd tolerates the file being absent. Returns null (with a message
  *  already on stderr) for a path containing a line break — everything else
- *  reuses the null-on-invalid contract `resolveSystemdUnitOptions()` expects. */
-function parseEnvFile(flags: Record<string, string | boolean>): string | undefined | null {
+ *  reuses the null-on-invalid contract `resolveSystemdUnitOptions()` expects.
+ *  `home` expands a leading `~` — the --run-as user's home for a system-scope
+ *  install, not the installing (root) process's own. */
+function parseEnvFile(flags: Record<string, string | boolean>, home: string): string | undefined | null {
   const raw = flags['env-file'];
   if (raw === undefined) return undefined;
   if (typeof raw !== 'string' || raw.trim() === '') {
@@ -516,7 +538,7 @@ function parseEnvFile(flags: Record<string, string | boolean>): string | undefin
     process.stderr.write('--env-file requires a path.\n');
     return null;
   }
-  const resolved = path.resolve(expandHome(raw));
+  const resolved = path.resolve(expandHomeAs(raw, home));
   if (hasUnsafeUnitChars(resolved)) {
     process.stderr.write('Invalid --env-file path — must not contain a NUL byte or line break.\n');
     return null;
@@ -524,36 +546,54 @@ function parseEnvFile(flags: Record<string, string | boolean>): string | undefin
   return resolved;
 }
 
-/** Resolve and validate everything `renderSystemdUnit()` needs beyond the
- *  shared LaunchSpec triple. Returns null (with a message already on stderr)
- *  on any invalid input — install must never write a unit from a half-parsed
- *  flag set. */
-function resolveSystemdUnitOptions(flags: Record<string, string | boolean>, scope: ServiceScope): SystemdUnitOptions | null {
+/** Validate/trim `--run-as`'s format and its combination with `scope` — not
+ *  whether the named user actually exists (that's `resolveRunAsUser()`, a
+ *  separate concern this function knows nothing about, since it also needs
+ *  no privilege but does need a subprocess call). Returns `undefined` when
+ *  `scope !== 'system'` and `--run-as` wasn't passed (the normal case), or
+ *  null (message already on stderr) on any invalid combination. Split out
+ *  from `resolveSystemdUnitOptions()` so the caller can resolve `--run-as`'s
+ *  home *before* parsing `--env-file`, which needs that home to expand a
+ *  leading `~` correctly. */
+function resolveRunAsFlag(flags: Record<string, string | boolean>, scope: ServiceScope): string | undefined | null {
+  if (scope !== 'system') {
+    if (flags['run-as'] !== undefined) {
+      // Loudly rejected rather than silently dropped, like every other
+      // nonsensical combination this function checks — --run-as only means
+      // anything for a unit that runs as a fixed system account.
+      process.stderr.write('--run-as only applies to --scope system.\n');
+      return null;
+    }
+    return undefined;
+  }
+  if (typeof flags['run-as'] !== 'string' || flags['run-as'].trim() === '') {
+    process.stderr.write('--scope system requires --run-as <user>.\n');
+    return null;
+  }
+  if (hasUnsafeUnitChars(flags['run-as'])) {
+    process.stderr.write('Invalid --run-as value — must not contain a NUL byte or line break.\n');
+    return null;
+  }
+  return flags['run-as'].trim();
+}
+
+/** Resolve and validate `--after`/`--env`/`--env-file` beyond the shared
+ *  LaunchSpec triple. Returns null (with a message already on stderr) on any
+ *  invalid input — install must never write a unit from a half-parsed flag
+ *  set. `runAs` and `home` are already resolved by the caller (see
+ *  `resolveRunAsFlag()`/`resolveRunAsUser()`). */
+function resolveSystemdUnitOptions(
+  flags: Record<string, string | boolean>,
+  scope: ServiceScope,
+  runAs: string | undefined,
+  home: string,
+): SystemdUnitOptions | null {
   const after = parseAfterTargets(flags);
   if (after === null) return null;
   const extraEnv = parseExtraEnv(flags);
   if (extraEnv === null) return null;
-  const envFile = parseEnvFile(flags);
+  const envFile = parseEnvFile(flags, home);
   if (envFile === null) return null;
-
-  let runAs: string | undefined;
-  if (scope === 'system') {
-    if (typeof flags['run-as'] !== 'string' || flags['run-as'].trim() === '') {
-      process.stderr.write('--scope system requires --run-as <user>.\n');
-      return null;
-    }
-    if (hasUnsafeUnitChars(flags['run-as'])) {
-      process.stderr.write('Invalid --run-as value — must not contain a NUL byte or line break.\n');
-      return null;
-    }
-    runAs = flags['run-as'].trim();
-  } else if (flags['run-as'] !== undefined) {
-    // Loudly rejected rather than silently dropped, like every other
-    // nonsensical combination this function checks — --run-as only means
-    // anything for a unit that runs as a fixed system account.
-    process.stderr.write('--run-as only applies to --scope system.\n');
-    return null;
-  }
 
   return { scope, runAs, after, envFile, extraEnv };
 }
@@ -563,27 +603,35 @@ async function systemdInstall(
   config: CliConfigView,
   scope: ServiceScope,
 ): Promise<number> {
-  const unitOpts = resolveSystemdUnitOptions(flags, scope);
-  if (!unitOpts) return 1;
+  const runAsFlag = resolveRunAsFlag(flags, scope);
+  if (runAsFlag === null) return 1;
 
   // A --scope system install runs this CLI as root, but the rendered unit
-  // runs the gateway as unitOpts.runAs — WorkingDirectory/HOME/config must be
+  // runs the gateway as runAsFlag — WorkingDirectory/HOME/config must be
   // *that* user's, not root's, or the process starts in the wrong place with
   // the wrong HOME entirely (getent is a read-only NSS lookup, so this needs
-  // no privilege and can run even for a --print preview).
+  // no privilege and can run even for a --print preview). Resolved before
+  // parsing --env-file/--config below, which need this home to expand a
+  // leading `~` against the right account.
   let home = os.homedir();
   let runAsIds: { uid: number; gid: number } | null = null;
-  if (scope === 'system' && unitOpts.runAs) {
-    const resolved = resolveRunAsUser(unitOpts.runAs);
+  if (scope === 'system' && runAsFlag) {
+    const resolved = resolveRunAsUser(runAsFlag);
     if (!resolved) {
-      process.stderr.write(`Could not resolve --run-as ${unitOpts.runAs} via \`getent passwd\` — does that user exist on this host?\n`);
+      process.stderr.write(`Could not resolve --run-as ${runAsFlag} via \`getent passwd\` — does that user exist on this host?\n`);
       return 1;
     }
     home = resolved.home;
     runAsIds = { uid: resolved.uid, gid: resolved.gid };
   }
 
-  const spec = resolveLaunchSpec(flags, home);
+  const unitOpts = resolveSystemdUnitOptions(flags, scope, runAsFlag, home);
+  if (!unitOpts) return 1;
+
+  // $GATEWAY_CONFIG belongs to the installing (root) process's own
+  // environment for a system-scope install — not reliably meaningful for
+  // runAsFlag, so it's not consulted there; only an explicit --config is.
+  const spec = resolveLaunchSpec(flags, home, scope !== 'system');
   if (!spec) return 1;
   const unit = renderSystemdUnit(spec, unitOpts);
   const file = unitPath(scope);
@@ -661,13 +709,16 @@ async function systemdInstall(
     // A --scope system install creates this directory as root — if it didn't
     // already exist, it comes out root-owned, and the gateway (running as
     // runAsIds, not root) would be unable to write its pid file/logs into
-    // its own WorkingDirectory. Chown it to match only when this install
-    // just created it: an already-existing directory (e.g. the run-as user
-    // already used the gateway under their own account before this) is
-    // trusted to already have correct ownership, not silently reassigned.
+    // its own WorkingDirectory. Also reassert ownership when the directory
+    // already exists but belongs to someone other than the *current*
+    // --run-as target — e.g. a prior install used a different --run-as user
+    // and this one reassigns the service to another account — rather than
+    // only checking "did this install just create it", which missed that
+    // case entirely. A directory that already belongs to the right user is
+    // left alone (no redundant chown).
     const cwdExisted = fs.existsSync(spec.cwd);
     fs.mkdirSync(spec.cwd, { recursive: true });
-    if (runAsIds && !cwdExisted) {
+    if (runAsIds && (!cwdExisted || fs.statSync(spec.cwd).uid !== runAsIds.uid)) {
       fs.chownSync(spec.cwd, runAsIds.uid, runAsIds.gid);
     }
     fs.mkdirSync(path.dirname(file), { recursive: true, mode: scope === 'user' ? 0o700 : 0o755 });

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -31,6 +31,13 @@ const UNIT_NAME = 'claude-gateway.service';
 const PM2_NAME = 'gateway';
 const HEALTH_ATTEMPTS = 20;
 const HEALTH_INTERVAL_MS = 500;
+/** `install`'s exit code when everything succeeded (unit written, enabled/
+ *  started) but `/health` never answered within the poll window — distinct
+ *  from `1` (install/enable itself failed, or a validation/confirmation gate
+ *  refused) so a caller checking the exit code alone, not just the JSON
+ *  result on stdout, can tell "didn't happen" apart from "happened, health
+ *  unconfirmed". */
+const EXIT_HEALTH_TIMEOUT = 2;
 /** Env var names the installer itself sets — `--env` may not override these. */
 const RESERVED_ENV_KEYS = new Set(['HOME', 'PATH', 'GATEWAY_CONFIG']);
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -761,7 +768,7 @@ async function systemdInstall(
   );
   if (!healthy) {
     process.stderr.write(`Service did not answer /health yet — check: journalctl ${scopeHintPrefix(scope)}-u ${UNIT_NAME} -n 50 --no-pager\n`);
-    return 1;
+    return EXIT_HEALTH_TIMEOUT;
   }
   return 0;
 }
@@ -884,7 +891,7 @@ async function pm2Install(
   process.stderr.write('PM2 process list saved. Run `pm2 startup` once if you also want start-on-boot.\n');
   if (!healthy) {
     process.stderr.write(`Service did not answer /health yet — check: pm2 logs ${PM2_NAME}\n`);
-    return 1;
+    return EXIT_HEALTH_TIMEOUT;
   }
   return 0;
 }

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -213,7 +213,12 @@ Wants=network-online.target
 After=${after}
 
 [Service]
-Type=simple
+# exec (not simple): the unit is only considered "started" once the actual
+# execve() succeeds — simple would report started right after fork(), before
+# knowing whether ExecStart could even run at all, which reports a healthier
+# state than reality if the binary/entry can't be exec'd. No known downside
+# for a plain, long-running daemon like this.
+Type=exec
 ${userLine}# WorkingDirectory is deliberately unquoted, unlike every other value here:
 # systemd takes the rest of the line as the path, and rejects a quoted one
 # ("path is not absolute"). Escaping is unnecessary for the same reason.

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -499,9 +499,14 @@ function resolveSystemdUnitOptions(flags: Record<string, string | boolean>, scop
       process.stderr.write('Invalid --run-as value — must not contain a NUL byte or line break.\n');
       return null;
     }
-    runAs = flags['run-as'];
+    runAs = flags['run-as'].trim();
+  } else if (flags['run-as'] !== undefined) {
+    // Loudly rejected rather than silently dropped, like every other
+    // nonsensical combination this function checks — --run-as only means
+    // anything for a unit that runs as a fixed system account.
+    process.stderr.write('--run-as only applies to --scope system.\n');
+    return null;
   }
-
 
   return { scope, runAs, after, envFile, extraEnv };
 }
@@ -525,9 +530,13 @@ async function systemdInstall(
   if (flags.print === true) return 0;
 
   // The root check goes here, after the print short-circuit above, matching
-  // the crossScopeConflict() check below: `--print` is a pure read — it
-  // must always show the preview regardless of any other reason install
-  // itself would be refused.
+  // the crossScopeConflict() check below: both are STATE/PRIVILEGE gates
+  // unrelated to what the unit would contain, so `--print` — a pure read —
+  // must never need them just to render a preview. This is narrower than
+  // "print always succeeds": resolveSystemdUnitOptions() above (e.g. the
+  // --run-as requirement) still runs first, because without valid input
+  // there is no unit content to preview at all — print can't show bytes
+  // that could never be written.
   if (scope === 'system' && !isRoot()) {
     process.stderr.write(
       `--scope system must be run as root — it writes ${unitPath('system')} and can restart a system-wide unit.\n` +
@@ -572,7 +581,14 @@ async function systemdInstall(
   let previousContent: string | null;
   try {
     previousContent = fs.readFileSync(file, 'utf8') as unknown as string;
-  } catch {
+  } catch (err) {
+    // Distinct from "no prior unit" (ENOENT, the normal first-install case):
+    // any other error (e.g. EACCES) is surfaced rather than silently treated
+    // as a fresh install, matching the unlinkSync error handling below.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      process.stderr.write(`Could not read the existing unit at ${file}: ${(err as Error).message}\n`);
+      return 1;
+    }
     previousContent = null;
   }
   const wasActive = unitFlagState(scope === 'user').active;
@@ -825,16 +841,39 @@ function parseManager(flags: Record<string, string | boolean>, action: ServiceAc
  *  (exit 0) while the system-scope unit keeps running untouched (issue #457
  *  review). Mirrors `detectServiceManager()`'s "detect what's actually there"
  *  approach for --manager. */
-function detectServiceScope(action: ServiceAction): ServiceScope {
+function detectServiceScope(action: ServiceAction): ServiceScope | null {
   if (action === 'install') return 'user';
-  if (fs.existsSync(unitPath('user'))) return 'user';
-  if (fs.existsSync(unitPath('system'))) return 'system';
+  const userInstalled = fs.existsSync(unitPath('user'));
+  const systemInstalled = fs.existsSync(unitPath('system'));
+  // Both installed at once (e.g. a --force system-scope install alongside a
+  // still-enabled user-scope one) is exactly the state crossScopeConflict()
+  // exists to prevent — but --force means it can happen anyway. Silently
+  // picking one would leave the other's real state unreported by `status`,
+  // or untouched by `uninstall` while it reports success (issue #457
+  // review) — refuse and make the caller say which one explicitly instead.
+  if (userInstalled && systemInstalled) return null;
+  if (userInstalled) return 'user';
+  if (systemInstalled) return 'system';
   return 'user';
 }
 
 function parseScope(flags: Record<string, string | boolean>, action: ServiceAction): ServiceScope | null {
   const raw = flags.scope;
-  if (raw === undefined) return detectServiceScope(action);
+  if (raw === undefined) {
+    // Scope is a systemd-only concept — skip probing for it entirely when
+    // the manager is explicitly pm2. Beyond being pointless work, treating
+    // unrelated systemd unit paths as ambiguous input to a decision pm2
+    // never uses could wrongly refuse a pm2 action over a conflict that
+    // doesn't apply to it at all.
+    if (flags.manager === 'pm2') return 'user';
+    const detected = detectServiceScope(action);
+    if (detected === null) {
+      process.stderr.write(
+        `Both a user-scope and a system-scope ${UNIT_NAME} unit are installed — pass --scope user or --scope system to say which one.\n`,
+      );
+    }
+    return detected;
+  }
   if (raw === 'user' || raw === 'system') return raw;
   process.stderr.write('Unknown --scope. Expected user or system.\n');
   return null;
@@ -881,9 +920,19 @@ export async function runService(
   const manager = parseManager(flags, action, scope);
   if (!manager) return 1;
 
-  if (manager === 'pm2' && scope === 'system') {
-    process.stderr.write('--scope system only applies to the systemd manager, not pm2.\n');
-    return 1;
+  if (manager === 'pm2') {
+    if (scope === 'system') {
+      process.stderr.write('--scope system only applies to the systemd manager, not pm2.\n');
+      return 1;
+    }
+    // Every other systemd-only unit customization flag: reject rather than
+    // silently drop, so `--manager pm2 --env-file secrets.env` doesn't exit 0
+    // having wired in nothing the caller asked for.
+    const systemdOnlyFlag = (['after', 'env', 'env-file', 'run-as'] as const).find((name) => flags[name] !== undefined);
+    if (systemdOnlyFlag) {
+      process.stderr.write(`--${systemdOnlyFlag} only applies to the systemd manager, not pm2.\n`);
+      return 1;
+    }
   }
 
   if (manager === 'systemd') {

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -306,11 +306,10 @@ async function waitForHealth(config: CliConfigView, flags: Record<string, string
 
 /** `is-enabled`/`is-active` for `UNIT_NAME` at the given scope — the query
  *  both `systemdState()` (the install's own scope, for `service status`) and
- *  `systemScopeConflict()` (always system scope, for the user-scope
- *  install-time check below) need, differing only in scope. A named boolean
- *  rather than a raw argv fragment (`['--user']`/`[]`) so a future call site
- *  passing the wrong array fails to compile instead of silently querying the
- *  wrong scope. */
+ *  `crossScopeConflict()` (the opposite scope, for the install-time check
+ *  below) need, differing only in scope. A named boolean rather than a raw
+ *  argv fragment (`['--user']`/`[]`) so a future call site passing the wrong
+ *  array fails to compile instead of silently querying the wrong scope. */
 function unitFlagState(userScope: boolean): { enabled: boolean; active: boolean } {
   const scopeArgs = userScope ? ['--user'] : [];
   let enabled = false;
@@ -343,28 +342,35 @@ function systemdStatus(flags: Record<string, string | boolean>, scope: ServiceSc
 }
 
 /**
- * True when a same-named unit already exists and is enabled or active at
- * *system* scope (`/etc/systemd/system/`) — e.g. from an externally
- * provisioned image. Installing the user-scope unit alongside it would leave
- * both `enabled`, racing for the port on the next reboot (see issue #450).
+ * True when a same-named unit already exists and is enabled or active at the
+ * scope OPPOSITE to the one being installed — e.g. installing user scope
+ * while an externally-provisioned system-scope unit is already enabled (the
+ * original case, issue #450), or installing system scope while a prior
+ * user-scope install is still active (issue #457 review — a system-scope
+ * install only ever self-checked, missing this direction entirely). Either
+ * way, two independent units end up racing for the same port on the next
+ * boot.
  *
- * Reading system scope needs no privileges: `systemctl is-enabled`/`is-active`
- * without `--user` queries it as any user, so this check costs nothing extra.
+ * Reading the opposite scope needs no privileges: `systemctl
+ * is-enabled`/`is-active` in either scope queries as any user, so this check
+ * costs nothing extra.
  */
-function systemScopeConflict(): boolean {
-  const { enabled, active } = unitFlagState(false);
+function crossScopeConflict(scope: ServiceScope): boolean {
+  const { enabled, active } = unitFlagState(scope === 'system');
   return enabled || active;
 }
 
-/** Written to stderr when `systemScopeConflict()` refuses an install — shared
+/** Written to stderr when `crossScopeConflict()` refuses an install — shared
  *  by both the pre-prompt check and the re-check right after `confirm()`
  *  below, so the two call sites can't drift into different wording. */
-function writeSystemScopeConflictRefusal(): void {
+function writeCrossScopeConflictRefusal(scope: ServiceScope): void {
+  const otherScope: ServiceScope = scope === 'user' ? 'system' : 'user';
+  const disableHint = otherScope === 'system' ? `  sudo systemctl disable --now ${UNIT_NAME}\n` : `  systemctl --user disable --now ${UNIT_NAME}\n`;
   process.stderr.write(
-    `A ${UNIT_NAME} unit already exists at system scope (/etc/systemd/system/${UNIT_NAME}) and is enabled or active.\n` +
-      `Installing a second, independent unit at user scope would race it for the port on the next reboot.\n` +
+    `A ${UNIT_NAME} unit already exists at ${otherScope} scope (${unitPath(otherScope)}) and is enabled or active.\n` +
+      `Installing a second, independent unit at ${scope} scope would race it for the port on the next reboot.\n` +
       `Disable the existing one first, then re-run this command:\n` +
-      `  sudo systemctl disable --now ${UNIT_NAME}\n` +
+      disableHint +
       'Pass --force to install anyway.\n',
   );
 }
@@ -452,8 +458,18 @@ function parseExtraEnv(flags: Record<string, string | boolean>): Record<string, 
  *  already on stderr) for a path containing a line break — everything else
  *  reuses the null-on-invalid contract `resolveSystemdUnitOptions()` expects. */
 function parseEnvFile(flags: Record<string, string | boolean>): string | undefined | null {
-  if (typeof flags['env-file'] !== 'string') return undefined;
-  const resolved = path.resolve(expandHome(flags['env-file']));
+  const raw = flags['env-file'];
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    // Distinct from "not passed at all": the shared CLI parser (src/cli/args.ts)
+    // reads a flag with no following value (last token, or immediately
+    // followed by another flag) as boolean `true` — silently treating that as
+    // "omitted" would install with no EnvironmentFile= line while the caller
+    // believes their secrets file is wired in.
+    process.stderr.write('--env-file requires a path.\n');
+    return null;
+  }
+  const resolved = path.resolve(expandHome(raw));
   if (hasUnsafeUnitChars(resolved)) {
     process.stderr.write('Invalid --env-file path — must not contain a NUL byte or line break.\n');
     return null;
@@ -509,7 +525,7 @@ async function systemdInstall(
   if (flags.print === true) return 0;
 
   // The root check goes here, after the print short-circuit above, matching
-  // the systemScopeConflict() check below: `--print` is a pure read — it
+  // the crossScopeConflict() check below: `--print` is a pure read — it
   // must always show the preview regardless of any other reason install
   // itself would be refused.
   if (scope === 'system' && !isRoot()) {
@@ -520,12 +536,12 @@ async function systemdInstall(
     return 1;
   }
 
-  // The system-scope conflict guard exists to protect a *user-scope* install
-  // from racing an externally-provisioned system-scope unit (issue #450). A
-  // system-scope install IS that externally-provisioned unit — checking it
-  // against itself would always refuse.
-  if (scope === 'user' && flags.force !== true && systemScopeConflict()) {
-    writeSystemScopeConflictRefusal();
+  // Guards against installing alongside an already-enabled/active unit at the
+  // OTHER scope (either direction — see crossScopeConflict()'s doc comment).
+  // A scope's install only ever conflicts with the opposite scope, never with
+  // itself, so a repeated install of the same scope never trips this.
+  if (flags.force !== true && crossScopeConflict(scope)) {
+    writeCrossScopeConflictRefusal(scope);
     return 1;
   }
 
@@ -541,8 +557,8 @@ async function systemdInstall(
   // `confirm()` can block indefinitely on the y/N prompt — re-check right
   // before writing anything, in case a conflicting unit appeared while it
   // was waiting on the operator.
-  if (scope === 'user' && flags.force !== true && systemScopeConflict()) {
-    writeSystemScopeConflictRefusal();
+  if (flags.force !== true && crossScopeConflict(scope)) {
+    writeCrossScopeConflictRefusal(scope);
     return 1;
   }
 
@@ -565,6 +581,13 @@ async function systemdInstall(
     fs.mkdirSync(spec.cwd, { recursive: true });
     fs.mkdirSync(path.dirname(file), { recursive: true, mode: scope === 'user' ? 0o700 : 0o755 });
     fs.writeFileSync(file, unit, { encoding: 'utf8', mode: scope === 'user' ? 0o600 : 0o644 });
+    // writeFileSync's `mode` option only applies when the file is newly
+    // created — overwriting an existing one (e.g. adopting an
+    // externally-provisioned unit, or a repeated install) leaves its current
+    // permission bits untouched. chmod explicitly so the intended mode is
+    // guaranteed either way — this file can carry --env values, so its
+    // permissions are a real boundary, not cosmetic.
+    fs.chmodSync(file, scope === 'user' ? 0o600 : 0o644);
     run('systemctl', [...scopeArgs, 'daemon-reload']);
     if (wasActive && previousContent !== null && previousContent !== unit) {
       run('systemctl', [...scopeArgs, 'restart', UNIT_NAME]);
@@ -792,9 +815,26 @@ function parseManager(flags: Record<string, string | boolean>, action: ServiceAc
   return null;
 }
 
-function parseScope(flags: Record<string, string | boolean>): ServiceScope | null {
+/** Pick the systemd scope to act on when `--scope` is omitted. `install`
+ *  always defaults to `user` — it must never silently write a root-owned
+ *  unit nobody explicitly asked for, no matter what already exists.
+ *  `status`/`uninstall` instead detect: prefer an installed user-scope unit,
+ *  fall back to system-scope. Without this, a bare `service status` after a
+ *  `--scope system` install silently checks the (nonexistent) user-scope path
+ *  and reports "not installed" — and `service uninstall` would report success
+ *  (exit 0) while the system-scope unit keeps running untouched (issue #457
+ *  review). Mirrors `detectServiceManager()`'s "detect what's actually there"
+ *  approach for --manager. */
+function detectServiceScope(action: ServiceAction): ServiceScope {
+  if (action === 'install') return 'user';
+  if (fs.existsSync(unitPath('user'))) return 'user';
+  if (fs.existsSync(unitPath('system'))) return 'system';
+  return 'user';
+}
+
+function parseScope(flags: Record<string, string | boolean>, action: ServiceAction): ServiceScope | null {
   const raw = flags.scope;
-  if (raw === undefined) return 'user';
+  if (raw === undefined) return detectServiceScope(action);
   if (raw === 'user' || raw === 'system') return raw;
   process.stderr.write('Unknown --scope. Expected user or system.\n');
   return null;
@@ -835,7 +875,7 @@ export async function runService(
     return 1;
   }
 
-  const scope = parseScope(flags);
+  const scope = parseScope(flags, action);
   if (!scope) return 1;
 
   const manager = parseManager(flags, action, scope);

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -51,13 +51,13 @@ export interface LaunchSpec {
   pathEnv: string;
 }
 
-function gatewayHome(): string {
-  return path.join(os.homedir(), '.claude-gateway');
+function gatewayHome(home: string = os.homedir()): string {
+  return path.join(home, '.claude-gateway');
 }
 
-function configPath(flags: Record<string, string | boolean>): string {
+function configPath(flags: Record<string, string | boolean>, home: string = os.homedir()): string {
   const explicit = typeof flags.config === 'string' ? flags.config : process.env.GATEWAY_CONFIG;
-  return path.resolve(expandHome(explicit ?? path.join(gatewayHome(), 'config.json')));
+  return path.resolve(expandHome(explicit ?? path.join(gatewayHome(home), 'config.json')));
 }
 
 /**
@@ -69,13 +69,18 @@ function configPath(flags: Record<string, string | boolean>): string {
  * directories the gateway actually needs — the node that will run it, the
  * `claude` binary it spawns, and the standard system paths — keeping only
  * those that exist.
+ *
+ * `home` defaults to the *installing* process's home (`os.homedir()`), but a
+ * `--scope system --run-as <user>` install passes the run-as user's home
+ * instead — a root-run install must not bake root's own `~/.local/bin` /
+ * `~/.bun/bin` into a unit that runs as someone else entirely.
  */
-export function servicePath(): string {
+export function servicePath(home: string = os.homedir()): string {
   const candidates = [
     path.dirname(process.execPath),
     claudeBinDir(),
-    path.join(os.homedir(), '.local', 'bin'),
-    path.join(os.homedir(), '.bun', 'bin'),
+    path.join(home, '.local', 'bin'),
+    path.join(home, '.bun', 'bin'),
     '/usr/local/sbin',
     '/usr/local/bin',
     '/usr/sbin',
@@ -102,10 +107,37 @@ function claudeBinDir(): string | null {
   }
 }
 
+/**
+ * `getent passwd <user>` → that user's uid/gid/home, or null if the user
+ * doesn't exist or `getent` itself isn't available. NSS-aware (works for
+ * LDAP/sssd-backed accounts, not just local `/etc/passwd` entries), which a
+ * naive `/etc/passwd` file parse would silently miss — the standard,
+ * distro-agnostic way to resolve this on Linux.
+ */
+function resolveRunAsUser(username: string): { uid: number; gid: number; home: string } | null {
+  try {
+    const line = capture('getent', ['passwd', username]).trim();
+    // name:password:UID:GID:GECOS:directory:shell
+    const fields = line.split(':');
+    const uid = Number(fields[2]);
+    const gid = Number(fields[3]);
+    const home = fields[5];
+    if (!Number.isInteger(uid) || !Number.isInteger(gid) || !home || !path.isAbsolute(home)) return null;
+    return { uid, gid, home };
+  } catch {
+    return null;
+  }
+}
+
 /** Resolve the absolute launch triple (node, entry, cwd) for a generated unit.
  *  Returns null — with a message — when the entry point can't be located, so a
- *  broken install never produces a unit that silently fails at boot. */
-export function resolveLaunchSpec(flags: Record<string, string | boolean>): LaunchSpec | null {
+ *  broken install never produces a unit that silently fails at boot.
+ *
+ *  `home` defaults to the installing process's own home. A `--scope system
+ *  --run-as <user>` install passes that user's real home instead — the unit
+ *  runs as them (`User=<user>`), so its WorkingDirectory/HOME/config path
+ *  must be theirs, not the root process that wrote the unit. */
+export function resolveLaunchSpec(flags: Record<string, string | boolean>, home: string = os.homedir()): LaunchSpec | null {
   // dist/cli/commands/service.js → dist/entry.js, the thin dispatcher that
   // loads only the side it needs. index.js is still a working boot entry and is
   // used when a partially-updated install predates the split, so a unit is
@@ -124,10 +156,10 @@ export function resolveLaunchSpec(flags: Record<string, string | boolean>): Laun
   return {
     node,
     entry,
-    cwd: gatewayHome(),
-    config: configPath(flags),
-    home: os.homedir(),
-    pathEnv: servicePath(),
+    cwd: gatewayHome(home),
+    config: configPath(flags, home),
+    home,
+    pathEnv: servicePath(home),
   };
 }
 
@@ -529,7 +561,24 @@ async function systemdInstall(
   const unitOpts = resolveSystemdUnitOptions(flags, scope);
   if (!unitOpts) return 1;
 
-  const spec = resolveLaunchSpec(flags);
+  // A --scope system install runs this CLI as root, but the rendered unit
+  // runs the gateway as unitOpts.runAs — WorkingDirectory/HOME/config must be
+  // *that* user's, not root's, or the process starts in the wrong place with
+  // the wrong HOME entirely (getent is a read-only NSS lookup, so this needs
+  // no privilege and can run even for a --print preview).
+  let home = os.homedir();
+  let runAsIds: { uid: number; gid: number } | null = null;
+  if (scope === 'system' && unitOpts.runAs) {
+    const resolved = resolveRunAsUser(unitOpts.runAs);
+    if (!resolved) {
+      process.stderr.write(`Could not resolve --run-as ${unitOpts.runAs} via \`getent passwd\` — does that user exist on this host?\n`);
+      return 1;
+    }
+    home = resolved.home;
+    runAsIds = { uid: resolved.uid, gid: resolved.gid };
+  }
+
+  const spec = resolveLaunchSpec(flags, home);
   if (!spec) return 1;
   const unit = renderSystemdUnit(spec, unitOpts);
   const file = unitPath(scope);
@@ -604,7 +653,18 @@ async function systemdInstall(
   const wasActive = unitFlagState(scope === 'user').active;
 
   try {
+    // A --scope system install creates this directory as root — if it didn't
+    // already exist, it comes out root-owned, and the gateway (running as
+    // runAsIds, not root) would be unable to write its pid file/logs into
+    // its own WorkingDirectory. Chown it to match only when this install
+    // just created it: an already-existing directory (e.g. the run-as user
+    // already used the gateway under their own account before this) is
+    // trusted to already have correct ownership, not silently reassigned.
+    const cwdExisted = fs.existsSync(spec.cwd);
     fs.mkdirSync(spec.cwd, { recursive: true });
+    if (runAsIds && !cwdExisted) {
+      fs.chownSync(spec.cwd, runAsIds.uid, runAsIds.gid);
+    }
     fs.mkdirSync(path.dirname(file), { recursive: true, mode: scope === 'user' ? 0o700 : 0o755 });
     fs.writeFileSync(file, unit, { encoding: 'utf8', mode: scope === 'user' ? 0o600 : 0o644 });
     // writeFileSync's `mode` option only applies when the file is newly

--- a/tests/unit/cli-service-force-flag.test.ts
+++ b/tests/unit/cli-service-force-flag.test.ts
@@ -12,6 +12,8 @@ jest.mock('fs', () => ({
   mkdirSync: jest.fn(),
   writeFileSync: jest.fn(),
   unlinkSync: jest.fn(),
+  readFileSync: jest.fn(),
+  chmodSync: jest.fn(),
 }));
 jest.mock('../../src/cli/http-client', () => ({
   ...jest.requireActual('../../src/cli/http-client'),

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -6,6 +6,7 @@ jest.mock('fs', () => ({
   unlinkSync: jest.fn(),
   readFileSync: jest.fn(),
   chmodSync: jest.fn(),
+  chownSync: jest.fn(),
 }));
 
 import * as fs from 'fs';
@@ -29,6 +30,20 @@ const mockReadFileSync = fs.readFileSync as unknown as jest.Mock;
 
 const unitPath = path.join(os.homedir(), '.config', 'systemd', 'user', 'claude-gateway.service');
 const systemUnitPath = '/etc/systemd/system/claude-gateway.service';
+const gwuserHome = '/home/gwuser';
+
+/** `resolveRunAsUser()` looks the --run-as user up via `getent passwd`
+ *  before building the launch spec — every --scope system --run-as gwuser
+ *  test needs this mocked too now, not just systemctl. Wraps a
+ *  systemctl-focused implementation with a getent response for 'gwuser'. */
+function withGetentGwuser(systemctlImpl: (file: string, args: string[]) => Buffer): (file: string, args: string[]) => Buffer {
+  return (file, args) => {
+    if (file === 'getent' && args[0] === 'passwd' && args[1] === 'gwuser') {
+      return Buffer.from(`gwuser:x:1500:1500:gwuser,,,:${gwuserHome}:/bin/bash\n`);
+    }
+    return systemctlImpl(file, args);
+  };
+}
 
 /**
  * Assert nothing was *changed*. Read-only probes are fine and expected —
@@ -604,6 +619,7 @@ describe('service install/uninstall/status — --scope system (issue #457)', () 
 
   it('refuses --scope system install when not running as root — never escalates via sudo', async () => {
     jest.spyOn(process, 'getuid').mockReturnValue(1000);
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
     const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
     expect(code).toBe(1);
     expect(mockWriteFileSync).not.toHaveBeenCalled();
@@ -613,10 +629,12 @@ describe('service install/uninstall/status — --scope system (issue #457)', () 
 
   it('shows the --print preview for --scope system even when not root — a pure read must never need root', async () => {
     jest.spyOn(process, 'getuid').mockReturnValue(1000);
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
     try {
       const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', print: true });
       expect(code).toBe(0);
       expect(stderr.join('')).toContain('User=gwuser');
+      expect(stderr.join('')).toContain(`WorkingDirectory=${gwuserHome}/.claude-gateway`);
       expect(mockWriteFileSync).not.toHaveBeenCalled();
       expectNoStateChange();
     } finally {
@@ -642,6 +660,7 @@ describe('service install/uninstall/status — --scope system (issue #457)', () 
 
   it('writes /etc/systemd/system unit with User= and WantedBy=multi-user.target, as root with --run-as', async () => {
     jest.spyOn(process, 'getuid').mockReturnValue(0);
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
     try {
       const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
@@ -652,6 +671,14 @@ describe('service install/uninstall/status — --scope system (issue #457)', () 
         expect.objectContaining({ mode: 0o644 }),
       );
       expect(mockWriteFileSync).toHaveBeenCalledWith(systemUnitPath, expect.stringContaining('WantedBy=multi-user.target'), expect.anything());
+      // The unit runs as gwuser, so its WorkingDirectory/HOME/config must be
+      // gwuser's — not root's, even though this install itself runs as root.
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        systemUnitPath,
+        expect.stringContaining(`WorkingDirectory=${gwuserHome}/.claude-gateway`),
+        expect.anything(),
+      );
+      expect(mockWriteFileSync).toHaveBeenCalledWith(systemUnitPath, expect.stringContaining(`Environment="HOME=${gwuserHome}"`), expect.anything());
       expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['daemon-reload'], expect.anything());
       expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['enable', '--now', 'claude-gateway.service'], expect.anything());
       // system scope must never shell out to sudo either — same rule as user scope
@@ -668,11 +695,11 @@ describe('service install/uninstall/status — --scope system (issue #457)', () 
     jest.spyOn(process, 'getuid').mockReturnValue(0);
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
     try {
-      mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      mockExecFileSync.mockImplementation((withGetentGwuser(((file: string, args: string[]) => {
         if (file === 'systemctl' && args[0] === 'is-enabled') return Buffer.from('enabled\n');
         if (file === 'systemctl' && args[0] === 'is-active') return Buffer.from('active\n');
         return Buffer.from('');
-      }) as unknown as typeof execFileSync);
+      }) as (file: string, args: string[]) => Buffer) as unknown) as typeof execFileSync);
       const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
       expect(code).toBe(0);
       // The self-conflict guard specifically must not fire; the success
@@ -687,10 +714,10 @@ describe('service install/uninstall/status — --scope system (issue #457)', () 
   it('does not double-space the systemctl hint for system scope (no --user token to join)', async () => {
     jest.spyOn(process, 'getuid').mockReturnValue(0);
     try {
-      mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      mockExecFileSync.mockImplementation((withGetentGwuser(((file: string, args: string[]) => {
         if (file === 'systemctl' && args.includes('enable')) throw new Error('boom');
         return Buffer.from('');
-      }) as unknown as typeof execFileSync);
+      }) as (file: string, args: string[]) => Buffer) as unknown) as typeof execFileSync);
       const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
       expect(code).toBe(1);
       expect(stderr.join('')).toContain('Inspect it with: systemctl status claude-gateway.service --no-pager');
@@ -803,10 +830,10 @@ describe('service install — cross-scope conflict, both directions (issue #457 
   it('refuses a --scope system install when a user-scope unit is already enabled', async () => {
     jest.spyOn(process, 'getuid').mockReturnValue(0);
     try {
-      mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      mockExecFileSync.mockImplementation((withGetentGwuser(((file: string, args: string[]) => {
         if (file === 'systemctl' && args.includes('--user') && args.includes('is-enabled')) return Buffer.from('enabled\n');
         return Buffer.from('');
-      }) as unknown as typeof execFileSync);
+      }) as (file: string, args: string[]) => Buffer) as unknown) as typeof execFileSync);
       const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
       expect(code).toBe(1);
       expect(mockWriteFileSync).not.toHaveBeenCalled();
@@ -822,10 +849,10 @@ describe('service install — cross-scope conflict, both directions (issue #457 
     jest.spyOn(process, 'getuid').mockReturnValue(0);
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
     try {
-      mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      mockExecFileSync.mockImplementation((withGetentGwuser(((file: string, args: string[]) => {
         if (file === 'systemctl' && args.includes('--user') && args.includes('is-enabled')) return Buffer.from('enabled\n');
         return Buffer.from('');
-      }) as unknown as typeof execFileSync);
+      }) as (file: string, args: string[]) => Buffer) as unknown) as typeof execFileSync);
       const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true, force: true });
       expect(code).toBe(0);
       expect(mockWriteFileSync).toHaveBeenCalledWith(systemUnitPath, expect.stringContaining('User=gwuser'), expect.anything());
@@ -927,6 +954,7 @@ describe('service install — chmod is applied explicitly, not left to writeFile
 
   it("chmods the unit file to 0644 after writing it at system scope — writeFileSync's mode is a no-op on an existing file", async () => {
     jest.spyOn(process, 'getuid').mockReturnValue(0);
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
     try {
       const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
@@ -994,6 +1022,7 @@ describe('service install — --run-as only applies to --scope system (issue #45
 
   it('trims --run-as before writing it into User=, matching how --after/--env are normalized', async () => {
     jest.spyOn(process, 'getuid').mockReturnValue(0);
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
     try {
       const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': '  gwuser  ', yes: true });
@@ -1041,5 +1070,91 @@ describe('service install — --after target names cannot contain whitespace (is
   it('still accepts properly comma-separated targets with no embedded whitespace', () => {
     const unit = renderSystemdUnit(resolveLaunchSpec({})!, { scope: 'user', after: ['docker.service', 'foo.target'], extraEnv: {} });
     expect(unit).toContain('After=network-online.target docker.service foo.target');
+  });
+});
+
+describe('service install — --scope system resolves --run-as user\'s real home (issue #457 review, external report)', () => {
+  it('refuses when the --run-as user cannot be resolved via getent, instead of falling back to the installer\'s own home', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    try {
+      // getent fails for every user — simulates a nonexistent --run-as user,
+      // or getent itself being unavailable.
+      mockExecFileSync.mockImplementation((() => {
+        throw new Error('getent: gwuser: not found');
+      }) as unknown as typeof execFileSync);
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(1);
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expectNoStateChange();
+      expect(stderr.join('')).toMatch(/Could not resolve --run-as gwuser/);
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+    }
+  });
+
+  it('chowns a freshly-created WorkingDirectory to the --run-as user — root creates it, but the unit runs as someone else', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      // The gateway's own cwd doesn't exist yet; everything else the code
+      // touches (entry.js resolution, PATH candidates) still needs to.
+      mockExistsSync.mockImplementation((p: unknown) => String(p) !== `${gwuserHome}/.claude-gateway`);
+      mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      expect(fs.mkdirSync).toHaveBeenCalledWith(`${gwuserHome}/.claude-gateway`, { recursive: true });
+      expect(fs.chownSync).toHaveBeenCalledWith(`${gwuserHome}/.claude-gateway`, 1500, 1500);
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('does not chown an already-existing WorkingDirectory — trusts ownership from prior use rather than reassigning it', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      // Default beforeEach mock: existsSync → true everywhere, including
+      // gwuser's .claude-gateway — it already exists.
+      mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      expect(fs.chownSync).not.toHaveBeenCalled();
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('the rendered unit config path is also under the --run-as user\'s home, not the installer\'s', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        systemUnitPath,
+        expect.stringContaining(`GATEWAY_CONFIG=${gwuserHome}/.claude-gateway/config.json`),
+        expect.anything(),
+      );
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('a plain --scope user install is unaffected — still uses the installer\'s own os.homedir(), no getent lookup at all', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+      for (const [file] of mockExecFileSync.mock.calls as unknown as Array<[string]>) {
+        expect(file).not.toBe('getent');
+      }
+      expect(mockWriteFileSync).toHaveBeenCalledWith(unitPath, expect.stringContaining(`Environment="HOME=${os.homedir()}"`), expect.anything());
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -353,9 +353,15 @@ describe('service — argument validation', () => {
 });
 
 describe('service uninstall', () => {
-  /** systemd reports the unit as installed+active until it is removed. */
+  /** systemd reports the (user-scope) unit as installed+active until it is
+   *  removed. Scoped to the user-scope path specifically, not a blanket
+   *  `mockReturnValue(true)` — with scope auto-detection now probing both
+   *  paths when --scope is omitted (issue #457 review), a blanket true would
+   *  make the system-scope path look installed too and trip the "both
+   *  scopes installed, say which one" refusal instead of exercising what
+   *  this helper is actually named for. */
   function unitIsLive(): void {
-    mockExistsSync.mockReturnValue(true);
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === unitPath);
     mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
       if (file === 'systemctl' && args.includes('is-active')) return Buffer.from('active\n');
       if (file === 'systemctl' && args.includes('is-enabled')) return Buffer.from('enabled\n');
@@ -925,5 +931,95 @@ describe('service install — chmod is applied explicitly, not left to writeFile
       (process.getuid as unknown as jest.Mock).mockRestore();
       fetchSpy.mockRestore();
     }
+  });
+});
+
+describe('service status/uninstall — both scopes installed at once (issue #457 review round 2)', () => {
+  /** A --force system-scope install alongside a still-active user-scope one
+   *  is exactly how this state can arise in practice. */
+  function bothScopesInstalled(): void {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && args.includes('is-active')) return Buffer.from('active\n');
+      if (file === 'systemctl' && args.includes('is-enabled')) return Buffer.from('enabled\n');
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+  }
+
+  it('refuses a scope-omitted status when both a user-scope and a system-scope unit are installed', async () => {
+    bothScopesInstalled();
+    const code = await runService(['status'], { manager: 'systemd' });
+    expect(code).toBe(1);
+    expect(stderr.join('')).toMatch(/Both a user-scope and a system-scope/);
+  });
+
+  it('refuses a scope-omitted uninstall when both scopes are installed — never silently acts on only one', async () => {
+    bothScopesInstalled();
+    const code = await runService(['uninstall'], { manager: 'systemd', yes: true });
+    expect(code).toBe(1);
+    expectNoStateChange();
+    expect(fs.unlinkSync).not.toHaveBeenCalled();
+    expect(stderr.join('')).toMatch(/Both a user-scope and a system-scope/);
+  });
+
+  it('an explicit --scope still works normally even when both are installed', async () => {
+    bothScopesInstalled();
+    const code = await runService(['status'], { manager: 'systemd', scope: 'system' });
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join(''))).toEqual(expect.objectContaining({ manager: 'systemd-system' }));
+  });
+
+  it('a pm2 request is unaffected by two systemd scopes both being installed — scope is irrelevant to pm2', async () => {
+    bothScopesInstalled();
+    mockExecFileSync.mockReturnValue(Buffer.from(JSON.stringify([{ name: 'gateway', pm2_env: { status: 'online' } }])) as never);
+    const code = await runService(['status'], { manager: 'pm2' });
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join(''))).toEqual(expect.objectContaining({ manager: 'pm2' }));
+  });
+});
+
+describe('service install — --run-as only applies to --scope system (issue #457 review round 2)', () => {
+  it('rejects --run-as passed with the default (user) scope instead of silently dropping it', async () => {
+    const code = await runService(['install'], { manager: 'systemd', yes: true, 'run-as': 'gwuser' });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/--run-as only applies to --scope system/);
+  });
+
+  it('trims --run-as before writing it into User=, matching how --after/--env are normalized', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': '  gwuser  ', yes: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(systemUnitPath, expect.stringContaining('User=gwuser\n'), expect.anything());
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('service install — systemd-only flags rejected under --manager pm2 (issue #457 review round 2)', () => {
+  it.each(['after', 'env', 'env-file', 'run-as'])('rejects --%s with --manager pm2 instead of silently dropping it', async (flagName) => {
+    const code = await runService(['install'], { manager: 'pm2', yes: true, [flagName]: 'x' });
+    expect(code).toBe(1);
+    expect(stderr.join('')).toMatch(new RegExp(`--${flagName} only applies to the systemd manager`));
+  });
+});
+
+describe('service install — a non-ENOENT read error on the existing unit is surfaced, not swallowed (issue #457 review round 2)', () => {
+  it('aborts and reports the read failure instead of silently treating it as a fresh install', async () => {
+    mockReadFileSync.mockImplementation(() => {
+      const err = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
+      err.code = 'EACCES';
+      throw err;
+    });
+    const code = await runService(['install'], { manager: 'systemd', yes: true });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/Could not read the existing unit/);
   });
 });

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -4,6 +4,7 @@ jest.mock('fs', () => ({
   mkdirSync: jest.fn(),
   writeFileSync: jest.fn(),
   unlinkSync: jest.fn(),
+  readFileSync: jest.fn(),
 }));
 
 import * as fs from 'fs';
@@ -23,8 +24,10 @@ import { renderSystemdUnit, pm2StartArgs, resolveLaunchSpec, runService, service
 const mockExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
 const mockExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
 const mockWriteFileSync = fs.writeFileSync as jest.MockedFunction<typeof fs.writeFileSync>;
+const mockReadFileSync = fs.readFileSync as unknown as jest.Mock;
 
 const unitPath = path.join(os.homedir(), '.config', 'systemd', 'user', 'claude-gateway.service');
+const systemUnitPath = '/etc/systemd/system/claude-gateway.service';
 
 /**
  * Assert nothing was *changed*. Read-only probes are fine and expected —
@@ -49,6 +52,9 @@ let ttyDescriptor: PropertyDescriptor | undefined;
 beforeEach(() => {
   jest.clearAllMocks();
   mockExistsSync.mockReturnValue(true);
+  mockReadFileSync.mockImplementation(() => {
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  });
   stdout = [];
   stderr = [];
   outSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
@@ -443,5 +449,258 @@ describe('service — --print is install-only', () => {
     expect(await runService(['status'], { manager: 'systemd', print: true })).toBe(1);
     expectNoStateChange();
     expect(stderr.join('')).toMatch(/--print only applies to/);
+  });
+});
+
+describe('service — unit customization: --after / --env-file / --env (issue #457)', () => {
+  it('appends extra After= targets on top of the default network-online.target', () => {
+    const unit = renderSystemdUnit(resolveLaunchSpec({})!, { scope: 'user', after: ['docker.service', 'foo.target'], extraEnv: {} });
+    const line = unit.split('\n').find((l) => l.startsWith('After='));
+    expect(line).toBe('After=network-online.target docker.service foo.target');
+  });
+
+  it('adds EnvironmentFile=-<path> when envFile is set', () => {
+    const unit = renderSystemdUnit(resolveLaunchSpec({})!, {
+      scope: 'user',
+      after: [],
+      extraEnv: {},
+      envFile: '/etc/claude-gateway/extra.env',
+    });
+    expect(unit).toContain('EnvironmentFile=-"/etc/claude-gateway/extra.env"');
+  });
+
+  it('adds extra Environment="KEY=VALUE" lines, quoted the same way as the built-in vars', () => {
+    const unit = renderSystemdUnit(resolveLaunchSpec({})!, {
+      scope: 'user',
+      after: [],
+      extraEnv: { DOCKER_BUILDKIT: '0', FOO: 'bar baz' },
+    });
+    expect(unit).toContain('Environment="DOCKER_BUILDKIT=0"');
+    expect(unit).toContain('Environment="FOO=bar baz"');
+  });
+
+  it('CLI: parses comma-separated --after and --env into the rendered unit', async () => {
+    // Explicit default: a prior test in this file may have left a custom
+    // execFileSync implementation behind (jest.clearAllMocks() clears call
+    // history, not implementations), which would otherwise leak in here.
+    mockExecFileSync.mockReturnValue(Buffer.from('') as never);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], {
+        manager: 'systemd',
+        yes: true,
+        after: 'docker.service,other.target',
+        env: 'FOO=bar,BAZ=qux',
+      });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        unitPath,
+        expect.stringContaining('After=network-online.target docker.service other.target'),
+        expect.anything(),
+      );
+      expect(mockWriteFileSync).toHaveBeenCalledWith(unitPath, expect.stringContaining('Environment="FOO=bar"'), expect.anything());
+      expect(mockWriteFileSync).toHaveBeenCalledWith(unitPath, expect.stringContaining('Environment="BAZ=qux"'), expect.anything());
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('rejects a malformed --env entry and writes nothing', async () => {
+    const code = await runService(['install'], { manager: 'systemd', yes: true, env: 'not-a-pair' });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/Invalid --env entry/);
+  });
+
+  it('rejects --env attempting to override a reserved variable', async () => {
+    const code = await runService(['install'], { manager: 'systemd', yes: true, env: 'PATH=/evil' });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/installer itself/);
+  });
+});
+
+describe('service install/uninstall/status — --scope system (issue #457)', () => {
+  afterEach(() => {
+    if ((process.getuid as unknown as jest.Mock)?.mockRestore) (process.getuid as unknown as jest.Mock).mockRestore();
+  });
+
+  it('rejects an unknown --scope', async () => {
+    const code = await runService(['install'], { manager: 'systemd', scope: 'nope' });
+    expect(code).toBe(1);
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/Unknown --scope/);
+  });
+
+  it('rejects --scope system combined with --manager pm2', async () => {
+    const code = await runService(['install'], { manager: 'pm2', scope: 'system', 'run-as': 'gwuser', yes: true });
+    expect(code).toBe(1);
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/only applies to the systemd manager/);
+  });
+
+  it('refuses --scope system install when not running as root — never escalates via sudo', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(1000);
+    const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/must be run as root/);
+  });
+
+  it('refuses --scope system uninstall when not running as root', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(1000);
+    const code = await runService(['uninstall'], { manager: 'systemd', scope: 'system', yes: true });
+    expect(code).toBe(1);
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/must be run as root/);
+  });
+
+  it('requires --run-as for --scope system install, even as root', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const code = await runService(['install'], { manager: 'systemd', scope: 'system', yes: true });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(stderr.join('')).toMatch(/--run-as/);
+  });
+
+  it('writes /etc/systemd/system unit with User= and WantedBy=multi-user.target, as root with --run-as', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        systemUnitPath,
+        expect.stringContaining('User=gwuser'),
+        expect.objectContaining({ mode: 0o644 }),
+      );
+      expect(mockWriteFileSync).toHaveBeenCalledWith(systemUnitPath, expect.stringContaining('WantedBy=multi-user.target'), expect.anything());
+      expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['daemon-reload'], expect.anything());
+      expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['enable', '--now', 'claude-gateway.service'], expect.anything());
+      // system scope must never shell out to sudo either — same rule as user scope
+      expect(mockExecFileSync).not.toHaveBeenCalledWith('sudo', expect.anything(), expect.anything());
+      expect(JSON.parse(stdout.join(''))).toEqual(expect.objectContaining({ manager: 'systemd-system', health: 'up' }));
+      // system scope has no login session to survive — the hint is meaningless there
+      expect(stderr.join('')).not.toMatch(/loginctl/);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('does not refuse a system-scope install against its own already-enabled unit', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+        if (file === 'systemctl' && args[0] === 'is-enabled') return Buffer.from('enabled\n');
+        if (file === 'systemctl' && args[0] === 'is-active') return Buffer.from('active\n');
+        return Buffer.from('');
+      }) as unknown as typeof execFileSync);
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      // The self-conflict guard specifically must not fire; the success
+      // message legitimately mentions "system scope" too, so match the exact
+      // refusal wording rather than the substring.
+      expect(stderr.join('')).not.toMatch(/already exists at system scope/);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('service status against a system-scope unit reports systemd-system and never passes --user', async () => {
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && args[0] === 'is-active') return Buffer.from('active\n');
+      if (file === 'systemctl' && args[0] === 'is-enabled') return Buffer.from('enabled\n');
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+    const code = await runService(['status'], { manager: 'systemd', scope: 'system' });
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join(''))).toEqual(expect.objectContaining({ manager: 'systemd-system', unit: systemUnitPath, active: true }));
+    for (const [file, args] of mockExecFileSync.mock.calls as unknown as Array<[string, string[]]>) {
+      if (file === 'systemctl') expect(args).not.toContain('--user');
+    }
+  });
+
+  it('uninstalls a system-scope unit without --user flags, as root', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    try {
+      // installed before the call, gone after — same convention as the
+      // user-scope uninstall test above; is-active/is-enabled report false
+      // throughout, which is fine since `installed` alone (via existsSync)
+      // already carries the before/after distinction this test needs.
+      mockExistsSync.mockReturnValueOnce(true).mockReturnValue(false);
+      mockExecFileSync.mockReturnValue(Buffer.from('') as never);
+      const code = await runService(['uninstall'], { manager: 'systemd', scope: 'system', yes: true });
+      expect(code).toBe(0);
+      expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['disable', '--now', 'claude-gateway.service'], expect.anything());
+      expect(fs.unlinkSync).toHaveBeenCalledWith(systemUnitPath);
+      for (const [file, args] of mockExecFileSync.mock.calls as unknown as Array<[string, string[]]>) {
+        if (file === 'systemctl') expect(args).not.toContain('--user');
+      }
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+    }
+  });
+});
+
+describe('service install — restart-on-change for an already-running unit (issue #457)', () => {
+  it('restarts an already-active unit when the rendered content changed', async () => {
+    mockReadFileSync.mockReturnValue('OLD CONTENT\n');
+    // Scoped to --user: an unscoped 'is-active' match would also answer the
+    // system-scope conflict pre-check, which must stay "inactive" here — this
+    // test is a user-scope install, not a system-scope one.
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && args.includes('--user') && args.includes('is-active')) return Buffer.from('active\n');
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+      expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['--user', 'restart', 'claude-gateway.service'], expect.anything());
+      expect(mockExecFileSync).not.toHaveBeenCalledWith('systemctl', ['--user', 'enable', '--now', 'claude-gateway.service'], expect.anything());
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('does not restart an already-active unit when the rendered content is unchanged', async () => {
+    // Pre-populate with the exact bytes the default spec would render, so the
+    // "unchanged" branch is exercised honestly rather than by omission.
+    mockReadFileSync.mockReturnValue(renderSystemdUnit(resolveLaunchSpec({})!));
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && args.includes('--user') && args.includes('is-active')) return Buffer.from('active\n');
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+      expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['--user', 'enable', '--now', 'claude-gateway.service'], expect.anything());
+      expect(mockExecFileSync).not.toHaveBeenCalledWith('systemctl', ['--user', 'restart', 'claude-gateway.service'], expect.anything());
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('does not restart a fresh install of an inactive unit even though there was no previous content to compare', async () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    // Explicit default, not an inherited one: a prior test in this file may
+    // have left a custom execFileSync implementation behind.
+    mockExecFileSync.mockReturnValue(Buffer.from('') as never);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+      expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['--user', 'enable', '--now', 'claude-gateway.service'], expect.anything());
+      expect(mockExecFileSync).not.toHaveBeenCalledWith('systemctl', ['--user', 'restart', 'claude-gateway.service'], expect.anything());
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -131,6 +131,14 @@ describe('service — generated launch configuration', () => {
     expect(unit).not.toContain('Restart=on-failure');
   });
 
+  it('uses Type=exec, not Type=simple — reported "started" only once the actual execve() succeeds', () => {
+    // simple would report the unit started right after fork(), before
+    // knowing whether ExecStart could even be exec'd at all.
+    const unit = renderSystemdUnit(resolveLaunchSpec({})!);
+    expect(unit).toContain('Type=exec');
+    expect(unit).not.toContain('Type=simple');
+  });
+
   it('sets OOMPolicy=continue so an OOM-killed child process cannot take the whole gateway down', () => {
     // systemd's default OOMPolicy=stop treats an OOM-killed process anywhere
     // in this unit's cgroup as the unit failing, which combined with

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -750,6 +750,11 @@ describe('service install — restart-on-change for an already-running unit (iss
       const code = await runService(['install'], { manager: 'systemd', yes: true });
       expect(code).toBe(0);
       expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['--user', 'restart', 'claude-gateway.service'], expect.anything());
+      // Restart alone doesn't guarantee the unit is enabled — the previous
+      // active state could have been active-but-disabled — so the restart
+      // path must still explicitly enable it, just via a separate call
+      // instead of the combined `enable --now` the non-restart path uses.
+      expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['--user', 'enable', 'claude-gateway.service'], expect.anything());
       expect(mockExecFileSync).not.toHaveBeenCalledWith('systemctl', ['--user', 'enable', '--now', 'claude-gateway.service'], expect.anything());
     } finally {
       fetchSpy.mockRestore();
@@ -1021,5 +1026,20 @@ describe('service install — a non-ENOENT read error on the existing unit is su
     expect(mockWriteFileSync).not.toHaveBeenCalled();
     expectNoStateChange();
     expect(stderr.join('')).toMatch(/Could not read the existing unit/);
+  });
+});
+
+describe('service install — --after target names cannot contain whitespace (issue #457 review round 3)', () => {
+  it('rejects a space inside a single --after entry instead of silently splitting it into two targets', async () => {
+    const code = await runService(['install'], { manager: 'systemd', yes: true, after: 'foo.target bar.service' });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/cannot contain whitespace/);
+  });
+
+  it('still accepts properly comma-separated targets with no embedded whitespace', () => {
+    const unit = renderSystemdUnit(resolveLaunchSpec({})!, { scope: 'user', after: ['docker.service', 'foo.target'], extraEnv: {} });
+    expect(unit).toContain('After=network-online.target docker.service foo.target');
   });
 });

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -466,7 +466,10 @@ describe('service — unit customization: --after / --env-file / --env (issue #4
       extraEnv: {},
       envFile: '/etc/claude-gateway/extra.env',
     });
-    expect(unit).toContain('EnvironmentFile=-"/etc/claude-gateway/extra.env"');
+    // Unquoted, like WorkingDirectory= — systemd reads a quoted value here as
+    // part of the path and rejects it (verified with `systemd-analyze verify`).
+    expect(unit).toContain('EnvironmentFile=-/etc/claude-gateway/extra.env');
+    expect(unit).not.toContain('EnvironmentFile=-"');
   });
 
   it('adds extra Environment="KEY=VALUE" lines, quoted the same way as the built-in vars', () => {
@@ -520,6 +523,53 @@ describe('service — unit customization: --after / --env-file / --env (issue #4
     expectNoStateChange();
     expect(stderr.join('')).toMatch(/installer itself/);
   });
+
+  it('rejects a line break in an --env value instead of letting it inject an extra unit directive', async () => {
+    const code = await runService(['install'], { manager: 'systemd', yes: true, env: 'FOO=bar\nExecStart=/bin/evil' });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/line break/);
+  });
+
+  it('rejects a line break in an --after target', async () => {
+    const code = await runService(['install'], { manager: 'systemd', yes: true, after: 'docker.service\n[Service]\nExecStart=/bin/evil' });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/line break/);
+  });
+
+  it('rejects a line break in --env-file', async () => {
+    const code = await runService(['install'], { manager: 'systemd', yes: true, 'env-file': '/etc/x\n[Service]\nExecStart=/bin/evil' });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/line break/);
+  });
+
+  it('rejects a line break in --run-as', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', yes: true, 'run-as': 'gwuser\nExecStart=/bin/evil' });
+      expect(code).toBe(1);
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(stderr.join('')).toMatch(/line break/);
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+    }
+  });
+
+  it('rejects a NUL byte in an --env value the same way as a line break', async () => {
+    // Matches the settings.json value guard in src/session/process.ts, which
+    // rejects the same two byte classes for the same reason (NUL throws at
+    // spawn; a newline is never legitimate mid-value).
+    const code = await runService(['install'], { manager: 'systemd', yes: true, env: 'FOO=bar\0baz' });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/NUL byte/);
+  });
 });
 
 describe('service install/uninstall/status — --scope system (issue #457)', () => {
@@ -548,6 +598,19 @@ describe('service install/uninstall/status — --scope system (issue #457)', () 
     expect(mockWriteFileSync).not.toHaveBeenCalled();
     expectNoStateChange();
     expect(stderr.join('')).toMatch(/must be run as root/);
+  });
+
+  it('shows the --print preview for --scope system even when not root — a pure read must never need root', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(1000);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', print: true });
+      expect(code).toBe(0);
+      expect(stderr.join('')).toContain('User=gwuser');
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expectNoStateChange();
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+    }
   });
 
   it('refuses --scope system uninstall when not running as root', async () => {
@@ -607,6 +670,21 @@ describe('service install/uninstall/status — --scope system (issue #457)', () 
       expect(stderr.join('')).not.toMatch(/already exists at system scope/);
     } finally {
       fetchSpy.mockRestore();
+    }
+  });
+
+  it('does not double-space the systemctl hint for system scope (no --user token to join)', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    try {
+      mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+        if (file === 'systemctl' && args.includes('enable')) throw new Error('boom');
+        return Buffer.from('');
+      }) as unknown as typeof execFileSync);
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(1);
+      expect(stderr.join('')).toContain('Inspect it with: systemctl status claude-gateway.service --no-pager');
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
     }
   });
 

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -5,6 +5,7 @@ jest.mock('fs', () => ({
   writeFileSync: jest.fn(),
   unlinkSync: jest.fn(),
   readFileSync: jest.fn(),
+  chmodSync: jest.fn(),
 }));
 
 import * as fs from 'fs';
@@ -402,7 +403,11 @@ describe('service uninstall', () => {
     mockExistsSync.mockReturnValueOnce(true).mockReturnValue(false);
     mockExecFileSync.mockReturnValue(Buffer.from('') as never);
 
-    const code = await runService(['uninstall'], { manager: 'systemd', yes: true });
+    // Explicit scope: with --scope omitted, detectServiceScope() now makes
+    // its own existsSync probe first (issue #457 review) — pass it directly
+    // so this test's mockReturnValueOnce sequencing still lines up with the
+    // single existsSync read systemdState() makes inside systemdUninstall().
+    const code = await runService(['uninstall'], { manager: 'systemd', scope: 'user', yes: true });
 
     expect(code).toBe(0);
     expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['--user', 'disable', '--now', 'claude-gateway.service'], expect.anything());
@@ -418,7 +423,7 @@ describe('service uninstall', () => {
       err.code = 'ENOENT';
       throw err;
     });
-    expect(await runService(['uninstall'], { manager: 'systemd', yes: true })).toBe(0);
+    expect(await runService(['uninstall'], { manager: 'systemd', scope: 'user', yes: true })).toBe(0);
   });
 
   it('reports the observed state, not the intent, when the unit survives removal', async () => {
@@ -778,6 +783,146 @@ describe('service install — restart-on-change for an already-running unit (iss
       expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['--user', 'enable', '--now', 'claude-gateway.service'], expect.anything());
       expect(mockExecFileSync).not.toHaveBeenCalledWith('systemctl', ['--user', 'restart', 'claude-gateway.service'], expect.anything());
     } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('service install — cross-scope conflict, both directions (issue #457 review)', () => {
+  it('refuses a --scope system install when a user-scope unit is already enabled', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    try {
+      mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+        if (file === 'systemctl' && args.includes('--user') && args.includes('is-enabled')) return Buffer.from('enabled\n');
+        return Buffer.from('');
+      }) as unknown as typeof execFileSync);
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(1);
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expectNoStateChange();
+      expect(stderr.join('')).toMatch(/already exists at user scope/);
+      expect(stderr.join('')).toMatch(/systemctl --user disable --now claude-gateway\.service/);
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+    }
+  });
+
+  it('--force installs --scope system anyway despite an active user-scope unit', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+        if (file === 'systemctl' && args.includes('--user') && args.includes('is-enabled')) return Buffer.from('enabled\n');
+        return Buffer.from('');
+      }) as unknown as typeof execFileSync);
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true, force: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(systemUnitPath, expect.stringContaining('User=gwuser'), expect.anything());
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('still refuses a plain --scope user install when a system-scope unit is enabled (original issue #450 direction, unchanged)', async () => {
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && !args.includes('--user') && args[0] === 'is-enabled') return Buffer.from('enabled\n');
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+    const code = await runService(['install'], { manager: 'systemd', yes: true });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(stderr.join('')).toMatch(/already exists at system scope/);
+    expect(stderr.join('')).toMatch(/sudo systemctl disable --now claude-gateway\.service/);
+  });
+});
+
+describe('service status/uninstall — scope auto-detection when --scope is omitted (issue #457 review)', () => {
+  it('status with no --scope finds a system-scope-only install instead of reporting not-installed', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === systemUnitPath);
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && !args.includes('--user') && args[0] === 'is-active') return Buffer.from('active\n');
+      if (file === 'systemctl' && !args.includes('--user') && args[0] === 'is-enabled') return Buffer.from('enabled\n');
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+    const code = await runService(['status'], { manager: 'systemd' });
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join(''))).toEqual(expect.objectContaining({ manager: 'systemd-system', unit: systemUnitPath, active: true }));
+  });
+
+  it('uninstall with no --scope finds and removes a system-scope-only install instead of silently reporting success', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    try {
+      // No user-scope unit ever. System-scope: installed for the scope-detect
+      // read and the before-state read, gone by the final state read after
+      // removal — same "installed, then gone" shape as the plain uninstall
+      // test above, just keyed by path since two paths are probed now.
+      let systemPathReads = 0;
+      mockExistsSync.mockImplementation((p: unknown) => {
+        if (String(p) === unitPath) return false;
+        systemPathReads++;
+        return systemPathReads <= 2;
+      });
+      mockExecFileSync.mockReturnValue(Buffer.from('') as never);
+      const code = await runService(['uninstall'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+      expect(mockExecFileSync).toHaveBeenCalledWith('systemctl', ['disable', '--now', 'claude-gateway.service'], expect.anything());
+      expect(fs.unlinkSync).toHaveBeenCalledWith(systemUnitPath);
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+    }
+  });
+
+  it('install still always defaults to --scope user even when the (unrelated) entry-point/other-scope existsSync checks are true — never auto-detects a scope for install', async () => {
+    // detectServiceScope() special-cases action==='install' to return 'user'
+    // unconditionally, without even reading existsSync — so this only needs
+    // the default beforeEach mock (existsSync → true everywhere, which is
+    // also what resolveLaunchSpec()'s own entry-point check needs to succeed).
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(unitPath, expect.anything(), expect.anything());
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('service install — --env-file requires a value (issue #457 review)', () => {
+  it('rejects a bare --env-file with no path instead of silently treating it as omitted', async () => {
+    // The shared CLI parser reads a flag with no following value (last token,
+    // or immediately followed by another flag) as boolean true — a plain
+    // `typeof !== 'string'` check would silently read that as "not passed".
+    const code = await runService(['install'], { manager: 'systemd', yes: true, 'env-file': true });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expectNoStateChange();
+    expect(stderr.join('')).toMatch(/--env-file requires a path/);
+  });
+});
+
+describe('service install — chmod is applied explicitly, not left to writeFileSync (issue #457 review)', () => {
+  it('chmods the unit file to 0600 after writing it at user scope', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+      expect(fs.chmodSync).toHaveBeenCalledWith(unitPath, 0o600);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("chmods the unit file to 0644 after writing it at system scope — writeFileSync's mode is a no-op on an existing file", async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      expect(fs.chmodSync).toHaveBeenCalledWith(systemUnitPath, 0o644);
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
       fetchSpy.mockRestore();
     }
   });

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -1282,3 +1282,51 @@ describe('service install — chown reasserts ownership when --run-as changes on
     }
   });
 });
+
+describe('service install — exit code distinguishes health-check timeout from an actual failure (manual /code-review round)', () => {
+  it('systemd: exits 2 (not 1) when install/enable succeeded but /health never answers', async () => {
+    jest.useFakeTimers();
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false } as Response);
+    try {
+      const promise = runService(['install'], { manager: 'systemd', yes: true });
+      // 20 attempts * 500ms interval, plus slack for the probe's own await chain.
+      await jest.advanceTimersByTimeAsync(20 * 500 + 5_000);
+      const code = await promise;
+      expect(code).toBe(2);
+      // The install itself genuinely succeeded — only health is unconfirmed.
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      expect(JSON.parse(stdout.join(''))).toEqual(expect.objectContaining({ health: 'down' }));
+    } finally {
+      fetchSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it('systemd: still exits 1, not 2, when install/enable itself fails outright', async () => {
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'systemctl' && args.includes('enable')) throw new Error('boom');
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+    const code = await runService(['install'], { manager: 'systemd', yes: true });
+    expect(code).toBe(1);
+    expect(mockWriteFileSync).toHaveBeenCalled(); // unit was written before the enable call failed
+  });
+
+  it('pm2: exits 2 (not 1) when registration succeeded but /health never answers', async () => {
+    jest.useFakeTimers();
+    mockExecFileSync.mockImplementation(((file: string, args: string[]) => {
+      if (file === 'pm2' && args[0] === 'jlist') return Buffer.from('[]');
+      return Buffer.from('');
+    }) as unknown as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false } as Response);
+    try {
+      const promise = runService(['install'], { manager: 'pm2', yes: true });
+      await jest.advanceTimersByTimeAsync(20 * 500 + 5_000);
+      const code = await promise;
+      expect(code).toBe(2);
+    } finally {
+      fetchSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/cli-service.test.ts
+++ b/tests/unit/cli-service.test.ts
@@ -7,6 +7,7 @@ jest.mock('fs', () => ({
   readFileSync: jest.fn(),
   chmodSync: jest.fn(),
   chownSync: jest.fn(),
+  statSync: jest.fn(),
 }));
 
 import * as fs from 'fs';
@@ -71,6 +72,11 @@ beforeEach(() => {
   mockReadFileSync.mockImplementation(() => {
     throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
   });
+  // Default: an already-existing WorkingDirectory is owned by gwuser's uid
+  // already, matching the default --run-as used throughout this file — so
+  // the "already correct, no-op" chown path is what most tests exercise
+  // unless a test deliberately overrides it.
+  (fs.statSync as jest.Mock).mockReturnValue({ uid: 1500 });
   stdout = [];
   stderr = [];
   outSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
@@ -1162,6 +1168,116 @@ describe('service install — --scope system resolves --run-as user\'s real home
       }
       expect(mockWriteFileSync).toHaveBeenCalledWith(unitPath, expect.stringContaining(`Environment="HOME=${os.homedir()}"`), expect.anything());
     } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('service install — --config/--env-file `~` expansion and $GATEWAY_CONFIG under --scope system (manual /code-review round)', () => {
+  it('expands a `~/...` --config path against the --run-as user\'s home, not the installing root process\'s', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', config: '~/custom.json', yes: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        systemUnitPath,
+        expect.stringContaining(`GATEWAY_CONFIG=${gwuserHome}/custom.json`),
+        expect.anything(),
+      );
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('expands a `~/...` --env-file path against the --run-as user\'s home, not root\'s', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], {
+        manager: 'systemd',
+        scope: 'system',
+        'run-as': 'gwuser',
+        'env-file': '~/secrets.env',
+        yes: true,
+      });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(systemUnitPath, expect.stringContaining(`EnvironmentFile=-${gwuserHome}/secrets.env`), expect.anything());
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('ignores $GATEWAY_CONFIG from the installing (root) process\'s environment for --scope system', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    const prevEnv = process.env.GATEWAY_CONFIG;
+    process.env.GATEWAY_CONFIG = '/root/some-other-config.json';
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        systemUnitPath,
+        expect.stringContaining(`GATEWAY_CONFIG=${gwuserHome}/.claude-gateway/config.json`),
+        expect.anything(),
+      );
+      expect(mockWriteFileSync).not.toHaveBeenCalledWith(systemUnitPath, expect.stringContaining('some-other-config.json'), expect.anything());
+    } finally {
+      if (prevEnv === undefined) delete process.env.GATEWAY_CONFIG;
+      else process.env.GATEWAY_CONFIG = prevEnv;
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('a plain --scope user install still honours $GATEWAY_CONFIG — only --scope system suppresses it', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    const prevEnv = process.env.GATEWAY_CONFIG;
+    process.env.GATEWAY_CONFIG = '/env/cg.json';
+    try {
+      const code = await runService(['install'], { manager: 'systemd', yes: true });
+      expect(code).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(unitPath, expect.stringContaining('GATEWAY_CONFIG=/env/cg.json'), expect.anything());
+    } finally {
+      if (prevEnv === undefined) delete process.env.GATEWAY_CONFIG;
+      else process.env.GATEWAY_CONFIG = prevEnv;
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('service install — chown reasserts ownership when --run-as changes on an existing WorkingDirectory (manual /code-review round)', () => {
+  it('chowns an existing WorkingDirectory still owned by a previous --run-as user to the new one', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    (fs.statSync as jest.Mock).mockReturnValue({ uid: 9999 }); // some other, stale owner
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      expect(fs.chownSync).toHaveBeenCalledWith(`${gwuserHome}/.claude-gateway`, 1500, 1500);
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('does not chown when the existing WorkingDirectory already belongs to the current --run-as target', async () => {
+    jest.spyOn(process, 'getuid').mockReturnValue(0);
+    (fs.statSync as jest.Mock).mockReturnValue({ uid: 1500 }); // already gwuser
+    mockExecFileSync.mockImplementation((withGetentGwuser(() => Buffer.from('')) as unknown) as typeof execFileSync);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    try {
+      const code = await runService(['install'], { manager: 'systemd', scope: 'system', 'run-as': 'gwuser', yes: true });
+      expect(code).toBe(0);
+      expect(fs.chownSync).not.toHaveBeenCalled();
+    } finally {
+      (process.getuid as unknown as jest.Mock).mockRestore();
       fetchSpy.mockRestore();
     }
   });


### PR DESCRIPTION
## Summary
Adds a `--scope system` mode to `claude-gateway service install/status/uninstall` for automated/infra provisioning that needs the gateway to run under a fixed system account, alongside the existing default user-scope install. Also adds `--after`/`--env-file`/`--env` to customize the generated unit, switches the generated unit to `Type=exec`, distinguishes a health-check timeout from an actual install failure by exit code, and fixes a latent bug where a repeated install with changed unit content silently left the stale unit running.

## Related Issue
Closes #457

## Changes Made
- `src/cli/commands/service.ts`:
  - `renderSystemdUnit()` takes a new optional `SystemdUnitOptions` (scope, runAs, after, envFile, extraEnv); defaults to the prior exact user-scope output so `--scope user` (or omitting it) is a strict no-op.
  - `--scope system` writes `/etc/systemd/system/claude-gateway.service`, sets `User=<run-as>` and `WantedBy=multi-user.target`, refuses non-root (never auto-escalates via `sudo`), and requires `--run-as <user>`.
  - `WorkingDirectory=`/`HOME=`/the config path resolve to `--run-as`'s real home (looked up via `getent passwd`, NSS-aware), not the installing root process's — including `~`-expansion in `--config`/`--env-file`, and `$GATEWAY_CONFIG` from root's own environment is not consulted for `--scope system`. A freshly-created `WorkingDirectory` is `chown`'d to `--run-as`, and ownership is reasserted if the directory already exists but belongs to a different user (e.g. `--run-as` changed between installs).
  - `--after <target,...>`, `--env-file <path>`, `--env KEY=VALUE,...` (comma-separated, since the shared CLI parser has no repeatable-flag concept) add extra `After=` targets, an `EnvironmentFile=-<path>`, and extra `Environment=` lines respectively. Validated against NUL/newline injection and (for `--after`) embedded whitespace; `--env` rejects malformed pairs and refuses to override `HOME`/`PATH`/`GATEWAY_CONFIG`.
  - The generated unit uses `Type=exec` (was `Type=simple`) — reported "started" only once the actual `execve()` succeeds, not right after `fork()`.
  - `crossScopeConflict()` guards both directions: installing user scope while an externally-provisioned system-scope unit is active (the original #450 case), and installing system scope while a prior user-scope install is still active. Neither direction fires against a repeat install of the same scope.
  - `service status`/`service uninstall` auto-detect scope when `--scope` is omitted (mirrors `--manager` auto-detection); refuse if both scopes are simultaneously installed rather than silently picking one. `install` always defaults to `user` regardless of what already exists.
  - Re-running `install` against an already-active unit whose rendered content changed now restarts it (and re-enables it, in case it had drifted to active-but-disabled) instead of leaving the stale unit running.
  - `install`'s exit code distinguishes `1` (install/enable failed, or a validation/confirmation gate refused — nothing written) from `2` (install/enable succeeded but `/health` never answered in time), for both the systemd and pm2 paths.
- `README.md`: documents `--scope system` usage, the exit-code contract, and replaces the now-obsolete "reinstall then manually restart" migration note with the automatic-restart-on-change behavior.
- `scripts/gen-cli.ts` / `CLI.md`: regenerated service-install doc block for the new flags and exit codes.
- `tests/unit/cli-service.test.ts` / `tests/unit/cli-service-force-flag.test.ts`: extensive new coverage — scope validation/root-check/run-as requirement and home resolution (including `getent` failure, `~`-expansion, chown-on-create vs. chown-reassignment), unit rendering with `--after`/`--env-file`/`--env` and injection guards, cross-scope conflict in both directions, scope auto-detection and the dual-scope-installed refusal, `Type=exec`, the exit-code-2 distinction (using fake timers to avoid a real 10s health-poll wait), and the restart-vs-enable regression. Every regression test in this PR was proven to fail on the pre-fix code (temporarily reverting the fix, confirming red, then restoring) before being accepted.

## Review history
This PR went through 6 review passes before merge: self-review, three independent `/code-review` passes, one manual `/gateway-code-review` pass, plus a round of fixes from an externally-reported review. Each pass found and fixed real issues — see the commit history for the specific findings and fixes from each round.

## Testing
- `npm run typecheck`: pass
- `npm run gen-cli:check`: up to date
- `npm test`: 237 suites / 4457 tests pass
