### PR TITLE
fix: surface gateway.publicUrl misconfiguration before generate_image

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -56,7 +56,11 @@ dead local service as healthy.
 `doctor` probes the address the CLI will use (that check decides its exit code) and adds an
 **informational** probe of the other address whenever the two differ, marked `[--]`. A public URL
 that rejects an unauthenticated `/health` is reported, but never fails `doctor` — the CLI is not
-using that address.
+using that address. It also checks `gateway.publicUrl` itself (marked `[warn]` when unset — a
+capability gap, not a misconfiguration — and `[!!]` when set but nothing answers), since that value
+backs `generate_image` reference edits, `share_file`, and `/cli`, and nothing else surfaces its
+absence (#472). Skipped when `--url`/`$CLAUDE_GATEWAY_URL` point at a different host — it is this
+host's own config file, so it is not context for a question about another machine.
 
 **Colour.** Help and diagnostic text is coloured only when the stream it is going to is a
 terminal — stdout for a requested help listing, stderr for everything else — so piping either one

--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -516,7 +516,12 @@ export class ImageModule implements ToolModule {
       // which the share API only fills when gateway.publicUrl is configured.
       if (minted.some((m) => !m.url)) {
         await revokeSharesBestEffort(minted.map((m) => m.share_id));
-        return fail('generate_image: image reference sharing requires gateway.publicUrl to be configured.');
+        return fail(
+          'generate_image: image reference sharing requires gateway.publicUrl to be configured ' +
+          '(set it in ~/.claude-gateway/config.json to your externally reachable base URL ending ' +
+          'in /gateway, then restart the gateway). As a workaround, pass a publicly reachable ' +
+          'https:// image URL instead of a local path or artifact ref.',
+        );
       }
     }
     // Merge back preserving the caller's order. taskIds/priorPrompts are

--- a/mcp/tools/video/module.ts
+++ b/mcp/tools/video/module.ts
@@ -418,7 +418,12 @@ export class VideoModule implements ToolModule {
     // share API only fills when gateway.publicUrl is configured.
     if (!item.url) {
       await revokeSharesBestEffort([item.share_id]);
-      return fail('generate_video: source-frame sharing requires gateway.publicUrl to be configured.');
+      return fail(
+        'generate_video: source-frame sharing requires gateway.publicUrl to be configured ' +
+        '(set it in ~/.claude-gateway/config.json to your externally reachable base URL ending ' +
+        'in /gateway, then restart the gateway). As a workaround, pass a publicly reachable ' +
+        'https:// image URL instead of a local path or artifact ref.',
+      );
     }
     return { url: item.url, mintedShareIds: [item.share_id] };
   }

--- a/scripts/gen-cli.ts
+++ b/scripts/gen-cli.ts
@@ -127,7 +127,11 @@ dead local service as healthy.
 \`doctor\` probes the address the CLI will use (that check decides its exit code) and adds an
 **informational** probe of the other address whenever the two differ, marked \`[--]\`. A public URL
 that rejects an unauthenticated \`/health\` is reported, but never fails \`doctor\` — the CLI is not
-using that address.
+using that address. It also checks \`gateway.publicUrl\` itself (marked \`[warn]\` when unset — a
+capability gap, not a misconfiguration — and \`[!!]\` when set but nothing answers), since that value
+backs \`generate_image\` reference edits, \`share_file\`, and \`/cli\`, and nothing else surfaces its
+absence (#472). Skipped when \`--url\`/\`$CLAUDE_GATEWAY_URL\` point at a different host — it is this
+host's own config file, so it is not context for a question about another machine.
 
 **Colour.** Help and diagnostic text is coloured only when the stream it is going to is a
 terminal — stdout for a requested help listing, stderr for everything else — so piping either one

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -17,6 +17,11 @@ interface Check {
   /** Informational only: reported, but never fails the command. Used for the
    *  URL the CLI is *not* using — its state is context, not a verdict. */
   info?: boolean;
+  /** A real gap worth the operator's attention, but not a failure: some
+   *  deployments (LINE-only, localhost-only) are legitimately fine without the
+   *  thing being warned about. Never fails the command, like `info`, but
+   *  rendered distinctly so it doesn't read as "nothing to see here". */
+  warn?: boolean;
 }
 
 function printHelp(): void {
@@ -75,6 +80,34 @@ export async function runDoctor(flags: Record<string, string | boolean>, config:
   const health = await probeHealth(baseUrl);
   checks.push({ name: 'health', ok: health.ok, detail: health.detail });
 
+  // #472: gateway.publicUrl backs every feature that hands out a public link
+  // (generate_image reference edits, share_file, /cli). Nothing else in
+  // `doctor` checks for its presence — the row below (`publicUrl`/`publicHealth`)
+  // only exists when the value happens to be set, and stays silent otherwise.
+  // Gated on `diagnosingThisHost` like `manager` above: this is this host's own
+  // config file, so it is noise (and a config leak) when --url points elsewhere.
+  if (diagnosingThisHost) {
+    const gatewayPublicUrl = (config.publicUrl ?? '').trim().replace(/\/+$/, '');
+    if (!gatewayPublicUrl) {
+      checks.push({
+        name: 'gatewayPublicUrl',
+        ok: true,
+        warn: true,
+        detail: 'not set — generate_image reference edits, share_file, and /cli will not work (see README "gateway.publicUrl")',
+      });
+    } else {
+      const shareHealth = await probeHealth(gatewayPublicUrl);
+      // `answered`, not `ok`: a proxy that answers 401/403 to an unauthenticated
+      // probe is up and doing its job, not unreachable — same reasoning as the
+      // publicHealth note below. Only "nothing answered at all" is a real fail.
+      checks.push({
+        name: 'gatewayPublicUrl',
+        ok: shareHealth.answered,
+        detail: shareHealth.answered ? `reachable (${gatewayPublicUrl})` : `unreachable: ${shareHealth.detail}`,
+      });
+    }
+  }
+
   // A gateway fronted by a reverse proxy has two addresses for one process.
   // Probe the one the CLI is *not* using as well: without it, the most
   // confusing states — proxy down while the gateway is healthy, or the reverse
@@ -103,13 +136,14 @@ export async function runDoctor(flags: Record<string, string | boolean>, config:
     checks.push({ name: alt.healthName, ok: altHealth.ok, detail: altHealth.detail, info: true });
   }
 
-  const allOk = checks.every((c) => c.info || c.ok);
+  const allOk = checks.every((c) => c.info || c.warn || c.ok);
   const c = paletteFor(process.stderr);
   // Pad before colouring so escape codes never count toward the column width.
   const lines = checks.map((chk) => {
-    // `info` is checked first: an advisory row is marked `[--]` whether it
-    // passed or not, so the reader can tell the verdict rows from the context.
-    const mark = chk.info ? c.dim('[--]') : chk.ok ? c.green('[ok]') : c.red('[!!]');
+    // `warn`/`info` are checked first: an advisory row is marked distinctly
+    // whether it passed or not, so the reader can tell the verdict rows from
+    // the context.
+    const mark = chk.warn ? c.yellow('[warn]') : chk.info ? c.dim('[--]') : chk.ok ? c.green('[ok]') : c.red('[!!]');
     return `  ${mark} ${c.bold(chk.name.padEnd(12))} ${chk.detail}`;
   });
   // Name the right component. A public URL that answered with a status is not

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -3,6 +3,7 @@ import { probeHealth, HealthProbe } from '../health';
 import { detectManager } from '../manager';
 import { printJson, helpStream, writeCommandHelp } from '../output';
 import { paletteFor } from '../colors';
+import { normalizePublicUrl } from '../../cli-viewer/url';
 
 /**
  * `doctor` — quick health check of the CLI's view of the gateway: is config
@@ -80,6 +81,26 @@ export async function runDoctor(flags: Record<string, string | boolean>, config:
   const health = await probeHealth(baseUrl);
   checks.push({ name: 'health', ok: health.ok, detail: health.detail });
 
+  // Shared by the new check below and the alt-address block further down —
+  // both describe `config.publicUrl`, and using one normalizer (rather than
+  // each hand-rolling trim/strip) keeps them from silently disagreeing on
+  // what "the same URL" means.
+  const normalizedPublicUrl = normalizePublicUrl(config.publicUrl) ?? '';
+
+  // A gateway fronted by a reverse proxy has two addresses for one process.
+  // Resolved here (selection only, no network call yet) so the new
+  // gatewayPublicUrl check below can detect when it's about to probe the
+  // identical URL and share one fetch instead of firing two.
+  const alt =
+    baseUrl === localUrl
+      ? normalizedPublicUrl && normalizedPublicUrl !== baseUrl
+        ? { urlName: 'publicUrl', healthName: 'publicHealth', url: normalizedPublicUrl }
+        : undefined
+      : manager !== 'unknown'
+        ? { urlName: 'localUrl', healthName: 'localHealth', url: localUrl }
+        : undefined;
+  let altHealth: HealthProbe | undefined;
+
   // #472: gateway.publicUrl backs every feature that hands out a public link
   // (generate_image reference edits, share_file, /cli). Nothing else in
   // `doctor` checks for its presence — the row below (`publicUrl`/`publicHealth`)
@@ -87,7 +108,7 @@ export async function runDoctor(flags: Record<string, string | boolean>, config:
   // Gated on `diagnosingThisHost` like `manager` above: this is this host's own
   // config file, so it is noise (and a config leak) when --url points elsewhere.
   if (diagnosingThisHost) {
-    const gatewayPublicUrl = (config.publicUrl ?? '').trim().replace(/\/+$/, '');
+    const gatewayPublicUrl = normalizedPublicUrl;
     if (!gatewayPublicUrl) {
       checks.push({
         name: 'gatewayPublicUrl',
@@ -109,7 +130,18 @@ export async function runDoctor(flags: Record<string, string | boolean>, config:
         detail: `configured (${gatewayPublicUrl}) — contains an unresolved \${VAR}; reachability cannot be checked from the CLI`,
       });
     } else {
-      const shareHealth = await probeHealth(gatewayPublicUrl);
+      // Reuse an existing probe of the identical URL rather than firing a
+      // second one: `health` already covers the no-proxy case (publicUrl ==
+      // baseUrl), and the alt block below covers the reverse-proxy case
+      // (publicUrl == alt.url). Two independent probes of the same address a
+      // few hundred ms apart can disagree under a flaky/loaded proxy, which
+      // would otherwise show up as two contradictory rows for one fact.
+      const shareHealth =
+        gatewayPublicUrl === baseUrl
+          ? health
+          : alt?.urlName === 'publicUrl'
+            ? (altHealth = await probeHealth(alt.url))
+            : await probeHealth(gatewayPublicUrl);
       // `answered`, not `ok`: a proxy that answers 401/403 to an unauthenticated
       // probe is up and doing its job, not unreachable — same reasoning as the
       // publicHealth note below. Only "nothing answered at all" is a real fail.
@@ -121,7 +153,6 @@ export async function runDoctor(flags: Record<string, string | boolean>, config:
     }
   }
 
-  // A gateway fronted by a reverse proxy has two addresses for one process.
   // Probe the one the CLI is *not* using as well: without it, the most
   // confusing states — proxy down while the gateway is healthy, or the reverse
   // — appear as a single contradictory line with nothing to explain it. The
@@ -132,20 +163,9 @@ export async function runDoctor(flags: Record<string, string | boolean>, config:
   // somewhere else. Passing the flag through would make it echo the target back
   // as its own alternative, and then offer this host's publicUrl as context for
   // a question about another host entirely.
-  const publicUrl = (config.publicUrl ?? '').replace(/\/+$/, '');
-  const alt =
-    baseUrl === localUrl
-      ? publicUrl && publicUrl !== baseUrl
-        ? { urlName: 'publicUrl', healthName: 'publicHealth', url: publicUrl }
-        : undefined
-      : manager !== 'unknown'
-        ? { urlName: 'localUrl', healthName: 'localHealth', url: localUrl }
-        : undefined;
-
-  let altHealth: HealthProbe | undefined;
   if (alt) {
     checks.push({ name: alt.urlName, ok: true, detail: alt.url, info: true });
-    altHealth = await probeHealth(alt.url);
+    altHealth = altHealth ?? (await probeHealth(alt.url));
     checks.push({ name: alt.healthName, ok: altHealth.ok, detail: altHealth.detail, info: true });
   }
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -95,6 +95,19 @@ export async function runDoctor(flags: Record<string, string | boolean>, config:
         warn: true,
         detail: 'not set — generate_image reference edits, share_file, and /cli will not work (see README "gateway.publicUrl")',
       });
+    } else if (/\$\{[^}]+\}/.test(gatewayPublicUrl)) {
+      // `loadCliConfig` (http-client.ts) reads config.json directly and does not
+      // interpolate ${VAR} placeholders like the gateway process's own loader
+      // does — this CLI invocation may not even share that env. Probing the
+      // literal placeholder string always fails, which would report a healthy,
+      // correctly configured gateway as broken. Configured-but-unverifiable is
+      // not a failure.
+      checks.push({
+        name: 'gatewayPublicUrl',
+        ok: true,
+        info: true,
+        detail: `configured (${gatewayPublicUrl}) — contains an unresolved \${VAR}; reachability cannot be checked from the CLI`,
+      });
     } else {
       const shareHealth = await probeHealth(gatewayPublicUrl);
       // `answered`, not `ok`: a proxy that answers 401/403 to an unauthenticated

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -32,8 +32,8 @@ function printHelp(): void {
     'check config, key resolution, manager and connectivity',
     'claude-gateway doctor [--url <url>] [--key <key>] [--config <path>] [--json]',
     [
-      `  Exits 0 when every check passes. Rows marked ${c.dim('[--]')} are informational and`,
-      '  never fail the command. The key itself is never printed.',
+      `  Exits 0 when every check passes. Rows marked ${c.dim('[--]')} are informational and ${c.yellow('[warn]')}`,
+      '  rows are advisory — neither fails the command. The key itself is never printed.',
     ],
   );
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -280,12 +280,24 @@ export function loadConfig(configPath: string, options?: LoadConfigOptions): Gat
   // Interpolate gateway config (fatal if env vars missing here)
   const interpolatedGateway = interpolateObject(config.gateway) as Record<string, unknown>;
   const rawPublicUrl = interpolatedGateway.publicUrl;
-  if (typeof rawPublicUrl === 'string' && !rawPublicUrl.trim()) {
-    // Blank/whitespace-only is "not configured", not "invalid". Normalize to
-    // undefined so downstream consumers see a single unset representation and
+  if (rawPublicUrl === undefined || (typeof rawPublicUrl === 'string' && !rawPublicUrl.trim())) {
+    // Blank/whitespace-only/absent is "not configured", not "invalid". Normalize
+    // to undefined so downstream consumers see a single unset representation and
     // report "not configured" rather than throwing or emitting a broken link.
+    //
+    // Warn once here rather than staying silent: nothing else in the load path
+    // reports this gap, and it otherwise surfaces only much later as an
+    // unrelated-looking failure inside generate_image (#472). This is a
+    // capability limitation, not a misconfiguration — LINE-only and
+    // localhost-only deployments are legitimately fine without the key — so it
+    // is a warning, never a thrown error.
+    console.warn(
+      '[gateway] gateway.publicUrl is not set — public share links are disabled.\n' +
+      '          generate_image reference edits, share_file, and /cli will not work.\n' +
+      '          See README "gateway.publicUrl".',
+    );
     interpolatedGateway.publicUrl = undefined;
-  } else if (rawPublicUrl !== undefined) {
+  } else {
     const normalizedPublicUrl = resolveGatewayPublicUrl(rawPublicUrl);
     if (!normalizedPublicUrl) {
       throw new ConfigValidationError(

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -120,6 +120,14 @@ export interface LoadConfigOptions {
    * is diagnosable — see issue #427.
    */
   onSkippedAgent?: (skipped: SkippedAgent) => void;
+  /**
+   * Called when `gateway.publicUrl` resolves to unset (absent, blank, or
+   * whitespace-only). Same rationale as `onSkippedAgent` (#427): a bare
+   * `console.warn` here never reaches `logs/gateway.log` under structured
+   * logging, so callers that have a logger should pass this to make the gap
+   * diagnosable there too — see issue #472.
+   */
+  onPublicUrlUnset?: () => void;
 }
 
 /**
@@ -296,6 +304,7 @@ export function loadConfig(configPath: string, options?: LoadConfigOptions): Gat
       '          generate_image reference edits, share_file, and /cli will not work.\n' +
       '          See README "gateway.publicUrl".',
     );
+    options?.onPublicUrlUnset?.();
     interpolatedGateway.publicUrl = undefined;
   } else {
     const normalizedPublicUrl = resolveGatewayPublicUrl(rawPublicUrl);

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -134,9 +134,14 @@ export class ConfigWatcher extends EventEmitter {
     // agent produces exactly zero diff, so this is the only trace it leaves.
     logSkippedAgents(this.logger, skipped, 'Agent skipped during config reload');
     // Same #427 rationale as skipped agents (#472): the console.warn inside
-    // loadConfig never reaches logs/gateway.log on its own.
-    if (publicUrlUnset) {
-      this.logger.warn('gateway.publicUrl is not set after reload — public share links are disabled');
+    // loadConfig never reaches logs/gateway.log on its own. Gated on the
+    // transition (was set, now unset) rather than firing on every reload: a
+    // LINE-only/localhost-only deployment intentionally keeps this unset, and
+    // every unrelated config.json edit (adding an agent, tuning a timeout)
+    // would otherwise re-log the same fact forever, burying genuinely new
+    // warnings.
+    if (publicUrlUnset && this.currentConfig.gateway.publicUrl !== undefined) {
+      this.logger.warn('gateway.publicUrl became unset on reload — public share links are now disabled');
     }
 
     const { fieldChanges, addedAgents } = this.diffConfig(this.currentConfig, newConfig);

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -116,9 +116,11 @@ export class ConfigWatcher extends EventEmitter {
 
     let newConfig: GatewayConfig;
     const skipped: SkippedAgent[] = [];
+    let publicUrlUnset = false;
     try {
       newConfig = loadConfig(this.configPath, {
         onSkippedAgent: (s) => skipped.push(s),
+        onPublicUrlUnset: () => { publicUrlUnset = true; },
       });
       newConfig.gateway.logDir = expandHome(newConfig.gateway.logDir);
     } catch (err) {
@@ -131,6 +133,11 @@ export class ConfigWatcher extends EventEmitter {
     // Report drops before the no-change bail-out below: a silently dropped
     // agent produces exactly zero diff, so this is the only trace it leaves.
     logSkippedAgents(this.logger, skipped, 'Agent skipped during config reload');
+    // Same #427 rationale as skipped agents (#472): the console.warn inside
+    // loadConfig never reaches logs/gateway.log on its own.
+    if (publicUrlUnset) {
+      this.logger.warn('gateway.publicUrl is not set after reload — public share links are disabled');
+    }
 
     const { fieldChanges, addedAgents } = this.diffConfig(this.currentConfig, newConfig);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -588,8 +588,10 @@ async function main(): Promise<void> {
   // replayed through globalLogger below so a dropped agent is diagnosable from
   // logs/gateway.log at startup too, not only on reload (#427).
   const startupSkips: SkippedAgent[] = [];
+  let publicUrlUnsetAtStartup = false;
   const config: GatewayConfig = loadConfig(CONFIG_PATH, {
     onSkippedAgent: (s) => startupSkips.push(s),
+    onPublicUrlUnset: () => { publicUrlUnsetAtStartup = true; },
   });
   config.gateway.logDir = expandTilde(config.gateway.logDir);
 
@@ -604,6 +606,12 @@ async function main(): Promise<void> {
   // went missing.
   const globalLogger = createLogger('gateway', expandTilde(config.gateway.logDir));
   logSkippedAgents(globalLogger, startupSkips, 'Agent skipped at startup');
+  // Same #427 rationale as skipped agents: the console.warn already happened
+  // inside loadConfig (before logDir/globalLogger could exist), replay it here
+  // so it also reaches logs/gateway.log under structured/JSON logging (#472).
+  if (publicUrlUnsetAtStartup) {
+    globalLogger.warn('gateway.publicUrl is not set at startup — public share links are disabled');
+  }
 
   // ── Context isolation check ──────────────────────────────────────────────
   const guard = new ContextIsolationGuard();

--- a/tests/unit/cli-doctor.test.ts
+++ b/tests/unit/cli-doctor.test.ts
@@ -6,7 +6,7 @@ import type { CliConfigView } from '../../src/cli/http-client';
 
 interface DoctorReport {
   ok: boolean;
-  checks: Array<{ name: string; ok: boolean; detail: string; info?: boolean }>;
+  checks: Array<{ name: string; ok: boolean; detail: string; info?: boolean; warn?: boolean }>;
 }
 
 describe('cli doctor', () => {
@@ -51,7 +51,7 @@ describe('cli doctor', () => {
     expect(code).toBe(0);
     const body = report();
     expect(body.ok).toBe(true);
-    expect(body.checks.map((c) => c.name)).toEqual(['config', 'apiKey', 'url', 'manager', 'health']);
+    expect(body.checks.map((c) => c.name)).toEqual(['config', 'apiKey', 'url', 'manager', 'health', 'gatewayPublicUrl']);
     expect(body.checks.every((c) => c.ok)).toBe(true);
   });
 
@@ -123,9 +123,12 @@ describe('cli doctor', () => {
       const code = await runDoctor({}, proxied);
 
       const body = report();
-      expect(body.checks.map((c) => c.name)).toEqual(['config', 'apiKey', 'url', 'manager', 'health', 'publicUrl', 'publicHealth']);
+      expect(body.checks.map((c) => c.name)).toEqual(['config', 'apiKey', 'url', 'manager', 'health', 'gatewayPublicUrl', 'publicUrl', 'publicHealth']);
       expect(body.checks.find((c) => c.name === 'url')?.detail).toMatch(/^http:\/\/127\.0\.0\.1:/);
       expect(body.checks.find((c) => c.name === 'publicHealth')?.info).toBe(true);
+      expect(body.checks.find((c) => c.name === 'gatewayPublicUrl')).toEqual(
+        expect.objectContaining({ ok: true, detail: expect.stringContaining('reachable') }),
+      );
       expect(code).toBe(0);
     });
 
@@ -211,6 +214,84 @@ describe('cli doctor', () => {
       const names = report().checks.map((c) => c.name);
       expect(names).not.toContain('publicHealth');
       expect(names).not.toContain('localHealth');
+    });
+  });
+
+  /**
+   * #472: gateway.publicUrl backs every feature that hands out a public link
+   * (generate_image reference edits, share_file, /cli). Nothing checked for its
+   * presence before this — a misconfigured or unset value only ever surfaced as
+   * a late, unrelated-looking failure deep inside generate_image.
+   */
+  describe('gateway.publicUrl check (#472)', () => {
+    it('unset → warn, lists the disabled features, does not fail doctor', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+
+      const code = await runDoctor({}, configWithKey);
+
+      const body = report();
+      const check = body.checks.find((c) => c.name === 'gatewayPublicUrl')!;
+      expect(check.ok).toBe(true);
+      expect(check.warn).toBe(true);
+      expect(check.detail).toMatch(/generate_image/);
+      expect(check.detail).toMatch(/share_file/);
+      expect(body.ok).toBe(true);
+      expect(code).toBe(0);
+    });
+
+    it('set and reachable → ok, no warn', async () => {
+      const proxied: CliConfigView = { ...configWithKey, publicUrl: 'https://proxy.example.com/gateway', bind: '0.0.0.0' };
+      global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+
+      const code = await runDoctor({}, proxied);
+
+      const check = report().checks.find((c) => c.name === 'gatewayPublicUrl')!;
+      expect(check.ok).toBe(true);
+      expect(check.warn).toBeFalsy();
+      expect(check.detail).toContain('reachable');
+      expect(code).toBe(0);
+    });
+
+    it('set but nothing answers → fails doctor', async () => {
+      const proxied: CliConfigView = { ...configWithKey, publicUrl: 'https://proxy.example.com/gateway', bind: '0.0.0.0' };
+      global.fetch = jest.fn().mockImplementation((url: string) =>
+        String(url).startsWith('http://127.0.0.1') ? Promise.resolve({ ok: true } as Response) : Promise.reject(new Error('ECONNREFUSED')),
+      );
+
+      const code = await runDoctor({}, proxied);
+
+      const body = report();
+      const check = body.checks.find((c) => c.name === 'gatewayPublicUrl')!;
+      expect(check.ok).toBe(false);
+      expect(check.warn).toBeFalsy();
+      expect(check.detail).toMatch(/unreachable/);
+      expect(body.ok).toBe(false);
+      expect(code).toBe(1);
+    });
+
+    it('set but answers with an auth-rejecting status → still counted reachable (proxy is doing its job)', async () => {
+      const proxied: CliConfigView = { ...configWithKey, publicUrl: 'https://proxy.example.com/gateway', bind: '0.0.0.0' };
+      global.fetch = jest.fn().mockImplementation((url: string) =>
+        String(url).startsWith('http://127.0.0.1')
+          ? Promise.resolve({ ok: true } as Response)
+          : Promise.resolve({ ok: false, status: 401 } as Response),
+      );
+
+      const code = await runDoctor({}, proxied);
+
+      const check = report().checks.find((c) => c.name === 'gatewayPublicUrl')!;
+      expect(check.ok).toBe(true);
+      expect(code).toBe(0);
+    });
+
+    it('does not run when --url points at a different host (this host\'s config is not the subject)', async () => {
+      const proxied: CliConfigView = { ...configWithKey, publicUrl: 'https://proxy.example.com/gateway', bind: '0.0.0.0' };
+      global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+
+      await runDoctor({ url: 'http://other-host:8080' }, proxied);
+
+      const names = report().checks.map((c) => c.name);
+      expect(names).not.toContain('gatewayPublicUrl');
     });
   });
 

--- a/tests/unit/cli-doctor.test.ts
+++ b/tests/unit/cli-doctor.test.ts
@@ -284,6 +284,28 @@ describe('cli doctor', () => {
       expect(code).toBe(0);
     });
 
+    // Independent review of #474: `loadCliConfig` (http-client.ts) parses
+    // config.json directly and never interpolates ${VAR} — unlike the gateway
+    // process's own loader.ts. A publicUrl configured with an env placeholder
+    // (a pattern loader.ts explicitly supports) would otherwise reach this
+    // check as the literal string, fail to fetch, and report a healthy,
+    // correctly configured gateway as broken.
+    it('set with an unresolved ${VAR} placeholder → informational, does not fail doctor', async () => {
+      const proxied: CliConfigView = { ...configWithKey, publicUrl: 'https://${PUBLIC_HOST}/gateway', bind: '0.0.0.0' };
+      global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+
+      const code = await runDoctor({}, proxied);
+
+      const body = report();
+      const check = body.checks.find((c) => c.name === 'gatewayPublicUrl')!;
+      expect(check.ok).toBe(true);
+      expect(check.info).toBe(true);
+      expect(check.warn).toBeFalsy();
+      expect(check.detail).toContain('unresolved');
+      expect(body.ok).toBe(true);
+      expect(code).toBe(0);
+    });
+
     it('does not run when --url points at a different host (this host\'s config is not the subject)', async () => {
       const proxied: CliConfigView = { ...configWithKey, publicUrl: 'https://proxy.example.com/gateway', bind: '0.0.0.0' };
       global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);

--- a/tests/unit/cli-doctor.test.ts
+++ b/tests/unit/cli-doctor.test.ts
@@ -155,6 +155,27 @@ describe('cli doctor', () => {
       expect(stderr.join('')).toMatch(/the public URL answered HTTP 401/);
     });
 
+    // Independent review of #474: gatewayPublicUrl and the alt-address block
+    // both describe config.publicUrl — when they resolve to the identical
+    // URL (the common reverse-proxy case exercised here), they must share
+    // one probe rather than firing two, which could otherwise disagree under
+    // a flaky proxy and double the load on the operator's public endpoint.
+    it('gatewayPublicUrl and publicHealth share one probe when they resolve to the same URL', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({ ok: true } as Response);
+      global.fetch = fetchMock;
+
+      const code = await runDoctor({}, proxied);
+
+      const body = report();
+      const gw = body.checks.find((c) => c.name === 'gatewayPublicUrl')!;
+      const pub = body.checks.find((c) => c.name === 'publicHealth')!;
+      expect(gw.ok).toBe(true);
+      expect(pub.ok).toBe(true);
+      const proxyCalls = fetchMock.mock.calls.filter((c) => String(c[0]).startsWith('https://proxy.example.com'));
+      expect(proxyCalls).toHaveLength(1);
+      expect(code).toBe(0);
+    });
+
     it('falls back to publicUrl when no gateway is live on this host', async () => {
       (readLocalGateway as jest.Mock).mockReturnValue(null);
       global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
@@ -314,6 +335,25 @@ describe('cli doctor', () => {
 
       const names = report().checks.map((c) => c.name);
       expect(names).not.toContain('gatewayPublicUrl');
+    });
+
+    // Independent review of #474: when publicUrl equals the CLI's own base
+    // URL (no reverse proxy — same host, same address), gatewayPublicUrl must
+    // reuse the already-computed `health` probe rather than firing a second
+    // one against the identical address.
+    it('reuses the health probe when publicUrl equals this host\'s own address (no proxy)', async () => {
+      const samePlace: CliConfigView = { ...configWithKey, publicUrl: 'http://127.0.0.1:10850' };
+      const fetchMock = jest.fn().mockResolvedValue({ ok: true } as Response);
+      global.fetch = fetchMock;
+
+      const code = await runDoctor({}, samePlace);
+
+      const body = report();
+      expect(body.checks.find((c) => c.name === 'gatewayPublicUrl')).toEqual(
+        expect.objectContaining({ ok: true, detail: expect.stringContaining('reachable') }),
+      );
+      expect(fetchMock.mock.calls.filter((c) => String(c[0]).includes('127.0.0.1:10850'))).toHaveLength(1);
+      expect(code).toBe(0);
     });
   });
 

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -308,6 +308,41 @@ describe('config-loader', () => {
     }
   });
 
+  // Independent review of #474: the console.warn alone never reaches
+  // logs/gateway.log under structured logging — the exact #427 failure mode
+  // for skipped agents. onPublicUrlUnset lets a caller with a real logger
+  // replay the warning there too.
+  it('onPublicUrlUnset fires once when unset, never when a value is configured (#472)', () => {
+    const configPath = path.join(tmpDir, 'public-url-callback.json');
+    const write = (publicUrl: unknown) => {
+      fs.writeFileSync(configPath, JSON.stringify({
+        gateway: { logDir: '/tmp', timezone: 'UTC', publicUrl },
+        agents: [{
+          id: 'test',
+          description: '',
+          workspace: '/tmp',
+          env: '/tmp/.env',
+          telegram: { botToken: 'tok' },
+          claude: { model: 'claude-sonnet-4-6', dangerouslySkipPermissions: false, extraFlags: [] },
+        }],
+      }));
+      return configPath;
+    };
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      let fired = 0;
+      loadConfig(write(undefined), { onPublicUrlUnset: () => { fired += 1; } });
+      expect(fired).toBe(1);
+
+      fired = 0;
+      loadConfig(write('https://pod-maxma.example.com/gateway'), { onPublicUrlUnset: () => { fired += 1; } });
+      expect(fired).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('boots from the shipped config.template.json gateway block', () => {
     const template = JSON.parse(
       fs.readFileSync(path.join(__dirname, '..', '..', 'config.template.json'), 'utf-8'),

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -247,22 +247,29 @@ describe('config-loader', () => {
       return configPath;
     };
 
-    const valid = write('public-url-valid.json', 'https://pod-maxma.example.com/gateway/');
-    expect(loadConfig(valid).gateway.publicUrl).toBe('https://pod-maxma.example.com/gateway');
+    // #472: a configured value must never trigger the "not set" warning.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const valid = write('public-url-valid.json', 'https://pod-maxma.example.com/gateway/');
+      expect(loadConfig(valid).gateway.publicUrl).toBe('https://pod-maxma.example.com/gateway');
+      expect(warnSpy).not.toHaveBeenCalled();
 
-    for (const [index, value] of [
-      'https://pod-maxma.example.com',
-      'http://pod-maxma.example.com/gateway',
-      'https://pod-maxma.example.com/gateway?token=x',
-      'not-a-url',
-    ].entries()) {
-      expect(() => loadConfig(write(`public-url-invalid-${index}.json`, value))).toThrow(
-        /gateway\.publicUrl/,
-      );
+      for (const [index, value] of [
+        'https://pod-maxma.example.com',
+        'http://pod-maxma.example.com/gateway',
+        'https://pod-maxma.example.com/gateway?token=x',
+        'not-a-url',
+      ].entries()) {
+        expect(() => loadConfig(write(`public-url-invalid-${index}.json`, value))).toThrow(
+          /gateway\.publicUrl/,
+        );
+      }
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 
-  it('treats blank/whitespace/absent gateway.publicUrl as unset (no throw)', () => {
+  it('treats blank/whitespace/absent gateway.publicUrl as unset (no throw), and warns exactly once each (#472)', () => {
     const write = (name: string, publicUrl: unknown) => {
       const configPath = path.join(tmpDir, name);
       fs.writeFileSync(configPath, JSON.stringify({
@@ -279,12 +286,26 @@ describe('config-loader', () => {
       return configPath;
     };
 
-    // Empty string (the value config.template.json used to ship) → unset, boots.
-    expect(loadConfig(write('public-url-empty.json', '')).gateway.publicUrl).toBeUndefined();
-    // Whitespace-only → same as empty.
-    expect(loadConfig(write('public-url-blank.json', '   ')).gateway.publicUrl).toBeUndefined();
-    // Absent key (JSON.stringify drops undefined) → unset, no regression.
-    expect(loadConfig(write('public-url-absent.json', undefined)).gateway.publicUrl).toBeUndefined();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // Empty string (the value config.template.json used to ship) → unset, boots, warns once.
+      warnSpy.mockClear();
+      expect(loadConfig(write('public-url-empty.json', '')).gateway.publicUrl).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]![0]).toMatch(/gateway\.publicUrl is not set/);
+
+      // Whitespace-only → same as empty, warns once.
+      warnSpy.mockClear();
+      expect(loadConfig(write('public-url-blank.json', '   ')).gateway.publicUrl).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // Absent key (JSON.stringify drops undefined) → unset, no regression, warns once.
+      warnSpy.mockClear();
+      expect(loadConfig(write('public-url-absent.json', undefined)).gateway.publicUrl).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('boots from the shipped config.template.json gateway block', () => {

--- a/tests/unit/config-watcher.test.ts
+++ b/tests/unit/config-watcher.test.ts
@@ -607,6 +607,22 @@ describe('config-watcher', () => {
     watcher.stop();
   });
 
+  // Independent review of #474: gateway.publicUrl staying unset across many
+  // reloads (LINE-only/localhost-only deployments, called out as legitimate)
+  // must not re-log on every unrelated config edit — only on the transition
+  // into that state.
+  it('does not re-warn about gateway.publicUrl on a reload where it was already unset', () => {
+    const configPath = path.join(tmpDir, 'config-public-url-persist-unset.json');
+    writeConfigFile(configPath, rawConfig());
+    const watcher = new ConfigWatcher(configPath, loadConfig(configPath), logger);
+
+    writeConfigFile(configPath, rawConfig({ alfredModel: 'claude-sonnet-4-6' }));
+    watcher.reload();
+
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('gateway.publicUrl'));
+    watcher.stop();
+  });
+
   // ---------------------------------------------------------------------------
   // U-CW-06: config.json changes rapidly multiple times — debounce, emit once
   // ---------------------------------------------------------------------------

--- a/tests/unit/share-normalize.test.ts
+++ b/tests/unit/share-normalize.test.ts
@@ -394,6 +394,23 @@ describe('generate_image share-bridge normalization (#70)', () => {
       expect(res.isError).toBe(true);
       expect(revokeCalls().map((c) => c.url)).toEqual([`${GATEWAY}/api/v1/shares/shr_1`]);
     });
+
+    // #472: on a host with gateway.publicUrl unset, share mint succeeds
+    // (token, no url) but the ref cannot be made into a fetchable https://
+    // URL for the provider. The failure must name the remedy and the
+    // workaround rather than just "not configured", and the now-unusable
+    // share must still be revoked rather than leaked.
+    test('minted share with no url (gateway.publicUrl unset) → actionable error, share revoked', async () => {
+      shareItems = [{ share_id: 'shr_1', url: '', expires_at: new Date(Date.now() + 60000).toISOString() }];
+      const res = await generate({ image: 'media/session-1/duck.png' });
+      expect(res.isError).toBe(true);
+      expect(res.content[0]!.text).toContain('generate_image: image reference sharing requires gateway.publicUrl to be configured');
+      expect(res.content[0]!.text).toContain('~/.claude-gateway/config.json');
+      expect(res.content[0]!.text).toContain('restart the gateway');
+      expect(res.content[0]!.text).toContain('https:// image URL instead of a local path or artifact ref');
+      expect(shareCalls()).toHaveLength(1);
+      expect(revokeCalls().map((c) => c.url)).toEqual([`${GATEWAY}/api/v1/shares/shr_1`]);
+    });
   });
 
   describe('artifact registration after delivery (§8)', () => {

--- a/tests/unit/video-generate-deliver.test.ts
+++ b/tests/unit/video-generate-deliver.test.ts
@@ -345,6 +345,47 @@ describe('generate_video image-to-video source-frame resolution (normalizeRef)',
     expect(submitBody.image).toBe('https://gw.example.com/shared/tok-1');
   });
 
+  // #472: on a host with gateway.publicUrl unset, share mint succeeds (token,
+  // no url) but the source frame cannot be made into a fetchable https:// URL.
+  // Mirrors the generate_image fix — same actionable remedy + workaround, and
+  // the now-unusable share is still revoked rather than leaked.
+  test('share bridge ON but the minted share has no url (gateway.publicUrl unset) → actionable error, share revoked', async () => {
+    process.env.GATEWAY_API_URL = GATEWAY;
+    process.env.GATEWAY_API_KEY = 'gw-key';
+    process.env.GATEWAY_AGENT_ID = 'agent-1';
+    process.env.GATEWAY_SESSION_ID = 'session-1';
+
+    global.fetch = jest.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ url, method, body: init?.body });
+      if (url.endsWith('/api/v1/shares') && method === 'POST') {
+        return new Response(
+          JSON.stringify({ items: [{ share_id: 'sh-1', token: 'tok-1', url: '', expires_at: '2099-01-01T00:00:00Z' }] }),
+          { status: 201 },
+        );
+      }
+      if (url.includes('/api/v1/shares/') && method === 'DELETE') {
+        return new Response(JSON.stringify({ revoked: true }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    const res = await new VideoModule().handleTool('generate_video', {
+      action: 'generate',
+      model: 'grok-video/grok-imagine',
+      prompt: 'animate this',
+      image: 'media/session-1/frame.png',
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('generate_video: source-frame sharing requires gateway.publicUrl to be configured');
+    expect(res.content[0]!.text).toContain('~/.claude-gateway/config.json');
+    expect(res.content[0]!.text).toContain('restart the gateway');
+    expect(calls.some((c) => c.method === 'DELETE' && c.url.includes('/api/v1/shares/sh-1'))).toBe(true);
+    expect(calls.some((c) => c.url.endsWith('/v1/videos/generations'))).toBe(false);
+  });
+
   test('share bridge ON but an artifact ref does not exist → error surfaced, no submit', async () => {
     process.env.GATEWAY_API_URL = GATEWAY;
     process.env.GATEWAY_API_KEY = 'gw-key';


### PR DESCRIPTION
## Summary

`gateway.publicUrl` backs every feature that hands out a public link (generate_image reference edits, share_file, `/cli`), but nothing ever writes it and its absence was invisible — the first signal was a late, unrelated-looking failure deep inside `generate_image`.

This implements Fixes 1–3 from #472 (Fix 4 is deliberately out of scope, per the issue's own recommendation: `doctor`'s new check already covers discoverability without re-adding `publicUrl: ""` to `config.template.json` and risking a #285 regression).

## Changes

- **`src/config/loader.ts`** — warn once (`console.warn`) when `gateway.publicUrl` resolves to unset (absent, blank, or whitespace-only), naming the disabled features. Never fatal: LINE-only and localhost-only deployments are legitimately fine without the key.
- **`src/cli/commands/doctor.ts`** — new `gatewayPublicUrl` check, independent of the existing informational `publicUrl`/`publicHealth` alt-address probe:
  - unset → `[warn]`, lists the disabled features, does not fail the command
  - set but nothing answers → `[!!]`, fails the command, includes the probe detail
  - set and answers (even a proxy 401 rejecting an unauthenticated probe) → `[ok]`
  - skipped when `--url`/`$CLAUDE_GATEWAY_URL` point at a different host, matching the existing `manager` check's convention — it's this host's own config file, not context for a remote diagnosis
- **`mcp/tools/image/module.ts`** — `generate_image`'s terminal error now names the remedy (set the key in `~/.claude-gateway/config.json`, restart) and the workaround (pass a public `https://` URL instead of a local/artifact ref).
- **`CLI.md`** — regenerated (`npm run gen-cli`) after updating the doctor description in `scripts/gen-cli.ts`.

## Tests

- `tests/unit/config-loader.test.ts` — asserts the warning fires exactly once for unset/blank/whitespace-only `publicUrl`, and never fires for a valid or invalid one.
- `tests/unit/cli-doctor.test.ts` — new `describe('gateway.publicUrl check (#472)')` covering all three states plus the `--url`-elsewhere skip; updated existing exact check-name-array assertions to include the new row.
- `tests/unit/share-normalize.test.ts` — new regression test: a minted share with no `url` now returns the actionable error message and still revokes the now-unusable share.

All new tests were verified to fail against the pre-fix code (reverted the three source files, confirmed 8 failures, restored).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 252 suites / 4846 tests passing
- [x] Regression tests proven to fail on pre-fix code, then pass after restoring the fix

Closes #472