### PR TITLE
fix(image): authoritative model note, mirroring the ref-selection pattern

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1284,13 +1284,24 @@ export class AgentRunner extends EventEmitter {
     ].filter(Boolean);
     const refs = (p.image_refs ?? []).filter((r) => typeof r === 'string' && r.trim().length > 0);
     if (!attrs.length && !refs.length) return '';
+    // Make the model authoritative, mirroring the explicit-selection wording used
+    // for reference images below. The composer dropdown is the user's explicit
+    // choice, but the generate_image schema lets the agent pick its own model; when
+    // the model isn't nailed down the agent falls back to action="list" and
+    // self-selects a different one (the composer selection is then silently ignored).
+    const modelNote = p.model
+      ? `The user explicitly SELECTED model="${AgentRunner.escapeXmlAttr(p.model)}" in the composer. ` +
+        `Call generate_image with that exact model — do NOT call action="list" to second-guess an ` +
+        `explicit selection or substitute a different model.\n`
+      : '';
     if (!refs.length) {
       return (
         `<image-params ${attrs.join(' ')} />\n` +
         `The user selected the image-generation options above in the composer. When the request ` +
         `involves creating or editing an image, call the generate_image tool (action="generate") ` +
         `using these values (pass image_ref as the "image" argument for image-to-image), then ` +
-        `deliver the returned image with your reply tool.\n`
+        `deliver the returned image with your reply tool.\n` +
+        modelNote
       );
     }
     // Explicitly selected reference images (#73). Rendered as nested elements so a
@@ -1308,6 +1319,7 @@ export class AgentRunner extends EventEmitter {
       `The user selected the image-generation options above in the composer. When the request ` +
       `involves creating or editing an image, call the generate_image tool (action="generate") ` +
       `using these values, then deliver the returned image with your reply tool.\n` +
+      modelNote +
       `The user explicitly SELECTED the reference image(s) listed above in the composer, in this order. ` +
       `${passInstruction} Do NOT reinterpret which images they are, do NOT call list_refs to ` +
       `second-guess an explicit selection, and do not drop any of them. ` +

--- a/tests/unit/image-refs-wire.test.ts
+++ b/tests/unit/image-refs-wire.test.ts
@@ -145,14 +145,20 @@ describe('image_params.image_refs validation (#73)', () => {
 });
 
 describe('buildImageParamsNote with image_refs (#73)', () => {
+  const MODEL_NOTE =
+    'The user explicitly SELECTED model="gpt-image" in the composer. ' +
+    'Call generate_image with that exact model — do NOT call action="list" to second-guess an ' +
+    'explicit selection or substitute a different model.\n';
+
   const LEGACY_NOTE =
     '<image-params model="gpt-image" quality="high" />\n' +
     'The user selected the image-generation options above in the composer. When the request ' +
     'involves creating or editing an image, call the generate_image tool (action="generate") ' +
     'using these values (pass image_ref as the "image" argument for image-to-image), then ' +
-    'deliver the returned image with your reply tool.\n';
+    'deliver the returned image with your reply tool.\n' +
+    MODEL_NOTE;
 
-  it('0 refs → legacy self-closing output is unchanged', () => {
+  it('0 refs → legacy self-closing output, plus the authoritative model note', () => {
     expect(buildNote({ model: 'gpt-image', quality: 'high' })).toBe(LEGACY_NOTE);
     expect(buildNote({ model: 'gpt-image', quality: 'high', image_refs: [] })).toBe(LEGACY_NOTE);
   });
@@ -164,8 +170,16 @@ describe('buildImageParamsNote with image_refs (#73)', () => {
         'The user selected the image-generation options above in the composer. When the request ' +
         'involves creating or editing an image, call the generate_image tool (action="generate") ' +
         'using these values (pass image_ref as the "image" argument for image-to-image), then ' +
-        'deliver the returned image with your reply tool.\n',
+        'deliver the returned image with your reply tool.\n' +
+        MODEL_NOTE,
     );
+  });
+
+  it('no model → no authoritative model note (only refs/values wording)', () => {
+    // The model note is gated on p.model; a refs-only send must not fabricate one.
+    const note = buildNote({ quality: 'high' });
+    expect(note).not.toContain('explicitly SELECTED model=');
+    expect(note).not.toContain('substitute a different model');
   });
 
   it('returns empty string when nothing usable is present', () => {
@@ -200,6 +214,7 @@ describe('buildImageParamsNote with image_refs (#73)', () => {
         'The user selected the image-generation options above in the composer. When the request ' +
         'involves creating or editing an image, call the generate_image tool (action="generate") ' +
         'using these values, then deliver the returned image with your reply tool.\n' +
+        MODEL_NOTE +
         'The user explicitly SELECTED the reference image(s) listed above in the composer, in this order. ' +
         'Pass all 3 refs as the "images" argument of generate_image, in the same order. ' +
         'Do NOT reinterpret which images they are, do NOT call list_refs to ' +


### PR DESCRIPTION
## Problem
The composer image-model dropdown selection is injected into the agent's message via `buildImageParamsNote`. The wording was **advisory** and the `generate_image` MCP tool has **no default model**, so when the model wasn't nailed down the agent fell back to `action="list"` and self-selected a different model — the dropdown choice was silently ignored.

## Change (follows the existing pattern)
`buildImageParamsNote` already makes the *reference-image* selection authoritative ("The user explicitly SELECTED … do NOT call `list_refs` to second-guess an explicit selection"). This mirrors that exact pattern for the **model**, gated on `p.model` and appended to both the no-refs and refs branches; the original sentences are otherwise unchanged:

> The user explicitly SELECTED model="<M>" in the composer. Call generate_image with that exact model — do NOT call `action="list"` to second-guess an explicit selection or substitute a different model.

Runtime half of a two-repo fix — the getpod web side (Crown-Labs/getpod#2662) now sends `image_params` every turn a model is selected, so this note is present whenever it's relevant. The in-pod agent is a long-lived process whose image tool can't read per-turn session state, so the injected note is the only per-turn channel — a tool-level default isn't feasible.

## Verification (no PR CI in this repo — release workflow runs on tags only)
- `tsc --noEmit`: clean.
- `image-refs-wire.test.ts` (27, incl. a new no-model gating case), `image-generate-cancel` + `image-list-refs` (20): all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)