### PR TITLE
fix(share): inbound-Host fallback for share URLs so i2i/i2v work without gateway.publicUrl

### DIFF
--- a/mcp/tools/image/module.ts
+++ b/mcp/tools/image/module.ts
@@ -512,15 +512,19 @@ export class ImageModule implements ToolModule {
         await revokeSharesBestEffort(minted.map((m) => m.share_id));
         return fail('generate_image: image share service returned a mismatched share count.');
       }
-      // Provider fetches these refs over HTTPS, so each needs an absolute URL —
-      // which the share API only fills when gateway.publicUrl is configured.
+      // Provider fetches these refs over HTTPS, so each needs an absolute URL.
+      // The share API fills `url` from gateway.publicUrl, or — when that is unset
+      // — from the public host learned off a real inbound (Traefik-fronted)
+      // request. If it is still empty the gateway hasn't seen an external request
+      // yet this run, so ask the user to resend rather than push a broken URL.
       if (minted.some((m) => !m.url)) {
         await revokeSharesBestEffort(minted.map((m) => m.share_id));
         return fail(
-          'generate_image: image reference sharing requires gateway.publicUrl to be configured ' +
-          '(set it in ~/.claude-gateway/config.json to your externally reachable base URL ending ' +
-          'in /gateway, then restart the gateway). As a workaround, pass a publicly reachable ' +
-          'https:// image URL instead of a local path or artifact ref.',
+          'generate_image: could not resolve the gateway public URL for the reference image yet. ' +
+          'Send your request again (the gateway learns its public URL from an inbound message). ' +
+          'If it keeps failing, set gateway.publicUrl in ~/.claude-gateway/config.json to your ' +
+          'externally reachable base URL ending in /gateway, or pass a publicly reachable https:// ' +
+          'image URL instead of a local path or artifact ref.',
         );
       }
     }

--- a/mcp/tools/video/module.ts
+++ b/mcp/tools/video/module.ts
@@ -414,15 +414,19 @@ export class VideoModule implements ToolModule {
     }
     const item = minted[0];
     if (!item) return fail('generate_video: share service returned no share for the source frame.');
-    // The provider fetches this over HTTPS, so it needs an absolute URL — which the
-    // share API only fills when gateway.publicUrl is configured.
+    // The provider fetches this over HTTPS, so it needs an absolute URL. The
+    // share API fills `url` from gateway.publicUrl, or — when that is unset — from
+    // the public host learned off a real inbound (Traefik-fronted) request. If it
+    // is still empty the gateway hasn't seen an external request yet this run, so
+    // ask the user to resend rather than push a broken URL.
     if (!item.url) {
       await revokeSharesBestEffort([item.share_id]);
       return fail(
-        'generate_video: source-frame sharing requires gateway.publicUrl to be configured ' +
-        '(set it in ~/.claude-gateway/config.json to your externally reachable base URL ending ' +
-        'in /gateway, then restart the gateway). As a workaround, pass a publicly reachable ' +
-        'https:// image URL instead of a local path or artifact ref.',
+        'generate_video: could not resolve the gateway public URL for the source frame yet. ' +
+        'Send your request again (the gateway learns its public URL from an inbound message). ' +
+        'If it keeps failing, set gateway.publicUrl in ~/.claude-gateway/config.json to your ' +
+        'externally reachable base URL ending in /gateway, or pass a publicly reachable https:// ' +
+        'image URL instead of a local path or artifact ref.',
       );
     }
     return { url: item.url, mintedShareIds: [item.share_id] };

--- a/src/api/gateway-router.ts
+++ b/src/api/gateway-router.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import * as http from 'node:http';
 import { exec } from 'child_process';
 import * as crypto from 'crypto';
