### PR TITLE
feat(api): bridge composer video_params to the agent

### DIFF
--- a/API.md
+++ b/API.md
@@ -1313,6 +1313,7 @@ Send a message to an agent. Returns a JSON response or SSE stream.
 | `media_files` | No | Array of `mediaPath` strings returned by the Media Upload endpoint |
 | `store_user_message` | No | Set to `false` to skip persisting the user message in session history — only the assistant response is stored. Requires a write or admin key. Useful for proactive/trigger prompts where the user trigger should be invisible. |
 | `image_params` | No | Composer-selected image-generation options, surfaced to the agent so it calls the built-in `generate_image` tool with them. An object with optional string fields `model`, `quality`, `size`, `aspect_ratio`, `image_ref` and optional positive number `n`. Empty/whitespace strings are ignored; a non-object (or `n < 1`) returns `400`. The latest sent value is persisted to session meta as `imageConfig` (see the sessions list endpoint) so a web client can restore the selection on reload. |
+| `video_params` | No | Composer-selected video-generation options, surfaced to the agent so it calls the built-in `generate_video` tool with them (model/duration/aspect made authoritative — no invented cap, no scene split). An object with optional string fields `model`, `resolution`, `aspect_ratio`, `image_ref` (source frame for image-to-video) and optional positive integer `duration`. Empty/whitespace strings are ignored; a non-object (or `duration < 1`) returns `400`. The latest sent value is persisted to session meta as `videoConfig` (see the sessions list endpoint) so a web client can restore the selection on reload. |
 
 #### Slash command dispatch
 
@@ -2836,6 +2837,7 @@ curl -H "X-Api-Key: admin-key-456" \
           "lastMessage": "Sure, I can help with that!",
           "sessionName": "Project Planning",
           "imageConfig": { "model": "openai/gpt-image-1", "quality": "medium" },
+          "videoConfig": { "model": "grok-video/grok-imagine-video-1.5", "duration": 15 },
           "model": "claude-opus-4-8"
         }
       ]
@@ -2857,6 +2859,7 @@ curl -H "X-Api-Key: admin-key-456" \
 | `lastMessage` | string\|null | Preview of the last message content |
 | `sessionName` | string\|null | Human-readable session name (set via `/rename` or `POST /sessions`) |
 | `imageConfig` | object\|null | Last `image_params` sent for this session (composer image-generation options); `null` when none set. Lets a web client restore the composer selection on reload. |
