### PR TITLE
Fix secrets at rest: ~/.claude-gateway permissions and .sessions cleanup

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1007,7 +1007,9 @@ export class AgentRunner extends EventEmitter {
     if (agent) {
       agent.claude.model = newModel;
       const tmp = this.configPath + '.tmp';
-      fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n');
+      // mode: 0o600 — rename() carries this file's mode onto config.json,
+      // silently downgrading an existing 0600 config to 0644 otherwise (#460).
+      fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
       fs.renameSync(tmp, this.configPath);
     }
   }
@@ -2904,6 +2906,7 @@ export class AgentRunner extends EventEmitter {
 
   async start(): Promise<void> {
     this.stopping = false;
+    this.sweepStaleSessionDirs();
     await this.startCallbackServer();
     if (this.agentConfig.telegram?.botToken) {
       this.receiver = new TelegramReceiver(
@@ -2929,6 +2932,38 @@ export class AgentRunner extends EventEmitter {
     this.startIdleCleaner();
     this._startCleanupScheduler();
     this.logger.info('AgentRunner started', { agentId: this.agentConfig.id });
+  }
+
+  /**
+   * Remove any `.sessions/<id>/` directory not backed by a currently-live
+   * `SessionProcess` — leftovers from a hard kill (SIGKILL, crash, host
+   * reboot) that `SessionProcess.stop()`'s own cleanup never got to run for.
+   * Each holds a `mcp-config.json` with fully-substituted secrets (channel
+   * bot tokens, GATEWAY_API_KEY) that must not accumulate unbounded (#460).
+   *
+   * Called once per runner instance at the top of `start()`, before any of
+   * this agent's own sessions exist yet, so `this.sessions` is normally
+   * empty here — but the liveness check is real, not just a formality: skip
+   * anything present in `this.sessions` regardless, rather than assuming
+   * "start() always runs on an empty pool" and deleting unconditionally.
+   */
+  private sweepStaleSessionDirs(): void {
+    const sessionsRoot = path.join(this.agentConfig.workspace, '.sessions');
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(sessionsRoot, { withFileTypes: true });
+    } catch {
+      return; // no .sessions directory yet — nothing to sweep
+    }
+    const liveSessionIds = new Set(Array.from(this.sessions.values(), (s) => s.sessionId));
+    for (const entry of entries) {
+      if (!entry.isDirectory() || liveSessionIds.has(entry.name)) continue;
+      try {
+        fs.rmSync(path.join(sessionsRoot, entry.name), { recursive: true, force: true });
+      } catch {
+        /* best-effort cleanup — a stubborn leftover isn't worth failing boot over */
+      }
+    }
   }
 
   updateAgentConfig(newConfig: AgentConfig): void {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1009,7 +1009,11 @@ export class AgentRunner extends EventEmitter {
       const tmp = this.configPath + '.tmp';
       // mode: 0o600 — rename() carries this file's mode onto config.json,
       // silently downgrading an existing 0600 config to 0644 otherwise (#460).
+      // writeFileSync's mode option is IGNORED if a stale tmp file from a
+      // prior crashed write is already sitting at this fixed path, so chmod
+      // explicitly rather than relying on it.
       fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
+      fs.chmodSync(tmp, 0o600);
       fs.renameSync(tmp, this.configPath);
     }
   }
@@ -2906,7 +2910,7 @@ export class AgentRunner extends EventEmitter {
 
   async start(): Promise<void> {
     this.stopping = false;
-    this.sweepStaleSessionDirs();
+    await this.sweepStaleSessionDirs();
     await this.startCallbackServer();
     if (this.agentConfig.telegram?.botToken) {
       this.receiver = new TelegramReceiver(
@@ -2946,12 +2950,17 @@ export class AgentRunner extends EventEmitter {
    * empty here — but the liveness check is real, not just a formality: skip
    * anything present in `this.sessions` regardless, rather than assuming
    * "start() always runs on an empty pool" and deleting unconditionally.
+   *
+   * Async (fsPromises) rather than sync fs calls: a first upgrade to this fix
+   * can face a real backlog of leftovers accumulated before it existed, and
+   * synchronous readdir/rm would block the event loop — and every other
+   * agent's start() sharing this process — for the duration.
    */
-  private sweepStaleSessionDirs(): void {
+  private async sweepStaleSessionDirs(): Promise<void> {
     const sessionsRoot = path.join(this.agentConfig.workspace, '.sessions');
-    let entries: fs.Dirent[];
+    let entries: import('fs').Dirent[];
     try {
-      entries = fs.readdirSync(sessionsRoot, { withFileTypes: true });
+      entries = await fsPromises.readdir(sessionsRoot, { withFileTypes: true });
     } catch {
       return; // no .sessions directory yet — nothing to sweep
     }
@@ -2959,7 +2968,7 @@ export class AgentRunner extends EventEmitter {
     for (const entry of entries) {
       if (!entry.isDirectory() || liveSessionIds.has(entry.name)) continue;
       try {
-        fs.rmSync(path.join(sessionsRoot, entry.name), { recursive: true, force: true });
+        await fsPromises.rm(path.join(sessionsRoot, entry.name), { recursive: true, force: true });
       } catch {
         /* best-effort cleanup — a stubborn leftover isn't worth failing boot over */
       }

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -344,7 +344,11 @@ export function createApiRouter(
     }
     mutate(config.agents);
     const tmp = cfgPath + '.tmp.' + randomUUID();
-    await fsp.writeFile(tmp, JSON.stringify(config, null, 2), 'utf-8');
+    // mode: 0o600 — config.json carries the admin API key and every agent's
+    // channel bot tokens; rename() onto cfgPath carries this file's mode
+    // with it, so an unmoded tmp file silently downgrades an existing 0600
+    // config to 0644 on its very first edit (issue #460).
+    await fsp.writeFile(tmp, JSON.stringify(config, null, 2), { encoding: 'utf-8', mode: 0o600 });
     await fsp.rename(tmp, cfgPath);
   }
 

--- a/src/apps/agent-manager.ts
+++ b/src/apps/agent-manager.ts
@@ -435,9 +435,14 @@ export class AgentManager {
   }
 
   private writeConfig(config: RawConfig): void {
-    fs.mkdirSync(path.dirname(this.configPath), { recursive: true });
+    // mode: 0o700 — same secret-bearing directory bootstrap.ts creates; this
+    // mkdirSync is usually a recursive no-op once that's already run, but
+    // must not itself default to 0755 on any path that reaches here first.
+    fs.mkdirSync(path.dirname(this.configPath), { recursive: true, mode: 0o700 });
     const tmp = `${this.configPath}.tmp.${process.pid}`;
-    fs.writeFileSync(tmp, JSON.stringify(config, null, 2), 'utf-8');
+    // mode: 0o600 — rename() carries this file's mode onto config.json,
+    // silently downgrading an existing 0600 config to 0644 otherwise (#460).
+    fs.writeFileSync(tmp, JSON.stringify(config, null, 2), { encoding: 'utf-8', mode: 0o600 });
     fs.renameSync(tmp, this.configPath);
   }
 

--- a/src/config/bootstrap.ts
+++ b/src/config/bootstrap.ts
@@ -44,7 +44,10 @@ export function ensureConfigExists(configPath: string, templatePath: string): Bo
     ],
   };
 
-  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  // 0o700: config.json living inside carries secrets (admin API key, agent
+  // bot tokens). Without an explicit mode this lands at 0755, letting any
+  // local user traverse in and read whatever's inside (issue #460).
+  fs.mkdirSync(path.dirname(configPath), { recursive: true, mode: 0o700 });
   try {
     // 'wx' fails with EEXIST instead of overwriting if another process won a
     // concurrent first-boot race; mode 0o600 keeps the embedded admin key

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { GatewayConfig, Logger } from '../types';
 import { resolveGatewayPublicUrl } from './public-url';
@@ -185,9 +186,16 @@ export function loadConfig(configPath: string, options?: LoadConfigOptions): Gat
   // recursive mkdirSync on an already-existing one is a no-op mode-wise, so
   // an install that predates #460 (i.e. every existing install) never
   // benefits from that fix at all, staying 0755 forever otherwise.
+  //
+  // Scoped to the default `~/.claude-gateway` home only — a `--config` /
+  // `GATEWAY_CONFIG` pointed at a directory the operator shares with
+  // something else (a sidecar, another service under a different user) must
+  // keep whatever permissions they set on it; only config.json itself
+  // (chmod'd above, unconditionally) needs locking down in that case.
   try {
     const dir = path.dirname(configPath);
-    if ((fs.statSync(dir).mode & 0o777) !== 0o700) {
+    const defaultGatewayHome = path.join(os.homedir(), '.claude-gateway');
+    if (dir === defaultGatewayHome && (fs.statSync(dir).mode & 0o777) !== 0o700) {
       fs.chmodSync(dir, 0o700);
     }
   } catch {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { GatewayConfig, Logger } from '../types';
 import { resolveGatewayPublicUrl } from './public-url';
 
@@ -174,6 +175,20 @@ export function loadConfig(configPath: string, options?: LoadConfigOptions): Gat
   try {
     if ((fs.statSync(configPath).mode & 0o777) !== 0o600) {
       fs.chmodSync(configPath, 0o600);
+    }
+  } catch {
+    /* stat/chmod failed — not fatal, config still loads */
+  }
+
+  // Same repair for the containing directory: bootstrap.ts's mkdirSync(dir,
+  // {mode: 0o700}) only applies its mode when it *creates* the directory —
+  // recursive mkdirSync on an already-existing one is a no-op mode-wise, so
+  // an install that predates #460 (i.e. every existing install) never
+  // benefits from that fix at all, staying 0755 forever otherwise.
+  try {
+    const dir = path.dirname(configPath);
+    if ((fs.statSync(dir).mode & 0o777) !== 0o700) {
+      fs.chmodSync(dir, 0o700);
     }
   } catch {
     /* stat/chmod failed — not fatal, config still loads */

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -166,6 +166,19 @@ export function loadConfig(configPath: string, options?: LoadConfigOptions): Gat
     throw new ConfigValidationError(`Cannot read config file at "${configPath}": ${(err as Error).message}`);
   }
 
+  // Self-heal a config.json left wider than 0600 by a writer that predates
+  // #460's fix (or ran before this fix reached that call site) — every
+  // reload is a chance to repair it, not just the first one after upgrading.
+  // Best-effort: an unreadable/immutable mode bit must not block loading a
+  // config that otherwise parses and validates fine.
+  try {
+    if ((fs.statSync(configPath).mode & 0o777) !== 0o600) {
+      fs.chmodSync(configPath, 0o600);
+    }
+  } catch {
+    /* stat/chmod failed — not fatal, config still loads */
+  }
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -612,7 +612,12 @@ export function applyMigration(
   const tmpPath = configPath + '.tmp';
   // mode: 0o600 — rename() carries this file's mode onto config.json,
   // silently downgrading an existing 0600 config to 0644 otherwise (#460).
+  // writeFileSync's mode option is IGNORED if a stale tmp file from a prior
+  // crashed migration is already sitting at this fixed path (same reasoning
+  // as backupPath's explicit chmod above), so chmod explicitly rather than
+  // relying on it.
   fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
+  fs.chmodSync(tmpPath, 0o600);
   fs.renameSync(tmpPath, configPath);
 
   return { migrated: true, addedFields: added, removedFields: removed, warnings };

--- a/src/config/migrator.ts
+++ b/src/config/migrator.ts
@@ -603,10 +603,16 @@ export function applyMigration(
   // Backup before writing
   const backupPath = configPath + '.bak';
   fs.copyFileSync(configPath, backupPath);
+  // copyFileSync preserves configPath's current mode, which may already be a
+  // downgraded 0644 from before this fix — chmod explicitly rather than
+  // relying on the source being 0600 by the time this runs (issue #460).
+  fs.chmodSync(backupPath, 0o600);
 
   // Write atomically via temp file
   const tmpPath = configPath + '.tmp';
-  fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  // mode: 0o600 — rename() carries this file's mode onto config.json,
+  // silently downgrading an existing 0600 config to 0644 otherwise (#460).
+  fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
   fs.renameSync(tmpPath, configPath);
 
   return { migrated: true, addedFields: added, removedFields: removed, warnings };

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -1756,6 +1756,13 @@ export class SessionProcess extends EventEmitter {
     if (this.source === 'telegram') {
       try { fs.rmSync(path.join(this.typingDir, `${this.chatId}.processing`), { force: true }); } catch {}
     }
+    // mcp-config.json under here holds fully-substituted secrets (channel bot
+    // tokens, GATEWAY_API_KEY, connector OAuth tokens) — it must not outlive
+    // the session that needed it (issue #460). Recreated automatically on the
+    // next spawn, so removing it here is safe across restarts.
+    try {
+      fs.rmSync(path.join(this.agentConfig.workspace, '.sessions', this.sessionId), { recursive: true, force: true });
+    } catch {}
     if (!this.process) return;
 
     return new Promise((resolve) => {

--- a/src/session/process.ts
+++ b/src/session/process.ts
@@ -1759,11 +1759,20 @@ export class SessionProcess extends EventEmitter {
     // mcp-config.json under here holds fully-substituted secrets (channel bot
     // tokens, GATEWAY_API_KEY, connector OAuth tokens) — it must not outlive
     // the session that needed it (issue #460). Recreated automatically on the
-    // next spawn, so removing it here is safe across restarts.
-    try {
-      fs.rmSync(path.join(this.agentConfig.workspace, '.sessions', this.sessionId), { recursive: true, force: true });
-    } catch {}
-    if (!this.process) return;
+    // next spawn, so removing it here is safe across restarts. Deferred until
+    // the process has actually exited below (not removed up front here) — the
+    // subprocess (or, for a container agent, the still-running container that
+    // bind-mounts this path) can be alive for up to the 10s graceful-shutdown
+    // window immediately after this point, and must not find it gone under it.
+    const removeSessionDir = (): void => {
+      try {
+        fs.rmSync(path.join(this.agentConfig.workspace, '.sessions', this.sessionId), { recursive: true, force: true });
+      } catch {}
+    };
+    if (!this.process) {
+      removeSessionDir();
+      return;
+    }
 
     return new Promise((resolve) => {
       const proc = this.process!;
@@ -1774,6 +1783,7 @@ export class SessionProcess extends EventEmitter {
           forceKillTimer = null;
         }
         this.process = null;
+        removeSessionDir();
         resolve();
       });
       proc.kill('SIGTERM');

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -357,7 +357,7 @@ describe('AgentRunner (session pool)', () => {
     // AgentRunner only ever calls it once, at the top of start(), before any
     // of its own sessions exist. Calling it again proves the liveness check
     // itself is correct, not just "it happens to run before sessions do".
-    (runner as unknown as { sweepStaleSessionDirs(): void }).sweepStaleSessionDirs();
+    await (runner as unknown as { sweepStaleSessionDirs(): Promise<void> }).sweepStaleSessionDirs();
 
     expect(fs.existsSync(liveDir)).toBe(true);
   }, 15000);

--- a/tests/unit/agent-runner.test.ts
+++ b/tests/unit/agent-runner.test.ts
@@ -324,6 +324,43 @@ describe('AgentRunner (session pool)', () => {
     expect(internal.tooLargeRecoveries.has('chat:reset')).toBe(false);
     expect(internal.tooLargeExhausted.has('chat:reset')).toBe(false);
   }, 15000);
+
+  // --------------------------------------------------------------------------
+  // #460: .sessions/<id>/mcp-config.json holds fully-substituted secrets
+  // (channel bot tokens, GATEWAY_API_KEY) and must not accumulate unbounded —
+  // a hard kill (SIGKILL, crash, host reboot) skips SessionProcess.stop()'s
+  // own cleanup, so start() sweeps what's left behind.
+  // --------------------------------------------------------------------------
+  it('#460: start() removes a stale leftover .sessions/<id>/ directory from a previous run', async () => {
+    const staleDir = path.join(agentConfig.workspace, '.sessions', 'chat:stale-from-crash');
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.writeFileSync(path.join(staleDir, 'mcp-config.json'), '{"mcpServers":{}}');
+
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+
+    expect(fs.existsSync(staleDir)).toBe(false);
+  }, 15000);
+
+  it('#460: does not sweep a directory backed by a currently-live session', async () => {
+    runner = new AgentRunner(agentConfig, gatewayConfig);
+    await runner.start();
+    const port = getCallbackPort(runner);
+
+    await sendChannelPost(port, 'chat:111', 'hello');
+    await waitForSession(runner, 'chat:111');
+    const liveSessionId = getSessions(runner).get('chat:111')!.sessionId;
+    const liveDir = path.join(agentConfig.workspace, '.sessions', liveSessionId);
+    expect(fs.existsSync(liveDir)).toBe(true); // sanity: writeMcpConfig() already created it
+
+    // Exercise the sweep directly rather than a second start() — this
+    // AgentRunner only ever calls it once, at the top of start(), before any
+    // of its own sessions exist. Calling it again proves the liveness check
+    // itself is correct, not just "it happens to run before sessions do".
+    (runner as unknown as { sweepStaleSessionDirs(): void }).sweepStaleSessionDirs();
+
+    expect(fs.existsSync(liveDir)).toBe(true);
+  }, 15000);
 });
 
 // ── tokenUsage → session model persistence (#273) ────────────────────────────

--- a/tests/unit/api-agent-name.test.ts
+++ b/tests/unit/api-agent-name.test.ts
@@ -86,6 +86,14 @@ describe('Agent display name API', () => {
     expect(configs.get(AGENT_ID)!.name).toBe('Alfred the Butler');
   });
 
+  // #460: config.json carries agent bot tokens and the admin API key.
+  // writeAgentsToConfigImpl()'s tmp-then-rename pattern silently downgraded
+  // it from 0600 to the tmp file's default mode (0644) on every write.
+  it('keeps config.json at 0600 after a PATCH write, even though it started at the fixture\'s default mode', async () => {
+    await patch({ name: 'Alfred the Butler' });
+    expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+  });
+
   it('trims whitespace on the persisted name', async () => {
     await patch({ name: '  Spacey Name  ' });
     const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf8'));

--- a/tests/unit/apps/agent-manager.test.ts
+++ b/tests/unit/apps/agent-manager.test.ts
@@ -424,6 +424,19 @@ describe('AgentManager', () => {
       expect(config.agents.filter((a) => a['id'] === 'my-agent')).toHaveLength(1);
     });
 
+    // #460: config.json carries agent bot tokens and the admin API key.
+    // writeConfig()'s tmp-then-rename pattern silently downgraded it from
+    // 0600 to the tmp file's default mode (0644) on every write.
+    it('writes config.json at 0600, even on the very first write to a fresh directory', async () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      const entry = makeEntry(tmpDir);
+
+      await manager.upsertAgent(entry);
+
+      expect(fs.existsSync(configPath)).toBe(true);
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+    });
+
     it('updates symlink if it already exists', async () => {
       const entry = makeEntry(tmpDir);
       await manager.upsertAgent(entry);

--- a/tests/unit/config-bootstrap.test.ts
+++ b/tests/unit/config-bootstrap.test.ts
@@ -75,6 +75,13 @@ describe('config-bootstrap', () => {
     expect(mode).toBe(0o600);
   });
 
+  it('creates the config directory with owner-only permissions (0700), not the 0755 default (#460)', () => {
+    ensureConfigExists(configPath, TEMPLATE_PATH);
+
+    const dirMode = fs.statSync(path.dirname(configPath)).mode & 0o777;
+    expect(dirMode).toBe(0o700);
+  });
+
   it('loses a concurrent-first-boot race safely instead of overwriting the winner', () => {
     // Simulate a second process racing to create the same file first, after
     // this call already decided (via existsSync) that no config exists yet.

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -449,6 +449,33 @@ describe('config-loader', () => {
 
       expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
     });
+
+    // Independent-review finding: bootstrap.ts's mkdirSync(dir, {mode:0o700})
+    // only applies its mode on *creation* — a directory that already existed
+    // before #460 (i.e. every existing install) never gets repaired by that
+    // fix alone. loadConfig() must repair the directory too, on every load,
+    // not just the file.
+    it('chmods the containing directory back to 0700 on load, not just config.json itself', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o600 });
+      // mkdtempSync already creates tmpDir at 0700 — chmod wider first to
+      // simulate a pre-#460 install whose directory was never restricted.
+      fs.chmodSync(tmpDir, 0o755);
+
+      loadConfig(configPath);
+
+      expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o700);
+    });
+
+    it('leaves an already-0700 config directory at 0700 (idempotent)', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o600 });
+      fs.chmodSync(tmpDir, 0o700);
+
+      loadConfig(configPath);
+
+      expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o700);
+    });
   });
   });
 });

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -12,6 +12,19 @@ import {
 
 const FIXTURES = path.join(__dirname, '../fixtures/configs');
 
+/**
+ * The directory self-heal (#460) is scoped to `os.homedir()/.claude-gateway`
+ * only. `jest.spyOn(os, 'homedir')` throws "Cannot redefine property" on this
+ * Node, so a module mock is used instead — see tests/unit/cli-logs.test.ts
+ * for the same pattern. Defers to the real implementation unless a test asks
+ * otherwise.
+ */
+let mockHomeDir: string | undefined;
+jest.mock('os', () => {
+  const actual = jest.requireActual('os');
+  return { ...actual, homedir: () => mockHomeDir ?? actual.homedir() };
+});
+
 describe('config-loader', () => {
   let tmpDir: string;
 
@@ -454,27 +467,60 @@ describe('config-loader', () => {
     // only applies its mode on *creation* — a directory that already existed
     // before #460 (i.e. every existing install) never gets repaired by that
     // fix alone. loadConfig() must repair the directory too, on every load,
-    // not just the file.
-    it('chmods the containing directory back to 0700 on load, not just config.json itself', () => {
-      const configPath = path.join(tmpDir, 'config.json');
-      fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o600 });
-      // mkdtempSync already creates tmpDir at 0700 — chmod wider first to
-      // simulate a pre-#460 install whose directory was never restricted.
-      fs.chmodSync(tmpDir, 0o755);
+    // not just the file — but ONLY the default `~/.claude-gateway` home, not
+    // an arbitrary directory a custom --config/GATEWAY_CONFIG path resolves
+    // to (a later independent-review finding: forcing 0700 on a directory an
+    // operator may be deliberately sharing with something else would be an
+    // overreach the operator didn't ask for).
+    describe('directory chmod, scoped to the default gateway home', () => {
+      let fakeHome: string;
+      let gatewayHomeDir: string;
 
-      loadConfig(configPath);
+      beforeEach(() => {
+        fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cl-home-'));
+        gatewayHomeDir = path.join(fakeHome, '.claude-gateway');
+        fs.mkdirSync(gatewayHomeDir, { mode: 0o700 });
+        mockHomeDir = fakeHome;
+      });
 
-      expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o700);
-    });
+      afterEach(() => {
+        mockHomeDir = undefined;
+        fs.rmSync(fakeHome, { recursive: true, force: true });
+      });
 
-    it('leaves an already-0700 config directory at 0700 (idempotent)', () => {
-      const configPath = path.join(tmpDir, 'config.json');
-      fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o600 });
-      fs.chmodSync(tmpDir, 0o700);
+      it('chmods the default gateway home directory back to 0700 on load, not just config.json itself', () => {
+        const configPath = path.join(gatewayHomeDir, 'config.json');
+        fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o600 });
+        // Created at 0700 above — chmod wider first to simulate a pre-#460
+        // install whose directory was never restricted.
+        fs.chmodSync(gatewayHomeDir, 0o755);
 
-      loadConfig(configPath);
+        loadConfig(configPath);
 
-      expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o700);
+        expect(fs.statSync(gatewayHomeDir).mode & 0o777).toBe(0o700);
+      });
+
+      it('leaves an already-0700 default gateway home directory at 0700 (idempotent)', () => {
+        const configPath = path.join(gatewayHomeDir, 'config.json');
+        fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o600 });
+
+        loadConfig(configPath);
+
+        expect(fs.statSync(gatewayHomeDir).mode & 0o777).toBe(0o700);
+      });
+
+      it('does not chmod a custom config directory outside the default gateway home', () => {
+        // tmpDir here stands in for a --config/GATEWAY_CONFIG path pointed at
+        // a directory the operator shares with something else — its own
+        // permissions are the operator's call, not loadConfig()'s.
+        const configPath = path.join(tmpDir, 'config.json');
+        fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o600 });
+        fs.chmodSync(tmpDir, 0o755);
+
+        loadConfig(configPath);
+
+        expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o755);
+      });
     });
   });
   });

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -427,5 +427,28 @@ describe('config-loader', () => {
 
       expect(warn).not.toHaveBeenCalled();
     });