@@ -30,6 +30,7 @@ import {
 import { cliPairingStore, type CliPairing } from '../cli-viewer/pairing-store';
 import { verifyTelegramInitData } from '../cli-viewer/telegram-initdata';
 import { normalizePublicUrl } from '../cli-viewer/url';
+import { externalHostFromHeaders, persistPublicBase } from '../config/public-base';
 import { createApiRouter } from './router';
 import { createCronRouter } from './cron-router';
 import { createMetaRouter } from './meta-router';
@@ -630,6 +631,22 @@ export class GatewayRouter {
     );
 
     this.app.use(express.json());
+
+    // Inbound-Host fallback for share URLs: learn the gateway's own public base
+    // from real external requests. Production pods sit behind Traefik, whose
+    // routing rule pins the Host to the pod's FQDN, so the Host of an external
+    // request IS the gateway's public host. Persisting it lets the share mint
+    // endpoint fill `url` even on pods whose `gateway.publicUrl` was never set at
+    // provision time (getpod #1939), so image-to-image / image-to-video work
+    // without a per-pod config edit or restart. Loopback / internal / dotless
+    // hosts (MCP subprocess, health checks) are ignored so they can't clobber it.
+    // Best-effort and idempotent (writes only on change); never blocks a request.
+    const agentsRootForBase = this.agentsRoot();
+    this.app.use((req: Request, _res: Response, next: NextFunction) => {
+      const host = externalHostFromHeaders(req.headers);
+      if (host) persistPublicBase(agentsRootForBase, host);
+      next();
+    });
 
     // `/cli` webview terminal viewer routes (device flow + agent-scoped viewer).
     // Registered here (after the body parser, before the /api auth router) so it

--- a/src/api/share-router.ts
+++ b/src/api/share-router.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_SHARE_TTL_SECONDS,
 } from '../share/share-store';
 import { computeSessionImageCatalog } from '../share/session-image-catalog';
+import { readPublicBase } from '../config/public-base';
 import { computeSessionVideoCatalog } from '../share/session-video-catalog';
 
 /**
@@ -267,8 +268,10 @@ export function createSharesPrivateRouter(
    * Body: { agent_id, session_id, purpose?, ttl_seconds?, allow_documents?, refs: [{artifact_id}|{path}] }
    * Response: { items: [{ share_id, token, url?, expires_at }] } — order preserved.
    * `token` is always present (host-agnostic capability); `url` is a convenience
-   * built from `gateway.publicUrl` and is omitted when that is unset — callers
-   * with their own public base (e.g. LINE) build the URL from `token`.
+   * built from `gateway.publicUrl` when set, else from the inbound-Host fallback
+   * (`.public-base`, learned from real external requests behind Traefik). It is
+   * omitted only when neither is known — callers with their own public base
+   * (e.g. LINE) build the URL from `token`.
    * `allow_documents` widens the allowlist to PDF for THIS request only and is
    * recorded on each minted row (#444); without it a PDF is still 415.
    */
@@ -411,6 +414,12 @@ export function createSharesPrivateRouter(
       return;
     }
 