+| `videoConfig` | object\|null | Last `video_params` sent for this session (composer video-generation options); `null` when none set. Lets a web client restore the composer selection on reload. |
 | `model` | string\|null | Real Claude model that produced the session's latest turn, captured from the stream and updated every turn (so a mid-session `/model` switch is reflected). `null` for legacy sessions recorded before this was tracked, or when no turn has run yet. |
 
 **Error responses:**

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1400,18 +1400,31 @@ export class AgentRunner extends EventEmitter {
    * session path; refs that were never staged (catalog refs, artifact:<id>)
    * pass through untouched. (#74)
    */
-  static remapImageParamsRefs(
-    p: ImageParams | undefined,
+  // Build the staging→promoted path map: promoteUiUploads moves a turn's
+  // ui-upload files into per-session storage, so any ref built from a staging
+  // path must follow the file to its new location (#74). Empty map = nothing
+  // moved (or no uploads), so callers leave their refs untouched.
+  private static buildRefRemap(
     stagedPaths: readonly string[] | undefined,
     promotedPaths: readonly string[] | undefined,
-  ): ImageParams | undefined {
-    if (!p || !stagedPaths?.length || !promotedPaths?.length) return p;
+  ): Map<string, string> {
     const map = new Map<string, string>();
+    if (!stagedPaths?.length || !promotedPaths?.length) return map;
     for (let i = 0; i < Math.min(stagedPaths.length, promotedPaths.length); i++) {
       const from = stagedPaths[i]!;
       const to = promotedPaths[i]!;
       if (from !== to) map.set(from, to);
     }
+    return map;
+  }
+
+  static remapImageParamsRefs(
+    p: ImageParams | undefined,
+    stagedPaths: readonly string[] | undefined,
+    promotedPaths: readonly string[] | undefined,
+  ): ImageParams | undefined {
+    if (!p) return p;
+    const map = AgentRunner.buildRefRemap(stagedPaths, promotedPaths);
     if (!map.size) return p;
     const remap = (r: string): string => map.get(r) ?? r;
     return {
@@ -1419,6 +1432,21 @@ export class AgentRunner extends EventEmitter {
       ...(p.image_ref ? { image_ref: remap(p.image_ref) } : {}),
       ...(p.image_refs?.length ? { image_refs: p.image_refs.map(remap) } : {}),
     };
+  }
+
+  // Video analogue of remapImageParamsRefs. The composer's image-to-video
+  // source frame (VideoParams.image_ref) is built from a staging path; without
+  // this remap the raw ref dangles after promoteUiUploads moves the file, and
+  // generate_video fails share_ref_not_found. artifact:/catalog refs aren't in
+  // the map, so they pass through untouched.
+  static remapVideoParamsRefs(
+    p: VideoParams | undefined,
+    stagedPaths: readonly string[] | undefined,
+    promotedPaths: readonly string[] | undefined,
+  ): VideoParams | undefined {
+    if (!p?.image_ref) return p;
+    const to = AgentRunner.buildRefRemap(stagedPaths, promotedPaths).get(p.image_ref);
+    return to ? { ...p, image_ref: to } : p;
   }
 
   private static buildChannelXml(params: {
@@ -3386,6 +3414,8 @@ export class AgentRunner extends EventEmitter {
     // Refs built from staging paths must follow the files to their promoted
     // location — see remapImageParamsRefs (#74).
     const imageParams = AgentRunner.remapImageParamsRefs(opts.imageParams, opts.mediaFiles, finalMediaFiles);
+    // The image-to-video source frame follows the same staging→promoted move.
+    const videoParams = AgentRunner.remapVideoParamsRefs(opts.videoParams, opts.mediaFiles, finalMediaFiles);
 
     // Resolve media files to absolute paths for file-path based image passing
     // (same pattern as Telegram — Claude Code reads files via Read tool instead of base64 inline)
@@ -3447,7 +3477,7 @@ export class AgentRunner extends EventEmitter {
     // Build channel XML with image_path attribute (like Telegram) for first image
     const imageAttr = effectiveImagePaths.length ? ` image_path="${AgentRunner.escapeXmlAttr(effectiveImagePaths[0]!)}"` : '';
     const imageParamsNote = imageParams ? AgentRunner.buildImageParamsNote(imageParams) : '';
-    const videoParamsNote = opts.videoParams ? AgentRunner.buildVideoParamsNote(opts.videoParams) : '';
+    const videoParamsNote = videoParams ? AgentRunner.buildVideoParamsNote(videoParams) : '';
     // Persist the composer image options to session meta so the web can restore the
     // selection on reload (SessionMeta.imageConfig). Only when the send carries them
     // (the web sends image_params on first-set/change), so this holds the latest.
@@ -3685,6 +3715,8 @@ export class AgentRunner extends EventEmitter {
     // Refs built from staging paths must follow the files to their promoted
     // location — see remapImageParamsRefs (#74).
     const imageParamsStream = AgentRunner.remapImageParamsRefs(opts.imageParams, opts.mediaFiles, finalMediaFilesStream);
+    // The image-to-video source frame follows the same staging→promoted move.
+    const videoParamsStream = AgentRunner.remapVideoParamsRefs(opts.videoParams, opts.mediaFiles, finalMediaFilesStream);
 
     // Resolve media files to absolute paths for file-path based image passing
     const imagePathsStream = finalMediaFilesStream?.length ? this.resolveMediaPaths(finalMediaFilesStream) : [];
@@ -3964,7 +3996,7 @@ export class AgentRunner extends EventEmitter {
     // Build channel XML with image_path attribute (like Telegram) for first image
     const imageAttrStream = effectiveImagePathsStream.length ? ` image_path="${AgentRunner.escapeXmlAttr(effectiveImagePathsStream[0]!)}"` : '';
     const imageParamsNoteStream = imageParamsStream ? AgentRunner.buildImageParamsNote(imageParamsStream) : '';
-    const videoParamsNoteStream = opts.videoParams ? AgentRunner.buildVideoParamsNote(opts.videoParams) : '';
+    const videoParamsNoteStream = videoParamsStream ? AgentRunner.buildVideoParamsNote(videoParamsStream) : '';
     // Persist composer image config to session meta (SessionMeta.imageConfig) so the
     // web restores the selection on reload. This is the streaming path the web uses.
     // image_refs are per-turn and deliberately excluded (#73).

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -3489,6 +3489,12 @@ export class AgentRunner extends EventEmitter {
         .updateSessionMeta(this.agentConfig.id, chatId, sessionId, { imageConfig: durableImageConfig }, 'api')
         .catch(() => {});
     }
+    // Persist composer video options the same way (SessionMeta.videoConfig).
+    if (videoParams) {
+      this.sessionStore
+        .updateSessionMeta(this.agentConfig.id, chatId, sessionId, { videoConfig: videoParams }, 'api')
+        .catch(() => {});
+    }
     const channelXml =
       `<channel source="api" chat_id="${chatId}" session_id="${sessionId}" ts="${new Date().toISOString()}"${imageAttr}>\n` +
       `${message}\n\n` +
@@ -4009,6 +4015,12 @@ export class AgentRunner extends EventEmitter {
         .updateSessionMeta(this.agentConfig.id, chatId, sessionId, { imageConfig: durableImageConfigStream }, 'api')
         .catch(() => {});
     }
+    // Persist composer video options the same way (SessionMeta.videoConfig).
+    if (videoParamsStream) {
+      this.sessionStore
+        .updateSessionMeta(this.agentConfig.id, chatId, sessionId, { videoConfig: videoParamsStream }, 'api')
+        .catch(() => {});
+    }
     const channelXml =
       `<channel source="api" chat_id="${chatId}" session_id="${sessionId}" ts="${new Date().toISOString()}"${imageAttrStream}>\n` +
       `${message}\n\n` +
@@ -4168,7 +4180,7 @@ export class AgentRunner extends EventEmitter {
     return this.historyDb;
   }
 
-  getAllSessionMeta(): Promise<Map<string, { name: string; imageConfig?: ImageParams; model?: string }>> {
+  getAllSessionMeta(): Promise<Map<string, { name: string; imageConfig?: ImageParams; videoConfig?: VideoParams; model?: string }>> {
     return this.sessionStore.getAllSessionMeta(this.agentConfig.id);
   }
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -6,7 +6,7 @@ import * as http from 'http';
 import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
-import { AgentConfig, CustomConnectorEntry, GatewayConfig, Logger, Message, ModelConfig, StreamEvent, ApiAttachment, ImageParams } from '../types';
+import { AgentConfig, CustomConnectorEntry, GatewayConfig, Logger, Message, ModelConfig, StreamEvent, ApiAttachment, ImageParams, VideoParams } from '../types';
 import { withConfigWriteLock, writeConfigAtomicSync } from '../config/config-write-lock';
 import { createLogger } from '../logger';
 import { SessionProcess, MAX_HISTORY_MESSAGES, resolveMaxHistoryMessages, INTERRUPTED_NO_REPLY_TEXT } from '../session/process';
@@ -1326,6 +1326,57 @@ export class AgentRunner extends EventEmitter {
       `second-guess an explicit selection, and do not drop any of them. ` +
       `Do NOT open or Read the referenced files first — the image model receives the actual files; ` +
       `reading them wastes minutes and can push the request past its timeout. Go straight to generate_image.\n`
+    );
+  }
+
+  /**
+   * Render composer-selected video options as a directive the agent reads and
+   * forwards to the generate_video MCP tool. Mirrors buildImageParamsNote. Returns
+   * '' when no usable options are present. Without this the agent gets no composer
+   * context for video and invents duration/aspect (a phantom 10s cap, an 8+8 scene
+   * split, or a landscape clip when 9:16 was picked).
+   */
+  private static buildVideoParamsNote(p: VideoParams): string {
+    const attrs = [
+      p.model ? `model="${AgentRunner.escapeXmlAttr(p.model)}"` : '',
+      p.resolution ? `resolution="${AgentRunner.escapeXmlAttr(p.resolution)}"` : '',
+      p.aspect_ratio ? `aspect_ratio="${AgentRunner.escapeXmlAttr(p.aspect_ratio)}"` : '',
+      typeof p.duration === 'number' ? `duration="${p.duration}"` : '',
+      p.image_ref ? `image_ref="${AgentRunner.escapeXmlAttr(p.image_ref)}"` : '',
+    ].filter(Boolean);
+    if (!attrs.length) return '';
+    // The generate_video schema lets the agent pick model/duration itself; when the
+    // composer selection isn't made authoritative the agent falls back to
+    // action="list" and self-selects, or invents a duration cap and splits the clip
+    // into multiple scenes. Nail every field down.
+    const modelNote = p.model
+      ? `The user explicitly SELECTED model="${AgentRunner.escapeXmlAttr(p.model)}" in the composer. ` +
+        `Call generate_video with that exact model — do NOT call action="list" to second-guess an ` +
+        `explicit selection or substitute a different model.\n`
+      : '';
+    const durationNote =
+      typeof p.duration === 'number'
+        ? `duration=${p.duration} is a valid length for the selected model — pass it verbatim as the "duration" ` +
+          `argument. Do NOT invent a maximum, do NOT clamp it to a smaller value, and do NOT split the request ` +
+          `into multiple shorter scenes/clips. Generate exactly ONE clip of this duration.\n`
+        : '';
+    const aspectNote = p.aspect_ratio
+      ? `Pass aspect_ratio="${AgentRunner.escapeXmlAttr(p.aspect_ratio)}" verbatim — do NOT change the orientation.\n`
+      : '';
+    const refNote = p.image_ref
+      ? `The user selected a source image for image-to-video. Pass image_ref="${AgentRunner.escapeXmlAttr(p.image_ref)}" ` +
+        `as the "image" argument of generate_video (the source frame's own aspect then wins). ` +
+        `Do NOT call list_refs to second-guess it, and do NOT open or Read the file first.\n`
+      : '';
+    return (
+      `<video-params ${attrs.join(' ')} />\n` +
+      `The user selected the video-generation options above in the composer. When the request involves ` +
+      `creating a video, call the generate_video tool (action="generate") using these exact values, then ` +
+      `deliver the returned video with your reply tool.\n` +
+      modelNote +
+      durationNote +
+      aspectNote +
+      refNote
     );
   }
 
@@ -3309,7 +3360,7 @@ export class AgentRunner extends EventEmitter {
     sessionId: string,
     chatId: string,
     message: string,
-    opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[]; model?: string; skipUserMessage?: boolean; imageParams?: ImageParams },
+    opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[]; model?: string; skipUserMessage?: boolean; imageParams?: ImageParams; videoParams?: VideoParams },
   ): Promise<{ text: string; attachments: ApiAttachment[] }> {
     if (this.pendingApiSessions.has(sessionId)) {
       const err = Object.assign(
@@ -3396,6 +3447,7 @@ export class AgentRunner extends EventEmitter {
     // Build channel XML with image_path attribute (like Telegram) for first image
     const imageAttr = effectiveImagePaths.length ? ` image_path="${AgentRunner.escapeXmlAttr(effectiveImagePaths[0]!)}"` : '';
     const imageParamsNote = imageParams ? AgentRunner.buildImageParamsNote(imageParams) : '';
+    const videoParamsNote = opts.videoParams ? AgentRunner.buildVideoParamsNote(opts.videoParams) : '';
     // Persist the composer image options to session meta so the web can restore the
     // selection on reload (SessionMeta.imageConfig). Only when the send carries them
     // (the web sends image_params on first-set/change), so this holds the latest.
@@ -3412,6 +3464,7 @@ export class AgentRunner extends EventEmitter {
       `${message}\n\n` +
       `${systemNote}` +
       `${imageParamsNote}` +
+      `${videoParamsNote}` +
       `</channel>` +
       (skillInvocation ? `\n${formatSkillContext(skillInvocation)}` : '');
 
@@ -3606,7 +3659,7 @@ export class AgentRunner extends EventEmitter {
     chatId: string,
     message: string,
     callbacks: ApiStreamCallbacks,
-    opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[]; model?: string; skipUserMessage?: boolean; imageParams?: ImageParams; requestId?: string },
+    opts: { timeoutMs: number; allowTools?: boolean; mediaFiles?: string[]; model?: string; skipUserMessage?: boolean; imageParams?: ImageParams; videoParams?: VideoParams; requestId?: string },
   ): Promise<() => void> {
     if (this.pendingApiSessions.has(sessionId)) {
       const err = Object.assign(
@@ -3911,6 +3964,7 @@ export class AgentRunner extends EventEmitter {
     // Build channel XML with image_path attribute (like Telegram) for first image
     const imageAttrStream = effectiveImagePathsStream.length ? ` image_path="${AgentRunner.escapeXmlAttr(effectiveImagePathsStream[0]!)}"` : '';
     const imageParamsNoteStream = imageParamsStream ? AgentRunner.buildImageParamsNote(imageParamsStream) : '';
+    const videoParamsNoteStream = opts.videoParams ? AgentRunner.buildVideoParamsNote(opts.videoParams) : '';
     // Persist composer image config to session meta (SessionMeta.imageConfig) so the
     // web restores the selection on reload. This is the streaming path the web uses.
     // image_refs are per-turn and deliberately excluded (#73).
@@ -3928,6 +3982,7 @@ export class AgentRunner extends EventEmitter {
       `${message}\n\n` +
       systemNote +
       imageParamsNoteStream +
+      videoParamsNoteStream +
       `</channel>` +
       (skillInvocationStream ? `\n${formatSkillContext(skillInvocationStream)}` : '');
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -815,7 +815,7 @@ export function createApiRouter(
           description: cfg?.description ?? '',
           sessions: sessions.map((s) => {
             const meta = metaMap.get(s.sessionId);
-            return { ...s, sessionName: meta?.name ?? null, imageConfig: meta?.imageConfig ?? null, model: meta?.model ?? null };
+            return { ...s, sessionName: meta?.name ?? null, imageConfig: meta?.imageConfig ?? null, videoConfig: meta?.videoConfig ?? null, model: meta?.model ?? null };
           }),
         };
       }),

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { spawn } from 'child_process';
 import { AgentRunner } from '../agent/runner';
 import { callbackSink, errorCode, type ApiStreamCallbacks } from '../agent/turn-stream';
-import { AgentConfig, ApiKey, ImageParams, ModelConfig } from '../types';
+import { AgentConfig, ApiKey, ImageParams, ModelConfig, VideoParams } from '../types';
 import { isValidConnectorId } from '../connectors/custom';
 import { agentsDirForConfig } from '../config/agent-env';
 import { withConfigWriteLock, writeConfigAtomic } from '../config/config-write-lock';
@@ -406,8 +406,9 @@ export function createApiRouter(
       model?: unknown;
       store_user_message?: unknown;
       image_params?: unknown;
+      video_params?: unknown;
     };
-    const { message, chat_id, session_id, stream, timeout_ms, media_files, model: requestModel, store_user_message, image_params } = body;
+    const { message, chat_id, session_id, stream, timeout_ms, media_files, model: requestModel, store_user_message, image_params, video_params } = body;
 
     if (message !== undefined && typeof message !== 'string') {
       res.status(400).json({ error: 'message must be a string if provided' });
@@ -504,6 +505,38 @@ export function createApiRouter(
       if (Object.keys(out).length) validatedImageParams = out;
     }
 
+    // Validate optional video_params — mirrors image_params. Surfaced to the agent
+    // so it calls generate_video with the composer-selected model/duration/
+    // resolution/aspect_ratio instead of inventing them.
+    let validatedVideoParams: VideoParams | undefined;
+    if (video_params !== undefined) {
+      if (typeof video_params !== 'object' || video_params === null || Array.isArray(video_params)) {
+        res.status(400).json({ error: 'video_params must be an object if provided' });
+        return;
+      }
+      const vp = video_params as Record<string, unknown>;
+      const vStrFields = ['model', 'resolution', 'aspect_ratio', 'image_ref'] as const;
+      const vOut: VideoParams = {};
+      for (const f of vStrFields) {
+        const v = vp[f];
+        if (v !== undefined) {
+          if (typeof v !== 'string') {
+            res.status(400).json({ error: `video_params.${f} must be a string` });
+            return;
+          }
+          if (v.trim()) vOut[f] = v.trim();
+        }
+      }
+      if (vp.duration !== undefined) {
+        if (typeof vp.duration !== 'number' || !Number.isFinite(vp.duration) || vp.duration < 1) {
+          res.status(400).json({ error: 'video_params.duration must be a positive number' });
+          return;
+        }
+        vOut.duration = Math.floor(vp.duration);
+      }
+      if (Object.keys(vOut).length) validatedVideoParams = vOut;
+    }
+
     // Allow message OR media_files. Image-only sends pass an empty text
     // alongside the image_path attribute on channelXml so Claude can Read the file.
     const trimmedMessage = typeof message === 'string' ? message.trim() : '';
@@ -595,7 +628,7 @@ export function createApiRouter(
           chatIdStr,
           trimmedMessage,
           sseCallbacks,
-          { timeoutMs, allowTools, mediaFiles: validatedMediaFiles, model: modelStr, skipUserMessage, imageParams: validatedImageParams, requestId },
+          { timeoutMs, allowTools, mediaFiles: validatedMediaFiles, model: modelStr, skipUserMessage, imageParams: validatedImageParams, videoParams: validatedVideoParams, requestId },
         );
 
         // Client disconnect — detaches this connection's sink. The turn keeps
@@ -637,6 +670,7 @@ export function createApiRouter(
             model: modelStr,
             skipUserMessage,
             imageParams: validatedImageParams,
+            videoParams: validatedVideoParams,
           }));
         }
         const syncResult: Record<string, unknown> = {

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import PQueue from 'p-queue';
-import { ImageParams, Message, SessionIndex, SessionMeta } from '../types';
+import { ImageParams, Message, SessionIndex, SessionMeta, VideoParams } from '../types';
 import { CHAT_CHANNELS, type ChatChannelOrApi } from '../history/types';
 
 // getAllSessionMeta's directory-prefix scan below needs 'api' alongside the
@@ -453,7 +453,7 @@ export class SessionStore {
     agentId: string,
     chatId: string,
     sessionId: string,
-    meta: Partial<Pick<SessionMeta, 'name' | 'totalTokensUsed' | 'messageCount' | 'lastInputTokens' | 'loadedAtSpawn' | 'archivedCount' | 'messageCountAtSpawn' | 'imageConfig' | 'model'>>,
+    meta: Partial<Pick<SessionMeta, 'name' | 'totalTokensUsed' | 'messageCount' | 'lastInputTokens' | 'loadedAtSpawn' | 'archivedCount' | 'messageCountAtSpawn' | 'imageConfig' | 'videoConfig' | 'model'>>,
     channel: ChatChannelOrApi = 'telegram',
   ): Promise<void> {
     const queue = this.getTelegramQueue(agentId, chatId);
@@ -615,8 +615,8 @@ export class SessionStore {
   }
 
   /** Get all session metadata (name) for an agent, keyed by sessionId. */
-  async getAllSessionMeta(agentId: string): Promise<Map<string, { name: string; imageConfig?: ImageParams; model?: string }>> {
-    const metaMap = new Map<string, { name: string; imageConfig?: ImageParams; model?: string }>();
+  async getAllSessionMeta(agentId: string): Promise<Map<string, { name: string; imageConfig?: ImageParams; videoConfig?: VideoParams; model?: string }>> {
+    const metaMap = new Map<string, { name: string; imageConfig?: ImageParams; videoConfig?: VideoParams; model?: string }>();
     const sessionsDir = path.join(this.agentsBaseDir, agentId, 'sessions');
     let entries: fs.Dirent[];
     try {
@@ -631,7 +631,7 @@ export class SessionStore {
         const chatId = e.name.slice(channel.length + 1);
         const index = await this.loadIndex(agentId, chatId, channel);
         if (index) {
-          for (const s of index.sessions) metaMap.set(s.id, { name: s.name, imageConfig: s.imageConfig, model: s.model });
+          for (const s of index.sessions) metaMap.set(s.id, { name: s.name, imageConfig: s.imageConfig, videoConfig: s.videoConfig, model: s.model });
         }
       });
     await Promise.all(reads);

--- a/src/types.ts
+++ b/src/types.ts
@@ -591,6 +591,28 @@ export type ImageParams = {
   n?: number;
 };
 
+/**
+ * Video-generation options selected in the web composer (per-session), passed
+ * through the chat send body as `video_params` and surfaced to the agent so it
+ * calls the `generate_video` MCP tool with these exact values. Mirrors ImageParams.
+ * Without this bridge the agent receives no composer context for video and invents
+ * duration/aspect (e.g. a non-existent 10s cap, an 8+8 scene split, or a landscape
+ * clip when 9:16 was selected).
+ */
+export type VideoParams = {
+  model?: string;
+  resolution?: string;
+  aspect_ratio?: string;
+  /** Discrete clip length in seconds (model-specific, e.g. 6/10/15). */
+  duration?: number;
+  /**
+   * Source frame for image-to-video, if the composer selected one. A `ref` value
+   * (media-relative path or `artifact:<id>`) passed as the generate_video `image`
+   * argument. When present the source frame's own aspect wins over aspect_ratio.
+   */
+  image_ref?: string;
+};
+
 export type StreamEvent =
   | { type: 'text_delta'; text: string }
   | { type: 'tool_use'; name: string; id: string; input?: Record<string, unknown> }

--- a/src/types.ts
+++ b/src/types.ts
@@ -554,6 +554,10 @@ export interface SessionMeta {
    *  can restore the composer selection on reload; the agent's own context is the
    *  functional source of truth. Updated whenever a send carries image_params. */
   imageConfig?: ImageParams;
+  /** Last composer video options sent for this session. Mirrors imageConfig —
+   *  persisted so the web can restore the composer selection on reload. Updated
+   *  whenever a send carries video_params. */
+  videoConfig?: VideoParams;
   /** Real model from Claude stream, updated per turn (e.g. "claude-opus-4-8"). */
   model?: string;
 }

--- a/tests/unit/api-router.test.ts
+++ b/tests/unit/api-router.test.ts
@@ -99,14 +99,14 @@ class MockAgentRunner extends EventEmitter {
   // Backing data for GET /v1/agents/sessions — override per-test via the impl fields.
   getHistoryDbImpl: () => { listSessions: (chatId?: string) => Array<Record<string, unknown>> } =
     () => ({ listSessions: () => [] });
-  getAllSessionMetaImpl: () => Promise<Map<string, { name: string; imageConfig?: unknown; model?: string }>> =
+  getAllSessionMetaImpl: () => Promise<Map<string, { name: string; imageConfig?: unknown; videoConfig?: unknown; model?: string }>> =
     () => Promise.resolve(new Map());
 
   getHistoryDb(): { listSessions: (chatId?: string) => Array<Record<string, unknown>> } {
     return this.getHistoryDbImpl();
   }
 
-  getAllSessionMeta(): Promise<Map<string, { name: string; imageConfig?: unknown; model?: string }>> {
+  getAllSessionMeta(): Promise<Map<string, { name: string; imageConfig?: unknown; videoConfig?: unknown; model?: string }>> {
     return this.getAllSessionMetaImpl();
   }
 }
@@ -1071,7 +1071,7 @@ describe('GET /api/v1/agents/sessions', () => {
     };
   }
 
-  function buildSessionsApp(agents: Record<string, { sessions: Array<Record<string, unknown>>; metaMap: Map<string, { name: string; imageConfig?: unknown; model?: string }> }>) {
+  function buildSessionsApp(agents: Record<string, { sessions: Array<Record<string, unknown>>; metaMap: Map<string, { name: string; imageConfig?: unknown; videoConfig?: unknown; model?: string }> }>) {
     const runners = new Map<string, import('../../src/agent/runner').AgentRunner>();
     const configs = new Map<string, AgentConfig>();
     for (const [id, data] of Object.entries(agents)) {
@@ -1103,6 +1103,24 @@ describe('GET /api/v1/agents/sessions', () => {
     expect(session.sessionName).toBe('My Session');
   });
 
+  it('S1b: exposes videoConfig from getAllSessionMeta, mirroring imageConfig', async () => {
+    const app = buildSessionsApp({
+      [AGENT_ID]: {
+        sessions: [makeHistorySession('sess-vid')],
+        metaMap: new Map([
+          ['sess-vid', { name: 'Vid Session', videoConfig: { model: 'grok-video/x', duration: 15 } }],
+        ]),
+      },
+    });
+
+    const res = await supertest.default(app).get(SESSIONS_URL).set(ADMIN_AUTH);
+
+    expect(res.status).toBe(200);
+    const session = res.body.agents[0].sessions[0];
+    expect(session.videoConfig).toEqual({ model: 'grok-video/x', duration: 15 });
+    expect(session.imageConfig).toBeNull();
+  });
+
   it('S2 (bad case): a session with no meta entry at all reports model: null, not undefined/missing', async () => {
     const app = buildSessionsApp({
       [AGENT_ID]: {
@@ -1117,6 +1135,7 @@ describe('GET /api/v1/agents/sessions', () => {
     const session = res.body.agents[0].sessions[0];
     expect(session).toHaveProperty('model');
     expect(session.model).toBeNull();
+    expect(session.videoConfig).toBeNull();
   });
 
   it('S3 (bad case): a meta entry that predates the model field reports model: null', async () => {

--- a/tests/unit/video-params-wire.test.ts
+++ b/tests/unit/video-params-wire.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for composer video options on the wire:
+ *   - POST /api/v1/agents/:agentId/messages validation of `video_params`
+ *     (string model/resolution/aspect_ratio/image_ref, positive-integer duration)
+ *     and its forwarding to the runner.
+ *   - AgentRunner.buildVideoParamsNote rendering the selection as a <video-params>
+ *     directive that makes model/duration/aspect authoritative so the agent stops
+ *     inventing a duration cap, splitting into scenes, or flipping the orientation.
+ */
+import express from 'express';
+import * as supertest from 'supertest';
+import { createApiRouter } from '../../src/api/router';
+import { AgentRunner } from '../../src/agent/runner';
+import { AgentConfig, ApiKey, ApiAttachment, VideoParams } from '../../src/types';
+
+// ── Router fixtures ───────────────────────────────────────────────────────────
+
+const AGENT_ID = 'alfred';
+
+const agentConfig: AgentConfig = {
+  id: AGENT_ID,
+  description: 'Personal assistant',
+  workspace: '/tmp/alfred',
+  env: '',
+  telegram: { botToken: 'tok' },
+  claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: true, extraFlags: [] },
+};
+
+const apiKeys: ApiKey[] = [{ key: 'sk-test-app', agents: [AGENT_ID] }];
+const AUTH = { Authorization: 'Bearer sk-test-app' };
+const POST_URL = `/api/v1/agents/${AGENT_ID}/messages`;
+
+interface SendOpts {
+  timeoutMs: number;
+  allowTools?: boolean;
+  videoParams?: VideoParams;
+}
+
+function buildApp(): { app: express.Express; lastOpts: () => SendOpts | undefined } {
+  let captured: SendOpts | undefined;
+  const runner = {
+    async sendApiMessage(
+      _sessionId: string,
+      _chatId: string,
+      _message: string,
+      opts: SendOpts,
+    ): Promise<{ text: string; attachments: ApiAttachment[] }> {
+      captured = opts;
+      return { text: 'ok', attachments: [] };
+    },
+    hasActiveApiSession: () => false,
+    getAgentsBaseDir: () => '/tmp',
+  };
+  const runners = new Map([[AGENT_ID, runner as unknown as AgentRunner]]);
+  const configs = new Map([[AGENT_ID, agentConfig]]);
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createApiRouter(runners, configs, apiKeys));
+  return { app, lastOpts: () => captured };
+}
+
+const send = (app: express.Express, body: Record<string, unknown>) =>
+  supertest.default(app).post(POST_URL).set(AUTH).send({ message: 'make a clip', chat_id: 'c1', ...body });
+
+// ── Note-builder helper ───────────────────────────────────────────────────────
+
+const buildNote = (p: VideoParams): string =>
+  (AgentRunner as unknown as { buildVideoParamsNote: (p: VideoParams) => string })
+    .buildVideoParamsNote(p);
+
+// ── Router validation ─────────────────────────────────────────────────────────
+
+describe('video_params validation', () => {
+  it('accepts a full composer selection and forwards it to the runner', async () => {
+    const { app, lastOpts } = buildApp();
+    const video_params = {
+      model: 'grok-video/grok-imagine-video-1.5',
+      duration: 15,
+      resolution: '480p',
+      aspect_ratio: '9:16',
+    };
+    const res = await send(app, { video_params });
+    expect(res.status).toBe(200);
+    expect(lastOpts()!.videoParams).toEqual(video_params);
+  });
+
+  it('trims string fields and floors duration', async () => {
+    const { app, lastOpts } = buildApp();
+    const res = await send(app, {
+      video_params: { model: '  grok-video/x  ', resolution: ' 720p ', duration: 10.9 },
+    });
+    expect(res.status).toBe(200);
+    expect(lastOpts()!.videoParams).toEqual({ model: 'grok-video/x', resolution: '720p', duration: 10 });
+  });
+
+  it('carries an image_ref for image-to-video', async () => {
+    const { app, lastOpts } = buildApp();
+    const res = await send(app, { video_params: { image_ref: 'artifact:frame1' } });
+    expect(res.status).toBe(200);
+    expect(lastOpts()!.videoParams).toEqual({ image_ref: 'artifact:frame1' });
+  });
+
+  it('forwards no videoParams when video_params is absent', async () => {
+    const { app, lastOpts } = buildApp();
+    const res = await send(app, {});
+    expect(res.status).toBe(200);
+    expect(lastOpts()!.videoParams).toBeUndefined();
+  });
+
+  it.each([
+    ['an array', []],
+    ['null', null],
+    ['a string', 'grok'],
+  ])('rejects video_params that is %s with 400', async (_label, video_params) => {
+    const { app } = buildApp();
+    const res = await send(app, { video_params });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('video_params must be an object if provided');
+  });
+
+  it('rejects a non-string model with 400', async () => {
+    const { app } = buildApp();
+    const res = await send(app, { video_params: { model: 42 } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('video_params.model must be a string');
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -5],
+    ['non-finite', Number.POSITIVE_INFINITY],
+    ['a string', '15'],
+  ])('rejects duration that is %s with 400', async (_label, duration) => {
+    const { app } = buildApp();
+    const res = await send(app, { video_params: { duration } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('video_params.duration must be a positive number');
+  });
+});
+
+// ── Note builder ──────────────────────────────────────────────────────────────
+
+describe('buildVideoParamsNote', () => {
+  it('returns empty string when nothing usable is present', () => {
+    expect(buildNote({})).toBe('');
+  });
+
+  it('renders the selection as a self-closing <video-params> tag', () => {
+    const note = buildNote({
+      model: 'grok-video/grok-imagine-video-1.5',
+      resolution: '480p',
+      aspect_ratio: '9:16',
+      duration: 15,
+    });
+    expect(note).toContain(
+      '<video-params model="grok-video/grok-imagine-video-1.5" resolution="480p" aspect_ratio="9:16" duration="15" />\n',
+    );
+  });
+
+  it('makes the model authoritative and forbids action="list"', () => {
+    const note = buildNote({ model: 'grok-video/x' });
+    expect(note).toContain('explicitly SELECTED model="grok-video/x"');
+    expect(note).toContain('do NOT call action="list"');
+  });
+
+  it('nails the duration down — no invented cap, no scene split', () => {
+    const note = buildNote({ duration: 15 });
+    expect(note).toContain('duration=15 is a valid length');
+    expect(note).toContain('do NOT split the request');
+    expect(note).toContain('exactly ONE clip');
+  });
+
+  it('locks the aspect ratio orientation', () => {
+    const note = buildNote({ aspect_ratio: '9:16' });
+    expect(note).toContain('Pass aspect_ratio="9:16" verbatim');
+  });
+
+  it('routes image_ref to the "image" argument for image-to-video', () => {
+    const note = buildNote({ image_ref: 'artifact:frame1' });
+    expect(note).toContain('image_ref="artifact:frame1"');
+    expect(note).toContain('as the "image" argument of generate_video');
+    expect(note).toContain('Do NOT call list_refs');
+  });
+
+  it('omits the model note when no model is selected', () => {
+    const note = buildNote({ duration: 6 });
+    expect(note).not.toContain('explicitly SELECTED model=');
+  });
+});

--- a/tests/unit/video-params-wire.test.ts
+++ b/tests/unit/video-params-wire.test.ts
@@ -187,3 +187,39 @@ describe('buildVideoParamsNote', () => {
     expect(note).not.toContain('explicitly SELECTED model=');
   });
 });
+
+describe('remapVideoParamsRefs — the i2v source frame follows promoted files (#74)', () => {
+  const STAGED = ['media/ui-upload/abc123/frame.jpeg'];
+  const PROMOTED = ['media/api-s1/1-frame.jpeg'];
+
+  const remap = (p: VideoParams | undefined, staged?: string[], promoted?: string[]) =>
+    AgentRunner.remapVideoParamsRefs(p, staged, promoted);
+
+  it('rewrites a staged image_ref to its promoted path', () => {
+    const out = remap(
+      { model: 'grok-imagine-video-1.5', aspect_ratio: '9:16', image_ref: STAGED[0] },
+      STAGED,
+      PROMOTED,
+    );
+    expect(out).toEqual({
+      model: 'grok-imagine-video-1.5',
+      aspect_ratio: '9:16',
+      image_ref: PROMOTED[0],
+    });
+  });
+
+  it('leaves a catalog/artifact source frame untouched', () => {
+    const p: VideoParams = { image_ref: 'artifact:frame_x' };
+    expect(remap(p, STAGED, PROMOTED)).toBe(p);
+  });
+
+  it('is a no-op without params, without an image_ref, without media files, or when promotion failed', () => {
+    expect(remap(undefined, STAGED, PROMOTED)).toBeUndefined();
+    const noRef: VideoParams = { model: 'grok-imagine-video-1.5', duration: 6 };
+    expect(remap(noRef, STAGED, PROMOTED)).toBe(noRef);
+    const p: VideoParams = { image_ref: STAGED[0] };
+    expect(remap(p, undefined, undefined)).toBe(p);
+    // promoteUiUploads returns the ORIGINAL path when a move fails — no mapping entry.
+    expect(remap(p, STAGED, [...STAGED])).toBe(p);
+  });
+});


### PR DESCRIPTION
## Problem

The web composer sends `video_params` (model, duration, resolution, aspect_ratio) on every chat send, but the gateway **never parsed it**. PR #467 shipped the `generate_video` tool and the composer sends the selection, but the `image_params` → agent bridge that makes image respect the composer was never mirrored for video.

With zero composer context, the in-chat agent invents its own values:
- a **phantom 10s cap** ("the model maxes at 10s each")
- an **8+8 scene split** for a single 15s request
- a **landscape clip** when the user selected 9:16

Root cause: `router.ts` destructured `image_params` but not `video_params`; there was no `VideoParams` type and no `buildVideoParamsNote`.

## Fix

Mirror the `image_params` path end to end:
- **`VideoParams`** type (`src/types.ts`)
- **validate** `video_params` in the send handler — string `model`/`resolution`/`aspect_ratio`/`image_ref`, positive-integer `duration`; same shape and 400-error style as `image_params`
- **thread** it through both the sync (`sendApiMessage`) and streaming (`sendApiMessageStream`) runner paths
- **`buildVideoParamsNote`** — renders a `<video-params>` directive that makes the selection authoritative: call `generate_video` with the exact model (no `action="list"` second-guessing), pass the chosen `duration` verbatim and generate **exactly one clip** (no invented cap, no scene split), keep the `aspect_ratio` orientation, and route `image_ref` to the `image` arg for image-to-video.

## Tests

`tests/unit/video-params-wire.test.ts` — 19 cases (router validation + note builder). Full unit suite green (`npm run test:unit`, exit 0), `npm run build` clean.

## Notes

- Text-to-video is fully covered. i2v with a **freshly-uploaded** start frame isn't remapped through the ui-upload staging→session path yet (catalog/`artifact:` refs, the common case, work fine) — small follow-up if the composer grows that flow.
- Follow-up to merged #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)