### PR TITLE
feat(mcp): generate_video tool — in-chat video generation

### DIFF
--- a/mcp/instructions.ts
+++ b/mcp/instructions.ts
@@ -19,7 +19,16 @@ const IMAGE_INSTRUCTION = [
   '• NEVER tell the user to install an app or set up an MCP server for images.',
 ].join('\n');
 
-export function buildChannelInstructions(imageEnabled: boolean): string {
+const VIDEO_INSTRUCTION = [
+  'VIDEO GENERATION IS BUILT IN — you can create short video clips yourself; no app install or API-key setup is needed.',
+  '• To make ANY video you MUST use the generate_video tool. When the user asks to create / generate / make / animate a video or clip, call generate_video with action="list" to see the models, then action="generate".',
+  '• Video generation legitimately takes MINUTES. A "running" status (including the "still generating, call again with action=status" note) is normal, not stuck — keep polling with action="status" and the SAME task_id until it resolves to done/failed. Do NOT start a second generate for the same request while one is still running (you would pay for two clips).',
+  '• ONE clip, sent ONCE, then STOP: as soon as a generate SUCCEEDS, deliver that single mp4 with your reply tool exactly ONE time (files: ["/abs/path.mp4"]) and briefly mention the model. Do NOT re-generate or resend.',
+  '• IMAGE-TO-VIDEO: to animate an existing image, pass it in "image". If the user points at an earlier image ("animate image 2"), call action="list_refs" FIRST and use that item\'s "ref" — never count images from your own memory.',
+  '• If generation fails or no video model is available, tell the user PLAINLY — do NOT invent app-install / MCP-setup steps, and do NOT pretend a video was created.',
+].join('\n');
+
+export function buildChannelInstructions(imageEnabled: boolean, videoEnabled = false): string {
   const lines = [
     'The sender reads Telegram, not this session. Anything you want them to see must go through the reply tool — your transcript output never reaches their chat.',
     '',
@@ -36,6 +45,10 @@ export function buildChannelInstructions(imageEnabled: boolean): string {
 
   if (imageEnabled) {
     lines.push('', IMAGE_INSTRUCTION);
+  }
+
+  if (videoEnabled) {
+    lines.push('', VIDEO_INSTRUCTION);
   }
 
   return lines.join('\n');

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -21,6 +21,7 @@ import { SkillsModule } from './tools/skills/module';
 import { AgentModule } from './tools/agent/module';
 import { BrowserModule } from './tools/browser/module';
 import { ImageModule } from './tools/image/module';
+import { VideoModule } from './tools/video/module';
 import { ShareFileModule } from './tools/share-file/module';
 import { AppsModule } from './tools/apps/module';
 import { ApiModule } from './tools/api/module';
@@ -46,6 +47,7 @@ const modules: AnyModule[] = [
   new AgentModule(),
   new BrowserModule(),
   new ImageModule(),
+  new VideoModule(),
   new ShareFileModule(),
   new AppsModule(),
   new ApiModule(),
@@ -85,6 +87,7 @@ for (const mod of modules) {
 const shutdownController = new AbortController();
 
 const imageEnabled = visibleTools.some((t) => t.name === 'generate_image');
+const videoEnabled = visibleTools.some((t) => t.name === 'generate_video');
 
 const mcp = new Server(
   { name: 'gateway', version: '1.0.0' },
@@ -96,7 +99,7 @@ const mcp = new Server(
         'claude/channel/permission': {},
       },
     },
-    instructions: buildChannelInstructions(imageEnabled),
+    instructions: buildChannelInstructions(imageEnabled, videoEnabled),
   },
 );
 
@@ -136,10 +139,13 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
 await mcp.connect(new StdioServerTransport());
 
 // Graceful shutdown — used by stdin-close, SIGINT, and SIGTERM paths.
-// Awaits any in-flight image cancel (E3) before exiting so the provider
-// actually stops generating when the user presses Stop, rather than the
+// Awaits any in-flight cancel (E3) on the media modules before exiting so the
+// provider actually stops generating when the user presses Stop, rather than the
 // process dying mid-request and the cancel call never reaching the server.
-const imageModuleRef = modules.find((m) => m.id === 'image') as { drainCancel?: () => Promise<void> } | undefined;
+const drainableModules = modules.filter(
+  (m): m is AnyModule & { drainCancel: () => Promise<void> } =>
+    typeof (m as { drainCancel?: unknown }).drainCancel === 'function',
+);
 let shuttingDown = false;
 function shutdown(): void {
   if (shuttingDown) return;
@@ -156,7 +162,7 @@ function shutdown(): void {
   // Give the event loop one tick so the poll loop's sleep() onAbort listener
   // fires and cancelledResult() sets activeCancelPromise before we try to drain it.
   setImmediate(async () => {
-    try { await imageModuleRef?.drainCancel?.(); } catch { /* non-fatal */ }
+    try { await Promise.all(drainableModules.map((m) => m.drainCancel())); } catch { /* non-fatal */ }
     clearTimeout(forceExit);
     process.exit(0);
   });

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -14,6 +14,7 @@ import {
   type ShareRef,
   type ShareItem,
 } from '../shared/share-client';
+import { sleep, sanitize, readCapped, baseUrlIsSecure } from '../shared/media';
 
 /**
  * Image-generation tool module (#184, Track B).
@@ -661,7 +662,7 @@ export class ImageModule implements ToolModule {
           await assertSafeImageUrl(item);
           const res = await fetch(item, { signal: AbortSignal.timeout(30_000), redirect: 'error' });
           if (!res.ok) throw new Error(`download image failed: HTTP ${res.status}`);
-          buf = await readCapped(res, DOWNLOAD_MAX_BYTES);
+          buf = await readCapped(res, DOWNLOAD_MAX_BYTES, 'image');
         } else {
           // Base64 bytes (openai / gemini / stability / hf) — tolerate a data: URI
           // wrapper as well as raw base64.
@@ -791,25 +792,6 @@ export class ImageModule implements ToolModule {
   }
 }
 
-// Resolves early (without rejecting) on abort — the poll loop re-checks
-// signal.aborted itself right after, so this only needs to shorten the wait.
-// The abort listener is removed when the timer fires normally: sleep() is called
-// once per poll iteration against the SAME long-lived signal (up to ~75 times for
-// the default 150s/2s budget), so leaving { once: true } listeners around on the
-// non-abort path would pile them onto that one signal and trip Node's
-// MaxListenersExceededWarning.
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((r) => {
-    const onAbort = () => { clearTimeout(t); r(); };
-    const t = setTimeout(() => { signal?.removeEventListener('abort', onAbort); r(); }, ms);
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
-
-function sanitize(s: string): string {
-  return s.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 48) || 'default';
-}
-
 // SSRF guard for provider image URLs. Require https, then resolve the host and
 // reject if ANY resolved address is private / loopback / link-local / metadata —
 // so a compromised provider response can't make the gateway fetch internal or
@@ -873,29 +855,6 @@ function isBlockedAddress(ip: string): boolean {
   return true; // not a valid IP → block
 }
 
-// Read a response body into a Buffer with a hard byte ceiling: reject early on a
-// too-large Content-Length, and stream-count actual bytes so a chunked response
-// without Content-Length can't blow past the cap (OOM guard).
-async function readCapped(res: Response, cap: number): Promise<Buffer> {
-  const declared = Number(res.headers.get('content-length'));
-  if (Number.isFinite(declared) && declared > cap) {
-    throw new Error(`download image too large: ${declared} bytes (max ${cap})`);
-  }
-  if (!res.body) {
-    const ab = await res.arrayBuffer();
-    if (ab.byteLength > cap) throw new Error(`download image too large (max ${cap} bytes)`);
-    return Buffer.from(ab);
-  }
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
-    total += chunk.length;
-    if (total > cap) throw new Error(`download image exceeded ${cap} bytes`);
-    chunks.push(Buffer.from(chunk));
-  }
-  return Buffer.concat(chunks);
-}
-
 function defaultCodeForStatus(status: number): string {
   switch (status) {
     case 400: return 'invalid_model';
@@ -921,33 +880,6 @@ function detectImageExt(buf: Buffer): string | null {
   if (buf.length >= 12 && buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
       buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50) return 'webp';
   return null;
-}
-
-// https is required for a PUBLIC image endpoint (the Bearer proxy_secret is sent on
-// every call); http is tolerated only for a local/internal host — a trusted hop such
-// as host.docker.internal in dev, where cleartext never leaves the machine/network.
-function baseUrlIsSecure(raw: string): boolean {
-  if (!raw) return false;
-  let u: URL;
-  try {
-    u = new URL(raw);
-  } catch {
-    return false;
-  }
-  if (u.protocol === 'https:') return true;
-  if (u.protocol !== 'http:') return false;
-  const h = u.hostname.toLowerCase();
-  return (
-    h === 'localhost' ||
-    h === 'host.docker.internal' ||
-    h.endsWith('.internal') ||
-    h.endsWith('.local') ||
-    /^127\./.test(h) ||
-    h === '::1' ||
-    /^10\./.test(h) ||
-    /^192\.168\./.test(h) ||
-    /^172\.(1[6-9]|2[0-9]|3[01])\./.test(h)
-  );
 }
 
 const imageToolDefs: McpToolDefinition[] = [

--- a/mcp/tools/shared/media.ts
+++ b/mcp/tools/shared/media.ts
@@ -1,0 +1,76 @@
+/**
+ * Media-download/poll helpers shared by the image and video MCP tool modules.
+ * Self-contained on purpose, like share-client.ts: mcp/** ships as source
+ * without src/**, so this module must not import from src/ (see
+ * tests/unit/mcp-no-src-imports.test.ts).
+ */
+
+// Resolves early (without rejecting) on abort — a poll loop re-checks
+// signal.aborted itself right after, so this only needs to shorten the wait.
+// The abort listener is removed when the timer fires normally: sleep() is called
+// once per poll iteration against the SAME long-lived signal (up to dozens of
+// times for a multi-minute poll budget), so leaving { once: true } listeners
+// around on the non-abort path would pile them onto that one signal and trip
+// Node's MaxListenersExceededWarning.
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((r) => {
+    const onAbort = () => { clearTimeout(t); r(); };
+    const t = setTimeout(() => { signal?.removeEventListener('abort', onAbort); r(); }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export function sanitize(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 48) || 'default';
+}
+
+// Read a response body into a Buffer with a hard byte ceiling: reject early on a
+// too-large Content-Length, and stream-count actual bytes so a chunked response
+// without Content-Length can't blow past the cap (OOM guard). `label` (e.g.
+// "image"/"video") only shapes the error message.
+export async function readCapped(res: Response, cap: number, label = 'file'): Promise<Buffer> {
+  const declared = Number(res.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > cap) {
+    throw new Error(`download ${label} too large: ${declared} bytes (max ${cap})`);
+  }
+  if (!res.body) {
+    const ab = await res.arrayBuffer();
+    if (ab.byteLength > cap) throw new Error(`download ${label} too large (max ${cap} bytes)`);
+    return Buffer.from(ab);
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+    total += chunk.length;
+    if (total > cap) throw new Error(`download ${label} exceeded ${cap} bytes`);
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+// https is required for a PUBLIC endpoint (a Bearer proxy_secret is sent on
+// every call); http is tolerated only for a local/internal host — a trusted hop
+// such as host.docker.internal in dev, where cleartext never leaves the network.
+export function baseUrlIsSecure(raw: string): boolean {
+  if (!raw) return false;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (u.protocol === 'https:') return true;
+  if (u.protocol !== 'http:') return false;
+  const h = u.hostname.toLowerCase();
+  return (
+    h === 'localhost' ||
+    h === 'host.docker.internal' ||
+    h.endsWith('.internal') ||
+    h.endsWith('.local') ||
+    /^127\./.test(h) ||
+    h === '::1' ||
+    /^10\./.test(h) ||
+    /^192\.168\./.test(h) ||
+    /^172\.(1[6-9]|2[0-9]|3[01])\./.test(h)
+  );
+}

--- a/mcp/tools/video/module.ts
+++ b/mcp/tools/video/module.ts
@@ -11,6 +11,7 @@ import {
   type ShareRef,
   type ShareItem,
 } from '../shared/share-client';
+import { sleep, sanitize, readCapped, baseUrlIsSecure } from '../shared/media';
 
 /**
  * Video-generation tool module — the moving-picture parallel of the image module
@@ -523,7 +524,7 @@ export class VideoModule implements ToolModule {
         const body = await res.text().catch(() => '');
         return this.mapHttpError(res.status, body);
       }
-      const buf = await readCapped(res, DOWNLOAD_MAX_BYTES);
+      const buf = await readCapped(res, DOWNLOAD_MAX_BYTES, 'video');
       if (!isMp4(buf)) {
         // Not a recognized mp4 — reject instead of saving garbage (e.g. an api
         // error page that slipped through with a 200).
@@ -606,43 +607,6 @@ export class VideoModule implements ToolModule {
   }
 }
 
-// Resolves early (without rejecting) on abort — the poll loop re-checks
-// signal.aborted itself right after, so this only needs to shorten the wait.
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((r) => {
-    const onAbort = () => { clearTimeout(t); r(); };
-    const t = setTimeout(() => { signal?.removeEventListener('abort', onAbort); r(); }, ms);
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
-
-function sanitize(s: string): string {
-  return s.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 48) || 'default';
-}
-
-// Read a response body into a Buffer with a hard byte ceiling: reject early on a
-// too-large Content-Length, and stream-count actual bytes so a chunked response
-// without Content-Length can't blow past the cap (OOM guard).
-async function readCapped(res: Response, cap: number): Promise<Buffer> {
-  const declared = Number(res.headers.get('content-length'));
-  if (Number.isFinite(declared) && declared > cap) {
-    throw new Error(`download video too large: ${declared} bytes (max ${cap})`);
-  }
-  if (!res.body) {
-    const ab = await res.arrayBuffer();
-    if (ab.byteLength > cap) throw new Error(`download video too large (max ${cap} bytes)`);
-    return Buffer.from(ab);
-  }
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
-    total += chunk.length;
-    if (total > cap) throw new Error(`download video exceeded ${cap} bytes`);
-    chunks.push(Buffer.from(chunk));
-  }
-  return Buffer.concat(chunks);
-}
-
 function defaultCodeForStatus(status: number): string {
   switch (status) {
     case 400: return 'invalid_model';
@@ -665,29 +629,6 @@ function isMp4(buf: Buffer): boolean {
 // https is required for a PUBLIC api endpoint (the Bearer proxy_secret is sent on
 // every call); http is tolerated only for a local/internal host — a trusted hop
 // such as host.docker.internal in dev, where cleartext never leaves the network.
-function baseUrlIsSecure(raw: string): boolean {
-  if (!raw) return false;
-  let u: URL;
-  try {
-    u = new URL(raw);
-  } catch {
-    return false;
-  }
-  if (u.protocol === 'https:') return true;
-  if (u.protocol !== 'http:') return false;
-  const h = u.hostname.toLowerCase();
-  return (
-    h === 'localhost' ||
-    h === 'host.docker.internal' ||
-    h.endsWith('.internal') ||
-    h.endsWith('.local') ||
-    /^127\./.test(h) ||
-    h === '::1' ||
-    /^10\./.test(h) ||
-    /^192\.168\./.test(h) ||
-    /^172\.(1[6-9]|2[0-9]|3[01])\./.test(h)
-  );
-}
 
 const videoToolDefs: McpToolDefinition[] = [
   {
@@ -709,8 +650,7 @@ const videoToolDefs: McpToolDefinition[] = [
       'SOURCE IMAGE (image-to-video): to animate an existing image, pass its media path in "image" (a media path, an "artifact:<id>" ref, ' +
       'or an https URL). When the user points at an image from earlier in the chat ("animate image 2", "the first picture"), call ' +
       'action="list_refs" FIRST and pass the chosen item\'s "ref" — never count images from your own memory of the conversation. ' +
-      'Omit "image" for pure text-to-video (the service generates its own source frame from the prompt). ' +
-      'When the user selected options in the composer (a <video-params .../> tag in the turn), honor those values.',
+      'Omit "image" for pure text-to-video (the service generates its own source frame from the prompt).',
     inputSchema: {
       type: 'object',
       properties: {

--- a/mcp/tools/video/module.ts
+++ b/mcp/tools/video/module.ts
@@ -1,0 +1,736 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ToolModule, McpToolDefinition, McpToolResult, ToolVisibility } from '../../types';
+import {
+  ShareClientError,
+  createShares,
+  listSessionImages,
+  revokeSharesBestEffort,
+  shareBridgeEnabled,
+  type ShareRef,
+  type ShareItem,
+} from '../shared/share-client';
+
+/**
+ * Video-generation tool module — the moving-picture parallel of the image module
+ * (tools/image/module.ts), sharing the same env-configured endpoint and M2M
+ * `Authorization: Bearer <proxy_secret>` seam. A single `generate_video` tool with
+ * generate | status | list | list_refs actions, results written into the session
+ * media dir (like generate_image) so the existing reply tools deliver them.
+ *
+ * Flow (api contract, mirrors E1/E2 of the image path):
+ *   generate → POST /v1/videos/generations (202 { task_id })
+ *   → poll GET /v1/videos/jobs/:id → on done the job carries a `video_url`
+ *   (a stable, M2M-authed api path /v1/videos/files/:id.mp4). We download that
+ *   clip WITH the proxy secret — it is our own trusted api host, NOT an untrusted
+ *   provider URL — and write the mp4 into GATEWAY_SESSION_MEDIA_DIR.
+ *
+ * Key differences from the image tool, all driven by the medium:
+ *   - one clip per request (no `n`), so no batch delivery;
+ *   - the result is always a large binary the api streams back over an authed
+ *     path — never base64-in-JSON — so `deliver()` re-fetches by task_id with the
+ *     Bearer secret instead of running the image path's public-URL SSRF screen;
+ *   - a longer default poll budget (video generation legitimately runs minutes).
+ *   - `image` is a single optional SOURCE FRAME for image-to-video (share-bridge
+ *     minted to a public URL the provider fetches), not a batch of edit refs, and
+ *     there is no `continue_from` resume concept.
+ */
+
+const DEFAULT_POLL_INTERVAL_MS = 3000;
+const DEFAULT_POLL_TIMEOUT_MS = 300_000; // 5 min — video runs longer than an image
+const REQUEST_TIMEOUT_MS = 30_000;
+// A finished clip is a few MB, but bound the download so a hung/oversized upstream
+// can't OOM the tool. The api streams it off the microservice's disk.
+const DOWNLOAD_MAX_BYTES = 200 * 1024 * 1024; // 200 MB
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+
+/** Human-readable guidance per api error code (mirrors the video api taxonomy). */
+const ERROR_HINTS: Record<string, string> = {
+  invalid_model: 'The model id is not recognised. Call generate_video with action="list" to see valid video models.',
+  model_not_video: 'That model is not a video model. Use action="list" to pick a video-capable model.',
+  missing_prompt: 'A non-empty prompt is required to generate a video.',
+  unsupported_duration: 'The requested duration is out of range for this model. Try a shorter clip.',
+  unauthorized: 'The gateway is not authorised to call the video service (check the proxy secret).',
+  insufficient_credit: 'Not enough daily credit to generate this video on the managed pool. Try later.',
+  not_pool_eligible: 'That model is not pool-eligible for video generation. Pick a pool-eligible video model (action="list").',
+  no_credential: 'No provider key is available for video generation.',
+  rate_limited: 'Video generation is rate-limited right now. Wait a moment and try again.',
+  no_supply: 'No managed provider key is available for this provider right now. Try again later.',
+  provider_error: 'The video provider returned an error. Try again or adjust the prompt.',
+  provider_timeout: 'The video provider timed out. Try again.',
+  content_policy: 'The prompt was rejected by the provider content policy. Rephrase and try again.',
+  job_not_found: 'That video job was not found (it may have expired or belongs to another user).',
+  result_expired: 'The generated video expired before it was fetched (credit was already spent). Generate it again.',
+};
+
+type JobResponse = {
+  task_id?: string;
+  status?: 'queued' | 'running' | 'done' | 'failed';
+  // What actually generated (or is generating) the clip — echoed on every poll so
+  // a status re-poll in a LATER turn (no longer holding the original "model" arg)
+  // can still recover them instead of falling back to "unknown".
+  provider?: string;
+  model?: string;
+  provider_task_id?: string;
+  byok?: boolean;
+  cost?: number;
+  // Stable, M2M-authed api path (/v1/videos/files/:id.mp4) to the finished clip.
+  // Present only on a done job.
+  video_url?: string;
+  error?: { code?: string; message?: string };
+};
+
+export class VideoModule implements ToolModule {
+  id = 'video';
+  toolVisibility: ToolVisibility = 'all-configured';
+
+  isEnabled(): boolean {
+    // Enabled when the api endpoint is configured (same resolution as the image
+    // tool — video shares the getpod api) and not explicitly turned off.
+    if (!this.baseUrl() || process.env.VIDEO_DISABLED === 'true') return false;
+    // The Bearer proxy_secret rides every call — refuse a cleartext http URL to a
+    // PUBLIC host (that would leak the secret). http to a local/internal host is a
+    // trusted hop (e.g. host.docker.internal in dev) and stays allowed.
+    if (!baseUrlIsSecure(this.baseUrl())) {
+      if (!this.warnedInsecureUrl) {
+        this.warnedInsecureUrl = true;
+        console.error(
+          `[video] ANTHROPIC_BASE_URL is http to a non-local host — refusing to send the proxy secret in cleartext. Use https (or a local/internal host).`
+        );
+      }
+      return false;
+    }
+    return true;
+  }
+
+  private warnedInsecureUrl = false;
+
+  getTools(): McpToolDefinition[] {
+    return videoToolDefs;
+  }
+
+  async handleTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<McpToolResult> {
+    if (name !== 'generate_video') {
+      return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+    }
+    const action = typeof args.action === 'string' ? args.action : 'generate';
+    switch (action) {
+      case 'generate':
+        // Only "generate" gets the signal — it's the one action with a multi-second
+        // poll loop worth reacting to a Stop mid-flight. status/list/list_refs are
+        // single bounded requests already.
+        return this.handleGenerate(args, signal);
+      case 'status':
+        return this.handleStatus(args);
+      case 'list':
+        return this.handleList();
+      case 'list_refs':
+        return this.handleListRefs();
+      default:
+        return {
+          content: [{ type: 'text', text: `generate_video: unknown action "${action}" (expected generate | status | list | list_refs)` }],
+          isError: true,
+        };
+    }
+  }
+
+  // ── config ────────────────────────────────────────────────────────────────
+  // Identical resolution to the image tool: video targets the same getpod api.
+
+  private baseUrl(): string {
+    const raw =
+      process.env.VIDEO_BASE_URL ||
+      process.env.IMAGE_BASE_URL ||
+      process.env.ANTHROPIC_BASE_URL ||
+      this.settingsEnv('ANTHROPIC_BASE_URL');
+    return raw.replace(/\/+$/, '');
+  }
+
+  private authToken(): string {
+    return (
+      process.env.VIDEO_API_KEY ||
+      process.env.IMAGE_API_KEY ||
+      process.env.ANTHROPIC_AUTH_TOKEN ||
+      this.settingsEnv('ANTHROPIC_AUTH_TOKEN') ||
+      this.settingsEnv('CLAUDE_CODE_OAUTH_TOKEN')
+    );
+  }
+
+  // Parsed `env` block of the CLI config, read once per instance.
+  private settingsEnvCache?: Record<string, unknown> | null;
+
+  private settingsEnv(key: string): string {
+    if (this.settingsEnvCache === undefined) {
+      try {
+        const dir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+        this.settingsEnvCache =
+          JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf8'))?.env ?? null;
+      } catch {
+        this.settingsEnvCache = null;
+      }
+    }
+    const v = this.settingsEnvCache?.[key];
+    return typeof v === 'string' ? v : '';
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = this.authToken();
+    if (token) h['Authorization'] = `Bearer ${token}`;
+    const agentId = process.env.GATEWAY_AGENT_ID;
+    const sessionId = process.env.GATEWAY_SESSION_ID;
+    if (agentId) h['X-Agent-Id'] = agentId;
+    if (sessionId) h['X-Session-Id'] = sessionId;
+    return h;
+  }
+
+  // ── actions ───────────────────────────────────────────────────────────────
+
+  private async handleList(): Promise<McpToolResult> {
+    const url = `${this.baseUrl()}/v1/models?kind=video`;
+    let res: Response;
+    try {
+      res = await fetch(url, { method: 'GET', headers: this.headers(), signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+    } catch (err) {
+      return this.unavailable(err);
+    }
+    const body = await res.text().catch(() => '');
+    if (!res.ok) return this.mapHttpError(res.status, body);
+    return { content: [{ type: 'text', text: body || '[]' }] };
+  }
+
+  /**
+   * action="list_refs" — the same ground-truth catalog of this session's images
+   * the image tool exposes. For video it resolves a SOURCE FRAME for
+   * image-to-video ("animate image 2"). Read-only, gated on the share bridge.
+   */
+  private async handleListRefs(): Promise<McpToolResult> {
+    if (!shareBridgeEnabled()) {
+      return {
+        content: [{ type: 'text', text: 'generate_video: list_refs is unavailable (share bridge is not configured).' }],
+        isError: true,
+      };
+    }
+    let items;
+    try {
+      items = await listSessionImages();
+    } catch (err) {
+      if (err instanceof ShareClientError) {
+        return { content: [{ type: 'text', text: `generate_video: ${err.code}: ${err.message}` }], isError: true };
+      }
+      return {
+        content: [{ type: 'text', text: `generate_video: share service unavailable: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          images: items,
+          note: 'Ground-truth catalog of every image in this session, numbered in order of first appearance ("image 1" = index 1). '
+            + 'To animate one as the source frame, pass its "ref" value in the "image" argument of action="generate". '
+            + 'Do NOT count images from conversation memory. '
+            + 'When the user names an index ("Image 3", "the third image") or attached an image this turn, trust that exactly; '
+            + 'when they refer by content ("the dog picture"), match against each item\'s "desc". '
+            + 'If the reference is ambiguous or the index does not exist, ask the user instead of guessing. '
+            + 'Items with available:false can no longer be used.',
+        }),
+      }],
+    };
+  }
+
+  private async handleGenerate(args: Record<string, unknown>, signal?: AbortSignal): Promise<McpToolResult> {
+    const prompt = typeof args.prompt === 'string' ? args.prompt.trim() : '';
+    const model = typeof args.model === 'string' ? args.model.trim() : '';
+    if (!prompt) {
+      return { content: [{ type: 'text', text: `${ERROR_HINTS.missing_prompt}` }], isError: true };
+    }
+    if (!model) {
+      return { content: [{ type: 'text', text: 'generate_video: "model" is required (use action="list" to see options).' }], isError: true };
+    }
+
+    // Build request body — forward only defined optional fields.
+    const reqBody: Record<string, unknown> = { model, prompt };
+    for (const k of ['resolution', 'aspect_ratio'] as const) {
+      if (typeof args[k] === 'string' && (args[k] as string).length) reqBody[k] = args[k];
+    }
+    if (typeof args.duration === 'number' && args.duration > 0) {
+      reqBody.duration = Math.floor(args.duration);
+    }
+
+    // Optional source frame for image-to-video. With the share bridge on, a local
+    // media path or artifact:<id> is minted to a short-lived public URL the
+    // provider fetches; with the bridge off, it's an exact legacy pass-through.
+    const rawImage = typeof args.image === 'string' && args.image.length ? args.image.trim() : undefined;
+    let mintedShareIds: string[] = [];
+    if (rawImage) {
+      if (shareBridgeEnabled()) {
+        const normalized = await this.normalizeRef(rawImage);
+        if ('error' in normalized) return normalized.error;
+        mintedShareIds = normalized.mintedShareIds;
+        reqBody.image = normalized.url;
+      } else {
+        reqBody.image = rawImage;
+      }
+    }
+
+    // Submit. On an immediate submit failure, best-effort revoke any share URL
+    // minted for this call — the TTL still bounds exposure otherwise.
+    let res: Response;
+    try {
+      res = await fetch(`${this.baseUrl()}/v1/videos/generations`, {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify(reqBody),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      await revokeSharesBestEffort(mintedShareIds);
+      return this.unavailable(err);
+    }
+    const submitText = await res.text().catch(() => '');
+    if (!res.ok) {
+      await revokeSharesBestEffort(mintedShareIds);
+      return this.mapHttpError(res.status, submitText);
+    }
+
+    let submit: JobResponse;
+    try {
+      submit = JSON.parse(submitText) as JobResponse;
+    } catch {
+      await revokeSharesBestEffort(mintedShareIds);
+      return { content: [{ type: 'text', text: 'generate_video: invalid JSON from video service on submit' }], isError: true };
+    }
+    const taskId = submit.task_id;
+    if (!taskId) {
+      await revokeSharesBestEffort(mintedShareIds);
+      return { content: [{ type: 'text', text: 'generate_video: video service did not return a task_id' }], isError: true };
+    }
+
+    // Poll until done/failed, budget exceeded, or the caller cancels (Stop
+    // mid-generation). Checked at the top of every iteration AND inside sleep().
+    const deadline = Date.now() + this.pollTimeoutMs();
+    let last: JobResponse = submit;
+    while (Date.now() < deadline) {
+      if (signal?.aborted) return this.cancelledResult(taskId);
+      await sleep(DEFAULT_POLL_INTERVAL_MS, signal);
+      if (signal?.aborted) return this.cancelledResult(taskId);
+      const polled = await this.fetchJob(taskId, signal);
+      if (polled.__transportError) {
+        if (signal?.aborted) return this.cancelledResult(taskId);
+        continue;
+      }
+      if (polled.httpError) return this.mapHttpError(polled.httpError.status, polled.httpError.body);
+      last = polled.job!;
+      if (last.status === 'done') return await this.deliver(last, taskId, model);
+      if (last.status === 'failed') return this.mapJobError(last);
+    }
+
+    // Still running after the local poll budget — hand the task_id back so the
+    // agent can poll with action="status" (the api keeps the buffered result).
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          status: last.status ?? 'running',
+          task_id: taskId,
+          byok: last.byok ?? submit.byok ?? false,
+          cost: last.cost ?? submit.cost ?? 0,
+          note: 'Video is still generating. Call generate_video again with action="status" and this task_id to fetch the result.',
+        }),
+      }],
+    };
+  }
+
+  private async handleStatus(args: Record<string, unknown>): Promise<McpToolResult> {
+    const taskId = typeof args.task_id === 'string' ? args.task_id.trim() : '';
+    if (!taskId) {
+      return { content: [{ type: 'text', text: 'generate_video: action="status" requires "task_id"' }], isError: true };
+    }
+    const polled = await this.fetchJob(taskId);
+    if (polled.__transportError) return this.unavailable(polled.__transportError);
+    if (polled.httpError) return this.mapHttpError(polled.httpError.status, polled.httpError.body);
+    const job = polled.job!;
+    if (job.status === 'done') return await this.deliver(job, taskId);
+    if (job.status === 'failed') return this.mapJobError(job);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({ status: job.status ?? 'running', task_id: taskId, byok: job.byok ?? false, cost: job.cost ?? 0 }),
+      }],
+    };
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+
+  /**
+   * Normalize a single source-frame reference, preserving legacy pass-through when
+   * the share bridge is off (caller checks that before invoking this):
+   *   https URL     → validate syntax, pass through
+   *   http URL      → reject (requires HTTPS)
+   *   artifact:<id> → resolve+mint via gateway share API
+   *   local path    → validate+mint via gateway share API
+   */
+  private async normalizeRef(
+    raw: string,
+  ): Promise<{ url: string; mintedShareIds: string[] } | { error: McpToolResult }> {
+    const fail = (text: string): { error: McpToolResult } => ({
+      error: { content: [{ type: 'text', text }], isError: true },
+    });
+    const ref = raw.trim();
+    if (/^https:\/\//i.test(ref)) {
+      try {
+        new URL(ref);
+      } catch {
+        return fail('generate_video: reference URL is malformed.');
+      }
+      return { url: ref, mintedShareIds: [] };
+    }
+    if (/^http:\/\//i.test(ref)) {
+      return fail('generate_video: http:// reference URLs are not allowed — use https.');
+    }
+    let shareRef: ShareRef;
+    if (ref.startsWith('artifact:')) {
+      const id = ref.slice('artifact:'.length).trim();
+      if (!id) return fail('generate_video: empty artifact reference.');
+      shareRef = { artifact_id: id };
+    } else {
+      shareRef = { path: ref };
+    }
+    let minted: ShareItem[];
+    try {
+      minted = await createShares([shareRef], { purpose: 'codex_ref' });
+    } catch (err) {
+      if (err instanceof ShareClientError) {
+        if (err.code === 'share_ref_not_found' || err.code === 'image_ref_not_found') {
+          return fail(`generate_video: ${err.code}: the referenced image/artifact does not exist in this session.`);
+        }
+        return fail(`generate_video: ${err.code}: ${err.message}`);
+      }
+      return fail(`generate_video: share service unavailable: ${(err as Error).message}`);
+    }
+    const item = minted[0];
+    if (!item) return fail('generate_video: share service returned no share for the source frame.');
+    // The provider fetches this over HTTPS, so it needs an absolute URL — which the
+    // share API only fills when gateway.publicUrl is configured.
+    if (!item.url) {
+      await revokeSharesBestEffort([item.share_id]);
+      return fail('generate_video: source-frame sharing requires gateway.publicUrl to be configured.');
+    }
+    return { url: item.url, mintedShareIds: [item.share_id] };
+  }
+
+  private pollTimeoutMs(): number {
+    const raw = Number(process.env.VIDEO_POLL_TIMEOUT_MS);
+    return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_POLL_TIMEOUT_MS;
+  }
+
+  /** Best-effort E3 cancel — fires and never throws. */
+  private async cancelJob(taskId: string): Promise<void> {
+    try {
+      await fetch(`${this.baseUrl()}/v1/videos/jobs/${encodeURIComponent(taskId)}/cancel`, {
+        method: 'POST',
+        headers: this.headers(),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch {
+      // non-fatal — the local tool call already reports itself cancelled either way
+    }
+  }
+
+  // Tracks the in-flight cancel call so drainCancel() can await it before the
+  // server process exits (see the image module for the full stdin-close rationale).
+  private activeCancelPromise: Promise<void> | null = null;
+
+  /** Wait for any in-flight E3 cancel to complete. Called by the shutdown handler. */
+  async drainCancel(): Promise<void> {
+    if (this.activeCancelPromise) await this.activeCancelPromise;
+  }
+
+  /** Tool result for a Stop-triggered cancellation, firing the E3 cancel first. */
+  private cancelledResult(taskId: string): McpToolResult {
+    this.activeCancelPromise = this.cancelJob(taskId).finally(() => {
+      this.activeCancelPromise = null;
+    });
+    return {
+      content: [{
+        type: 'text',
+        text: `generate_video: cancelled (task_id ${taskId}).`,
+      }],
+      isError: true,
+    };
+  }
+
+  /** Fetch a job (E2), classifying transport vs HTTP errors so the poller can retry transient ones. */
+  private async fetchJob(taskId: string, signal?: AbortSignal): Promise<{ job?: JobResponse; httpError?: { status: number; body: string }; __transportError?: unknown }> {
+    let res: Response;
+    try {
+      const fetchSignal = signal
+        ? AbortSignal.any([AbortSignal.timeout(REQUEST_TIMEOUT_MS), signal])
+        : AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+      res = await fetch(`${this.baseUrl()}/v1/videos/jobs/${encodeURIComponent(taskId)}`, {
+        method: 'GET',
+        headers: this.headers(),
+        signal: fetchSignal,
+      });
+    } catch (err) {
+      return { __transportError: err };
+    }
+    const text = await res.text().catch(() => '');
+    if (!res.ok) return { httpError: { status: res.status, body: text } };
+    try {
+      return { job: JSON.parse(text) as JobResponse };
+    } catch {
+      return { httpError: { status: res.status, body: 'invalid JSON from video service' } };
+    }
+  }
+
+  /**
+   * Download the finished clip into the session media dir and return its path.
+   *
+   * Unlike the image path, the clip is not base64 in the job JSON — it is streamed
+   * by our OWN api at a stable, M2M-authed path we reconstruct from the task id
+   * (/v1/videos/files/:id.mp4). We fetch it WITH the proxy secret. Because that
+   * host is the same trusted api we just submitted to (not a provider-controlled
+   * URL), the image path's public-address SSRF screen does NOT apply — it would in
+   * fact block our own internal api host. The backstop against garbage is the mp4
+   * magic-byte check below.
+   */
+  // `model` is only known on the generate path (same-turn poll); the
+  // action="status" path re-enters in a later turn without it.
+  private async deliver(job: JobResponse, taskId: string, model?: string): Promise<McpToolResult> {
+    // Reconstruct the file URL from the task id rather than trusting job.video_url
+    // verbatim (defence in depth — it's our own fixed path shape either way).
+    const fileUrl = `${this.baseUrl()}/v1/videos/files/${encodeURIComponent(taskId)}.mp4`;
+    const mediaDir = this.resolveMediaDir();
+    let filePath: string;
+    try {
+      let res: Response;
+      try {
+        res = await fetch(fileUrl, { method: 'GET', headers: this.headers(), signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS), redirect: 'error' });
+      } catch (err) {
+        // A done job whose buffered clip is gone (TTL) surfaces here or as a 404.
+        return { content: [{ type: 'text', text: `generate_video: failed to fetch the finished clip: ${(err as Error).message}` }], isError: true };
+      }
+      if (res.status === 404) {
+        const code = job.error?.code ?? 'result_expired';
+        const msg = job.error?.message ?? ERROR_HINTS[code] ?? 'The generated video is no longer available.';
+        return { content: [{ type: 'text', text: `${code}: ${msg}` }], isError: true };
+      }
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        return this.mapHttpError(res.status, body);
+      }
+      const buf = await readCapped(res, DOWNLOAD_MAX_BYTES);
+      if (!isMp4(buf)) {
+        // Not a recognized mp4 — reject instead of saving garbage (e.g. an api
+        // error page that slipped through with a 200).
+        return { content: [{ type: 'text', text: 'generate_video: the video service returned data that is not a recognized mp4' }], isError: true };
+      }
+      fs.mkdirSync(mediaDir, { recursive: true });
+      const filename = `video_${sanitize(process.env.GATEWAY_SESSION_ID ?? 'default')}_${Date.now()}.mp4`;
+      filePath = path.join(mediaDir, filename);
+      fs.writeFileSync(filePath, buf);
+    } catch (err) {
+      return { content: [{ type: 'text', text: `generate_video: failed to save video: ${(err as Error).message}` }], isError: true };
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          status: 'done',
+          task_id: taskId,
+          ...(model ? { model } : {}),
+          byok: job.byok ?? false,
+          cost: job.cost ?? 0,
+          files: [filePath],
+          note: 'Video saved. Deliver it to the user with your channel delivery tool — api_reply/reply (files: [...]). Do NOT open/Read the file to inspect it first; attach it and answer briefly.'
+            + (model ? ` Mention which model made it (${model}).` : ''),
+        }),
+      }],
+    };
+  }
+
+  /**
+   * Where to write result clips. Prefer the per-session media dir the gateway
+   * provisions (GATEWAY_SESSION_MEDIA_DIR); otherwise derive the agent media root
+   * from the workspace (…/agents/<id>/media); last resort /tmp.
+   */
+  private resolveMediaDir(): string {
+    const sessionMediaDir = process.env.GATEWAY_SESSION_MEDIA_DIR;
+    if (sessionMediaDir) return sessionMediaDir;
+    const workspace = process.env.GATEWAY_WORKSPACE_DIR;
+    if (workspace) {
+      const sid = sanitize(process.env.GATEWAY_SESSION_ID ?? 'default');
+      return path.resolve(workspace, '..', 'media', `session-${sid}`);
+    }
+    return '/tmp';
+  }
+
+  private unavailable(err: unknown): McpToolResult {
+    return {
+      content: [{ type: 'text', text: `generate_video: video service unavailable: ${(err as Error).message}` }],
+      isError: true,
+    };
+  }
+
+  private mapHttpError(status: number, body: string): McpToolResult {
+    let code = '';
+    let message = '';
+    try {
+      const parsed = JSON.parse(body) as { error?: { code?: string; message?: string } };
+      code = parsed.error?.code ?? '';
+      message = parsed.error?.message ?? '';
+    } catch {
+      /* non-JSON error body */
+    }
+    if (!code) code = defaultCodeForStatus(status);
+    const hint = ERROR_HINTS[code];
+    const text = [`${code}${message ? `: ${message}` : ''}`, hint && hint !== message ? hint : '']
+      .filter(Boolean)
+      .join(' — ');
+    return { content: [{ type: 'text', text: text || `video service error (HTTP ${status})` }], isError: true };
+  }
+
+  private mapJobError(job: JobResponse): McpToolResult {
+    const code = job.error?.code ?? 'provider_error';
+    const message = job.error?.message ?? '';
+    const hint = ERROR_HINTS[code];
+    const text = [`${code}${message ? `: ${message}` : ''}`, hint && hint !== message ? hint : '']
+      .filter(Boolean)
+      .join(' — ');
+    return { content: [{ type: 'text', text: text || `video generation failed (${code})` }], isError: true };
+  }
+}
+
+// Resolves early (without rejecting) on abort — the poll loop re-checks
+// signal.aborted itself right after, so this only needs to shorten the wait.
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((r) => {
+    const onAbort = () => { clearTimeout(t); r(); };
+    const t = setTimeout(() => { signal?.removeEventListener('abort', onAbort); r(); }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function sanitize(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 48) || 'default';
+}
+
+// Read a response body into a Buffer with a hard byte ceiling: reject early on a
+// too-large Content-Length, and stream-count actual bytes so a chunked response
+// without Content-Length can't blow past the cap (OOM guard).
+async function readCapped(res: Response, cap: number): Promise<Buffer> {
+  const declared = Number(res.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > cap) {
+    throw new Error(`download video too large: ${declared} bytes (max ${cap})`);
+  }
+  if (!res.body) {
+    const ab = await res.arrayBuffer();
+    if (ab.byteLength > cap) throw new Error(`download video too large (max ${cap} bytes)`);
+    return Buffer.from(ab);
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+    total += chunk.length;
+    if (total > cap) throw new Error(`download video exceeded ${cap} bytes`);
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function defaultCodeForStatus(status: number): string {
+  switch (status) {
+    case 400: return 'invalid_model';
+    case 401: return 'unauthorized';
+    case 402: return 'insufficient_credit';
+    case 403: return 'no_credential';
+    case 404: return 'job_not_found';
+    case 429: return 'rate_limited';
+    case 503: return 'no_supply';
+    default: return 'provider_error';
+  }
+}
+
+// True when the buffer is an ISO-BMFF/mp4 container: the first box's type (bytes
+// 4..8) is "ftyp". Covers the H.264/AAC mp4 the grok-video path produces.
+function isMp4(buf: Buffer): boolean {
+  return buf.length >= 12 && buf[4] === 0x66 && buf[5] === 0x74 && buf[6] === 0x79 && buf[7] === 0x70;
+}
+
+// https is required for a PUBLIC api endpoint (the Bearer proxy_secret is sent on
+// every call); http is tolerated only for a local/internal host — a trusted hop
+// such as host.docker.internal in dev, where cleartext never leaves the network.
+function baseUrlIsSecure(raw: string): boolean {
+  if (!raw) return false;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (u.protocol === 'https:') return true;
+  if (u.protocol !== 'http:') return false;
+  const h = u.hostname.toLowerCase();
+  return (
+    h === 'localhost' ||
+    h === 'host.docker.internal' ||
+    h.endsWith('.internal') ||
+    h.endsWith('.local') ||
+    /^127\./.test(h) ||
+    h === '::1' ||
+    /^10\./.test(h) ||
+    /^192\.168\./.test(h) ||
+    /^172\.(1[6-9]|2[0-9]|3[01])\./.test(h)
+  );
+}
+
+const videoToolDefs: McpToolDefinition[] = [
+  {
+    name: 'generate_video',
+    description:
+      'Use this WHENEVER the user asks to create, generate, make, or animate a VIDEO or clip — it is built in, no app install needed. ' +
+      'Generate a short video from a text prompt (optionally animating a source image) via the configured video generation service. ' +
+      'action="generate" submits the request and returns the saved mp4 file path once ready — then deliver it with your channel reply ' +
+      'tool (files: [...]). AFTER A SUCCESSFUL GENERATE: do NOT open/Read the produced file to inspect it and do NOT re-analyze it — ' +
+      'the generation already succeeded; attach it with your reply tool and answer in one or two short sentences. ' +
+      'action="status" polls a previously returned task_id. ' +
+      'PATIENCE: video generation legitimately takes minutes — a "running" status (including the "still generating, call again with ' +
+      'action=status" note you get back when the local poll budget runs out) is normal, not stuck. Keep calling action="status" with ' +
+      'the SAME task_id until it resolves to done/failed. Do NOT submit a new action="generate" call for the same request while an ' +
+      'earlier task_id is still running — the earlier job may finish moments later and you will have generated and charged for the clip ' +
+      'twice while delivering only one. ' +
+      'action="list" returns every available video model with its parameters (durations, resolutions, cost). Call it FIRST when choosing ' +
+      'a model. ' +
+      'SOURCE IMAGE (image-to-video): to animate an existing image, pass its media path in "image" (a media path, an "artifact:<id>" ref, ' +
+      'or an https URL). When the user points at an image from earlier in the chat ("animate image 2", "the first picture"), call ' +
+      'action="list_refs" FIRST and pass the chosen item\'s "ref" — never count images from your own memory of the conversation. ' +
+      'Omit "image" for pure text-to-video (the service generates its own source frame from the prompt). ' +
+      'When the user selected options in the composer (a <video-params .../> tag in the turn), honor those values.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['generate', 'status', 'list', 'list_refs'],
+          description: 'generate (default) | status | list | list_refs (numbered catalog of this session\'s images, for resolving "animate the second image" style references)',
+        },
+        model: {
+          type: 'string',
+          description: 'Model id "provider/model" (required for generate). Use action="list" to discover valid ids.',
+        },
+        prompt: { type: 'string', description: 'Text prompt describing the video (required for generate).' },
+        duration: { type: 'integer', description: 'Optional clip length in seconds (provider default if omitted).' },
+        resolution: { type: 'string', description: 'Optional resolution, e.g. "480p" or "720p" (must be supported by the model).' },
+        aspect_ratio: { type: 'string', description: 'Optional aspect ratio, e.g. "9:16" or "16:9".' },
+        image: { type: 'string', description: 'Optional source frame for image-to-video: a media path (e.g. "media/xxx.png"), an "artifact:<id>" ref, or an https URL. Local/artifact refs are converted to short-lived URLs automatically. Omit for text-to-video.' },
+        task_id: { type: 'string', description: 'Job id to poll (required for action="status").' },
+      },
+      required: [],
+    },
+  },
+];

--- a/tests/unit/channel-instructions.test.ts
+++ b/tests/unit/channel-instructions.test.ts
@@ -10,6 +10,13 @@ describe('buildChannelInstructions', () => {
     'NEVER hand-draw the image yourself', // must use the tool, no SVG/ASCII fallback
   ];
 
+  const VIDEO_SUBSTRINGS = [
+    'VIDEO GENERATION IS BUILT IN',
+    'generate_video',
+    'legitimately takes MINUTES',
+    'IMAGE-TO-VIDEO',
+  ];
+
   it('includes image guidance when imageEnabled=true', () => {
     const out = buildChannelInstructions(true);
     for (const sub of IMAGE_SUBSTRINGS) {
@@ -21,6 +28,37 @@ describe('buildChannelInstructions', () => {
     const out = buildChannelInstructions(false);
     for (const sub of IMAGE_SUBSTRINGS) {
       expect(out).not.toContain(sub);
+    }
+  });
+
+  it('omits video guidance by default (videoEnabled defaults to false)', () => {
+    const out = buildChannelInstructions(true);
+    for (const sub of VIDEO_SUBSTRINGS) {
+      expect(out).not.toContain(sub);
+    }
+  });
+
+  it('includes video guidance when videoEnabled=true', () => {
+    const out = buildChannelInstructions(true, true);
+    for (const sub of VIDEO_SUBSTRINGS) {
+      expect(out).toContain(sub);
+    }
+  });
+
+  it('omits video guidance when videoEnabled=false explicitly', () => {
+    const out = buildChannelInstructions(true, false);
+    for (const sub of VIDEO_SUBSTRINGS) {
+      expect(out).not.toContain(sub);
+    }
+  });
+
+  it('video guidance is independent of image guidance (videoEnabled=true, imageEnabled=false)', () => {
+    const out = buildChannelInstructions(false, true);
+    for (const sub of IMAGE_SUBSTRINGS) {
+      expect(out).not.toContain(sub);
+    }
+    for (const sub of VIDEO_SUBSTRINGS) {
+      expect(out).toContain(sub);
     }
   });
 

--- a/tests/unit/video-generate-cancel.test.ts
+++ b/tests/unit/video-generate-cancel.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for generate_video's Stop-mid-generation cancellation — mirrors
+ * image-generate-cancel.test.ts for mcp/tools/video/module.ts's handleGenerate
+ * poll loop + its E3 cancel call (both modules share the same mechanism: the MCP
+ * SDK's per-call AbortSignal, threaded into VideoModule.handleTool by
+ * mcp/server.ts).
+ *
+ * Locked in here, entirely at the module level (no real CLI/MCP transport
+ * involved — fetch is mocked):
+ *
+ *  1. An aborted signal stops the poll loop promptly (does not run to
+ *     VIDEO_POLL_TIMEOUT_MS) and fires POST /v1/videos/jobs/:id/cancel for the
+ *     submitted task_id.
+ *  2. The tool result reports the cancellation (isError, mentions the task_id) —
+ *     not a generic timeout/error.
+ *  3. A cancel-call failure (network error) never throws out of handleTool — the
+ *     caller's own (already-cancelled) result still returns cleanly.
+ *  4. drainCancel() lets a process-exiting shutdown wait for an in-flight E3 call.
+ */
+import { VideoModule } from '../../mcp/tools/video/module';
+
+const BASE = 'https://video.example.com';
+
+const ENV_KEYS = ['VIDEO_BASE_URL', 'ANTHROPIC_BASE_URL', 'VIDEO_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'VIDEO_POLL_TIMEOUT_MS'] as const;
+
+type Captured = { url: string; method: string };
+
+describe('generate_video action="generate" — Stop mid-poll cancels the job', () => {
+  const saved: Record<string, string | undefined> = {};
+  const realFetch = global.fetch;
+  let calls: Captured[];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.ANTHROPIC_BASE_URL = BASE;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+    calls = [];
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test('aborting mid-poll cancels the job and returns promptly, not after the full poll timeout', async () => {
+    const controller = new AbortController();
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method });
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        // Abort right after submit — the poll loop's very first check (before its
+        // first sleep) must catch this, so the test never waits out a real
+        // DEFAULT_POLL_INTERVAL_MS.
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-1', status: 'queued' }), { status: 202 });
+      }
+      if (url.includes('/v1/videos/jobs/tid-1/cancel') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-1', cancelled: true, status: 'cancelling' }), { status: 200 });
+      }
+      // The poll loop must never reach GET .../jobs/tid-1 once aborted.
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool(
+      'generate_video',
+      { action: 'generate', model: 'grok-video/grok-imagine', prompt: 'a cat surfing' },
+      controller.signal
+    );
+
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain('cancelled');
+    expect((res.content[0] as { text: string }).text).toContain('tid-1');
+
+    const cancelCalls = calls.filter((c) => c.url.includes('/cancel'));
+    expect(cancelCalls).toHaveLength(1);
+    expect(cancelCalls[0]!.method).toBe('POST');
+
+    // The poll loop bailed BEFORE ever GETting the job status.
+    expect(calls.some((c) => c.url.endsWith('/v1/videos/jobs/tid-1'))).toBe(false);
+  });
+
+  test('a failed cancel call does not throw — the tool call still resolves cleanly', async () => {
+    const controller = new AbortController();
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-2', status: 'queued' }), { status: 202 });
+      }
+      if (url.includes('/v1/videos/jobs/tid-2/cancel')) {
+        throw new TypeError('network error');
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool(
+      'generate_video',
+      { action: 'generate', model: 'grok-video/grok-imagine', prompt: 'a cat surfing' },
+      controller.signal
+    );
+
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain('cancelled');
+  });
+
+  test('the poll loop reports "still generating" when the budget runs out without done/failed', async () => {
+    process.env.VIDEO_POLL_TIMEOUT_MS = '6000'; // ~3 real 2s sleeps, then deadline exit... 3s interval => ~2 polls
+    const controller = new AbortController();
+    let polls = 0;
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-leak', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/videos/jobs/tid-leak') && method === 'GET') {
+        polls++;
+        return new Response(JSON.stringify({ task_id: 'tid-leak', status: 'running' }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool(
+      'generate_video',
+      { action: 'generate', model: 'grok-video/grok-imagine', prompt: 'a cat surfing' },
+      controller.signal
+    );
+
+    expect(polls).toBeGreaterThanOrEqual(1);
+    expect(controller.signal.aborted).toBe(false);
+    expect((res.content[0] as { text: string }).text).toContain('still generating');
+  }, 20_000);
+
+  test('a transport error that coincides with an abort is not swallowed as retryable — it cancels', async () => {
+    // fetchJob maps a thrown fetch (network error / abort) to { __transportError }. The
+    // poll loop treats that as transient and would `continue` to retry — but it first
+    // checks signal.aborted so a Stop-triggered abort mid-fetch resolves to a cancel
+    // instead of silently looping.
+    const controller = new AbortController();
+    let getCount = 0;
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method });
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-terr', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/videos/jobs/tid-terr') && method === 'GET') {
+        getCount++;
+        controller.abort();
+        throw new TypeError('network error'); // → fetchJob returns { __transportError }
+      }
+      if (url.includes('/v1/videos/jobs/tid-terr/cancel') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-terr', cancelled: true, status: 'cancelling' }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool(
+      'generate_video',
+      { action: 'generate', model: 'grok-video/grok-imagine', prompt: 'a cat surfing' },
+      controller.signal
+    );
+
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain('cancelled');
+    expect((res.content[0] as { text: string }).text).toContain('tid-terr');
+    // The abort was honored immediately: exactly one GET (no retry), and a cancel fired.
+    expect(getCount).toBe(1);
+    expect(calls.filter((c) => c.url.includes('/cancel'))).toHaveLength(1);
+  });
+});
+
+describe('drainCancel() — lets a process-exiting shutdown wait for the E3 call', () => {
+  const saved: Record<string, string | undefined> = {};
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.ANTHROPIC_BASE_URL = BASE;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test('resolves immediately when nothing is in flight', async () => {
+    const mod = new VideoModule();
+    // No cancelledResult() ever ran — activeCancelPromise is still null.
+    await expect(mod.drainCancel()).resolves.toBeUndefined();
+  });
+
+  test('waits for an in-flight cancel call to actually finish before resolving', async () => {
+    const controller = new AbortController();
+    let resolveCancelFetch!: (res: Response) => void;
+    const cancelFetchGate = new Promise<Response>((resolve) => { resolveCancelFetch = resolve; });
+    let cancelFetchSettled = false;
+
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-drain', status: 'queued' }), { status: 202 });
+      }
+      if (url.includes('/v1/videos/jobs/tid-drain/cancel') && method === 'POST') {
+        // Held open deliberately — drainCancel() must not resolve before this does.
+        const res = await cancelFetchGate;
+        cancelFetchSettled = true;
+        return res;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const mod = new VideoModule();
+    // Don't await yet — the cancel HTTP call is parked on cancelFetchGate.
+    const genPromise = mod.handleTool(
+      'generate_video',
+      { action: 'generate', model: 'grok-video/grok-imagine', prompt: 'a cat surfing' },
+      controller.signal
+    );
+
+    // Give handleGenerate's poll loop a tick to reach cancelledResult() and set
+    // activeCancelPromise before we start racing drainCancel() against it.
+    await new Promise((r) => setImmediate(r));
+
+    let drainSettled = false;
+    const drainPromise = mod.drainCancel().then(() => { drainSettled = true; });
+
+    // The cancel fetch is still parked — neither the tool call nor drainCancel
+    // should have settled yet.
+    await new Promise((r) => setImmediate(r));
+    expect(cancelFetchSettled).toBe(false);
+    expect(drainSettled).toBe(false);
+
+    resolveCancelFetch(new Response(JSON.stringify({ task_id: 'tid-drain', cancelled: true, status: 'cancelling' }), { status: 200 }));
+
+    await drainPromise;
+    expect(drainSettled).toBe(true);
+    expect(cancelFetchSettled).toBe(true);
+
+    await genPromise;
+  });
+});

--- a/tests/unit/video-generate-deliver.test.ts
+++ b/tests/unit/video-generate-deliver.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Unit tests for generate_video's full generate → poll → deliver pipeline and
+ * the image-to-video source-frame reference resolver (normalizeRef). Neither
+ * had any coverage before — video-module.test.ts only covers config resolution
+ * and validation errors, and video-generate-cancel.test.ts only covers the E3
+ * cancel path. Locked in here (fetch is mocked, no real network):
+ *
+ *  1. happy path: submit → immediate done → deliver saves the mp4 into the
+ *     session media dir and returns its path.
+ *  2. deliver() rejects a 200 response whose body is not a recognized mp4
+ *     (the anti-garbage magic-byte backstop).
+ *  3. deliver() maps a 404 on the file fetch to result_expired.
+ *  4. action="status" re-entering in a later turn (no `model` in scope) still
+ *     delivers, just without the model field/note.
+ *  5. normalizeRef(): https pass-through, http rejected, share-bridge mint
+ *     (local path + artifact:), and legacy pass-through when the bridge is off.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { VideoModule } from '../../mcp/tools/video/module';
+
+const BASE = 'https://video.example.com';
+const GATEWAY = 'http://127.0.0.1:19999';
+
+const ENV_KEYS = [
+  'VIDEO_BASE_URL',
+  'ANTHROPIC_BASE_URL',
+  'VIDEO_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'GATEWAY_SESSION_MEDIA_DIR',
+  'GATEWAY_API_URL',
+  'GATEWAY_API_KEY',
+  'GATEWAY_AGENT_ID',
+  'GATEWAY_SESSION_ID',
+] as const;
+
+type Captured = { url: string; method: string; body: unknown };
+
+// A minimal, valid ISO-BMFF "ftyp" box: size(4) + 'ftyp' + 'isom' brand.
+const VALID_MP4 = Buffer.from([
+  0x00, 0x00, 0x00, 0x18,
+  0x66, 0x74, 0x79, 0x70, // 'ftyp'
+  0x69, 0x73, 0x6f, 0x6d, // 'isom'
+  0x00, 0x00, 0x02, 0x00,
+  0x69, 0x73, 0x6f, 0x6d,
+  0x00, 0x00, 0x00, 0x00,
+]);
+
+describe('generate_video — generate → poll → deliver pipeline', () => {
+  const saved: Record<string, string | undefined> = {};
+  const realFetch = global.fetch;
+  let mediaDir: string;
+  let calls: Captured[];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.ANTHROPIC_BASE_URL = BASE;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+    mediaDir = fs.mkdtempSync(path.join(os.tmpdir(), 'video-deliver-'));
+    process.env.GATEWAY_SESSION_MEDIA_DIR = mediaDir;
+    calls = [];
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    fs.rmSync(mediaDir, { recursive: true, force: true });
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test('happy path: submit → done on first poll → clip saved and file path returned', async () => {
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method, body: init?.body });
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-ok', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/videos/jobs/tid-ok') && method === 'GET') {
+        return new Response(JSON.stringify({ task_id: 'tid-ok', status: 'done' }), { status: 200 });
+      }
+      if (url.endsWith('/v1/videos/files/tid-ok.mp4') && method === 'GET') {
+        return new Response(VALID_MP4, { status: 200, headers: { 'content-length': String(VALID_MP4.length) } });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'a cat surfing',
+    });
+
+    expect(res.isError).toBeUndefined();
+    const payload = JSON.parse(res.content[0]!.text) as { status: string; task_id: string; model?: string; files: string[] };
+    expect(payload.status).toBe('done');
+    expect(payload.task_id).toBe('tid-ok');
+    expect(payload.model).toBe('grok-video/grok-imagine');
+    expect(payload.files).toHaveLength(1);
+    const savedPath = payload.files[0]!;
+    expect(fs.existsSync(savedPath)).toBe(true);
+    expect(fs.readFileSync(savedPath)).toEqual(VALID_MP4);
+    expect(path.dirname(savedPath)).toBe(mediaDir);
+  }, 15_000);
+
+  test('a done job whose clip is not a recognized mp4 is rejected, not saved', async () => {
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-bad', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/videos/jobs/tid-bad') && method === 'GET') {
+        return new Response(JSON.stringify({ task_id: 'tid-bad', status: 'done' }), { status: 200 });
+      }
+      if (url.endsWith('/v1/videos/files/tid-bad.mp4') && method === 'GET') {
+        return new Response('<html>not a video</html>', { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'a cat surfing',
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('not a recognized mp4');
+    expect(fs.readdirSync(mediaDir)).toHaveLength(0);
+  }, 15_000);
+
+  test('a 404 on the file fetch maps to result_expired', async () => {
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-404', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/videos/jobs/tid-404') && method === 'GET') {
+        return new Response(JSON.stringify({ task_id: 'tid-404', status: 'done' }), { status: 200 });
+      }
+      if (url.endsWith('/v1/videos/files/tid-404.mp4') && method === 'GET') {
+        return new Response(JSON.stringify({ error: { code: 'result_expired' } }), { status: 404 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'a cat surfing',
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('result_expired');
+  }, 15_000);
+
+  test('action="status" re-entering later (no model in scope) still delivers, without a model field', async () => {
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/videos/jobs/tid-status') && method === 'GET') {
+        return new Response(JSON.stringify({ task_id: 'tid-status', status: 'done' }), { status: 200 });
+      }
+      if (url.endsWith('/v1/videos/files/tid-status.mp4') && method === 'GET') {
+        return new Response(VALID_MP4, { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool('generate_video', { action: 'status', task_id: 'tid-status' });
+
+    expect(res.isError).toBeUndefined();
+    const payload = JSON.parse(res.content[0]!.text) as { status: string; model?: string; files: string[] };
+    expect(payload.status).toBe('done');
+    expect(payload.model).toBeUndefined();
+    expect(payload.files).toHaveLength(1);
+  });
+
+  test('a job that failed maps to its error code and hint', async () => {
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-fail', status: 'queued' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/videos/jobs/tid-fail') && method === 'GET') {
+        return new Response(JSON.stringify({ task_id: 'tid-fail', status: 'failed', error: { code: 'content_policy' } }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'a cat surfing',
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('content_policy');
+    expect(res.content[0]!.text).toContain('content policy');
+  }, 15_000);
+});
+
+describe('generate_video image-to-video source-frame resolution (normalizeRef)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const realFetch = global.fetch;
+  let calls: Captured[];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.ANTHROPIC_BASE_URL = BASE;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+    calls = [];
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  const captureSubmitBody = () => {
+    const controller = new AbortController();
+    const fetchMock = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method, body: init?.body });
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        // Abort right after submit so the poll loop bails on its very first check
+        // instead of waiting out the real (multi-minute) poll budget — this
+        // describe block only cares about the submitted request body.
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-i2v', status: 'running' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/videos/jobs/tid-i2v/cancel') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-i2v', cancelled: true }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+    return { fetchMock, signal: controller.signal };
+  };
+
+  test('share bridge OFF: an https image ref is passed straight through, unmodified', async () => {
+    const { fetchMock, signal } = captureSubmitBody();
+    global.fetch = fetchMock;
+    await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'animate this',
+      image: 'https://cdn.example.com/frame.png',
+    }, signal);
+    const submit = calls.find((c) => c.url.endsWith('/v1/videos/generations'))!;
+    const body = JSON.parse(submit.body as string) as { image?: string };
+    expect(body.image).toBe('https://cdn.example.com/frame.png');
+  });
+
+  test('share bridge OFF: a local media path is passed straight through as legacy behavior', async () => {
+    const { fetchMock, signal } = captureSubmitBody();
+    global.fetch = fetchMock;
+    await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'animate this',
+      image: 'media/session-1/frame.png',
+    }, signal);
+    const submit = calls.find((c) => c.url.endsWith('/v1/videos/generations'))!;
+    const body = JSON.parse(submit.body as string) as { image?: string };
+    expect(body.image).toBe('media/session-1/frame.png');
+  });
+
+  test('share bridge ON: an http:// image ref is rejected — https required', async () => {
+    process.env.GATEWAY_API_URL = GATEWAY;
+    process.env.GATEWAY_API_KEY = 'gw-key';
+    process.env.GATEWAY_AGENT_ID = 'agent-1';
+    process.env.GATEWAY_SESSION_ID = 'session-1';
+    const { fetchMock } = captureSubmitBody();
+    global.fetch = fetchMock;
+    const res = await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'animate this',
+      image: 'http://cdn.example.com/frame.png',
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('https');
+    expect(calls.some((c) => c.url.endsWith('/v1/videos/generations'))).toBe(false);
+  });
+
+  test('share bridge ON: a local path is minted to a public share URL before submit', async () => {
+    process.env.GATEWAY_API_URL = GATEWAY;
+    process.env.GATEWAY_API_KEY = 'gw-key';
+    process.env.GATEWAY_AGENT_ID = 'agent-1';
+    process.env.GATEWAY_SESSION_ID = 'session-1';
+
+    const controller = new AbortController();
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method, body: init?.body });
+      if (url.endsWith('/api/v1/shares') && method === 'POST') {
+        return new Response(
+          JSON.stringify({ items: [{ share_id: 'sh-1', token: 'tok-1', url: 'https://gw.example.com/shared/tok-1', expires_at: '2099-01-01T00:00:00Z' }] }),
+          { status: 201 },
+        );
+      }
+      if (url.endsWith('/v1/videos/generations') && method === 'POST') {
+        // Abort right after submit — this test only cares about the request
+        // bodies (mint + submit), not the poll outcome.
+        controller.abort();
+        return new Response(JSON.stringify({ task_id: 'tid-mint', status: 'running' }), { status: 202 });
+      }
+      if (url.endsWith('/v1/videos/jobs/tid-mint/cancel') && method === 'POST') {
+        return new Response(JSON.stringify({ task_id: 'tid-mint', cancelled: true }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'animate this',
+      image: 'media/session-1/frame.png',
+    }, controller.signal);
+
+    const mintCall = calls.find((c) => c.url.endsWith('/api/v1/shares'));
+    expect(mintCall).toBeDefined();
+    const mintBody = JSON.parse(mintCall!.body as string) as { refs: { path?: string }[] };
+    expect(mintBody.refs).toEqual([{ path: 'media/session-1/frame.png' }]);
+
+    const submit = calls.find((c) => c.url.endsWith('/v1/videos/generations'))!;
+    const submitBody = JSON.parse(submit.body as string) as { image?: string };
+    expect(submitBody.image).toBe('https://gw.example.com/shared/tok-1');
+  });
+
+  test('share bridge ON but an artifact ref does not exist → error surfaced, no submit', async () => {
+    process.env.GATEWAY_API_URL = GATEWAY;
+    process.env.GATEWAY_API_KEY = 'gw-key';
+    process.env.GATEWAY_AGENT_ID = 'agent-1';
+    process.env.GATEWAY_SESSION_ID = 'session-1';
+
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method, body: init?.body });
+      if (url.endsWith('/api/v1/shares') && method === 'POST') {
+        return new Response(JSON.stringify({ error: 'not found', code: 'share_ref_not_found' }), { status: 404 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'animate this',
+      image: 'artifact:missing-id',
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('share_ref_not_found');
+    expect(calls.some((c) => c.url.endsWith('/v1/videos/generations'))).toBe(false);
+  });
+});

--- a/tests/unit/video-list-refs.test.ts
+++ b/tests/unit/video-list-refs.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for generate_video action="list_refs" — mirrors
+ * image-list-refs.test.ts for mcp/tools/video/module.ts + the shared
+ * mcp/tools/shared/share-client.ts catalog endpoint.
+ *
+ * list_refs is the agent's ONLY sanctioned way to resolve "animate image 2" to a
+ * real file: the gateway computes the numbering, the agent never counts from its
+ * own transcript. Locked in here:
+ *
+ *  1. happy path — the gateway's items come back verbatim in the tool result;
+ *  2. bridge gating — with the share bridge unconfigured the action is inert and
+ *     performs NO network call (legacy mode gains no new behavior);
+ *  3. gateway errors (401 / 500, both error-body shapes) surface their code;
+ *  4. wire shape — GET, correct path + query, Bearer auth, no body;
+ *  5. the tool definition advertises the action.
+ *
+ * fetch is mocked, so these pass independently of the server-side endpoint.
+ */
+import { VideoModule } from '../../mcp/tools/video/module';
+
+const GATEWAY = 'http://127.0.0.1:19999';
+
+const ENV_KEYS = [
+  'GATEWAY_API_URL',
+  'GATEWAY_API_KEY',
+  'GATEWAY_AGENT_ID',
+  'GATEWAY_SESSION_ID',
+] as const;
+
+type Captured = { url: string; method: string; headers: Record<string, string>; body: unknown };
+
+const ITEMS = [
+  { index: 1, ref: 'artifact:img_a', relative_path: 'media/session-1/a.png', origin: 'upload', ts: 1700000000000, available: true },
+  { index: 2, ref: 'media/session-1/b.png', relative_path: 'media/session-1/b.png', origin: 'generated', ts: 1700000001000, available: false },
+];
+
+describe('generate_video action="list_refs"', () => {
+  const saved: Record<string, string | undefined> = {};
+  const realFetch = global.fetch;
+  let calls: Captured[];
+  let responder: () => Response;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.GATEWAY_API_URL = GATEWAY;
+    process.env.GATEWAY_API_KEY = 'gw-key';
+    process.env.GATEWAY_AGENT_ID = 'agent one';
+    process.env.GATEWAY_SESSION_ID = 'session-1';
+    calls = [];
+    responder = () => new Response(JSON.stringify({ items: ITEMS }), { status: 200 });
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries((init?.headers ?? {}) as Record<string, string>)) {
+        headers[k.toLowerCase()] = v;
+      }
+      calls.push({ url: String(input), method: (init?.method ?? 'GET').toUpperCase(), headers, body: init?.body });
+      return responder();
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  const listRefs = () => new VideoModule().handleTool('generate_video', { action: 'list_refs' });
+
+  test('happy path → catalog items returned verbatim, not an error', async () => {
+    const res = await listRefs();
+    expect(res.isError).toBeUndefined();
+    const payload = JSON.parse(res.content[0]!.text) as { images: typeof ITEMS; note: string };
+    expect(payload.images).toEqual(ITEMS);
+    // The note is what stops the agent counting images from its own memory.
+    expect(payload.note).toContain('first appearance');
+    expect(payload.note).toContain('Do NOT count images from conversation memory');
+    expect(calls).toHaveLength(1);
+  });
+
+  test('empty session → empty images array, still a success', async () => {
+    responder = () => new Response(JSON.stringify({ items: [] }), { status: 200 });
+    const res = await listRefs();
+    expect(res.isError).toBeUndefined();
+    expect((JSON.parse(res.content[0]!.text) as { images: unknown[] }).images).toEqual([]);
+  });
+
+  test('share bridge not configured → inert error, NO network call', async () => {
+    delete process.env.GATEWAY_SESSION_ID;
+    const res = await listRefs();
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toBe(
+      'generate_video: list_refs is unavailable (share bridge is not configured).',
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  test('401 from the gateway → mapped error carrying the code', async () => {
+    responder = () => new Response(JSON.stringify({ error: 'bad key', code: 'unauthorized' }), { status: 401 });
+    const res = await listRefs();
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('unauthorized');
+    expect(res.content[0]!.text).toContain('bad key');
+  });
+
+  test('nested { error: { code, message } } body shape is mapped too', async () => {
+    responder = () =>
+      new Response(JSON.stringify({ error: { code: 'catalog_unavailable', message: 'history db missing' } }), { status: 500 });
+    const res = await listRefs();
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('catalog_unavailable');
+    expect(res.content[0]!.text).toContain('history db missing');
+  });
+
+  test('500 with a non-JSON body → generic catalog_failed code', async () => {
+    responder = () => new Response('<html>boom</html>', { status: 500 });
+    const res = await listRefs();
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('catalog_failed');
+  });
+
+  test('200 with a malformed payload (no items array) → error, not a crash', async () => {
+    responder = () => new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const res = await listRefs();
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('catalog_failed');
+  });
+
+  test('request shape: GET /api/v1/image-catalog with encoded identity, Bearer auth, no body', async () => {
+    await listRefs();
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.method).toBe('GET');
+    expect(call.url).toBe(`${GATEWAY}/api/v1/image-catalog?agent_id=agent%20one&session_id=session-1`);
+    expect(call.headers.authorization).toBe('Bearer gw-key');
+    expect(call.body).toBeUndefined();
+  });
+
+  test('trailing slash on GATEWAY_API_URL is normalised away', async () => {
+    process.env.GATEWAY_API_URL = `${GATEWAY}/`;
+    await listRefs();
+    expect(calls[0]!.url.startsWith(`${GATEWAY}/api/v1/image-catalog?`)).toBe(true);
+  });
+
+  test('tool definition advertises the list_refs action', () => {
+    const tools = new VideoModule().getTools();
+    const def = tools.find((t) => t.name === 'generate_video')!;
+    const schema = JSON.parse(JSON.stringify(def.inputSchema)) as {
+      properties: { action: { enum: string[] } };
+    };
+    expect(schema.properties.action.enum).toContain('list_refs');
+    // …and the description tells the agent to call it before resolving "animate image 2".
+    expect(def.description).toContain('list_refs');
+  });
+
+  test('an unknown action still errors and lists list_refs among the valid ones', async () => {
+    const res = await new VideoModule().handleTool('generate_video', { action: 'nope' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('list_refs');
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/tests/unit/video-module.test.ts
+++ b/tests/unit/video-module.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the video MCP tool's endpoint resolution + https guard
+ * (mcp/tools/video/module.ts). Mirrors image-module.test.ts — config resolves in
+ * this order:
+ *
+ *   VIDEO_BASE_URL → IMAGE_BASE_URL → ANTHROPIC_BASE_URL (env) → ~/.claude/settings.json's env block.
+ *
+ * Video shares the getpod api with the image tool, so its resolution is the same
+ * with a VIDEO_* override on top. Two behaviors locked in:
+ *
+ *  1. baseUrl() resolves from the first source above that yields a value; absent all
+ *     ⇒ not configured ⇒ isEnabled() false. Env wins over settings.json, and the
+ *     VIDEO_* override wins over the shared IMAGE_/ANTHROPIC_ vars.
+ *  2. baseUrlIsSecure guard — the Bearer secret rides every call, so an http URL to a
+ *     PUBLIC host is refused. https, or http to a local/internal host, is allowed.
+ *
+ * baseUrl()/settingsEnv() are private, so we assert their OBSERVABLE effect via
+ * isEnabled(), driving it by the env / settings.json we set per test.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { VideoModule } from '../../mcp/tools/video/module';
+
+const ENV_KEYS = [
+  'VIDEO_BASE_URL',
+  'IMAGE_BASE_URL',
+  'ANTHROPIC_BASE_URL',
+  'VIDEO_API_KEY',
+  'IMAGE_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'VIDEO_DISABLED',
+] as const;
+
+describe('VideoModule.isEnabled() — endpoint resolution + https guard', () => {
+  let cfgDir: string;
+  let errSpy: jest.SpyInstance;
+  const saved: Record<string, string | undefined> = {};
+  const savedCfgDir = process.env.CLAUDE_CONFIG_DIR;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vidcfg-'));
+    process.env.CLAUDE_CONFIG_DIR = cfgDir;
+    errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+    fs.rmSync(cfgDir, { recursive: true, force: true });
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    if (savedCfgDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = savedCfgDir;
+  });
+
+  const setSettings = (env: Record<string, string>) =>
+    fs.writeFileSync(path.join(cfgDir, 'settings.json'), JSON.stringify({ env }));
+
+  const enabled = () => new VideoModule().isEnabled();
+
+  describe('env-based config', () => {
+    test('https ANTHROPIC_BASE_URL env (shared with image) → enabled', () => {
+      process.env.ANTHROPIC_BASE_URL = 'https://provider.example.com';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+      expect(enabled()).toBe(true);
+    });
+
+    test('VIDEO_BASE_URL env (separate video endpoint) → enabled', () => {
+      process.env.VIDEO_BASE_URL = 'https://video.example.com';
+      process.env.VIDEO_API_KEY = 'video-secret';
+      expect(enabled()).toBe(true);
+    });
+
+    test('no env and no settings.json → disabled (nothing configured)', () => {
+      expect(enabled()).toBe(false);
+    });
+
+    test('http to a PUBLIC host env → disabled (refuses Bearer secret in cleartext)', () => {
+      process.env.ANTHROPIC_BASE_URL = 'http://provider.example.com';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'proxy-secret';
+      expect(enabled()).toBe(false);
+      expect(errSpy).toHaveBeenCalled();
+    });
+
+    test('VIDEO_DISABLED=true → disabled even with a valid https env URL', () => {
+      process.env.ANTHROPIC_BASE_URL = 'https://provider.example.com';
+      process.env.VIDEO_DISABLED = 'true';
+      expect(enabled()).toBe(false);
+    });
+
+    test('http to a local host (host.docker.internal) → enabled (trusted hop)', () => {
+      process.env.VIDEO_BASE_URL = 'http://host.docker.internal:8080';
+      process.env.VIDEO_API_KEY = 'video-secret';
+      expect(enabled()).toBe(true);
+    });
+  });
+
+  describe('settings.json fallback (no env)', () => {
+    test('https ANTHROPIC_BASE_URL in settings.json → enabled', () => {
+      setSettings({ ANTHROPIC_BASE_URL: 'https://provider.example.com', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(true);
+    });
+
+    test('settings.json without ANTHROPIC_BASE_URL → disabled (no endpoint)', () => {
+      setSettings({ CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(false);
+    });
+
+    test('malformed settings.json → disabled (degrades, does not throw)', () => {
+      fs.writeFileSync(path.join(cfgDir, 'settings.json'), '{ not valid json');
+      expect(enabled()).toBe(false);
+    });
+
+    test('http to a PUBLIC host in settings.json → disabled', () => {
+      setSettings({ ANTHROPIC_BASE_URL: 'http://provider.example.com', CLAUDE_CODE_OAUTH_TOKEN: 'proxy-secret' });
+      expect(enabled()).toBe(false);
+      expect(errSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('precedence: VIDEO_* overrides the shared vars', () => {
+    test('a valid https VIDEO_BASE_URL wins over a public-http ANTHROPIC_BASE_URL', () => {
+      process.env.ANTHROPIC_BASE_URL = 'http://provider.example.com'; // public http ⇒ would disable
+      expect(enabled()).toBe(false);
+      process.env.VIDEO_BASE_URL = 'https://video.example.com';
+      expect(new VideoModule().isEnabled()).toBe(true);
+    });
+  });
+
+  describe('tool surface', () => {
+    test('exposes exactly the generate_video tool with the four actions', () => {
+      const tools = new VideoModule().getTools();
+      expect(tools).toHaveLength(1);
+      expect(tools[0]!.name).toBe('generate_video');
+      const schema = tools[0]!.inputSchema as { properties: { action: { enum: string[] } } };
+      expect(schema.properties.action.enum).toEqual(['generate', 'status', 'list', 'list_refs']);
+    });
+
+    test('rejects an unknown tool name', async () => {
+      const res = await new VideoModule().handleTool('generate_image', {});
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text).toContain('Unknown tool');
+    });
+
+    test('generate without a prompt is a validation error (no network)', async () => {
+      const res = await new VideoModule().handleTool('generate_video', { action: 'generate', model: 'grok-video/grok-imagine' });
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text.toLowerCase()).toContain('prompt');
+    });
+
+    test('generate without a model is a validation error (no network)', async () => {
+      const res = await new VideoModule().handleTool('generate_video', { action: 'generate', prompt: 'a cat surfing' });
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text).toContain('"model" is required');
+    });
+
+    test('status without a task_id is a validation error (no network)', async () => {
+      const res = await new VideoModule().handleTool('generate_video', { action: 'status' });
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text).toContain('task_id');
+    });
+
+    test('an unknown action is rejected', async () => {
+      const res = await new VideoModule().handleTool('generate_video', { action: 'frobnicate' });
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text).toContain('unknown action');
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds the last missing piece of the grok-video epic: the gateway MCP **`generate_video`** tool. With this, video generation fires end-to-end in chat — the agent calls the tool, it drives the getpod api, and the finished mp4 is delivered like a `generate_image` result.

Mirrors `mcp/tools/image/module.ts` closely, so the shape is familiar.

## Flow

```
generate → POST /v1/videos/generations  (202 {task_id})
         → poll GET /v1/videos/jobs/:id  until done/failed
         → on done: download the mp4 from the M2M-authed api path
           /v1/videos/files/:id.mp4 → write into GATEWAY_SESSION_MEDIA_DIR
           → return the path for the reply tool to attach
```

Actions: `generate | status | list | list_refs` (identical action surface to `generate_image`).

## Deliberate differences from the image tool (all medium-driven)

- **One clip per request** — no `n` / batch delivery.
- **Result is a large binary streamed over an authed api path**, never base64-in-JSON. `deliver()` re-fetches by `task_id` **with** the proxy secret. Because that host is our own trusted api (not a provider-controlled URL), the image path's public-URL SSRF screen deliberately does **not** apply — it would block our own internal host. An **mp4 magic-byte check** (`ftyp`) is the anti-garbage backstop, plus a 200 MB download cap.
- **Longer default poll budget** (5 min; `VIDEO_POLL_TIMEOUT_MS` override) — video legitimately runs minutes.
- **`image`** is a single optional **source frame** for image-to-video (share-bridge minted to a public URL the provider fetches); no `continue_from` resume concept.

## Registration

- `server.ts`: wires `VideoModule`; generalizes the shutdown cancel-drain to **every** module exposing `drainCancel` (image + video), so a Stop mid-generation still fires E3 cancel.
- `instructions.ts`: adds a `VIDEO_INSTRUCTION` block, appended only when the tool is enabled (`buildChannelInstructions` gains an optional `videoEnabled` param — existing single-arg callers unaffected).

## Config

Same resolution as the image tool, with a `VIDEO_*` override on top:
`VIDEO_BASE_URL → IMAGE_BASE_URL → ANTHROPIC_BASE_URL → settings.json`, and `VIDEO_API_KEY → IMAGE_API_KEY → ANTHROPIC_AUTH_TOKEN → settings.json`. Same https/cleartext-secret guard. `VIDEO_DISABLED=true` turns it off independently.

## Tests

`tests/unit/video-module.test.ts` mirrors `image-module.test.ts`: endpoint resolution, https guard, `VIDEO_*` precedence, tool surface + validation errors. Green locally alongside the image + instructions suites. `dist` build + bun bundle of the three files clean.

## Depends on

The api-side `/v1/videos/*` endpoints (getpod branch `feat/grok-video-backend`, PR #2701 + follow-ups). This tool is the gateway half of that chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)