+    // Resolve the public base for the `url` convenience field: the configured
+    // `gateway.publicUrl` wins; otherwise fall back to the inbound-Host base
+    // learned from real external (Traefik-fronted) requests. Read per-request so
+    // a base learned after startup takes effect without a gateway restart.
+    const baseUrl = publicBaseUrl ?? readPublicBase(agentsBaseDir) ?? undefined;
+
     const items = resolved.map((r) => {
       const mint = store.mintShare({
         agentId,
@@ -425,7 +434,7 @@ export function createSharesPrivateRouter(
       return {
         share_id: mint.shareId,
         token: mint.token,
-        ...(publicBaseUrl ? { url: `${publicBaseUrl}/shared/${mint.token}` } : {}),
+        ...(baseUrl ? { url: `${baseUrl}/shared/${mint.token}` } : {}),
         expires_at: new Date(mint.expiresAtMs).toISOString(),
         // only present for refs resolved from an artifact_id
         // whose generation recorded a provider task id — the hook a

--- a/src/config/public-base.ts
+++ b/src/config/public-base.ts
@@ -1,0 +1,109 @@
+/**
+ * Inbound-Host fallback for the gateway's own public base URL.
+ *
+ * Minted share URLs (`<base>/shared/<token>`) need the gateway's externally
+ * reachable base. `gateway.publicUrl` supplies it when set, but pods provisioned
+ * before that field was written at provision time (getpod #1939) never got it,
+ * so image-to-image / image-to-video fail closed: the mint returns a token but
+ * no `url`, and the media tools reject with "requires gateway.publicUrl".
+ *
+ * Rather than hand-edit every old pod, derive the base from the inbound request
+ * the same way the LINE webhook already does: production pods sit behind Traefik,
+ * whose routing rule pins the Host to the pod's own FQDN, so the Host header of a
+ * real external request IS the gateway's public host. We persist it to a
+ * gateway-level `.public-base` file (one host per pod, shared across agents) and
+ * read it back at mint time whenever `gateway.publicUrl` is unset.
+ *
+ * Scheme is hardcoded `https`: the pod's Traefik `web-vm` entrypoint does NOT
+ * trust forwarded headers, so `X-Forwarded-Proto` arrives as `http` (wrong)
+ * while the Host is reliable — same reasoning as `src/api/line-webhook-router.ts`.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { IncomingHttpHeaders } from 'http';
+
+/** host[:port] — letters, digits, dot, hyphen, colon. Mirrors line-webhook. */
+const HOST_RE = /^[a-z0-9.\-:]+$/;
+
+/** The gateway-level file, one directory above the agents root (i.e. the
+ *  `.claude-gateway` home), so it is shared by every agent on the pod. */
+function publicBaseFile(agentsRoot: string): string {
+  return path.resolve(agentsRoot, '..', '.public-base');
+}
+
+/**
+ * Extract a genuinely-external public host from an inbound request, or '' when
+ * the request is not one we can trust as the pod's public FQDN.
+ *
+ * Prefers `X-Forwarded-Host` (set by Traefik) then falls back to `Host`. Rejects
+ * loopback / internal / bare (dotless) hosts: those come from the MCP subprocess
+ * (127.0.0.1), Docker health checks, or direct-IP hits and must never clobber
+ * the real public host once it has been learned.
+ */
+export function externalHostFromHeaders(headers: IncomingHttpHeaders): string {
+  const fwd = headers['x-forwarded-host'];
+  const raw =
+    (typeof fwd === 'string' ? fwd : Array.isArray(fwd) ? fwd[0] : '') ||
+    (typeof headers.host === 'string' ? headers.host : '');
+  const hostPort = (raw.split(',')[0] ?? '').trim().toLowerCase();
+  if (!hostPort || !HOST_RE.test(hostPort)) return '';
+  const hostname = hostPort.split(':')[0] ?? '';
+  if (
+    !hostname.includes('.') || // bare name (localhost, docker service names)
+    hostname === 'localhost' ||
+    /^127\./.test(hostname) ||
+    hostname === '0.0.0.0' ||
+    hostname === '::1' ||
+    hostname.endsWith('.internal') ||
+    hostname.endsWith('.local')
+  ) {
+    return '';
+  }
+  return hostPort;
+}
+
+/** In-process memo of the last value written per target file, so the common
+ *  case (the same public host on every request) costs no disk I/O at all. */
+const lastWritten = new Map<string, string>();
+
+/**
+ * Persist the pod's public base derived from a trusted external host. Best
+ * effort and idempotent: only writes when the value changed (so it is cheap to
+ * call on every request), writes atomically (temp + rename), and never throws —
+ * a failure here must not break request handling.
+ */
+export function persistPublicBase(agentsRoot: string, host: string): void {
+  const h = host.trim();
+  if (!h || !HOST_RE.test(h)) return;
+  const base = `https://${h}/gateway`;
+  const target = publicBaseFile(agentsRoot);
+  if (lastWritten.get(target) === base) return; // hot path: no syscall
+  try {
+    let current = '';
+    try {
+      current = fs.readFileSync(target, 'utf8');
+    } catch {
+      current = '';
+    }
+    if (current === base) {
+      lastWritten.set(target, base);
+      return;
+    }
+    const tmp = path.join(path.dirname(target), `.public-base.${process.pid}.tmp`);
+    fs.writeFileSync(tmp, base, { mode: 0o600 });
+    fs.renameSync(tmp, target);
+    lastWritten.set(target, base);
+  } catch {
+    /* best-effort: never break the request path over a config-cache write */
+  }
+}
+
+/** Read the persisted public base (`https://<host>/gateway`), or null. */
+export function readPublicBase(agentsRoot: string): string | null {
+  try {
+    const v = fs.readFileSync(publicBaseFile(agentsRoot), 'utf8').trim().replace(/\/+$/, '');
+    return v || null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/public-base.test.ts
+++ b/tests/unit/public-base.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the inbound-Host fallback helper (src/config/public-base.ts):
+ * host extraction/validation, atomic idempotent persistence, and read-back.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  externalHostFromHeaders,
+  persistPublicBase,
+  readPublicBase,
+} from '../../src/config/public-base';
+
+describe('public-base inbound-Host fallback', () => {
+  describe('externalHostFromHeaders', () => {
+    it('accepts a real external FQDN from Host', () => {
+      expect(externalHostFromHeaders({ host: 'pod-abc.develop-vm.getpod.ai' })).toBe(
+        'pod-abc.develop-vm.getpod.ai',
+      );
+    });
+
+    it('prefers X-Forwarded-Host over Host', () => {
+      expect(
+        externalHostFromHeaders({
+          'x-forwarded-host': 'pod-fwd.develop-vm.getpod.ai',
+          host: 'internal:10850',
+        }),
+      ).toBe('pod-fwd.develop-vm.getpod.ai');
+    });
+
+    it('takes the first entry of a comma list and lowercases', () => {
+      expect(
+        externalHostFromHeaders({ 'x-forwarded-host': 'Pod-X.Vm.Example.com, other.com' }),
+      ).toBe('pod-x.vm.example.com');
+    });
+
+    it('keeps a port when present', () => {
+      expect(externalHostFromHeaders({ host: 'pod-x.vm.example.com:8443' })).toBe(
+        'pod-x.vm.example.com:8443',
+      );
+    });
+
+    it.each([
+      ['localhost'],
+      ['localhost:10850'],
+      ['127.0.0.1'],
+      ['127.0.0.1:10850'],
+      ['0.0.0.0'],
+      ['::1'],
+      ['gateway'], // bare docker service name (no dot)
+      ['pod-x.internal'],
+      ['pod-x.local'],
+      [''],
+      ['bad host!'], // fails HOST_RE
+    ])('rejects non-public host %p', (h) => {
+      expect(externalHostFromHeaders({ host: h })).toBe('');
+    });
+
+    it('returns empty when no host header is present', () => {
+      expect(externalHostFromHeaders({})).toBe('');
+    });
+  });
+
+  describe('persist + read', () => {
+    let root: string;
+    let agentsRoot: string;
+
+    beforeEach(() => {
+      root = fs.mkdtempSync(path.join(os.tmpdir(), 'pubbase-'));
+      agentsRoot = path.join(root, 'agents');
+      fs.mkdirSync(agentsRoot, { recursive: true });
+    });
+
+    afterEach(() => {
+      fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('round-trips the https /gateway base one level above the agents root', () => {
+      persistPublicBase(agentsRoot, 'pod-abc.develop-vm.getpod.ai');
+      expect(readPublicBase(agentsRoot)).toBe('https://pod-abc.develop-vm.getpod.ai/gateway');
+      // File lives at <agentsRoot>/../.public-base (gateway-level, shared by agents).
+      expect(fs.readFileSync(path.join(root, '.public-base'), 'utf8')).toBe(
+        'https://pod-abc.develop-vm.getpod.ai/gateway',
+      );
+    });
+
+    it('is idempotent: an unchanged value leaves no temp file behind', () => {
+      persistPublicBase(agentsRoot, 'pod-abc.develop-vm.getpod.ai');
+      persistPublicBase(agentsRoot, 'pod-abc.develop-vm.getpod.ai');
+      const leftovers = fs.readdirSync(root).filter((f) => f.includes('.tmp'));
+      expect(leftovers).toEqual([]);
+      expect(readPublicBase(agentsRoot)).toBe('https://pod-abc.develop-vm.getpod.ai/gateway');
+    });
+
+    it('overwrites when the host changes', () => {
+      persistPublicBase(agentsRoot, 'old.vm.example.com');
+      persistPublicBase(agentsRoot, 'new.vm.example.com');
+      expect(readPublicBase(agentsRoot)).toBe('https://new.vm.example.com/gateway');
+    });
+
+    it('ignores empty / invalid hosts', () => {
+      persistPublicBase(agentsRoot, '');
+      persistPublicBase(agentsRoot, 'bad host!');
+      expect(readPublicBase(agentsRoot)).toBeNull();
+    });
+
+    it('returns null when nothing was persisted', () => {
+      expect(readPublicBase(agentsRoot)).toBeNull();
+    });
+  });
+});

--- a/tests/unit/share-normalize.test.ts
+++ b/tests/unit/share-normalize.test.ts
@@ -395,18 +395,19 @@ describe('generate_image share-bridge normalization (#70)', () => {
       expect(revokeCalls().map((c) => c.url)).toEqual([`${GATEWAY}/api/v1/shares/shr_1`]);
     });
 
-    // #472: on a host with gateway.publicUrl unset, share mint succeeds
-    // (token, no url) but the ref cannot be made into a fetchable https://
-    // URL for the provider. The failure must name the remedy and the
-    // workaround rather than just "not configured", and the now-unusable
+    // #472: on a host with gateway.publicUrl unset AND no inbound-Host base
+    // learned yet, share mint succeeds (token, no url) but the ref cannot be
+    // made into a fetchable https:// URL for the provider. The failure must tell
+    // the user to resend (the gateway learns its public host from an inbound
+    // request) and name the config/workaround remedies, and the now-unusable
     // share must still be revoked rather than leaked.
     test('minted share with no url (gateway.publicUrl unset) → actionable error, share revoked', async () => {
       shareItems = [{ share_id: 'shr_1', url: '', expires_at: new Date(Date.now() + 60000).toISOString() }];
       const res = await generate({ image: 'media/session-1/duck.png' });
       expect(res.isError).toBe(true);
-      expect(res.content[0]!.text).toContain('generate_image: image reference sharing requires gateway.publicUrl to be configured');
+      expect(res.content[0]!.text).toContain('generate_image: could not resolve the gateway public URL');
+      expect(res.content[0]!.text).toContain('Send your request again');
       expect(res.content[0]!.text).toContain('~/.claude-gateway/config.json');
-      expect(res.content[0]!.text).toContain('restart the gateway');
       expect(res.content[0]!.text).toContain('https:// image URL instead of a local path or artifact ref');
       expect(shareCalls()).toHaveLength(1);
       expect(revokeCalls().map((c) => c.url)).toEqual([`${GATEWAY}/api/v1/shares/shr_1`]);

--- a/tests/unit/share-router.test.ts
+++ b/tests/unit/share-router.test.ts
@@ -125,6 +125,45 @@ describe('file share router', () => {
       const fetched = await supertest.default(noBaseApp).get(`/shared/${item.token}`);
       expect(fetched.status).toBe(200);
     });
+
+    test('inbound-Host fallback: url is filled from .public-base when no config base', async () => {
+      // Pod with no gateway.publicUrl, but the gateway has learned its public host
+      // from a real inbound request and persisted it to <agentsRoot>/../.public-base.
+      // The mint endpoint must fill `url` from that fallback so image/video i2i/i2v
+      // work without a per-pod config edit.
+      const target = path.resolve(baseDir, '..', '.public-base');
+      const FALLBACK = 'https://pod-fallback.develop-vm.getpod.ai/gateway';
+      fs.writeFileSync(target, FALLBACK);
+      try {
+        const noBaseApp = express();
+        noBaseApp.use(express.json());
+        noBaseApp.use(createSharesPublicRouter(store, baseDir));
+        noBaseApp.use('/api', createSharesPrivateRouter(store, KEYS, baseDir)); // no config base
+        const res = await supertest
+          .default(noBaseApp)
+          .post('/api/v1/shares')
+          .set(AUTH_A1)
+          .send({ agent_id: AGENT, session_id: SESSION, refs: [{ path: `${SESSION}/ok.png` }] });
+        expect(res.status).toBe(201);
+        const item = res.body.items[0] as { url?: string; token: string };
+        expect(item.url).toBe(`${FALLBACK}/shared/${item.token}`);
+      } finally {
+        fs.rmSync(target, { force: true });
+      }
+    });
+
+    test('config base wins over the .public-base fallback', async () => {
+      // buildApp() mounts the private router WITH BASE_URL; a stale .public-base
+      // must never override an explicitly configured gateway.publicUrl.
+      const target = path.resolve(baseDir, '..', '.public-base');
+      fs.writeFileSync(target, 'https://stale.example.com/gateway');
+      try {
+        const item = await mintOne();
+        expect(item.url.startsWith(`${BASE_URL}/shared/`)).toBe(true);
+      } finally {
+        fs.rmSync(target, { force: true });
+      }
+    });
   });
 
   describe('id format validation (HIGH #1 — sandbox-escape guard)', () => {

--- a/tests/unit/video-generate-deliver.test.ts
+++ b/tests/unit/video-generate-deliver.test.ts
@@ -345,10 +345,11 @@ describe('generate_video image-to-video source-frame resolution (normalizeRef)',
     expect(submitBody.image).toBe('https://gw.example.com/shared/tok-1');
   });
 
-  // #472: on a host with gateway.publicUrl unset, share mint succeeds (token,
-  // no url) but the source frame cannot be made into a fetchable https:// URL.
-  // Mirrors the generate_image fix — same actionable remedy + workaround, and
-  // the now-unusable share is still revoked rather than leaked.
+  // #472: on a host with gateway.publicUrl unset AND no inbound-Host base learned
+  // yet, share mint succeeds (token, no url) but the source frame cannot be made
+  // into a fetchable https:// URL. Mirrors the generate_image fix — resend
+  // guidance + config/workaround remedies, and the now-unusable share is still
+  // revoked rather than leaked.
   test('share bridge ON but the minted share has no url (gateway.publicUrl unset) → actionable error, share revoked', async () => {
     process.env.GATEWAY_API_URL = GATEWAY;
     process.env.GATEWAY_API_KEY = 'gw-key';
@@ -379,9 +380,9 @@ describe('generate_video image-to-video source-frame resolution (normalizeRef)',
     });
 
     expect(res.isError).toBe(true);
-    expect(res.content[0]!.text).toContain('generate_video: source-frame sharing requires gateway.publicUrl to be configured');
+    expect(res.content[0]!.text).toContain('generate_video: could not resolve the gateway public URL');
+    expect(res.content[0]!.text).toContain('Send your request again');
     expect(res.content[0]!.text).toContain('~/.claude-gateway/config.json');
-    expect(res.content[0]!.text).toContain('restart the gateway');
     expect(calls.some((c) => c.method === 'DELETE' && c.url.includes('/api/v1/shares/sh-1'))).toBe(true);
     expect(calls.some((c) => c.url.endsWith('/v1/videos/generations'))).toBe(false);
   });


### PR DESCRIPTION
## Problem

Image-to-image (`generate_image` with a ref) and image-to-video (`generate_video` with a source frame) **fail closed** on any pod whose `gateway.publicUrl` is unset: the share mint returns a `token` but no `url`, and the media tools reject with *"requires gateway.publicUrl to be configured."*

This is not rare. getpod writes `gateway.publicUrl` into each pod's `config.json` **only at provision/create/reprovision** (getpod #1939, 2026-07-30). Every pod created before that date never got it, and the incus-agent is **masked at activation** for tenant isolation — so those running pods can't be reached with `incus exec` to backfill the config. Hand-editing each pod (config edit + gateway-service restart) is the only current remedy, and it doesn't scale.

#472 added a clearer *error message* for this state but never resolved the underlying failure. This PR does.

## Fix

Learn the gateway's public base from **real inbound requests** instead of requiring it in config.

Production pods sit behind Traefik, whose routing rule pins the `Host` to the pod's own FQDN — so the `Host` header of a genuine external request **is** the gateway's public host. This is the exact trust model `line-webhook-router.ts` already relies on (`.public-base`, hardcoded `https` because the `web-vm` entrypoint doesn't trust `X-Forwarded-Proto`).

- A small global middleware persists the learned host to a **gateway-level `.public-base`** file (one host per pod, shared across agents).
- The share **mint endpoint** reads it as the base for the `url` convenience field whenever `gateway.publicUrl` is unset. Configured `publicUrl` always wins.

**One change fixes `generate_image` i2i, `generate_video` i2v, and `share_file` uniformly** — no per-pod config edit, no VM/gateway restart, no domain-munging, and no dependency on a gateway update ever reaching the old pods.

## Safety

- Loopback / internal / dotless hosts (MCP subprocess at `127.0.0.1`, Docker health checks) are rejected, so they can never clobber the learned public host.
- Scheme hardcoded `https`; host validated against the same charset as the LINE path.
- Write is best-effort (never throws into the request path), atomic (temp+rename), idempotent, and memoed in-process so the steady-state hot path costs **zero** disk I/O.
- The `url` field is only a convenience string; the capability is the token, which is minted and validated exactly as before. A spoofed Host can't reach this backend because Traefik routes by Host.

The media-tool errors now tell the user to **resend** (the host is learned from an inbound message) rather than "restart the gateway."

## Tests

- `public-base` helper: host extraction/validation (accepts real FQDN incl. `X-Forwarded-Host` precedence and port; rejects loopback/internal/dotless/invalid), atomic idempotent persist, read-back, overwrite-on-change.
- Mint endpoint: `url` filled from `.public-base` when no config base; config base wins over a stale fallback.
- Updated the `#472` i2i/i2v error-message assertions.

`tsc --noEmit` clean; affected unit suites (`public-base`, `share-router`, `share-normalize`, `video-generate-deliver`, `video-module`, `image-module`, `line-image`) all green (141 tests).

Relates to #472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)