### PR TITLE
fix(telegram): deliver files quoted in a reply

### DIFF
--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -30,6 +30,7 @@ import { homedir } from 'os'
 import { join, extname, sep } from 'path'
 import { execFileSync } from 'child_process'
 import { createWorkingStateManager, drainOrphanForwards, chunkText, htmlToPlain } from './typing'
+import { extractRepliedAttachment } from './reply-attachment'
 // Import compiled dist/, not raw src/ — src/ is not published (files: ["mcp/"]),
 // so a src/ import crashes this bun-run receiver on installed packages (the bug
 // that silenced every bot on systemd installs). Enforced by
@@ -587,7 +588,7 @@ const mcp = new Server(
     instructions: [
       'The sender reads Telegram, not this session. Anything you want them to see must go through the reply tool — your transcript output never reaches their chat.',
       '',
-      'Messages from Telegram arrive as <channel source="telegram" chat_id="..." message_id="..." user="..." ts="...">. If the tag has an image_path attribute, Read that file — it is a photo the sender attached. If the tag has attachment_file_id, call download_attachment with that file_id to fetch the file, then Read the returned path. Reply with the reply tool — pass chat_id back. Use reply_to (set to a message_id) only when replying to an earlier message; the latest message doesn\'t need a quote-reply, omit reply_to for normal responses.',
+      'Messages from Telegram arrive as <channel source="telegram" chat_id="..." message_id="..." user="..." ts="...">. If the tag has an image_path attribute, Read that file — it is a photo the sender attached. If the tag has attachment_file_id, call download_attachment with that file_id to fetch the file, then Read the returned path. A nested <replied> block quotes an earlier message; it may carry replied_image_path (Read it) or replied_attachment_file_id (pass to download_attachment) when the quoted message held a photo or file. Reply with the reply tool — pass chat_id back. Use reply_to (set to a message_id) only when replying to an earlier message; the latest message doesn\'t need a quote-reply, omit reply_to for normal responses.',
       '',
       'reply accepts file paths (files: ["/abs/path.png"]) for attachments. Use react to add emoji reactions, and edit_message for interim progress updates. Edits don\'t trigger push notifications — when a long task completes, send a new reply so the user\'s device pings.',
       '',
@@ -1048,6 +1049,12 @@ async function handleInbound(
     } catch {}
   }
 
+  // A replied-to message may also carry a non-photo attachment (document, video,
+  // audio, …). Photos become an image_path above; everything else is surfaced by
+  // file_id so the agent can fetch it with download_attachment — without this a
+  // quote-reply of e.g. a CSV dropped the file entirely.
+  const repliedAttachment = extractRepliedAttachment(replyMsg)
+
   // image_path goes in meta only — an in-content "[image attached — read: PATH]"
   // annotation is forgeable by any allowlisted sender typing that string.
   const channelParams = {
@@ -1074,6 +1081,13 @@ async function handleInbound(
         replied_user: replyMsg.from?.username ?? String(replyMsg.from?.id ?? ''),
         ...(replyMsg.text ? { replied_text: replyMsg.text } : {}),
         ...(repliedImagePath ? { replied_image_path: repliedImagePath } : {}),
+        ...(repliedAttachment ? {
+          replied_attachment_kind: repliedAttachment.kind,
+          replied_attachment_file_id: repliedAttachment.file_id,
+          ...(repliedAttachment.size != null ? { replied_attachment_size: String(repliedAttachment.size) } : {}),
+          ...(repliedAttachment.mime ? { replied_attachment_mime: repliedAttachment.mime } : {}),
+          ...(repliedAttachment.name ? { replied_attachment_name: repliedAttachment.name } : {}),
+        } : {}),
       } : {}),
     },
   }

--- a/mcp/tools/telegram/receiver-server.ts
+++ b/mcp/tools/telegram/receiver-server.ts
@@ -30,7 +30,7 @@ import { homedir } from 'os'
 import { join, extname, sep } from 'path'
 import { execFileSync } from 'child_process'
 import { createWorkingStateManager, drainOrphanForwards, chunkText, htmlToPlain } from './typing'
-import { extractRepliedAttachment } from './reply-attachment'
+import { extractRepliedAttachment, safeName } from './reply-attachment'
 // Import compiled dist/, not raw src/ — src/ is not published (files: ["mcp/"]),
 // so a src/ import crashes this bun-run receiver on installed packages (the bug
 // that silenced every bot on systemd installs). Enforced by
@@ -926,13 +926,6 @@ const CALLBACK_URL_BASE = (() => {
 })()
 
 // ─── Message helpers (shared across all polling modes) ───────────────────────
