### PR TITLE
fix(build): decouple test:unit from a forced full tsc rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ mcp/**/*.js.map
 mcp/**/*.d.ts
 mcp/**/*.d.ts.map
 
+# TypeScript incremental build cache (kept outside dist/ so it never ships in
+# the npm package, which whitelists dist/ via package.json `files`)
+.tsbuildinfo
+.tsbuildinfo-check
+
 # Environment & config
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -1577,6 +1577,9 @@ npm test
 
 # Type check without building
 npm run typecheck
+
+# Build + full test suite in one pipeline (build runs once, not twice)
+npm run check:full
 ```
 
 ### Writing tests that wait

--- a/README.md
+++ b/README.md
@@ -1577,9 +1577,6 @@ npm test
 
 # Type check without building
 npm run typecheck
-
-# Build + full test suite in one pipeline (build runs once, not twice)
-npm run check:full
 ```
 
 ### Writing tests that wait

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "integration:hb": "jest --testPathPattern=heartbeat-e2e --testTimeout=15000",
     "integration:cs": "jest --testPathPattern=character-system --testTimeout=15000",
     "typecheck": "tsc --noEmit --incremental --tsBuildInfoFile ./.tsbuildinfo-check",
-    "check:full": "npm run build && NODE_OPTIONS=--max-old-space-size=2560 jest",
     "gen-cli": "ts-node scripts/gen-cli.ts",
     "gen-cli:check": "ts-node scripts/gen-cli.ts --check"
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "start": "node --no-warnings=ExperimentalWarning --env-file-if-exists=.env dist/entry.js gateway start",
     "postinstall": "if command -v bun >/dev/null 2>&1; then bun install --cwd mcp; else echo 'Warning: bun not found. Run `cd mcp && bun install` manually to enable MCP tools.'; fi",
     "pretest": "npm run build",
+    "pretest:unit": "npm run build",
     "test": "NODE_OPTIONS=--max-old-space-size=2560 jest",
     "test:unit": "jest --testPathPattern=unit",
     "test:e2e": "jest --testPathPattern=tests/e2e --forceExit",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "postinstall": "if command -v bun >/dev/null 2>&1; then bun install --cwd mcp; else echo 'Warning: bun not found. Run `cd mcp && bun install` manually to enable MCP tools.'; fi",
     "pretest": "npm run build",
     "test": "NODE_OPTIONS=--max-old-space-size=2560 jest",
-    "pretest:unit": "npm run build",
     "test:unit": "jest --testPathPattern=unit",
     "test:e2e": "jest --testPathPattern=tests/e2e --forceExit",
     "integration": "jest --testPathPattern=integration --testTimeout=15000",
@@ -40,7 +39,8 @@
     "test:manual": "jest --testPathPattern=phase-manual --testTimeout=15000",
     "integration:hb": "jest --testPathPattern=heartbeat-e2e --testTimeout=15000",
     "integration:cs": "jest --testPathPattern=character-system --testTimeout=15000",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit --incremental --tsBuildInfoFile ./.tsbuildinfo-check",
+    "check:full": "npm run build && NODE_OPTIONS=--max-old-space-size=2560 jest",
     "gen-cli": "ts-node scripts/gen-cli.ts",
     "gen-cli:check": "ts-node scripts/gen-cli.ts --check"
   },

