### PR TITLE
feat(api): GET /v1/video-catalog — session video list for the Media panel

### DIFF
--- a/API.md
+++ b/API.md
@@ -255,6 +255,7 @@ before any path resolution.
 | `DELETE` | `/api/v1/shares/:shareId` | Key (owner/admin) | Revoke a share (uniform `404` when the key can't access the owner) |
 | `POST` | `/api/v1/image-artifacts` | Key (agent-scoped) | Register generated images as private artifacts (registration never makes a file public) |
 | `GET` | `/api/v1/image-catalog?agent_id=&session_id=` | Key (agent-scoped) | Deterministic per-session image list (oldest first); mints nothing, returns no token |
+| `GET` | `/api/v1/video-catalog?agent_id=&session_id=` | Key (agent-scoped) | Deterministic per-session video list (oldest first); the video analogue of `/v1/image-catalog`, kept separate so clips never enter the image-reference surface; mints nothing, returns no token |
 | `GET`/`HEAD` | `/shared/:token` | None (token IS the capability) | Stream the shared file — images `inline`, documents as an `attachment` whose filename is sanitised (RFC 8187) and whose **extension is forced to match the sniffed type**, not the agent-chosen basename (so `%PDF-` bytes named `invoice.html` download as `invoice.pdf`); always `X-Content-Type-Options: nosniff`; uniform `404` for unknown/expired/revoked/traversal/type-mismatch; per-IP rate limited. This is the single public share primitive — the gateway, MCP subprocesses, and LINE image delivery all mint through `/api/v1/shares` and serve here |
 
 **Renamed in #444** (the bridge is no longer image-only):

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_SHARE_TTL_SECONDS,
 } from '../share/share-store';
 import { computeSessionImageCatalog } from '../share/session-image-catalog';
+import { computeSessionVideoCatalog } from '../share/session-video-catalog';
 
 /**
  * Share bridge HTTP surface (#70, plan §10/§11).
@@ -557,6 +558,30 @@ export function createSharesPrivateRouter(
       return;
     }
     const items = computeSessionImageCatalog({ agentsBaseDir, store, agentId, sessionId });
+    res.json({ items });
+  });
+
+  /**
+   * GET /api/v1/video-catalog?agent_id=...&session_id=... — the deterministic
+   * video list of one session, oldest first. Response:
+   * { items: [{ index, relative_path, origin, ts, available, desc? }] }.
+   *
+   * The video analogue of /v1/image-catalog, kept separate so clips never leak
+   * into the image-reference surface. Read-only: mints nothing, returns no token.
+   */
+  router.get('/v1/video-catalog', auth, (req: Request, res: Response) => {
+    const apiKey = (req as AuthedRequest).apiKey;
+    const agentId = typeof req.query.agent_id === 'string' ? req.query.agent_id.trim() : '';
+    const sessionId = typeof req.query.session_id === 'string' ? req.query.session_id.trim() : '';
+    if (!isValidAgentId(agentId) || !isValidSessionId(sessionId)) {
+      res.status(400).json({ error: 'agent_id and session_id must be valid identifiers' });
+      return;
+    }
+    if (!canAccessAgent(apiKey, agentId)) {
+      res.status(403).json({ error: `API key has no access to agent '${agentId}'` });
+      return;
+    }
+    const items = computeSessionVideoCatalog({ agentsBaseDir, agentId, sessionId });
     res.json({ items });
   });
 

--- a/src/share/session-video-catalog.ts
+++ b/src/share/session-video-catalog.ts
@@ -15,7 +15,14 @@ import { MediaStore } from '../history/media-store';
  * videos in their own endpoint means image ordinals are untouched.
  */
 