-
-// Filenames and titles are uploader-controlled. They land inside the <channel>
-// notification — delimiter chars would let the uploader break out of the tag
-// or forge a second meta entry.
-function safeName(s: string | undefined): string | undefined {
-  return s?.replace(/[<>\[\]\r\n;]/g, '_')
-}
 
 type AttachmentMeta = {
   kind: string

--- a/mcp/tools/telegram/reply-attachment.ts
+++ b/mcp/tools/telegram/reply-attachment.ts
@@ -12,7 +12,10 @@ export type RepliedAttachment = {
   name?: string
 }
 
-function safeName(s: string | undefined): string | undefined {
+// Filenames and titles are uploader-controlled. They land inside the <channel>
+// notification — delimiter chars would let the uploader break out of the tag
+// or forge a second meta entry.
+export function safeName(s: string | undefined): string | undefined {
   return s?.replace(/[<>\[\]\r\n;]/g, '_')
 }
 

--- a/mcp/tools/telegram/reply-attachment.ts
+++ b/mcp/tools/telegram/reply-attachment.ts
@@ -1,0 +1,78 @@
+import type { Message } from 'grammy/types'
+
+/** Non-photo attachment metadata lifted off a message, mirroring the shape the
+ * live-message handlers build for `attachment_*`. Photos are handled separately
+ * (downloaded to an image_path); everything else is surfaced by file_id so the
+ * agent can fetch it on demand via download_attachment. */
+export type RepliedAttachment = {
+  kind: string
+  file_id: string
+  size?: number
+  mime?: string
+  name?: string
+}
+
+function safeName(s: string | undefined): string | undefined {
+  return s?.replace(/[<>\[\]\r\n;]/g, '_')
+}
+
+/**
+ * Extract a non-photo attachment from the message being replied to.
+ *
+ * A quote-reply carries the full replied-to message, including any document /
+ * video / audio / voice / video_note / sticker it held — but the receiver only
+ * ever downloaded a replied *photo*. So replying to (say) a CSV dropped the file
+ * entirely: the agent saw `<replied>` with no way to reach the attachment. This
+ * returns that attachment's metadata so the reply path can surface a
+ * `replied_attachment_file_id` the agent can pass to download_attachment.
+ *
+ * Returns undefined when the replied message has no such attachment (plain text,
+ * or a photo — which the caller handles as an image_path).
+ */
+export function extractRepliedAttachment(msg: Message | undefined): RepliedAttachment | undefined {
+  if (!msg) return undefined
+  if (msg.document)
+    return {
+      kind: 'document',
+      file_id: msg.document.file_id,
+      size: msg.document.file_size,
+      mime: msg.document.mime_type,
+      name: safeName(msg.document.file_name),
+    }
+  if (msg.video)
+    return {
+      kind: 'video',
+      file_id: msg.video.file_id,
+      size: msg.video.file_size,
+      mime: msg.video.mime_type,
+      name: safeName(msg.video.file_name),
+    }
+  if (msg.audio)
+    return {
+      kind: 'audio',
+      file_id: msg.audio.file_id,
+      size: msg.audio.file_size,
+      mime: msg.audio.mime_type,
+      name: safeName(msg.audio.file_name),
+    }
+  if (msg.voice)
+    return {
+      kind: 'voice',
+      file_id: msg.voice.file_id,
+      size: msg.voice.file_size,
+      mime: msg.voice.mime_type,
+    }
+  if (msg.video_note)
+    return {
+      kind: 'video_note',
+      file_id: msg.video_note.file_id,
+      size: msg.video_note.file_size,
+    }
+  if (msg.sticker)
+    return {
+      kind: 'sticker',
+      file_id: msg.sticker.file_id,
+      size: msg.sticker.file_size,
+    }
+  return undefined
+}

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/ubuntu/projects/claude-gateway/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/ubuntu/projects/claude-gateway/node_modules

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1397,6 +1397,10 @@ export class AgentRunner extends EventEmitter {
     if (meta['replied_message_id']) {
       const repliedAttrs = [
         'replied_image_path',
+        'replied_attachment_file_id',
+        'replied_attachment_kind',
+        'replied_attachment_mime',
+        'replied_attachment_name',
       ]
         .filter(k => meta[k])
         .map(k => ` ${k}="${meta[k]!.replace(/"/g, '&quot;')}"`)

--- a/tests/unit/channel-replied-attachment.test.ts
+++ b/tests/unit/channel-replied-attachment.test.ts
@@ -1,0 +1,38 @@
+import { AgentRunner } from '../../src/agent/runner'
+
+// buildChannelXml is a private static; poke it directly to assert the wire tag.
+const build = (meta: Record<string, string>): string =>
+  (AgentRunner as any).buildChannelXml({ content: 'hi', meta })
+
+describe('buildChannelXml — replied attachment', () => {
+  it('surfaces replied_attachment_file_id (+ kind/mime/name) inside <replied>', () => {
+    const xml = build({
+      source: 'telegram',
+      chat_id: '1',
+      message_id: '10',
+      user: 'jisack',
+      replied_message_id: '5',
+      replied_user: 'jisack',
+      replied_attachment_file_id: 'BQAC-doc',
+      replied_attachment_kind: 'document',
+      replied_attachment_mime: 'text/csv',
+      replied_attachment_name: 'keys.csv',
+    })
+    expect(xml).toContain('<replied message_id="5"')
+    expect(xml).toContain('replied_attachment_file_id="BQAC-doc"')
+    expect(xml).toContain('replied_attachment_name="keys.csv"')
+  })
+
+  it('omits replied attachment attrs when the quoted message had none', () => {
+    const xml = build({
+      chat_id: '1',
+      message_id: '10',
+      user: 'jisack',
+      replied_message_id: '5',
+      replied_user: 'jisack',
+      replied_text: 'just text',
+    })
+    expect(xml).toContain('<replied message_id="5"')
+    expect(xml).not.toContain('replied_attachment_file_id')
+  })
+})

--- a/tests/unit/reply-attachment.test.ts
+++ b/tests/unit/reply-attachment.test.ts
@@ -1,0 +1,33 @@
+import { extractRepliedAttachment } from '../../mcp/tools/telegram/reply-attachment'
+
+// The replied-to message is a full Telegram Message; we only care about the
+// attachment fields here, so cast minimal literals.
+const asMsg = (m: Record<string, unknown>) => m as any
+
+describe('extractRepliedAttachment', () => {
+  it('lifts a document (the CSV-quote-reply bug)', () => {
+    const att = extractRepliedAttachment(
+      asMsg({ document: { file_id: 'BQAC-doc', file_size: 1234, mime_type: 'text/csv', file_name: 'keys.csv' } }),
+    )
+    expect(att).toEqual({ kind: 'document', file_id: 'BQAC-doc', size: 1234, mime: 'text/csv', name: 'keys.csv' })
+  })
+
+  it('sanitizes a hostile file name', () => {
+    const att = extractRepliedAttachment(asMsg({ document: { file_id: 'x', file_name: 'a<b>[c]\nd;e' } }))
+    expect(att?.name).toBe('a_b__c__d_e')
+  })
+
+  it('lifts video / audio / voice / video_note / sticker', () => {
+    expect(extractRepliedAttachment(asMsg({ video: { file_id: 'v' } }))?.kind).toBe('video')
+    expect(extractRepliedAttachment(asMsg({ audio: { file_id: 'a' } }))?.kind).toBe('audio')
+    expect(extractRepliedAttachment(asMsg({ voice: { file_id: 'vo' } }))?.kind).toBe('voice')
+    expect(extractRepliedAttachment(asMsg({ video_note: { file_id: 'vn' } }))?.kind).toBe('video_note')
+    expect(extractRepliedAttachment(asMsg({ sticker: { file_id: 's' } }))?.kind).toBe('sticker')
+  })
+
+  it('returns undefined for a photo (handled as image_path), plain text, and nothing', () => {
+    expect(extractRepliedAttachment(asMsg({ photo: [{ file_id: 'p' }] }))).toBeUndefined()
+    expect(extractRepliedAttachment(asMsg({ text: 'hello' }))).toBeUndefined()
+    expect(extractRepliedAttachment(undefined)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem
A Telegram quote-reply carries the **full** replied-to message, but the receiver only ever downloaded a replied **photo**. Replying to a *document* (or video/audio/voice/…) dropped the file entirely — the agent saw a `<replied>` block with no `file_id`, so there was no way to fetch what the user quoted. This is exactly what bit us when a CSV was sent by quote-reply: the file was unreachable.

## Fix
Extract the quoted message's non-photo attachment and surface it as `replied_attachment_file_id` (+ `kind`/`mime`/`name`), mirroring the existing current-message attachment path, so the agent can fetch it with `download_attachment`.

- **new** `mcp/tools/telegram/reply-attachment.ts` — pure `extractRepliedAttachment()` helper (document/video/audio/voice/video_note/sticker; photos → `undefined`, handled as `image_path`)
- `receiver-server.ts` — populate `replied_attachment_*` meta on the reply branch
- `runner.ts` — emit `replied_attachment_*` attributes on the `<replied>` tag
- channel instructions — document the new attributes

## Tests
- `tests/unit/reply-attachment.test.ts` — extractor (document lift, hostile-name sanitize, all kinds, photo/text/none → undefined). **Verified locally: 4/4 pass under `bun test`.**
- `tests/unit/channel-replied-attachment.test.ts` — asserts the `<replied>` tag surfaces `replied_attachment_file_id`. (Runs in CI; couldn't run locally — `grammy` isn't installed in the checkout and `runner.ts` pulls `node:sqlite`, unsupported by `bun`.)

No behavior change for text/photo replies; the new attrs only appear when the quoted message actually held a non-photo attachment.