--- a/tests/unit/build-pipeline.test.ts
+++ b/tests/unit/build-pipeline.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression guard for #479 — `npm test`'s `pretest` hook forced a full,
+ * non-incremental `tsc` build on every invocation, pushing this 8GB shared
+ * host to ~95% RAM with swap saturated (peak RSS occurred during the
+ * `pretest` -> `tsc` step, not during the Jest run itself).
+ *
+ * `tests/unit/**` never touches `dist/` for real: the only unit test that
+ * references it (`whatsapp-cloud-mcp.test.ts`) uses `jest.mock(path, factory,
+ * { virtual: true })`, and `mcp-no-src-imports.test.ts` only checks that a
+ * matching `src/` counterpart exists via `existsSync`, never reads `dist/`
+ * itself. So `test:unit` paid the full build cost for nothing.
+ *
+ * The full `npm test` run is different: `tests/integration/cli-dispatch.test.ts`
+ * spawns the real `dist/entry.js` binary and `tests/helpers/pty-harness.ts`
+ * spawns the real `dist/shell/claude-pty-shell.js`, so that path still needs a
+ * real build — `pretest` must stay wired there. The fix is scoped to the
+ * `test:unit` path (which was needlessly building) plus incremental caching
+ * so repeat `tsc` invocations (full `npm test`, `typecheck`, `check:full`)
+ * stay cheap after the first.
+ */
+import { readFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+function readJson(relPath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(REPO_ROOT, relPath), 'utf8'));
+}
+
+describe('build pipeline is not needlessly heavy on this host (#479)', () => {
+  const pkg = readJson('package.json') as { scripts?: Record<string, string> };
+  const tsconfig = readJson('tsconfig.json') as {
+    compilerOptions?: { incremental?: boolean; tsBuildInfoFile?: string };
+  };
+  const scripts = pkg.scripts ?? {};
+
+  it('enables incremental tsc builds so repeat compiles reuse cached type info', () => {
+    expect(tsconfig.compilerOptions?.incremental).toBe(true);
+    expect(typeof tsconfig.compilerOptions?.tsBuildInfoFile).toBe('string');
+  });
+
+  it('keeps the incremental build-info cache out of the published dist/ tree', () => {
+    // dist/ ships to npm via package.json `files`, so a cache file that landed
+    // there would be published too. The buildinfo path must not resolve under dist/.
+    const buildInfoPath = tsconfig.compilerOptions?.tsBuildInfoFile ?? '';
+    expect(buildInfoPath.replace(/^\.\//, '').split('/')[0]).not.toBe('dist');
+  });
+
+  it('does not force a full tsc build before running unit tests alone', () => {
+    // test:unit only exercises tests/unit/**, none of which reads a real dist/
+    // artifact (mocks are `{ virtual: true }`, and the src-import guard checks
+    // src/ existence, not dist/ content) — so it must not carry a pretest:unit
+    // build hook.
+    expect(scripts['pretest:unit']).toBeUndefined();
+    expect(scripts['test:unit']).toBeDefined();
+  });
+
+  it('still forces a real build before the full suite, which needs dist/ for real', () => {
+    // tests/integration/cli-dispatch.test.ts and the pty-harness-based tests
+    // spawn the compiled dist/ binaries directly — this hook must survive.
+    expect(scripts['pretest']).toBe('npm run build');
+  });
+
+  it('provides a single check:full pipeline that does not run tsc twice', () => {
+    const checkFull = scripts['check:full'];
+    expect(checkFull).toBeDefined();
+    // `npm run build` (tsc, which type-checks as part of compiling) must appear
+    // exactly once, and check:full must not also shell out to `npm run
+    // typecheck` / a bare `tsc --noEmit` — that would type-check the same
+    // source tree a second time for nothing.
+    expect((checkFull!.match(/npm run build/g) ?? []).length).toBe(1);
+    expect(checkFull).not.toMatch(/npm run typecheck/);
+    expect(checkFull).not.toMatch(/tsc --noEmit/);
+    expect(checkFull).toMatch(/jest/);
+  });
+});

--- a/tests/unit/build-pipeline.test.ts
+++ b/tests/unit/build-pipeline.test.ts
@@ -4,19 +4,25 @@
  * host to ~95% RAM with swap saturated (peak RSS occurred during the
  * `pretest` -> `tsc` step, not during the Jest run itself).
  *
- * `tests/unit/**` never touches `dist/` for real: the only unit test that
- * references it (`whatsapp-cloud-mcp.test.ts`) uses `jest.mock(path, factory,
- * { virtual: true })`, and `mcp-no-src-imports.test.ts` only checks that a
- * matching `src/` counterpart exists via `existsSync`, never reads `dist/`
- * itself. So `test:unit` paid the full build cost for nothing.
+ * `pretest`/`pretest:unit` still build before tests run — several `mcp/tools/**`
+ * modules under test (`mcp/tools/telegram/typing.ts`, `whatsapp-cloud/module.ts`,
+ * `slack/module.ts`, `skills/handlers.ts`) contain real (non-mocked) TypeScript
+ * imports from `dist/**`, so ts-jest genuinely needs `dist/` built to resolve
+ * them — a `jest.mock(path, factory, { virtual: true })` only substitutes the
+ * module at runtime, it does not stop ts-jest's TypeScript compiler from
+ * resolving the import statement at compile time (confirmed by running
+ * `test:unit` against a checkout with no `dist/`: TS2307 "Cannot find module"
+ * on those four files). Skipping the build for `test:unit` alone would break
+ * it on any fresh checkout and in `release.yml`, which runs `npm run test:unit`
+ * before its separate `Build` step.
  *
- * The full `npm test` run is different: `tests/integration/cli-dispatch.test.ts`
- * spawns the real `dist/entry.js` binary and `tests/helpers/pty-harness.ts`
- * spawns the real `dist/shell/claude-pty-shell.js`, so that path still needs a
- * real build — `pretest` must stay wired there. The fix is scoped to the
- * `test:unit` path (which was needlessly building) plus incremental caching
- * so repeat `tsc` invocations (full `npm test`, `typecheck`, `check:full`)
- * stay cheap after the first.
+ * The actual fix is the `incremental: true` + `tsBuildInfoFile` cache below:
+ * the first build after a fresh checkout still pays full cost, but every
+ * repeat `tsc` invocation on the same checkout (`pretest`, `pretest:unit`,
+ * `typecheck`, `check:full`) reuses the cached type info instead of
+ * recompiling `src/` from scratch — which is the case that actually matters
+ * on this host, where the same checkout runs tests repeatedly across a
+ * session.
  */
 import { readFileSync } from 'fs';
 import { join, resolve } from 'path';
@@ -46,12 +52,13 @@ describe('build pipeline is not needlessly heavy on this host (#479)', () => {
     expect(buildInfoPath.replace(/^\.\//, '').split('/')[0]).not.toBe('dist');
   });
 
-  it('does not force a full tsc build before running unit tests alone', () => {
-    // test:unit only exercises tests/unit/**, none of which reads a real dist/
-    // artifact (mocks are `{ virtual: true }`, and the src-import guard checks
-    // src/ existence, not dist/ content) — so it must not carry a pretest:unit
-    // build hook.
-    expect(scripts['pretest:unit']).toBeUndefined();
+  it('still builds before unit tests — several mcp/tools/** files import dist/ for real', () => {
+    // mcp/tools/telegram/typing.ts, whatsapp-cloud/module.ts, slack/module.ts,
+    // and skills/handlers.ts import from dist/** directly (not behind a jest
+    // virtual mock), so ts-jest needs a real dist/ to type-check them.
+    // Removing this hook makes `npm run test:unit` fail with TS2307 on a
+    // fresh checkout (and in release.yml, which runs it before its build step).
+    expect(scripts['pretest:unit']).toBe('npm run build');
     expect(scripts['test:unit']).toBeDefined();
   });
 

--- a/tests/unit/build-pipeline.test.ts
+++ b/tests/unit/build-pipeline.test.ts
@@ -19,10 +19,9 @@
  * The actual fix is the `incremental: true` + `tsBuildInfoFile` cache below:
  * the first build after a fresh checkout still pays full cost, but every
  * repeat `tsc` invocation on the same checkout (`pretest`, `pretest:unit`,
- * `typecheck`, `check:full`) reuses the cached type info instead of
- * recompiling `src/` from scratch — which is the case that actually matters
- * on this host, where the same checkout runs tests repeatedly across a
- * session.
+ * `typecheck`) reuses the cached type info instead of recompiling `src/`
+ * from scratch — which is the case that actually matters on this host,
+ * where the same checkout runs tests repeatedly across a session.
  */
 import { readFileSync } from 'fs';
 import { join, resolve } from 'path';
@@ -68,16 +67,10 @@ describe('build pipeline is not needlessly heavy on this host (#479)', () => {
     expect(scripts['pretest']).toBe('npm run build');
   });
 
-  it('provides a single check:full pipeline that does not run tsc twice', () => {
-    const checkFull = scripts['check:full'];
-    expect(checkFull).toBeDefined();
-    // `npm run build` (tsc, which type-checks as part of compiling) must appear
-    // exactly once, and check:full must not also shell out to `npm run
-    // typecheck` / a bare `tsc --noEmit` — that would type-check the same
-    // source tree a second time for nothing.
-    expect((checkFull!.match(/npm run build/g) ?? []).length).toBe(1);
-    expect(checkFull).not.toMatch(/npm run typecheck/);
-    expect(checkFull).not.toMatch(/tsc --noEmit/);
-    expect(checkFull).toMatch(/jest/);
+  it('does not carry a redundant check:full script duplicating npm test', () => {
+    // npm test already runs `pretest` (npm run build) before jest, so a
+    // separate check:full: "npm run build && jest" script would be an exact
+    // duplicate of `npm test` — not a distinct pipeline.
+    expect(scripts['check:full']).toBeUndefined();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuildinfo"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Summary
`npm test`'s `pretest` hook ran a full, non-incremental `tsc` build on every invocation, pushing this shared 8GB host to ~95% RAM with swap saturated (peak RSS occurred during the `pretest` -> `tsc` build step, not during the Jest run itself). See #479 for the measured evidence (203 samples @ 1.5s intervals, peak 95.3% RAM / 372MB available).

## Root cause
- `pretest: "npm run build"` (and `pretest:unit`) forced a full `tsc` compile before every `npm test` / `npm run test:unit` run.
- `tsconfig.json` had no `incremental`/`composite` option, so every invocation recompiled `src/` from scratch instead of reusing a `.tsbuildinfo` cache.
- That repeat-compile cost was the actual waste: `tsc` doesn't need to redo full type-checking work it already did on the previous run of the same checkout.

## Fix
- `tsconfig.json`: enable `incremental: true` with a `tsBuildInfoFile`, so repeat `tsc` invocations (`pretest`, `pretest:unit`, `typecheck`) reuse cached type info after the first run instead of recompiling `src/` from scratch. This is the actual fix — the first build after a fresh checkout still pays full cost, but every repeat invocation on the same checkout is cheap.
- `package.json`:
  - Keep `pretest:unit` building — see "Correction" below, this was **not** safe to drop.
  - Keep `pretest` (the full-suite hook) building, since `tests/integration/cli-dispatch.test.ts` and the pty-harness tests spawn the compiled `dist/` binaries directly and genuinely need it.
  - Add `typecheck` (`tsc --noEmit`) with its own incremental buildinfo cache, separate from the emit cache.
- `.gitignore`: ignore `.tsbuildinfo` / `.tsbuildinfo-check` so the new cache files never ship in the published npm package (`dist/` is what ships, per `package.json` `files`).

## Correction #1 (self-review finding, fixed in this PR)
The first version of this PR additionally removed `pretest:unit`'s `npm run build`, on the theory that `tests/unit/**` never touches `dist/` for real. **That was wrong.** Several `mcp/tools/**` modules under test have real (non-mocked) TypeScript imports from `dist/**`:
- `mcp/tools/telegram/typing.ts` → `dist/agent/turn-trace.js`
- `mcp/tools/whatsapp-cloud/module.ts` → `dist/api/whatsapp-cloud-client.js`, `dist/history/media-store.js`, `dist/shared/image-optimize.js`, `dist/api/whatsapp-cloud-access.js`
- `mcp/tools/slack/module.ts` → `dist/api/slack-client.js`
- `mcp/tools/skills/handlers.ts` → `dist/skills/parser.js`

These aren't behind `jest.mock(path, factory, { virtual: true })` in every test file — `tests/unit/slack-mcp.test.ts`, `tests/unit/skills-runtime.test.ts`, and `tests/unit/telegram-plugin/typing.test.ts` import the real module, so ts-jest's TypeScript compiler needs `dist/` to actually exist on disk to resolve those imports at compile time, regardless of runtime mocking.

**Proven live**: renamed `dist/` away and ran those three test files — all three failed with `TS2307: Cannot find module '.../dist/...'`. Restored `dist/` and they passed again (127/127 tests). Without `pretest:unit`, `npm run test:unit` would have broken on any fresh checkout — including `.github/workflows/release.yml`, which runs `npm run test:unit` *before* its separate `Build` step.

So `pretest:unit` stays wired to `npm run build`, same as before this PR. The win is entirely from the incremental cache: repeat `tsc` runs on the same checkout (which is the case that matters on this shared host, where the same checkout runs tests repeatedly across a session) reuse cached type info instead of a full rebuild.

## Correction #2 (independent review finding, fixed in this PR)
An earlier revision also added a `check:full` script (`npm run build && jest`) meant as "a single pipeline that doesn't build twice." An independent review caught that this is an exact duplicate of `npm test` — `npm test` already runs `pretest` (`npm run build`) before `jest`, with the same `NODE_OPTIONS` memory cap. `check:full` added no distinct behavior and nothing else in the repo referenced it, so it's been removed.

Two other independent-review findings were evaluated and **not** changed:
- *"Incremental caching doesn't reduce the cold-cache/first-build cost"* — true, but that's an inherent property of incremental compilation, already disclosed in the code comments, and matches issue #479's own scope (repeated runs on a long-lived shared-host checkout; the issue explicitly puts "adding CI workflow test runs" out of scope since no CI test workflow exists).
- *"Concurrent `tsc` invocations could race on the shared `.tsbuildinfo` file"* — a real but pre-existing risk class (concurrent `tsc` already raced on `dist/` output before this PR), and a stale/invalid buildinfo causes a cache-miss fallback to a full rebuild rather than corrupt output. Not something this diff needs to solve, especially given the standing operational rule on this host against running concurrent heavy builds.

## Regression test
`tests/unit/build-pipeline.test.ts` asserts on `package.json`/`tsconfig.json` directly:
- `tsconfig.json` has `incremental: true` + a `tsBuildInfoFile`.
- The buildinfo path doesn't resolve under `dist/` (so it can't leak into the published package).
- `pretest:unit` is `"npm run build"` (still builds — see Correction #1) and `test:unit` still exists.
- `pretest` (full suite) still runs `npm run build`.
- `check:full` does not exist (see Correction #2).

**Proven to fail on the pre-fix code**, twice:
1. Reverted `package.json`/`tsconfig.json`/`.gitignore` to the original pre-fix state — 3 of 5 assertions failed (`incremental` undefined, `check:full` assertion mismatched, `pretest:unit` mismatched the removed value).
2. After Correction #2, reverted only `package.json` to the intermediate (Correction #1 but not #2) state — the `check:full` assertion failed as expected (received the old script string, expected `undefined`).

Both times, restoring the fix made all 5 assertions pass again.

## Test plan
- [x] `npm run typecheck` — clean (incremental, reused existing `.tsbuildinfo-check`)
- [x] `npx jest --runInBand --runTestsByPath tests/unit/build-pipeline.test.ts` — 5/5 passed
- [x] Regression test confirmed to fail against two different pre-fix states, then pass again after restoring the fix (see above)
- [x] Live proof of the `dist/` import claim: renamed `dist/` away, confirmed TS2307 on the 3 affected test files, restored `dist/`, confirmed 127/127 pass again
- [x] Full suite (`npx jest --runInBand`, capped heap): run twice on this shared host — 273 suites / 5376 tests passed both times (1169s and 387s; the second run had less host contention)
- [x] Self-review (`/gateway-code-review`) and an independent `/code-review` pass both completed; every confirmed finding from both is fixed above

Closes #479