+
+  // -------------------------------------------------------------------------
+  // #460: loadConfig repairs a config.json left wider than 0600
+  // -------------------------------------------------------------------------
+  describe('permission self-heal (#460)', () => {
+    it('chmods a 0644 config.json back to 0600 on load', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o644 });
+
+      loadConfig(configPath);
+
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+    });
+
+    it('leaves an already-0600 config.json at 0600 (idempotent)', () => {
+      const configPath = path.join(tmpDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({ gateway: { logDir: '/logs' }, agents: [] }), { mode: 0o600 });
+
+      loadConfig(configPath);
+
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+    });
+  });
   });
 });

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -420,6 +420,21 @@ describe('config-migrator', () => {
       expect(backup).toEqual(original);
     });
 
+    it('writes config.json and its .bak backup at 0600, regardless of the source file\'s original mode (#460)', () => {
+      const original = { configVersion: '0.0.1', gateway: { logDir: '/logs' } };
+      const configPath = writeJson('config.json', original); // writeJson has no explicit mode — starts at the umask default
+      const template: Record<string, unknown> = {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', timezone: 'UTC' },
+      };
+      const config = structuredClone(original) as Record<string, unknown>;
+
+      applyMigration(configPath, config, template, '1.0.0');
+
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(configPath + '.bak').mode & 0o777).toBe(0o600);
+    });
+
     it('respects ignorePaths during merge', () => {
       const original = { configVersion: '0.0.1', gateway: { logDir: '/logs' } };
       const configPath = writeJson('config.json', original);

--- a/tests/unit/config-migrator.test.ts
+++ b/tests/unit/config-migrator.test.ts
@@ -435,6 +435,26 @@ describe('config-migrator', () => {
       expect(fs.statSync(configPath + '.bak').mode & 0o777).toBe(0o600);
     });
 
+    // #460 (independent review, round 3): applyMigration() writes to a FIXED
+    // tmp path (`config.json.tmp`), not a unique one — writeFileSync's `mode`
+    // option is silently ignored when that path already exists (e.g. left
+    // behind by a prior crashed migration), so an explicit chmodSync is
+    // required after the write, not just the mode option on it.
+    it('still ends up at 0600 even when a stale .tmp file from a prior crashed migration is already sitting at the fixed tmp path', () => {
+      const original = { configVersion: '0.0.1', gateway: { logDir: '/logs' } };
+      const configPath = writeJson('config.json', original);
+      fs.writeFileSync(configPath + '.tmp', 'stale leftover', { mode: 0o644 });
+      const template: Record<string, unknown> = {
+        configVersion: '1.0.0',
+        gateway: { logDir: '/default', timezone: 'UTC' },
+      };
+      const config = structuredClone(original) as Record<string, unknown>;
+
+      applyMigration(configPath, config, template, '1.0.0');
+
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+    });
+
     it('respects ignorePaths during merge', () => {
       const original = { configVersion: '0.0.1', gateway: { logDir: '/logs' } };
       const configPath = writeJson('config.json', original);

--- a/tests/unit/model-picker-commands.test.ts
+++ b/tests/unit/model-picker-commands.test.ts
@@ -198,6 +198,18 @@ describe('AgentRunner — /models and /model on Discord and LINE (issue #409)', 
     expect(persistedModel()).toBe('claude-opus-5');
   }, 15000);
 
+  // #460: config.json carries agent bot tokens and the admin API key.
+  // persistModelToConfig()'s tmp-then-rename pattern silently downgraded it
+  // from 0600 to the tmp file's default mode (0644) on every model switch.
+  it('keeps config.json at 0600 after a model switch, even though it started at the fixture\'s default mode', async () => {
+    const port = await startRunner();
+
+    await postChannelMessage(port, chatId, '/model opus', 'discord');
+    await waitForForward();
+
+    expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+  }, 15000);
+
   it('restarts the running session so the new model actually takes effect', async () => {
     // setModel only rewrites config. The session process was spawned with the
     // old model on its command line, so without a restart "Model set to X" is

--- a/tests/unit/model-picker-commands.test.ts
+++ b/tests/unit/model-picker-commands.test.ts
@@ -210,6 +210,21 @@ describe('AgentRunner — /models and /model on Discord and LINE (issue #409)', 
     expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
   }, 15000);
 
+  // #460 (independent review, round 3): persistModelToConfig() writes to a
+  // FIXED tmp path (`config.json.tmp`), not a unique one — writeFileSync's
+  // `mode` option is silently ignored when that path already exists (e.g.
+  // left behind by a prior crashed write), so an explicit chmodSync is
+  // required after the write, not just the mode option on it.
+  it('still ends up at 0600 even when a stale .tmp file from a prior crashed write is already sitting at the fixed tmp path', async () => {
+    fs.writeFileSync(configPath + '.tmp', 'stale leftover', { mode: 0o644 });
+
+    const port = await startRunner();
+    await postChannelMessage(port, chatId, '/model opus', 'discord');
+    await waitForForward();
+
+    expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+  }, 15000);
+
   it('restarts the running session so the new model actually takes effect', async () => {
     // setModel only rewrites config. The session process was spawned with the
     // old model on its command line, so without a restart "Model set to X" is

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -317,6 +317,38 @@ describe('SessionProcess', () => {
     expect(fs.existsSync(sessionDir)).toBe(false);
   });
 
+  // Independent-review finding: the directory must survive the up-to-10s
+  // graceful-shutdown window, not disappear the instant SIGTERM is sent —
+  // the still-alive subprocess (or a still-running container bind-mounting
+  // this path) could still need it right up until it actually exits.
+  it("#460: stop() does not remove the session directory until the subprocess has actually exited", async () => {
+    const sp = makeSp('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+    const child = lastProcess!;
+
+    const sessionDir = path.join(agentConfig.workspace, '.sessions', 'chat:111');
+    expect(fs.existsSync(sessionDir)).toBe(true);
+
+    // Don't auto-emit 'exit' on kill — simulate a subprocess still mid-shutdown.
+    child.kill = jest.fn((_signal?: string) => {
+      child.killed = true;
+      return true;
+    });
+
+    const stopPromise = sp.stop();
+    // Let stop()'s own awaits (restartWatcher.close(), etc.) settle up to the
+    // point it calls kill(), without letting a real 10s timer elapse.
+    await new Promise((r) => setImmediate(r));
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(fs.existsSync(sessionDir)).toBe(true); // still there — process hasn't exited yet
+
+    child.emit('exit', 0, 'SIGTERM');
+    await stopPromise;
+
+    expect(fs.existsSync(sessionDir)).toBe(false);
+  });
+
   // --------------------------------------------------------------------------
   // U-SP-06: No MCP config for api source
   // --------------------------------------------------------------------------

--- a/tests/unit/session-process.test.ts
+++ b/tests/unit/session-process.test.ts
@@ -302,6 +302,22 @@ describe('SessionProcess', () => {
   });
 
   // --------------------------------------------------------------------------
+  // #460: mcp-config.json holds fully-substituted secrets (bot tokens,
+  // GATEWAY_API_KEY) and must not outlive the session that needed it.
+  // --------------------------------------------------------------------------
+  it('#460: stop() removes the session directory, deleting mcp-config.json with it', async () => {
+    const sp = makeSp('chat:111', 'telegram', agentConfig, gatewayConfig, sessionStore);
+    await sp.start();
+
+    const sessionDir = path.join(agentConfig.workspace, '.sessions', 'chat:111');
+    expect(fs.existsSync(sessionDir)).toBe(true);
+
+    await sp.stop();
+
+    expect(fs.existsSync(sessionDir)).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
   // U-SP-06: No MCP config for api source
   // --------------------------------------------------------------------------
   it('U-SP-06: No MCP config written for api source', async () => {


### PR DESCRIPTION
## Summary
Fixes three independent, pre-existing defects in how the gateway persists secrets to disk — all found while reviewing an unrelated PR (#458), none caused by it:

- **A.** `~/.claude-gateway/` is created `0755` (world-traversable).
- **B.** `config.json` is created `0600` but silently downgraded to `0644` by every subsequent writer.
- **C.** `<workspace>/.sessions/<sessionId>/mcp-config.json` holds fully-substituted secrets and nothing ever removes it.

## Related Issue
Closes #460

## Changes Made

**A — `src/config/bootstrap.ts`**: `mkdirSync` for the config directory now passes `mode: 0o700` instead of defaulting to `0755`.

**B — six write sites named in the issue, four of which exist on `main`** (the fifth, `src/connectors/custom-connectors-store.ts`, belongs to the still-open, unmerged `#458` branch and does not exist here — noted in the commit, not fixed in this PR since there's nothing on `main` to fix):
- `src/api/router.ts` (`writeAgentsToConfigImpl`) — tmp write now passes `mode: 0o600`.
- `src/apps/agent-manager.ts` (`writeConfig`) — same, plus its own `mkdirSync` now passes `mode: 0o700` for defense-in-depth.
- `src/agent/runner.ts` (`persistModelToConfig`) — same.
- `src/config/migrator.ts` (`applyMigration`) — tmp write now passes `mode: 0o600`; the `.bak` backup (`copyFileSync`, which only preserves whatever mode the source already had) is now explicitly `chmod`'d to `0o600` too.
- `src/config/loader.ts` (`loadConfig`) — self-heals a `config.json` found wider than `0600` on every load (boot and every reload), not just once, so an install that never writes config again doesn't stay downgraded forever. Best-effort: a chmod failure never blocks loading an otherwise-valid config.

**C — session secrets never cleaned up**:
- `src/session/process.ts` (`SessionProcess.stop()`) — now removes `<workspace>/.sessions/<sessionId>/` alongside the restart-signal and typing-marker cleanup it already does. Recreated automatically on the next spawn, so this is safe across restarts.
- `src/agent/runner.ts` (`AgentRunner.start()`) — new `sweepStaleSessionDirs()` removes any `.sessions/<id>/` leftover from a hard kill (SIGKILL, crash, host reboot) that skipped `stop()`'s own cleanup. Checked against currently-live sessions (`this.sessions`), not assumed safe purely by call-timing.

## Testing
Every regression test proven to fail on the pre-fix code (temporarily reverting the fix, confirming red, then restoring) — done for: the directory mode (A), a representative config-write site (B, `router.ts`), `SessionProcess.stop()`'s directory removal (C), and `AgentRunner.start()`'s sweep (C).

- `npm run typecheck`: pass
- `npm test`: 237 suites / 4467 tests pass