-/** Clip containers the web renders with <video> (mirrors AGENT_VIDEO_URL_RE web-side). */
+/**
+ * Clip containers the web renders with <video>. MUST stay byte-identical to the
+ * web's AGENT_VIDEO_URL_RE (getpod apps/web: assistant.tsx + use-modal-chat.ts) —
+ * they live in separate repos, so there is no shared source to enforce it. A
+ * mismatch silently drops a clip the web can play (catalog too narrow) or lists
+ * one it cannot render (catalog too wide). Generated clips are always .mp4, so
+ * this only bites uploaded containers.
+ */
 const VIDEO_EXT_RE = /\.(mp4|webm|mov|m4v)$/i;
 
 export type SessionVideoCatalogItem = {

--- a/src/share/session-video-catalog.ts
+++ b/src/share/session-video-catalog.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import { HistoryDB } from '../history/db';
+import { MediaStore } from '../history/media-store';
+
+/**
+ * Session VIDEO catalog — the deterministic list of every video clip in ONE
+ * chat session, oldest first. The direct analogue of session-image-catalog (#72)
+ * for the Media panel's video gallery: derived fresh on every call from the same
+ * append-only message media_files, so the panel shows exactly the clips the
+ * session produced without a new table or a reconciliation job.
+ *
+ * Deliberately SEPARATE from the image catalog: the image catalog also backs the
+ * agent's `generate_image list_refs` / "Image N" reference resolution, and a video
+ * must never leak into that surface (it is not a valid image reference). Keeping
+ * videos in their own endpoint means image ordinals are untouched.
+ */
+
+/** Clip containers the web renders with <video> (mirrors AGENT_VIDEO_URL_RE web-side). */
+const VIDEO_EXT_RE = /\.(mp4|webm|mov|m4v)$/i;
+
+export type SessionVideoCatalogItem = {
+  /** 1-based ordinal by FIRST appearance — stable for the life of the session. */
+  index: number;
+  /** Media-ROOT-relative path ("<chatId>/<file>") — the web builds the media URL from this. */
+  relative_path: string;
+  origin: 'upload' | 'generated';
+  ts: number;
+  /** False when the bytes are gone from disk (the ordinal still holds its slot). */
+  available: boolean;
+  /** What the clip IS: the accompanying message text, so a content reference reads
+   *  without conversation memory. Omitted when there is no meaningful text. */
+  desc?: string;
+};
+
+/** Cap catalog descriptions — they describe, they are not a transcript. */
+const MAX_DESC_CHARS = 200;
+
+/** Channel receivers persist bare placeholders ("(video)") for captionless media
+ *  — those describe nothing, so they don't become a desc. */
+const PLACEHOLDER_CONTENT_RE = /^\((?:photo|image|video|file|sticker|audio|voice)\)$/i;
+
+function toDesc(text: string | null | undefined): string | undefined {
+  const t = (text ?? '').trim();
+  if (!t || PLACEHOLDER_CONTENT_RE.test(t)) return undefined;
+  return t.length > MAX_DESC_CHARS ? `${t.slice(0, MAX_DESC_CHARS)}…` : t;
+}
+
+/** History stores media as `media/<chat>/<file>`; normalise to the media-ROOT-
+ *  relative `<chat>/<file>` so the same file recorded either way dedupes to one
+ *  ordinal. MediaStore.resolvePath accepts both, so the emitted path stays usable. */
+function toMediaRootRelative(p: string): string {
+  return p.startsWith('media/') ? p.slice(6) : p;
+}
+
+/** available = the bytes are still on disk. A path that cannot even be resolved
+ *  (traversal, escaped symlink) is not addressable, so it is unavailable too. */
+function isOnDisk(agentsBaseDir: string, agentId: string, relativePath: string): boolean {
+  try {
+    return fs.existsSync(MediaStore.resolvePath(agentsBaseDir, agentId, relativePath));
+  } catch {
+    return false;
+  }
+}
+
+export function computeSessionVideoCatalog(opts: {
+  agentsBaseDir: string;
+  agentId: string;
+  sessionId: string;
+}): SessionVideoCatalogItem[] {
+  const { agentsBaseDir, agentId, sessionId } = opts;
+  const rows = HistoryDB.forAgent(agentsBaseDir, agentId).listSessionMedia(sessionId);
+
+  const items: SessionVideoCatalogItem[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    // Anything the agent produced is a generation; everything else is an upload.
+    const origin = row.role === 'assistant' ? 'generated' : 'upload';
+    for (const raw of row.mediaFiles) {
+      if (typeof raw !== 'string' || !raw.trim()) continue;
+      const relativePath = toMediaRootRelative(raw.trim());
+      if (!VIDEO_EXT_RE.test(relativePath)) continue;
+      // First appearance owns the ordinal forever.
+      if (seen.has(relativePath)) continue;
+      seen.add(relativePath);
+      const desc = toDesc(row.content);
+      items.push({
+        index: items.length + 1,
+        relative_path: relativePath,
+        origin,
+        ts: row.ts,
+        available: isOnDisk(agentsBaseDir, agentId, relativePath),
+        ...(desc ? { desc } : {}),
+      });
+    }
+  }
+  return items;
+}

--- a/tests/unit/session-video-catalog.test.ts
+++ b/tests/unit/session-video-catalog.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the deterministic session VIDEO catalog —
+ * src/share/session-video-catalog.ts. The direct analogue of the image catalog
+ * test, adapted to the two ways video differs: clips are classified by container
+ * EXTENSION (not by sniffing bytes), and they carry NO artifact reference (a clip
+ * must never enter the "Image N" surface). The contract under test is the same
+ * ORDINAL guarantee — "video N" names the same file for the life of the session,
+ * survives re-sends and deletions, and never reaches across sessions/agents.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { HistoryDB } from '../../src/history/db';
+import { computeSessionVideoCatalog } from '../../src/share/session-video-catalog';
+
+const AGENT = 'a1';
+const SESSION = 'session-1';
+
+describe('computeSessionVideoCatalog', () => {
+  let baseDir: string;
+  let mediaDir: string;
+  let db: HistoryDB;
+  let ts: number;
+
+  /** media_files as history really stores them: "media/<chat>/<file>". */
+  const mediaRef = (file: string, session = SESSION) => `media/${session}/${file}`;
+
+  const writeFile = (file: string, session = SESSION) => {
+    const dir = path.join(baseDir, AGENT, 'media', session);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, file), Buffer.alloc(32, 7));
+  };
+
+  const say = (
+    role: 'user' | 'assistant',
+    files: string[],
+    opts: { sessionId?: string; agentId?: string; content?: string } = {},
+  ) => {
+    const sessionId = opts.sessionId ?? SESSION;
+    const target = opts.agentId ? HistoryDB.forAgent(baseDir, opts.agentId) : db;
+    target.insertMessage({
+      chatId: `api-${sessionId}`,
+      sessionId,
+      source: 'api',
+      role,
+      content: opts.content ?? 'msg',
+      mediaFiles: files,
+      ts: (ts += 1000),
+    });
+  };
+
+  const catalog = (sessionId = SESSION, agentId = AGENT) =>
+    computeSessionVideoCatalog({ agentsBaseDir: baseDir, agentId, sessionId });
+
+  beforeEach(() => {
+    baseDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vidcatalog-')));
+    mediaDir = path.join(baseDir, AGENT, 'media', SESSION);
+    fs.mkdirSync(mediaDir, { recursive: true });
+    db = HistoryDB.forAgent(baseDir, AGENT);
+    ts = 1_700_000_000_000;
+  });
+
+  afterEach(() => {
+    HistoryDB.evict(baseDir, AGENT);
+    HistoryDB.evict(baseDir, 'a2');
+    fs.rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  test('6 media occurrences across 4 unique clips → 4 items in first-appearance order', () => {
+    for (const f of ['one.mp4', 'two.webm', 'three.mov', 'four.m4v']) writeFile(f);
+
+    say('user', [mediaRef('one.mp4'), mediaRef('two.webm')]);
+    say('assistant', [mediaRef('three.mov')]);
+    say('user', [mediaRef('two.webm')]); // repeat
+    say('user', [mediaRef('four.m4v'), mediaRef('one.mp4')]); // one repeat + one new
+
+    const items = catalog();
+    expect(items.map((i) => i.relative_path)).toEqual([
+      `${SESSION}/one.mp4`,
+      `${SESSION}/two.webm`,
+      `${SESSION}/three.mov`,
+      `${SESSION}/four.m4v`,
+    ]);
+    expect(items.map((i) => i.index)).toEqual([1, 2, 3, 4]);
+    expect(items.every((i) => i.available)).toBe(true);
+  });
+
+  test('re-sending the same clip keeps its original ordinal and adds no entry', () => {
+    writeFile('one.mp4');
+    writeFile('two.mp4');
+
+    say('user', [mediaRef('one.mp4')]);
+    const before = catalog();
+
+    say('user', [mediaRef('one.mp4')]);
+    say('user', [mediaRef('two.mp4')]);
+    say('assistant', [mediaRef('one.mp4')]);
+    const after = catalog();
+
+    expect(before).toHaveLength(1);
+    expect(after).toHaveLength(2);
+    // ordinal + origin + ts all come from the FIRST appearance
+    expect(after[0]).toEqual(before[0]);
+    expect(after[1]!.index).toBe(2);
+  });
+
+  test('origin follows the message role: assistant → generated, otherwise upload', () => {
+    writeFile('up.mp4');
+    writeFile('gen.mp4');
+
+    say('user', [mediaRef('up.mp4')]);
+    say('assistant', [mediaRef('gen.mp4')]);
+
+    expect(catalog().map((i) => [i.index, i.origin])).toEqual([
+      [1, 'upload'],
+      [2, 'generated'],
+    ]);
+  });
+
+  test('a clip deleted from disk stays listed as available:false without shifting ordinals', () => {
+    for (const f of ['one.mp4', 'two.mp4', 'three.mp4']) writeFile(f);
+    say('user', [mediaRef('one.mp4'), mediaRef('two.mp4'), mediaRef('three.mp4')]);
+
+    fs.unlinkSync(path.join(mediaDir, 'two.mp4'));
+
+    const items = catalog();
+    expect(items.map((i) => [i.index, i.relative_path, i.available])).toEqual([
+      [1, `${SESSION}/one.mp4`, true],
+      [2, `${SESSION}/two.mp4`, false],
+      [3, `${SESSION}/three.mp4`, true],
+    ]);
+  });
+
+  test('rows from another session or another agent are never included', () => {
+    writeFile('mine.mp4');
+    writeFile('theirs.mp4', 'session-2');
+    writeFile('other-agent.mp4');
+
+    say('user', [mediaRef('mine.mp4')]);
+    say('user', [mediaRef('theirs.mp4', 'session-2')], { sessionId: 'session-2' });
+    say('user', [mediaRef('other-agent.mp4')], { agentId: 'a2' });
+
+    expect(catalog().map((i) => i.relative_path)).toEqual([`${SESSION}/mine.mp4`]);
+    expect(catalog('session-2').map((i) => i.relative_path)).toEqual(['session-2/theirs.mp4']);
+    expect(catalog(SESSION, 'a2').map((i) => i.relative_path)).toEqual([
+      `${SESSION}/other-agent.mp4`,
+    ]);
+  });
+
+  test('non-video media are excluded and malformed media_files rows are skipped', () => {
+    writeFile('photo.png');
+    writeFile('first.mp4');
+    writeFile('broken.mp4');
+    writeFile('last.webm');
+
+    say('user', [mediaRef('photo.png'), mediaRef('first.mp4')]);
+    say('user', [mediaRef('broken.mp4')]); // corrupted below
+    say('user', [mediaRef('last.webm')]);
+
+    // Corrupt the middle row's media_files the way a truncated write would.
+    const raw = new DatabaseSync(path.join(baseDir, AGENT, 'history.db'));
+    raw.prepare(`UPDATE messages SET media_files = ? WHERE content = 'msg' AND ts = ?`).run(
+      '["media/session-1/broken.mp4"',
+      ts - 1000,
+    );
+    raw.close();
+
+    const items = catalog();
+    expect(items.map((i) => [i.index, i.relative_path])).toEqual([
+      [1, `${SESSION}/first.mp4`],
+      [2, `${SESSION}/last.webm`],
+    ]);
+  });
+
+  test('a media-root-relative path and its media/-prefixed form are one entry', () => {
+    writeFile('same.mp4');
+    say('user', [mediaRef('same.mp4')]);
+    say('assistant', [`${SESSION}/same.mp4`]);
+
+    const items = catalog();
+    expect(items).toHaveLength(1);
+    expect(items[0]!.origin).toBe('upload'); // first appearance wins
+  });
+
+  test('a session with no video yields an empty catalog', () => {
+    expect(catalog('empty-session')).toEqual([]);
+  });
+
+  describe('desc — the accompanying message text', () => {
+    test('meaningful message text becomes the desc', () => {
+      writeFile('clip.mp4');
+      say('assistant', [mediaRef('clip.mp4')], { content: 'a pug doing a backflip' });
+      expect(catalog()[0]!.desc).toBe('a pug doing a backflip');
+    });
+
+    test('a bare "(video)" placeholder describes nothing → no desc', () => {
+      writeFile('clip.mp4');
+      say('user', [mediaRef('clip.mp4')], { content: '(video)' });
+      expect(catalog()[0]!.desc).toBeUndefined();
+    });
+
+    test('desc is truncated with an ellipsis past the cap', () => {
+      writeFile('clip.mp4');
+      const long = 'x'.repeat(500);
+      say('assistant', [mediaRef('clip.mp4')], { content: long });
+      const desc = catalog()[0]!.desc!;
+      expect(desc.endsWith('…')).toBe(true);
+      expect(desc.length).toBe(201); // 200 chars + ellipsis
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `GET /api/v1/video-catalog?agent_id=…&session_id=…` — the deterministic list of every video clip in one chat session, oldest first. It's the video analogue of `/v1/image-catalog` (#72), backing the console Media panel's new video gallery.

```json
{ "items": [ { "index": 1, "relative_path": "<chat>/<file>.mp4", "origin": "generated", "ts": 1788859760246, "available": true, "desc": "…" } ] }
```

## Why a separate endpoint (not folded into image-catalog)

The image catalog also feeds the agent's `generate_image list_refs` / "Image N" reference resolution. A video is **not** a valid image reference, so it must never enter that surface. A dedicated endpoint + module keeps image ordinals untouched and clips out of the reference path.

## Shape

- **Read-only**, same `auth` + `canAccessAgent` checks as image-catalog; mints nothing, returns no token.
- Derived fresh on each call from the same append-only message `media_files` — no new table, no reconciliation job.
- Ordinals assigned by **first appearance** and never move (survives re-send and delete; a deleted clip stays listed as `available:false`).
- Clips classified by container extension (`.mp4/.webm/.mov/.m4v`), mirroring the web's render regex.
- `desc` = the accompanying message text (placeholder captions like `(video)` dropped, capped at 200 chars).

## Tests

11 unit tests (`session-video-catalog.test.ts`) covering ordinal stability, re-send/delete, cross-session/agent isolation, non-video exclusion, malformed-row skip, `media/`-prefix dedupe, and desc handling. Full unit suite green (4528 tests), build clean.

## Companion

Web consumer (Media panel video gallery + true-ratio video frame) ships in the getpod web PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)